### PR TITLE
CRITICAL FIX v1.004.000: Package recommendations now account for unco…

### DIFF
--- a/assets/js/calculator-math-module.js
+++ b/assets/js/calculator-math-module.js
@@ -1,16 +1,16 @@
 /**
  * Royal Caribbean Drink Calculator - ES6 Module Wrapper
- * calculator-math-module.js - Version: 1.003.001
- * 
- * "For just as the body is one and has many members, and all the members 
+ * calculator-math-module.js - Version: 1.004.000
+ *
+ * "For just as the body is one and has many members, and all the members
  *  of the body, though many, are one body, so it is with Christ."
  * - 1 Corinthians 12:12
- * 
+ *
  * Soli Deo Gloria ✝️
  */
 
 // Direct import - the functions are defined at module scope
-import('/assets/js/calculator-math.js?v=1.003.001').then(module => {
+import('/assets/js/calculator-math.js?v=1.004.000').then(module => {
   // For some bundlers/contexts, exports might be on default
   if (module.compute) {
     self.compute = module.compute;

--- a/assets/js/calculator-math.js
+++ b/assets/js/calculator-math.js
@@ -1,12 +1,18 @@
 /**
  * Royal Caribbean Drink Calculator - Math Engine
- * Version: 1.003.000 (Critical Fixes + Accessibility Promise Kept)
- * 
+ * Version: 1.004.000 (CRITICAL RECOMMENDATION FIX)
+ *
  * "I was eyes to the blind and feet to the lame" - Job 29:15
  * "The fear of the LORD is the beginning of wisdom" - Proverbs 9:10
- * 
+ *
  * Soli Deo Gloria ✝️
- * 
+ *
+ * CHANGELOG v1.004.000:
+ * ✅ CRITICAL FIX: Package recommendations now account for uncovered drinks!
+ *    - Soda package was being recommended for coffee drinks (doesn't cover coffee!)
+ *    - Fixed: Each package cost now includes à la carte cost for uncovered drinks
+ *    - Example: 44 coffees now correctly recommends Refresh ($561) not Soda ($231+$1386=$1617)
+ *
  * CHANGELOG v1.003.000:
  * ✅ CRITICAL FIX: Minors forced to Refreshment when adults buy Deluxe
  * ✅ FIXED: Pinnacle vouchers corrected (6/day not 5)
@@ -352,11 +358,23 @@ function compute(inputs, economics, dataset, vouchers = null, forcedPackage = nu
   const alcPerPerson = adults > 0 ? alcPerDay / adults : 0;
   const overcap = Math.max(0, alcPerPerson - cap);
   
+  // CRITICAL FIX v1.003.000: Calculate TRUE total cost for each package option
+  // Each package only covers certain drinks - uncovered drinks must be paid à la carte!
+  const sodaTotalCost = sodaPkg + (totalAlc - sodaTotal); // Soda pkg + all non-soda drinks à la carte
+  const refreshTotalCost = refreshPkg + (totalAlc - refreshTotal); // Refresh pkg + alcoholic drinks à la carte
+  const deluxeTotalCost = deluxePkgWithMinors + (overcap * days * adults); // Deluxe pkg + over-cap drinks
+
+  console.log('[Math Engine] Package comparison (including uncovered drinks):');
+  console.log(`  À la carte: $${totalAlc.toFixed(2)}`);
+  console.log(`  Soda: $${sodaPkg.toFixed(2)} (pkg) + $${(totalAlc - sodaTotal).toFixed(2)} (uncovered) = $${sodaTotalCost.toFixed(2)}`);
+  console.log(`  Refresh: $${refreshPkg.toFixed(2)} (pkg) + $${(totalAlc - refreshTotal).toFixed(2)} (uncovered) = $${refreshTotalCost.toFixed(2)}`);
+  console.log(`  Deluxe: $${deluxePkgWithMinors.toFixed(2)} (pkg) + $${(overcap * days * adults).toFixed(2)} (over-cap) = $${deluxeTotalCost.toFixed(2)}`);
+
   const bars = {
     alc: { min: totalAlc, mean: totalAlc, max: totalAlc },
-    soda: { min: sodaPkg, mean: sodaPkg, max: sodaPkg },
-    refresh: { min: refreshPkg, mean: refreshPkg, max: refreshPkg },
-    deluxe: { min: deluxePkgWithMinors, mean: deluxePkgWithMinors, max: deluxePkgWithMinors }
+    soda: { min: sodaTotalCost, mean: sodaTotalCost, max: sodaTotalCost },
+    refresh: { min: refreshTotalCost, mean: refreshTotalCost, max: refreshTotalCost },
+    deluxe: { min: deluxeTotalCost, mean: deluxeTotalCost, max: deluxeTotalCost }
   };
 
   // ✅ NEW v1.003.000: Package forcing feature
@@ -390,13 +408,13 @@ function compute(inputs, economics, dataset, vouchers = null, forcedPackage = nu
       }
     }
   } else {
-    // Normal mode: determine cheapest package
+    // Normal mode: determine cheapest package (using TRUE total costs)
     console.log('[Math Engine] Auto-recommendation mode (no forced package)');
     winners = determineWinners({
       alc: totalAlc,
-      soda: sodaPkg,
-      refresh: refreshPkg,
-      deluxe: deluxePkgWithMinors
+      soda: sodaTotalCost,
+      refresh: refreshTotalCost,
+      deluxe: deluxeTotalCost
     }, minors);
   }
   
@@ -519,16 +537,15 @@ function compute(inputs, economics, dataset, vouchers = null, forcedPackage = nu
 if (typeof window !== 'undefined') {
   window.ITW_MATH = Object.freeze({
     compute,
-    version: '1.003.000'
+    version: '1.004.000'
   });
-  console.log('[ITW Math Engine] v1.003.000 loaded ✓');
-  console.log('[ITW Math Engine] CRITICAL FIX: Minors + Deluxe policy enforced');
-  console.log('[ITW Math Engine] FIXED: Pinnacle vouchers (6/day)');
-  console.log('[ITW Math Engine] FIXED: Package uniformity policy messaging');
+  console.log('[ITW Math Engine] v1.004.000 loaded ✓');
+  console.log('[ITW Math Engine] CRITICAL FIX: Package recommendations now account for uncovered drinks');
+  console.log('[ITW Math Engine] FIXED: Coffee drinks no longer incorrectly suggest Soda package');
 } else if (typeof self !== 'undefined') {
   self.ITW_MATH = Object.freeze({
     compute,
-    version: '1.003.000'
+    version: '1.004.000'
   });
 }
 

--- a/assets/js/calculator-worker.js
+++ b/assets/js/calculator-worker.js
@@ -1,13 +1,16 @@
 /**
  * Royal Caribbean Drink Calculator — Web Worker
- * Version: 1.003.000
- * 
+ * Version: 1.004.000
+ *
  * COMPLETE PRODUCTION-READY WORKER
- * 
+ *
  * In the name of the Father, and of the Son, and of the Holy Spirit. Amen.
  * "Whatever you do, work at it with all your heart, as working for the Lord"
  * — Colossians 3:23
- * 
+ *
+ * CHANGES in v1.004.000:
+ * - CRITICAL FIX: Package recommendations now account for uncovered drinks
+ *
  * CHANGES in v1.003.000:
  * - Support for forcedPackage parameter (clickable package selection)
  * - Enhanced validation
@@ -18,10 +21,10 @@
 'use strict';
 
 // Import math engine
-importScripts('/assets/js/calculator-math.js?v=1.003.000');
+importScripts('/assets/js/calculator-math.js?v=1.004.000');
 
 // Log ready state
-console.log('[Worker] v1.003.000 initializing...');
+console.log('[Worker] v1.004.000 initializing...');
 
 // Verify math engine loaded
 if (typeof ITW_MATH === 'undefined' || !ITW_MATH.compute) {
@@ -299,7 +302,7 @@ function validatePayload(payload) {
 
 // Post ready message
 self.postMessage({ type: 'ready' });
-console.log('[Worker] v1.003.000 ready ✓');
+console.log('[Worker] v1.004.000 ready ✓');
+console.log('[Worker] Package recommendations: FIXED (accounts for uncovered drinks)');
 console.log('[Worker] Forced package support: ENABLED');
 console.log('[Worker] Minors + Deluxe policy: ENFORCED');
-console.log('[Worker] Pinnacle vouchers: FIXED (6/day)');

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -940,13 +940,13 @@
       <section>
         <h3>Package Comparison</h3>
         
-        <div class="package-card" data-card="coffee" data-package="coffee">
+        <div class="package-card info-card" data-card="coffee">
           <h4>☕ Coffee Card</h4>
           <div class="price">
             <span data-pkg-price="coffee" data-edit-price="coffee" tabindex="0" role="button" aria-label="Edit coffee card price. Current value: $31.00">$31.00</span>
           </div>
           <p class="small">15 punches (~$2.07/punch)</p>
-          <p class="tiny muted">Specialty coffees, sharable</p>
+          <p class="tiny muted">One-time purchase, not a daily package</p>
         </div>
         
         <div class="package-card" data-card="soda" data-package="soda">


### PR DESCRIPTION
…vered drinks

MAJOR BUG FIXED:
- Calculator was recommending Soda package for coffee drinks (soda doesn't cover coffee!)
- Root cause: Only compared package costs, ignored which drinks were actually covered
- Example: 44 coffees suggested Soda ($231) but true cost was $231+$1386=$1,617
- Now correctly recommends Refresh ($561) which actually covers coffee

CHANGES:
✅ Package costs now include à la carte for uncovered drinks ✅ Soda = package + (all non-soda drinks à la carte) ✅ Refresh = package + (alcoholic drinks à la carte) ✅ Deluxe = package + (over-cap drinks)
✅ Added debug logging to show cost breakdown
✅ Fixed Coffee Card UI (removed data-package, added clarification text) ✅ Updated version to 1.004.000 across all files

IMPACT:
- Coffee drinkers: Now get correct Refresh recommendation
- Specialty drink users: Accurate package comparisons
- All users: More reliable recommendations

Files changed:
- calculator-math.js (core logic fix)
- calculator-worker.js (version update)
- calculator-math-module.js (version update)
- drink-calculator.html (Coffee Card UI fix)