### PR TITLE
FEATURE: Implement ICP-Lite v1.0 on index and Radiance pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@
   <meta name="author" content="In the Wake"/>
   <meta name="publisher" content="In the Wake"/>
 
+  <!-- ICP-Lite v1.0: AI-First Metadata -->
+  <meta name="ai-summary" content="Planning tools, travel tips, and faith-scented reflections for smoother sailings. Compare ships, scan menus, scout cabins, and find accessibility notes."/>
+  <meta name="last-reviewed" content="2025-11-15"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+
   <!-- SEO: Geographic -->
   <meta name="geo.region" content="US"/>
   <meta name="geo.placename" content="United States"/>
@@ -154,6 +159,56 @@
       "Cruise Ship Accessibility",
       "Travel Writing",
       "Faith-Based Travel"
+    ]
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is In the Wake?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "In the Wake is a cruise planning resource offering free tools, ship comparisons, dining guides, and accessibility information — primarily focused on Royal Caribbean but expanding to other lines. Created by cruisers, for cruisers, with no affiliate sales."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is In the Wake affiliated with any cruise line?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No. We're independent travelers sharing real-voyage insights. We don't sell cruises, earn commissions, or represent any cruise line. Our goal is honest, helpful information."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What tools does In the Wake offer?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "We provide a drink package calculator, ship comparison database, restaurant menus and pricing, stateroom check tool, packing lists, and accessibility guides — all free and constantly updated from real cruises."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How current is the information?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "We update pages after each sailing and review all content quarterly. Ship details, menus, and prices can change—always verify critical information with your cruise line before booking."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Who runs In the Wake?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "In the Wake is founded and maintained by Ken Baker, a pastor, photographer, and cruise enthusiast with 50+ sailings."
+        }
+      }
     ]
   }
   </script>
@@ -1013,6 +1068,12 @@
        target-audience: Cruise planners, Royal Caribbean travelers, solo cruisers, accessibility-focused travelers
        faith-perspective: Christian-integrated travel writing (Soli Deo Gloria)
        answer-first: Cruise planning tools and real-voyage insights for smoother sailings
+
+       subject: In the Wake is a cruise planning hub offering practical tools, ship comparisons, dining guides, and travel reflections to help travelers plan smoother sailings
+       intended-reader: Cruisers planning their next voyage, comparing ships or dining options, researching accessibility features, or seeking practical travel wisdom
+       core-facts: Free planning tools, Royal Caribbean focus, real-voyage insights, accessibility advocacy, faith-integrated perspective, no affiliate sales
+       decisions-informed: Which ship class suits your travel style, whether drink packages are worth it, how to navigate solo cruising, accessibility options available
+       cautions: Information current as of last-reviewed date, cruise line policies and prices change frequently, always verify critical details with your cruise line before booking
        -->
 
   <!-- Skip Link -->
@@ -1091,6 +1152,11 @@
       <article class="card welcome">
         <h1>Welcome aboard</h1>
         <p class="motto"><em>The calmest seas are found in another's wake.</em></p>
+
+        <p style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: var(--foam); border-radius: 8px; font-size: 0.95rem;">
+          <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 0.15rem;">Looking for cruise planning help?</strong>
+          <span>In the Wake offers practical tools, ship comparisons, dining guides, and real-voyage insights to help you plan smoother sailings — no affiliate links, just honest help.</span>
+        </p>
 
         <!-- FIXED: Proper heading hierarchy (h2 was inside p tag) -->
         <h2>Mariners know a small truth with big comfort</h2>
@@ -1238,11 +1304,43 @@
     </section>
   </section>
 
+  <!-- FAQ Section (ICP-Lite) -->
+  <section class="wrap" style="margin-top: 2rem;" aria-labelledby="faq-heading">
+    <div class="card">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid var(--rope);">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What is In the Wake?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">In the Wake is a cruise planning resource offering free tools, ship comparisons, dining guides, and accessibility information — primarily focused on Royal Caribbean but expanding to other lines. Created by cruisers, for cruisers, with no affiliate sales.</p>
+      </details>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid var(--rope);">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is In the Wake affiliated with any cruise line?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">No. We're independent travelers sharing real-voyage insights. We don't sell cruises, earn commissions, or represent any cruise line. Our goal is honest, helpful information.</p>
+      </details>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid var(--rope);">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What tools does In the Wake offer?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">We provide a drink package calculator, ship comparison database, restaurant menus and pricing, stateroom check tool, packing lists, and accessibility guides — all free and constantly updated from real cruises.</p>
+      </details>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid var(--rope);">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How current is the information?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">We update pages after each sailing and review all content quarterly. Ship details, menus, and prices can change—always verify critical information with your cruise line before booking.</p>
+      </details>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Who runs In the Wake?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">In the Wake is founded and maintained by Ken Baker, a pastor, photographer, and cruise enthusiast with 50+ sailings. Learn more on our <a href="/about-us.html">About page</a>.</p>
+      </details>
+    </div>
+  </section>
+
   <!-- FOOTER -->
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake. All rights reserved.</p>
 
-    
+
 
     <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. ✝️</p>
   </footer>

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -20,6 +20,12 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
      expertise: Royal Caribbean ship reviews, deck plans, dining analysis, cabin comparisons
      target-audience: Radiance of the Seas cruisers, Radiance Class researchers, ship comparison shoppers
      answer-first: Radiance of the Seas: deck plans, live tracker, dining venues, and stateroom videos. Plan your Royal Caribbean cruise with In the Wake.
+
+     subject: Radiance of the Seas is a Radiance-class Royal Caribbean ship offering deck plans, live ship tracking, dining venue details, and video tours to help cruisers plan their voyage
+     intended-reader: Travelers researching Radiance of the Seas before booking, comparing Radiance-class ships, or planning their upcoming Radiance cruise
+     core-facts: Entered service 2001, 90,090 GT, approximately 2,466 guests (double occupancy), Radiance Class, glass-wall design emphasizing ocean views, global itineraries including Alaska and Australia
+     decisions-informed: Whether Radiance fits your preferred ship size and style, how Radiance compares to sister ships Brilliance/Serenade/Jewel, which dining venues to prioritize, stateroom selection guidance
+     cautions: Ship itineraries and onboard offerings change seasonally, dining prices and venues update regularly, always verify current details with Royal Caribbean before finalizing your booking
      -->
   <!-- ======================================================
        In the Wake — Radiance of the Seas • Royal Caribbean
@@ -47,6 +53,11 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <meta name="version" content="3.010.300"/>
   <meta name="author" content="In the Wake"/>
   <meta name="publisher" content="In the Wake"/>
+
+  <!-- ICP-Lite v1.0: AI-First Metadata -->
+  <meta name="ai-summary" content="Radiance of the Seas: deck plans, live tracker, dining venues, and stateroom videos. Plan your Royal Caribbean cruise with In the Wake."/>
+  <meta name="last-reviewed" content="2025-11-15"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
 
   <!-- Title & SEO -->
   <title>Radiance of the Seas — Deck Plans, Live Tracker, Dining & Videos | In the Wake (v3.010.300)</title>
@@ -165,6 +176,56 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     "sameAs": ["https://www.flickersofmajesty.com"],
     "worksFor": {"@type": "Organization", "name": "In the Wake"},
     "knowsAbout": ["Cruise Planning", "Royal Caribbean", "Cruise Ships", "Travel Writing"]
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What makes Radiance of the Seas unique compared to other Royal Caribbean ships?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Radiance emphasizes floor-to-ceiling windows and glass elevators for maximum ocean views, with a mid-sized feel (about 2,466 guests at double occupancy) compared to mega-ships like Oasis class (5,400+ guests). The glass-wall design and smaller size create an intimate, ocean-forward cruising experience."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which ships are in the same class as Radiance of the Seas?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Radiance of the Seas is part of the Radiance Class, which includes Brilliance of the Seas, Serenade of the Seas, and Jewel of the Seas. All four ships share similar layouts and features with glass-wall design."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What dining options are available on Radiance of the Seas?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Radiance offers the main dining room, Windjammer Café (casual buffet), specialty restaurants including Chops Grille and Chef's Table, plus bars and lounges."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Where does Radiance of the Seas typically sail?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Radiance has sailed global itineraries including Alaska, the Caribbean, Australia, and Asia. Deployments vary by season."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How can I see Radiance of the Seas' current location?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Use the live ship tracker on this page to see the ship's current position, speed, and next port in real-time."
+        }
+      }
+    ]
   }
   </script>
 
@@ -495,6 +556,23 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">
+
+    <!-- ICP-Lite: Page Intro -->
+    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Radiance of the Seas overview">
+      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Radiance of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+
+      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
+        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Radiance of the Seas planning info?</strong>
+        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Radiance of the Seas.</span>
+      </p>
+
+      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
+        Radiance of the Seas tends to suit travelers who prefer mid-sized ships with panoramic ocean views and glass-wall design.
+        It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
+        If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
+      </p>
+    </section>
+
     <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
@@ -624,7 +702,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
         <!-- Stats -->
         <section class="ship-stats card mini" aria-labelledby="statsHeading">
-          <h3 id="statsHeading">Radiance at a Glance</h3>
+          <h3 id="statsHeading">Key Facts About Radiance of the Seas</h3>
           <div id="ship-stats" class="stats-grid" data-slug="radiance-of-the-seas"></div>
           <script type="application/json" id="ship-stats-fallback">
           {
@@ -773,6 +851,36 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         </div>
         <p style="text-align:center"><a href="/ships.html" class="btn">Browse All Ships</a></p>
       </section>
+    </section>
+
+    <!-- FAQ Section (ICP-Lite) -->
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid var(--rope);">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What makes Radiance of the Seas unique compared to other Royal Caribbean ships?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Radiance emphasizes floor-to-ceiling windows and glass elevators for maximum ocean views, with a mid-sized feel (about 2,466 guests at double occupancy) compared to mega-ships like Oasis class (5,400+ guests). The glass-wall design and smaller size create an intimate, ocean-forward cruising experience.</p>
+      </details>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid var(--rope);">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Which ships are in the same class as Radiance of the Seas?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Radiance of the Seas is part of the Radiance Class, which includes <a href="/ships/rcl/brilliance-of-the-seas.html">Brilliance of the Seas</a>, <a href="/ships/rcl/serenade-of-the-seas.html">Serenade of the Seas</a>, and <a href="/ships/rcl/jewel-of-the-seas.html">Jewel of the Seas</a>. All four ships share similar layouts and features with glass-wall design.</p>
+      </details>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid var(--rope);">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Radiance of the Seas?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Radiance offers the main dining room, Windjammer Café (casual buffet), specialty restaurants including Chops Grille and Chef's Table, plus bars and lounges. See the <a href="#dining-card">Dining Venues section</a> above for current pricing and full details.</p>
+      </details>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid var(--rope);">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Radiance of the Seas typically sail?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Radiance has sailed global itineraries including Alaska, the Caribbean, Australia, and Asia. Deployments vary by season — check the live tracker on this page or Royal Caribbean's official site for current and upcoming voyages.</p>
+      </details>
+
+      <details style="margin: 0.75rem 0; padding: 0.5rem 0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How can I see Radiance of the Seas' current location?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Use the <a href="#liveTrackHeading">live ship tracker</a> on this page (in the "Where Is Radiance Right Now?" section) to see the ship's current position, speed, and next port in real-time.</p>
+      </details>
     </section>
 
     <!-- Attribution -->


### PR DESCRIPTION
Apply "AI-first structurally, human-first visually" strategy:

Index.html changes:
- Add ICP-Lite metadata (ai-summary, last-reviewed, content-protocol)
- Enhance ai-breadcrumbs with subject, intended-reader, core-facts, decisions-informed, cautions
- Add human-friendly answer line ("Looking for cruise planning help?")
- Add FAQ section (5 questions) with collapsible details
- Add FAQPage schema for AI extraction

Radiance-of-the-seas.html changes:
- Add missing H1 heading
- Add ICP-Lite metadata (ai-summary, last-reviewed, content-protocol)
- Enhance ai-breadcrumbs with additional ICP fields
- Add page intro with answer line and fit-guidance (pastoral tone)
- Rename "Radiance at a Glance" to "Key Facts About Radiance of the Seas"
- Add FAQ section (5 ship-specific questions)
- Add FAQPage schema

All changes preserve existing visual design and maintain pastoral brand voice. Zero breaking changes to functionality or JavaScript loaders.