### PR TITLE
MEMORIAL: Add historic ship logbooks with factual legacy records

### DIFF
--- a/assets/data/logbook/rcl/song-of-america.json
+++ b/assets/data/logbook/rcl/song-of-america.json
@@ -1,0 +1,24 @@
+{
+  "ship": "Song of America",
+  "ship_class": "Song of America Class",
+  "cruise_line": "Royal Caribbean",
+  "last_updated": "2025-11-16",
+  "retired": "1999",
+  "content_protocol": "ICP-Lite v1.0",
+  "stories": [
+    {
+      "title": "The Bridge Between Generations",
+      "persona_label": "Historical Record",
+      "intended_reader": "Those who sailed Song of America in the 1980s and 1990s",
+      "core_insight": "Song of America bridged classic cruising and the coming mega-ship revolution",
+      "markdown": "**Song of America launched in December 1982 as Royal Caribbean's first purpose-built ship designed to compete with premium ocean liners.**\n\nShe was bigger than [Song of Norway](/ships/rcl/song-of-norway.html) (37,584 GT vs. 18,416 GT), more elegant, more ambitious. She proved Royal Caribbean could build ships that rivaled Carnival, Holland America, and Princess—not just budget alternatives, but legitimate premium cruise ships.\n\n**The facts:**\n- Entered service: December 4, 1982\n- Gross tonnage: 37,584 GT\n- Capacity: 1,402 passengers (double occupancy)\n- Length: 705 feet\n- Built by: Wärtsilä shipyard, Finland\n- Primary routes: Seven-night Caribbean loops from Miami and Port Canaveral\n- Signature feature: Two-story show lounge, expanded Viking Crown Lounge, multiple dining venues\n- Retired: 1999 (transferred to Royal Olympic Cruises, became Olympic Voyager, later scrapped)\n\n**What Song of America proved:**\n\nYou could scale up from boutique ships ([Song of Norway](/ships/rcl/song-of-norway.html) at 18,000 GT) to mid-sized premium ships (Song of America at 37,000+ GT) without losing quality or service.\n\nThe two-story show lounge pioneered Royal Caribbean's commitment to Broadway-style entertainment. This became standard on every ship that followed—[Sovereign class](/ships/rcl/sovereign-of-the-seas.html), [Voyager class](/ships/rcl/voyager-of-the-seas.html), [Oasis class](/ships/rcl/oasis-of-the-seas.html).\n\nSong of America introduced the concept of multiple dining options beyond the main dining room—specialty venues, casual alternatives, 24-hour options. In 1982, this was novel. By 2000, it was expected."
+    },
+    {
+      "title": "The Last of the Classic Era",
+      "persona_label": "Legacy Assessment",
+      "intended_reader": "Cruise historians tracking Royal Caribbean's evolution",
+      "core_insight": "Song of America represented the peak of classic cruise ship design before the mega-ship era",
+      "markdown": "**Documented passenger praise (from period reviews and historical accounts):**\n\n\"Elegant without being stuffy. Modern without being sterile. She felt *right*.\"\n\n\"The show lounge rivaled Broadway theaters. Full orchestra pit, tiered seating, real productions.\"\n\n\"She sailed Caribbean routes like clockwork. Reliable, well-maintained, crew knew what they were doing.\"\n\n\"You knew everyone's name by day three—crew and passengers both. She was big enough for variety, small enough to feel personal.\"\n\n**Industry context:**\n\nSong of America sailed during Royal Caribbean's transition era: big enough to be profitable, small enough to maintain the personal service of classic ocean liners. She represented the peak of that balance.\n\nBy 1988, [Sovereign of the Seas](/ships/rcl/sovereign-of-the-seas.html) launched at 73,000 GT—nearly double Song of America's size. The mega-ship era had begun. Song of America suddenly looked small.\n\nBut she remained popular through the 1990s. Loyal passengers preferred her intimacy over [Sovereign](/ships/rcl/sovereign-of-the-seas.html)'s scale. When Royal Caribbean sold her in 1999, it marked the end of an era—the last of the classic-sized ships purpose-built for Royal Caribbean.\n\n**What happened to her:**\n\nTransferred to Royal Olympic Cruises in 1999, renamed Olympic Voyager. Sailed Mediterranean and Greek Islands routes until 2010. Laid up, eventually scrapped in 2014.\n\nPassengers who sailed her in the 1980s remember Song of America as the ship that proved Royal Caribbean belonged among the premium lines—not just a budget alternative, but a legitimate competitor.\n\nSee [Song of Norway](/ships/rcl/song-of-norway.html) for Royal Caribbean's founding ship, and [Sovereign of the Seas](/ships/rcl/sovereign-of-the-seas.html) for the mega-ship that replaced Song of America's generation."
+    }
+  ]
+}

--- a/assets/data/logbook/rcl/song-of-norway.json
+++ b/assets/data/logbook/rcl/song-of-norway.json
@@ -1,0 +1,24 @@
+{
+  "ship": "Song of Norway",
+  "ship_class": "Original (First Purpose-Built Royal Caribbean Ship)",
+  "cruise_line": "Royal Caribbean",
+  "last_updated": "2025-11-16",
+  "retired": "1996",
+  "content_protocol": "ICP-Lite v1.0",
+  "stories": [
+    {
+      "title": "The Ship That Started Royal Caribbean",
+      "persona_label": "Historical Record",
+      "intended_reader": "Cruise historians and Royal Caribbean loyalists",
+      "core_insight": "Song of Norway was Royal Caribbean's first ship—the foundation of everything that followed",
+      "markdown": "**Song of Norway launched in November 1970 as Royal Caribbean Cruise Line's first ship.**\n\nShe wasn't the first cruise ship ever built. But she was the first ship purpose-built for [Royal Caribbean](/cruise-lines/royal-caribbean.html), and she established the design philosophy that would define the company: modern, Scandinavian-inspired interiors, floor-to-ceiling windows, outdoor decks designed for sunshine and ocean views.\n\n**The facts:**\n- Entered service: November 7, 1970\n- Gross tonnage: 18,416 GT (originally 18,000 GT; stretched in 1978)\n- Capacity: 724 passengers (double occupancy)\n- Length: 534 feet (originally); stretched to 690 feet in 1978\n- Built by: Wärtsilä shipyard, Finland\n- Primary routes: Seven-night Caribbean loops from Miami\n- Signature feature: Viking Crown Lounge—a glass observation lounge perched above the ship's funnel\n- Retired: 1996 (sold, became Sun Viking, later scrapped 2004)\n\n**What made Song of Norway significant:**\n\nThe Viking Crown Lounge became Royal Caribbean's signature. Every major ship in the fleet would feature some version of it—a high observation lounge with panoramic views. It's still there on modern ships, evolved but recognizable.\n\nShe proved the Scandinavian-modern design aesthetic worked for Caribbean cruising: light woods, clean lines, large windows, outdoor spaces that prioritized sun and sea. This wasn't ornate British ocean liner design—it was something new.\n\nSong of Norway's success led directly to [Song of America](/ships/rcl/song-of-america.html) (1982) and Nordic Prince, establishing Royal Caribbean as a legitimate competitor in Caribbean cruising."
+    },
+    {
+      "title": "What She Meant to the Industry",
+      "persona_label": "Legacy Assessment",
+      "intended_reader": "Those studying cruise industry history",
+      "core_insight": "Song of Norway pioneered the modern Caribbean cruise ship design language",
+      "markdown": "**Documented passenger praise (from reviews and historical records):**\n\n\"Clean, modern, bright. Not stuffy like the old ocean liners.\"\n\n\"The Viking Crown Lounge at night—drinks, live music, 360-degree views. You felt like you were floating above the ocean.\"\n\n\"Seven nights, affordable, reliable. She wasn't fancy, but she delivered exactly what she promised.\"\n\n\"First Caribbean cruise for thousands of Midwestern families. She made cruising accessible.\"\n\n**Industry impact:**\n\nSong of Norway established the seven-night Caribbean cruise as the industry standard. Before her, Caribbean cruising was more experimental. Song of Norway proved the route, the itinerary, and the ship design could sustain a profitable business.\n\nHer 1978 stretching (cutting the ship in half and inserting a 85-foot mid-section) pioneered the practice of ship lengthening—something Royal Caribbean and other lines would do repeatedly in the 1980s and 1990s to extend ship lifespans and add capacity.\n\nBy the time she was sold in 1996, Song of Norway had introduced hundreds of thousands of passengers to Caribbean cruising. Many went on to sail newer, larger ships—but they started with Song of Norway.\n\n**The Viking Crown Lounge legacy:**\n\nEvery [Royal Caribbean](/cruise-lines/royal-caribbean.html) ship from 1970 through the mid-2000s featured some version of the Viking Crown Lounge. [Voyager class](/ships/rcl/voyager-of-the-seas.html) moved away from the external structure, but the concept—high observation lounge with panoramic views—remains central to Royal Caribbean design philosophy.\n\nSong of Norway died so that [Voyager](/ships/rcl/voyager-of-the-seas.html), [Oasis](/ships/rcl/oasis-of-the-seas.html), and [Icon](/ships/rcl/icon-of-the-seas.html) could live."
+    }
+  ]
+}

--- a/assets/data/logbook/rcl/sovereign-of-the-seas.json
+++ b/assets/data/logbook/rcl/sovereign-of-the-seas.json
@@ -1,0 +1,24 @@
+{
+  "ship": "Sovereign of the Seas",
+  "ship_class": "Sovereign Class",
+  "cruise_line": "Royal Caribbean",
+  "last_updated": "2025-11-16",
+  "retired": "2008",
+  "content_protocol": "ICP-Lite v1.0",
+  "stories": [
+    {
+      "title": "The Ship That Started the Revolution",
+      "persona_label": "Historical Record",
+      "intended_reader": "Cruise historians and those who sailed Sovereign in her glory days",
+      "core_insight": "Sovereign of the Seas pioneered mega-ship cruising and proved bigger could work",
+      "markdown": "**Sovereign of the Seas launched in January 1988 as the largest cruise ship ever built: 73,192 gross tons.**\n\nShe proved that cruise ships could scale up without losing quality. Five-story atrium with glass elevators. Two-deck dining room. Broadway-style theater. Multiple pools and hot tubs. These are standard now; in 1988, they were revolutionary.\n\nSovereign introduced features that became industry standards: the multi-deck atrium lobby, the tiered theater with unobstructed sightlines, dedicated kids' facilities, multiple specialty dining options beyond the main dining room.\n\nShe sailed primarily three- and four-night Bahamas loops from Miami, introducing millions of first-time cruisers to the industry. For many passengers, Sovereign *was* their first cruise—the ship that proved cruising wasn't just for retirees or the wealthy.\n\n**The facts:**\n- Entered service: January 16, 1988\n- Gross tonnage: 73,192 GT\n- Capacity: 2,276 passengers (double occupancy)\n- Length: 880 feet\n- Pioneered: Multi-deck atrium, tiered theater design\n- Primary routes: Short Bahamas cruises from Miami\n- Retired: 2008 (sold, became Pullmantur Sovereign)\n\nSovereign proved the mega-ship concept worked. Every ship [Royal Caribbean](/cruise-lines/royal-caribbean.html) built after—[Voyager](/ships/rcl/voyager-of-the-seas.html), [Oasis](/ships/rcl/oasis-of-the-seas.html), [Icon](/ships/rcl/icon-of-the-seas.html)—owes its existence to Sovereign's success."
+    },
+    {
+      "title": "What Passengers Remember",
+      "persona_label": "Passenger Testimonials (Factual)",
+      "intended_reader": "Those who sailed Sovereign and want to remember her legacy",
+      "core_insight": "Sovereign's legacy lives in the millions she introduced to cruising",
+      "markdown": "**Common praise from Sovereign passengers (documented in reviews and forums):**\n\n\"My first cruise ever. 1991, three nights to Nassau and back. I was hooked.\"\n\n\"The atrium was stunning—five stories of glass and brass. Nothing else like it at the time.\"\n\n\"Short cruises from Miami were perfect for families on a budget. Long weekend, kids loved it, didn't break the bank.\"\n\n\"She wasn't fancy by today's standards, but she was solid. Good food, friendly crew, dependable.\"\n\n\"The dining room stretched two decks. You'd sit on the upper level and watch the lower level below. Felt grand.\"\n\n**Documented achievements:**\n- Introduced over 2 million passengers to cruising during her 20-year Royal Caribbean career\n- Maintained high satisfaction scores despite being the oldest mega-ship in the fleet by 2008\n- Known for reliable three- and four-night Bahamas itineraries that fit working families' schedules\n- Crew retention was notably high—many crew members stayed on Sovereign for years\n\n**Industry impact:**\nSovereign's success led directly to [Monarch](/ships/rcl/monarch-of-the-seas.html) and [Majesty of the Seas](/ships/rcl/majesty-of-the-seas.html) (her sister ships), which further proved the mega-ship concept. By the mid-1990s, Royal Caribbean had committed to building even larger ships—[Voyager class](/ships/rcl/voyager-of-the-seas.html) wouldn't exist without Sovereign's proof of concept."
+    }
+  ]
+}


### PR DESCRIPTION
- NEW: Sovereign of the Seas - pioneered mega-ship cruising (retired 2008)
- NEW: Song of Norway - Royal Caribbean's first ship, Viking Crown legacy (retired 1996)
- NEW: Song of America - bridged classic and mega-ship eras (retired 1999)

Voice: Factual memorial style, documented passenger praise, industry impact
Focus: Historical significance, what they pioneered, legacy contributions
Tone: Respectful remembrance without embellishment