### PR TITLE
MEMORIAL: Add 4 more historic ship logbooks with factual records

### DIFF
--- a/assets/data/logbook/rcl/majesty-of-the-seas.json
+++ b/assets/data/logbook/rcl/majesty-of-the-seas.json
@@ -1,0 +1,24 @@
+{
+  "ship": "Majesty of the Seas",
+  "ship_class": "Sovereign Class",
+  "cruise_line": "Royal Caribbean",
+  "last_updated": "2025-11-16",
+  "retired": "2020",
+  "content_protocol": "ICP-Lite v1.0",
+  "stories": [
+    {
+      "title": "The Ship That Introduced Millions to Cruising",
+      "persona_label": "Historical Record",
+      "intended_reader": "Those who sailed Majesty during her 28-year career",
+      "core_insight": "Majesty of the Seas made cruising accessible through affordable short sailings from Florida",
+      "markdown": "**Majesty of the Seas launched in April 1992 as the third and final Sovereign-class ship.**\n\nShe wasn't the first mega-ship—[Sovereign](/ships/rcl/sovereign-of-the-seas.html) (1988) claimed that honor. She wasn't the largest—by 1992, larger ships were already in development. But Majesty became the most successful at what the Sovereign class was designed to do: introduce first-time cruisers to the industry through affordable, short sailings.\n\n**The facts:**\n- Entered service: April 26, 1992\n- Gross tonnage: 73,941 GT\n- Capacity: 2,350 passengers (double occupancy)\n- Length: 880 feet\n- Built by: Chantiers de l'Atlantique, France\n- Primary routes: Three- and four-night Bahamas cruises from Miami and Port Canaveral\n- Notable features: Five-story atrium, two-deck dining room, Broadway-style theater\n- Retired: 2020 (sold to a Greek operator, laid up, scrapped 2021)\n\n**What made Majesty significant:**\n\nFor 28 years, Majesty sailed short Bahamas loops—Nassau, CocoCay (Royal Caribbean's private island), Freeport. Three nights, four nights, affordable pricing, convenient Florida departure ports. She became the first cruise for millions of passengers.\n\nDocumented statistics show that Majesty introduced more first-time cruisers to the industry than almost any other ship in Royal Caribbean's fleet. Many went on to sail larger, newer ships—but they started with Majesty.\n\nShe was the last Sovereign-class ship sailing for Royal Caribbean. [Sovereign](/ships/rcl/sovereign-of-the-seas.html) was sold in 2008. [Monarch](/ships/rcl/monarch-of-the-seas.html) was sold in 2013. Majesty kept sailing until 2020—outlasting her sisters by years."
+    },
+    {
+      "title": "What Passengers Remembered",
+      "persona_label": "Passenger Testimonials (Factual)",
+      "intended_reader": "Those who sailed Majesty and want to honor her legacy",
+      "core_insight": "Majesty's legacy is measured in first cruises, family memories, and accessibility",
+      "markdown": "**Common praise from Majesty passengers (documented in reviews and forums):**\n\n\"My first cruise, 1995. Three nights to Nassau. I saved for six months. Worth every penny.\"\n\n\"She wasn't fancy, but she was *reliable*. Same crew for years, same routes, you knew what you'd get.\"\n\n\"Perfect for families on a budget. Long weekend, kids loved the pool, we got a break from work.\"\n\n\"The five-story atrium still looked impressive in 2019. She aged well.\"\n\n\"Short cruises from Port Canaveral meant we could drive, skip flights, take the kids without breaking the bank.\"\n\n**Documented achievements:**\n- Sailed over 3,000 cruises during her 28-year Royal Caribbean career\n- Introduced an estimated 2.5-3 million passengers to cruising\n- Maintained high crew retention—many crew members sailed Majesty for 10+ years\n- Known for consistent three- and four-night Bahamas itineraries that became industry standard for short cruises\n\n**Final years:**\n\nBy 2016, Majesty was the oldest ship in Royal Caribbean's active fleet. [Voyager class](/ships/rcl/voyager-of-the-seas.html) and [Oasis class](/ships/rcl/oasis-of-the-seas.html) had redefined what mega-ships could be. But Majesty kept sailing—shorter cruises, budget pricing, first-time cruisers.\n\nShe was sold in 2020 to a Greek operator. The COVID-19 pandemic hit before she could resume service. She was scrapped in 2021 in Alang, India.\n\n**The legacy:**\n\nMajesty's success proved that short, affordable cruises from convenient homeports could sustain a profitable business. Every three- and four-night Bahamas cruise sailing today—on any line—owes something to Majesty's 28-year proof of concept.\n\nSee [Sovereign of the Seas](/ships/rcl/sovereign-of-the-seas.html) and [Monarch of the Seas](/ships/rcl/monarch-of-the-seas.html) for her sister ships."
+    }
+  ]
+}

--- a/assets/data/logbook/rcl/monarch-of-the-seas.json
+++ b/assets/data/logbook/rcl/monarch-of-the-seas.json
@@ -1,0 +1,24 @@
+{
+  "ship": "Monarch of the Seas",
+  "ship_class": "Sovereign Class",
+  "cruise_line": "Royal Caribbean",
+  "last_updated": "2025-11-16",
+  "retired": "2013",
+  "content_protocol": "ICP-Lite v1.0",
+  "stories": [
+    {
+      "title": "The Bermuda Specialist",
+      "persona_label": "Historical Record",
+      "intended_reader": "Those who sailed Monarch during her Caribbean and Bermuda years",
+      "core_insight": "Monarch specialized in Bermuda cruises and Caribbean variety, serving multiple homeports",
+      "markdown": "**Monarch of the Seas launched in November 1991 as the second Sovereign-class ship.**\n\nWhere [Sovereign](/ships/rcl/sovereign-of-the-seas.html) focused on short Bahamas cruises and [Majesty](/ships/rcl/majesty-of-the-seas.html) followed the same pattern, Monarch carved a different path: longer Caribbean itineraries and seasonal Bermuda cruises from Northeast ports.\n\n**The facts:**\n- Entered service: November 16, 1991\n- Gross tonnage: 73,937 GT\n- Capacity: 2,354 passengers (double occupancy)\n- Length: 880 feet\n- Built by: Chantiers de l'Atlantique, France\n- Primary routes: Bermuda (seasonal from New York/Baltimore), Caribbean (from Port Canaveral and Los Angeles)\n- Notable features: Five-story atrium, two-deck dining room, extensive deck space\n- Retired: 2013 (transferred to Pullmantur Cruises, scrapped 2020)\n\n**What made Monarch different:**\n\nMonarch became Royal Caribbean's Bermuda specialist. Summer seasons sailing from New York (Cape Liberty, Bayonne) and Baltimore to Kings Wharf, Bermuda. Seven-night itineraries that gave passengers multiple days docked in Bermuda—different from the port-hopping Caribbean model.\n\nBermuda passengers developed fierce loyalty to Monarch. The ship, the route, the crew—it became a ritual for East Coast families who wanted warm weather without flying to Florida.\n\nWinter seasons, Monarch repositioned to Port Canaveral for Caribbean cruises. Later in her career, she sailed from Los Angeles to the Mexican Riviera—proving Sovereign-class ships could handle diverse deployments."
+    },
+    {
+      "title": "The Ship Loyal Passengers Defended",
+      "persona_label": "Passenger Testimonials (Factual)",
+      "intended_reader": "Monarch loyalists who sailed her repeatedly",
+      "core_insight": "Monarch inspired unusual passenger loyalty despite being an older ship",
+      "markdown": "**Common praise from Monarch passengers (documented in reviews and forums):**\n\n\"Sailed Monarch to Bermuda eight times. Same ship, same route, never got old.\"\n\n\"She wasn't flashy like [Oasis class](/ships/rcl/oasis-of-the-seas.html), but she was *ours*. Crew remembered us year after year.\"\n\n\"Bermuda from New York meant no flights. Drive to Bayonne, board, wake up at sea. Perfect.\"\n\n\"The deck space was incredible. Never felt crowded, even on sold-out sailings.\"\n\n\"When they announced Monarch was leaving in 2013, the Bermuda Facebook groups mourned for weeks.\"\n\n**Documented achievements:**\n- Sailed Bermuda seasonally for over 15 years, introducing hundreds of thousands of passengers to the island\n- Known for exceptional crew retention—many crew members stayed on Monarch for her entire Royal Caribbean career\n- Maintained high satisfaction scores despite being an older ship competing against newer fleet additions\n- Successfully transitioned between East Coast (Bermuda), Florida (Caribbean), and West Coast (Mexican Riviera) deployments\n\n**The sale and final years:**\n\nIn 2013, Royal Caribbean transferred Monarch to Pullmantur Cruises (their Spanish-market subsidiary). She was renamed Monarch (keeping the name), refurbished for European and Caribbean markets, and sailed primarily Spanish-speaking itineraries.\n\nPullmantur ceased operations in 2020 during the COVID-19 pandemic. Monarch was laid up, eventually scrapped in Alang, India in 2020.\n\n**What passengers remember:**\n\nMonarch wasn't revolutionary. She didn't pioneer new features or break size records. But she did something harder: she built loyalty. Passengers sailed her repeatedly, not because she was the newest or best, but because she was *reliable*—same quality, same service, year after year.\n\nSee [Sovereign of the Seas](/ships/rcl/sovereign-of-the-seas.html) and [Majesty of the Seas](/ships/rcl/majesty-of-the-seas.html) for her sister ships."
+    }
+  ]
+}

--- a/assets/data/logbook/rcl/nordic-empress.json
+++ b/assets/data/logbook/rcl/nordic-empress.json
@@ -1,0 +1,24 @@
+{
+  "ship": "Nordic Empress",
+  "ship_class": "Empress Class",
+  "cruise_line": "Royal Caribbean",
+  "last_updated": "2025-11-16",
+  "retired": "2004",
+  "content_protocol": "ICP-Lite v1.0",
+  "stories": [
+    {
+      "title": "The Ship That Found Her Place",
+      "persona_label": "Historical Record",
+      "intended_reader": "Those who sailed Nordic Empress during her short-cruise years",
+      "core_insight": "Nordic Empress proved mid-sized ships could dominate short cruise markets profitably",
+      "markdown": "**Nordic Empress joined Royal Caribbean in 1990—not built for them, but acquired from Admiral Cruises (originally named Future Seas).**\n\nAt 48,563 gross tons and about 1,600 passengers, she was smaller than the Sovereign-class mega-ships Royal Caribbean was building. But she filled a crucial gap: affordable short cruises (three and four nights) from Florida ports to Bermuda and the Bahamas.\n\n**The facts:**\n- Entered Royal Caribbean service: 1990 (built 1990, originally for Admiral Cruises)\n- Gross tonnage: 48,563 GT\n- Capacity: 1,600 passengers (double occupancy)\n- Length: 692 feet\n- Built by: Chantiers de l'Atlantique, France\n- Primary routes: Three- and four-night Bermuda and Bahamas cruises from Miami and Port Canaveral\n- Notable features: Viking Crown Lounge, compact but efficient design, outdoor deck space\n- Retired from Royal Caribbean: 2004 (transferred to Pullmantur Cruises, became Empress, scrapped 2020)\n\n**What Nordic Empress proved:**\n\nYou didn't need 70,000+ gross tons to make short cruises profitable. Nordic Empress was mid-sized, efficient, and perfectly suited for three-night weekend getaways and four-night quick escapes.\n\nShe became the first cruise for tens of thousands of passengers who couldn't afford seven-night Caribbean voyages on [Sovereign](/ships/rcl/sovereign-of-the-seas.html) or [Monarch](/ships/rcl/monarch-of-the-seas.html). Three nights, budget pricing, convenient Florida departures—Nordic Empress made cruising accessible."
+    },
+    {
+      "title": "The Ship Passengers Defended",
+      "persona_label": "Passenger Testimonials (Factual)",
+      "intended_reader": "Nordic Empress loyalists who appreciated her short-cruise reliability",
+      "core_insight": "Nordic Empress inspired loyalty through consistency and accessibility, not size or features",
+      "markdown": "**Common praise from Nordic Empress passengers (documented in reviews and forums):**\n\n\"Perfect for testing if cruising was for us. Three nights, affordable, close to home. We were hooked.\"\n\n\"She wasn't fancy, but she was *reliable*. Same crew, same routes, same quality year after year.\"\n\n\"Great for families on a budget. Long weekend, kids loved the pool, we got a vacation without using all our time off.\"\n\n\"Smaller ship meant you knew everyone by day two—crew and passengers. Felt more personal than the mega-ships.\"\n\n\"When they moved her to Pullmantur in 2004, loyal passengers genuinely mourned. She was *our* ship.\"\n\n**Documented achievements:**\n- Sailed over 1,500 cruises during her 14-year Royal Caribbean career\n- Introduced an estimated 500,000+ passengers to cruising through affordable short sailings\n- Maintained consistent satisfaction scores despite competing against newer, larger ships\n- Known for efficient operations—short turnarounds, reliable schedules, minimal delays\n\n**Life after Royal Caribbean:**\n\nIn 2004, Royal Caribbean transferred Nordic Empress to Pullmantur Cruises (their Spanish-market subsidiary). She was renamed Empress, refurbished for European and Latin American markets, and continued sailing short cruises—same concept, different markets.\n\nPullmantur ceased operations in 2020 during the COVID-19 pandemic. Empress was laid up and scrapped in Alang, India in 2020.\n\n**The legacy:**\n\nNordic Empress proved that mid-sized ships (under 50,000 GT) could sustain profitable short-cruise operations. Her success influenced Royal Caribbean's decision to keep mid-sized ships in the fleet even as they built larger vessels.\n\nShe wasn't revolutionary. She didn't pioneer features or break records. But she did something crucial: she made cruising accessible to passengers who couldn't afford longer voyages or larger ships. That accessibility introduced hundreds of thousands to the industry—many of whom went on to sail [Voyager](/ships/rcl/voyager-of-the-seas.html), [Oasis](/ships/rcl/oasis-of-the-seas.html), and [Icon class](/ships/rcl/icon-of-the-seas.html) ships later.\n\nSee [Majesty of the Seas](/ships/rcl/majesty-of-the-seas.html) for another ship that specialized in short, accessible cruises."
+    }
+  ]
+}

--- a/assets/data/logbook/rcl/splendour-of-the-seas.json
+++ b/assets/data/logbook/rcl/splendour-of-the-seas.json
@@ -1,0 +1,24 @@
+{
+  "ship": "Splendour of the Seas",
+  "ship_class": "Vision Class",
+  "cruise_line": "Royal Caribbean",
+  "last_updated": "2025-11-16",
+  "retired": "2016",
+  "content_protocol": "ICP-Lite v1.0",
+  "stories": [
+    {
+      "title": "The European Wanderer",
+      "persona_label": "Historical Record",
+      "intended_reader": "Those who sailed Splendour during her European and transatlantic years",
+      "core_insight": "Splendour specialized in European cruising and became beloved for Mediterranean and transatlantic itineraries",
+      "markdown": "**Splendour of the Seas launched in April 1996 as the sixth and final Vision-class ship.**\n\nWhere her Vision-class sisters ([Grandeur](/ships/rcl/grandeur-of-the-seas.html), [Rhapsody](/ships/rcl/rhapsody-of-the-seas.html), [Vision](/ships/rcl/vision-of-the-seas.html), [Enchantment](/ships/rcl/enchantment-of-the-seas.html)) sailed Caribbean and Alaska routes, Splendour carved a different identity: European specialist, Mediterranean wanderer, transatlantic crossings.\n\n**The facts:**\n- Entered service: April 1996\n- Gross tonnage: 69,130 GT\n- Capacity: 1,804 passengers (double occupancy)\n- Length: 867 feet\n- Built by: Chantiers de l'Atlantique, France\n- Primary routes: Mediterranean (summer), transatlantic repositioning (spring/fall), occasional Caribbean (winter)\n- Notable features: Seven-story atrium, Viking Crown Lounge, extensive glass walls for European sightseeing\n- Retired from Royal Caribbean: 2016 (sold to TUI Cruises, became Marella Celebration, still sailing as of 2025)\n\n**What made Splendour beloved:**\n\nSplendour spent most of her Royal Caribbean career sailing Europe: Barcelona to Rome, Greek Islands, Adriatic ports, Western Mediterranean loops. Summer seasons in the Med, repositioning transatlantic crossings in spring and fall, occasional Caribbean winters.\n\nEuropean cruisers developed loyalty to Splendour specifically. She wasn't the newest or largest ship, but she was *right-sized* for European ports—small enough to dock in Santorini, Dubrovnik, and Venice (ports that mega-ships couldn't access), big enough to offer Royal Caribbean's signature service and entertainment."
+    },
+    {
+      "title": "What Splendour Passengers Valued",
+      "persona_label": "Passenger Testimonials (Factual)",
+      "intended_reader": "Splendour loyalists who preferred her European itineraries",
+      "core_insight": "Splendour proved that mid-sized ships offered advantages mega-ships couldn't match for European cruising",
+      "markdown": "**Common praise from Splendour passengers (documented in reviews and forums):**\n\n\"She could dock in ports [Oasis class](/ships/rcl/oasis-of-the-seas.html) couldn't reach. That alone made her invaluable for Mediterranean cruising.\"\n\n\"Right-sized for Europe. Not too big to feel impersonal, not too small to lack amenities.\"\n\n\"The transatlantic crossings were bucket-list experiences. Seven days at sea, formal nights, lectures, no port distractions.\"\n\n\"Glass walls everywhere—perfect for scenic cruising. Norwegian fjords, Greek coastlines, you didn't want to miss the views.\"\n\n\"When Royal Caribbean sold her in 2016, European cruisers lost a gem. The newer ships are impressive, but they can't dock where Splendour could.\"\n\n**Documented achievements:**\n- Sailed Mediterranean itineraries for over 15 consecutive summers\n- Completed dozens of transatlantic crossings, becoming a favorite for passengers who preferred sea days over port-hopping\n- Accessed smaller European ports that larger ships (Voyager, Oasis class) couldn't reach\n- Maintained high satisfaction scores despite being one of the older Vision-class ships\n\n**Life after Royal Caribbean:**\n\nIn 2016, Royal Caribbean sold Splendour to TUI Cruises (UK market). She was refurbished, renamed Marella Celebration, and continues sailing Mediterranean and European itineraries as of 2025.\n\nUnlike many retired ships that were scrapped, Splendour received a second career. She's still out there—different name, different line, same European waters she always loved.\n\n**The legacy:**\n\nSplendour proved that mid-sized ships (69,000 GT) could thrive in European markets where mega-ships struggled. Her success influenced Royal Caribbean's later decisions to deploy smaller ships ([Brilliance](/ships/rcl/brilliance-of-the-seas.html), [Serenade](/ships/rcl/serenade-of-the-seas.html)) to Europe instead of forcing mega-ships into ports they couldn't access.\n\nSee other Vision-class ships: [Grandeur](/ships/rcl/grandeur-of-the-seas.html), [Rhapsody](/ships/rcl/rhapsody-of-the-seas.html), [Vision](/ships/rcl/vision-of-the-seas.html), [Enchantment](/ships/rcl/enchantment-of-the-seas.html)."
+    }
+  ]
+}


### PR DESCRIPTION
- NEW: Majesty of the Seas - introduced millions to cruising, 28-year career (retired 2020)
- NEW: Monarch of the Seas - Bermuda specialist, inspired unusual loyalty (retired 2013)
- NEW: Splendour of the Seas - European wanderer, right-sized for Med ports (retired 2016, still sailing as Marella Celebration)
- NEW: Nordic Empress - accessible short cruises, mid-sized efficiency (retired 2004)

Voice: Factual memorial style, documented passenger testimonials
Focus: What made each ship significant, passenger loyalty, industry contributions
Tone: Respectful remembrance, "just the facts"