### PR TITLE
FIX: Restore PNG logo site-wide for transparency

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -988,7 +988,7 @@
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.200">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -1037,7 +1037,7 @@
     <div class="hero">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/accessibility.html
+++ b/accessibility.html
@@ -982,7 +982,7 @@
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.200">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -1031,7 +1031,7 @@
     <div class="hero">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/admin/reports/articles.html
+++ b/admin/reports/articles.html
@@ -555,7 +555,7 @@ Page: /admin/reports/articles.html · v3.008 · Built: 2025-10-17T00:00:00Z
   <header class="hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.008" alt="In the Wake wordmark" width="256" height="64"/>
+        <img src="/assets/logo_wake.png?v=3.008" alt="In the Wake wordmark" width="256" height="64"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -602,7 +602,7 @@ Page: /admin/reports/articles.html · v3.008 · Built: 2025-10-17T00:00:00Z
 
     <div class="hero" role="img" aria-label="Watermark Header">
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.008" alt="In the Wake" width="560" height="144">
+        <img class="logo" src="/assets/logo_wake.png?v=3.008" alt="In the Wake" width="560" height="144">
         <div class="tagline">Articles Consistency Report</div>
       </div>
     </div>

--- a/admin/reports/sw-health.html
+++ b/admin/reports/sw-health.html
@@ -401,7 +401,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/authors/ken-baker.html
+++ b/authors/ken-baker.html
@@ -603,7 +603,7 @@
       
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake wordmark" width="256" height="64"/>
+        <img src="/assets/logo_wake.png" alt="In the Wake wordmark" width="256" height="64"/>
       </div>
       <nav class="nav" aria-label="Main site navigation">
         <div class="nav-item">
@@ -647,7 +647,7 @@
     <div class="hero" role="img" aria-label="Ocean horizon at dusk">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144">
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144">
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>

--- a/authors/tina-maulsby.html
+++ b/authors/tina-maulsby.html
@@ -587,7 +587,7 @@
       
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake wordmark" width="256" height="64"/>
+        <img src="/assets/logo_wake.png" alt="In the Wake wordmark" width="256" height="64"/>
       </div>
       <nav class="nav" aria-label="Main site navigation">
         <div class="nav-item">
@@ -631,7 +631,7 @@
     <div class="hero" role="img" aria-label="Ocean horizon at dusk">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144">
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144">
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>

--- a/cruise-lines.html
+++ b/cruise-lines.html
@@ -657,7 +657,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/carnival.html
+++ b/cruise-lines/carnival.html
@@ -588,7 +588,7 @@
   <header class="site-header hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake wordmark" width="256" height="64" />
+        <img src="/assets/logo_wake.png" alt="In the Wake wordmark" width="256" height="64" />
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -638,7 +638,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/celebrity.html
+++ b/cruise-lines/celebrity.html
@@ -588,7 +588,7 @@
   <header class="site-header hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake wordmark" width="256" height="64"/>
+        <img src="/assets/logo_wake.png" alt="In the Wake wordmark" width="256" height="64"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -638,7 +638,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/disney.html
+++ b/cruise-lines/disney.html
@@ -588,7 +588,7 @@
   <header class="site-header hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake wordmark" width="256" height="64"/>
+        <img src="/assets/logo_wake.png" alt="In the Wake wordmark" width="256" height="64"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -638,7 +638,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/holland-america.html
+++ b/cruise-lines/holland-america.html
@@ -588,7 +588,7 @@
   <header class="site-header hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake wordmark" width="256" height="64"/>
+        <img src="/assets/logo_wake.png" alt="In the Wake wordmark" width="256" height="64"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -638,7 +638,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/msc.html
+++ b/cruise-lines/msc.html
@@ -588,7 +588,7 @@
   <header class="site-header hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake wordmark" width="256" height="64"/>
+        <img src="/assets/logo_wake.png" alt="In the Wake wordmark" width="256" height="64"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -638,7 +638,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/norwegian.html
+++ b/cruise-lines/norwegian.html
@@ -598,7 +598,7 @@
   <header class="hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake wordmark" width="256" height="64"/>
+        <img src="/assets/logo_wake.png" alt="In the Wake wordmark" width="256" height="64"/>
         <span class="version-badge tiny">v3.007a</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -647,7 +647,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/princess.html
+++ b/cruise-lines/princess.html
@@ -594,7 +594,7 @@
   <header class="hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake wordmark" width="256" height="64"/>
+        <img src="/assets/logo_wake.png" alt="In the Wake wordmark" width="256" height="64"/>
         <span class="version-badge tiny">v3.007a</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -643,7 +643,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/royal-caribbean.html
+++ b/cruise-lines/royal-caribbean.html
@@ -621,7 +621,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/viking.html
+++ b/cruise-lines/viking.html
@@ -587,7 +587,7 @@ All work on this project is offered as a gift to God.
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -586,7 +586,7 @@ All work on this project is offered as a gift to God.
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/disability-at-sea.html
+++ b/disability-at-sea.html
@@ -478,7 +478,7 @@ ADDENDUM: Facebook Domain Verification v3.008.021
       <a class="visually-hidden-focusable" href="#content">Skip to main content</a>
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.100" width="256" height="64" alt="In the Wake wordmark"/>
+        <img src="/assets/logo_wake.png?v=3.010.100" width="256" height="64" alt="In the Wake wordmark"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -526,7 +526,7 @@ ADDENDUM: Facebook Domain Verification v3.008.021
     <div class="hero" role="img" aria-label="Ship wake at sunrise">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -1118,7 +1118,7 @@
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -1163,7 +1163,7 @@
     <div class="hero" role="img" aria-label="Ship wake at sunrise">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/offline.html
+++ b/offline.html
@@ -426,7 +426,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/packing-lists.html
+++ b/packing-lists.html
@@ -1025,7 +1025,7 @@
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.200">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -1074,7 +1074,7 @@
     <div class="hero">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/planning.html
+++ b/planning.html
@@ -1057,7 +1057,7 @@
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -1106,7 +1106,7 @@
     <div class="hero">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ports.html
+++ b/ports.html
@@ -604,7 +604,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -665,7 +665,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/restaurants.html
+++ b/restaurants.html
@@ -604,7 +604,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -665,7 +665,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -568,7 +568,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -617,7 +617,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -569,7 +569,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -618,7 +618,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -568,7 +568,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -617,7 +617,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -572,7 +572,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -621,7 +621,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -574,7 +574,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -623,7 +623,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/chops.html
+++ b/restaurants/chops.html
@@ -573,7 +573,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -622,7 +622,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -567,7 +567,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -616,7 +616,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -566,7 +566,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -615,7 +615,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/dining-activities.html
+++ b/restaurants/dining-activities.html
@@ -518,7 +518,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -567,7 +567,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -572,7 +572,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -621,7 +621,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -572,7 +572,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -621,7 +621,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/giovannis.html
+++ b/restaurants/giovannis.html
@@ -557,7 +557,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -606,7 +606,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/izumi.html
+++ b/restaurants/izumi.html
@@ -222,7 +222,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -271,7 +271,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -551,7 +551,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -600,7 +600,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -558,7 +558,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -607,7 +607,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -563,7 +563,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -612,7 +612,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -561,7 +561,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -610,7 +610,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/room-service.html
+++ b/restaurants/room-service.html
@@ -573,7 +573,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -622,7 +622,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -564,7 +564,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -613,7 +613,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -547,7 +547,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -596,7 +596,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -578,7 +578,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -627,7 +627,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -561,7 +561,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -610,7 +610,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -559,7 +559,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -608,7 +608,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -544,7 +544,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -593,7 +593,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -553,7 +553,7 @@
 <header class="hero-header">
   <div class="navbar">
     <div class="brand">
-      <img src="/assets/logo_wake.webp" alt="In the Wake" width="256" height="64"/>
+      <img src="/assets/logo_wake.png" alt="In the Wake" width="256" height="64"/>
       <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
     </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -602,7 +602,7 @@
     <div class="latlon-grid" aria-hidden="true"></div>
     <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
     <div class="hero-title">
-      <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+      <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
     </div>
     <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     <div class="hero-credit">

--- a/ships.html
+++ b/ships.html
@@ -916,7 +916,7 @@
   <header class="site-header hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -965,7 +965,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true">
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake">
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake">
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/carnival-cruise-line/carnival-adventure.html
+++ b/ships/carnival-cruise-line/carnival-adventure.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-breeze.html
+++ b/ships/carnival-cruise-line/carnival-breeze.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-celebration.html
+++ b/ships/carnival-cruise-line/carnival-celebration.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-conquest.html
+++ b/ships/carnival-cruise-line/carnival-conquest.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-dream.html
+++ b/ships/carnival-cruise-line/carnival-dream.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-ecstasy.html
+++ b/ships/carnival-cruise-line/carnival-ecstasy.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-elation.html
+++ b/ships/carnival-cruise-line/carnival-elation.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-encounter.html
+++ b/ships/carnival-cruise-line/carnival-encounter.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-fantasy.html
+++ b/ships/carnival-cruise-line/carnival-fantasy.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-fascination.html
+++ b/ships/carnival-cruise-line/carnival-fascination.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-festivale.html
+++ b/ships/carnival-cruise-line/carnival-festivale.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-firenze.html
+++ b/ships/carnival-cruise-line/carnival-firenze.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-freedom.html
+++ b/ships/carnival-cruise-line/carnival-freedom.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-glory.html
+++ b/ships/carnival-cruise-line/carnival-glory.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-horizon.html
+++ b/ships/carnival-cruise-line/carnival-horizon.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-imagination.html
+++ b/ships/carnival-cruise-line/carnival-imagination.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-inspiration.html
+++ b/ships/carnival-cruise-line/carnival-inspiration.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-jubilee.html
+++ b/ships/carnival-cruise-line/carnival-jubilee.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-legend.html
+++ b/ships/carnival-cruise-line/carnival-legend.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-liberty.html
+++ b/ships/carnival-cruise-line/carnival-liberty.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-luminosa.html
+++ b/ships/carnival-cruise-line/carnival-luminosa.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-magic.html
+++ b/ships/carnival-cruise-line/carnival-magic.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-mardi-gras.html
+++ b/ships/carnival-cruise-line/carnival-mardi-gras.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-miracle.html
+++ b/ships/carnival-cruise-line/carnival-miracle.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-panorama.html
+++ b/ships/carnival-cruise-line/carnival-panorama.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-paradise.html
+++ b/ships/carnival-cruise-line/carnival-paradise.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-pride.html
+++ b/ships/carnival-cruise-line/carnival-pride.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-radiance.html
+++ b/ships/carnival-cruise-line/carnival-radiance.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-sensation.html
+++ b/ships/carnival-cruise-line/carnival-sensation.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-spirit.html
+++ b/ships/carnival-cruise-line/carnival-spirit.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-splendor.html
+++ b/ships/carnival-cruise-line/carnival-splendor.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-sunrise.html
+++ b/ships/carnival-cruise-line/carnival-sunrise.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-sunshine.html
+++ b/ships/carnival-cruise-line/carnival-sunshine.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-tropicale.html
+++ b/ships/carnival-cruise-line/carnival-tropicale.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-valor.html
+++ b/ships/carnival-cruise-line/carnival-valor.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-venezia.html
+++ b/ships/carnival-cruise-line/carnival-venezia.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnival-vista.html
+++ b/ships/carnival-cruise-line/carnival-vista.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/carnivale.html
+++ b/ships/carnival-cruise-line/carnivale.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/celebration.html
+++ b/ships/carnival-cruise-line/celebration.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/festivale.html
+++ b/ships/carnival-cruise-line/festivale.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/holiday.html
+++ b/ships/carnival-cruise-line/holiday.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/jubilee.html
+++ b/ships/carnival-cruise-line/jubilee.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/mardi-gras.html
+++ b/ships/carnival-cruise-line/mardi-gras.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/tropicale.html
+++ b/ships/carnival-cruise-line/tropicale.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/unnamed-project-ace-1.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-1.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/unnamed-project-ace-2.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-2.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival-cruise-line/unnamed-project-ace-3.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-3.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-adventure.html
+++ b/ships/carnival/carnival-adventure.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-breeze.html
+++ b/ships/carnival/carnival-breeze.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-breeze.html
+++ b/ships/carnival/carnival-carnival-breeze.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-celebration.html
+++ b/ships/carnival/carnival-carnival-celebration.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-conquest.html
+++ b/ships/carnival/carnival-carnival-conquest.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-dream.html
+++ b/ships/carnival/carnival-carnival-dream.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-elation.html
+++ b/ships/carnival/carnival-carnival-elation.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-firenze.html
+++ b/ships/carnival/carnival-carnival-firenze.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-freedom.html
+++ b/ships/carnival/carnival-carnival-freedom.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-glory.html
+++ b/ships/carnival/carnival-carnival-glory.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-horizon.html
+++ b/ships/carnival/carnival-carnival-horizon.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-carnival-jubilee.html
+++ b/ships/carnival/carnival-carnival-jubilee.html
@@ -241,7 +241,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-celebration.html
+++ b/ships/carnival/carnival-celebration.html
@@ -438,7 +438,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -447,7 +447,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/carnival/carnival-conquest.html
+++ b/ships/carnival/carnival-conquest.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-dream.html
+++ b/ships/carnival/carnival-dream.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-ecstasy.html
+++ b/ships/carnival/carnival-ecstasy.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-elation.html
+++ b/ships/carnival/carnival-elation.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-encounter.html
+++ b/ships/carnival/carnival-encounter.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-fantasy.html
+++ b/ships/carnival/carnival-fantasy.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-fascination.html
+++ b/ships/carnival/carnival-fascination.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-festivale.html
+++ b/ships/carnival/carnival-festivale.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -368,7 +368,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-freedom.html
+++ b/ships/carnival/carnival-freedom.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-glory.html
+++ b/ships/carnival/carnival-glory.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-imagination.html
+++ b/ships/carnival/carnival-imagination.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-inspiration.html
+++ b/ships/carnival/carnival-inspiration.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-jubilee.html
+++ b/ships/carnival/carnival-jubilee.html
@@ -407,7 +407,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -416,7 +416,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/carnival/carnival-legend.html
+++ b/ships/carnival/carnival-legend.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-liberty.html
+++ b/ships/carnival/carnival-liberty.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-luminosa.html
+++ b/ships/carnival/carnival-luminosa.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-magic.html
+++ b/ships/carnival/carnival-magic.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-mardi-gras.html
+++ b/ships/carnival/carnival-mardi-gras.html
@@ -438,7 +438,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -447,7 +447,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/carnival/carnival-miracle.html
+++ b/ships/carnival/carnival-miracle.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-paradise.html
+++ b/ships/carnival/carnival-paradise.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-pride.html
+++ b/ships/carnival/carnival-pride.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-radiance.html
+++ b/ships/carnival/carnival-radiance.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-sensation.html
+++ b/ships/carnival/carnival-sensation.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-spirit.html
+++ b/ships/carnival/carnival-spirit.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-splendor.html
+++ b/ships/carnival/carnival-splendor.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-sunrise.html
+++ b/ships/carnival/carnival-sunrise.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-tropicale.html
+++ b/ships/carnival/carnival-tropicale.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-valor.html
+++ b/ships/carnival/carnival-valor.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -399,7 +399,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/carnival-vista.html
+++ b/ships/carnival/carnival-vista.html
@@ -438,7 +438,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -447,7 +447,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/carnival/carnivale.html
+++ b/ships/carnival/carnivale.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/celebration.html
+++ b/ships/carnival/celebration.html
@@ -367,7 +367,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/festivale.html
+++ b/ships/carnival/festivale.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/holiday.html
+++ b/ships/carnival/holiday.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/index.html
+++ b/ships/carnival/index.html
@@ -228,7 +228,7 @@
 </head><body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/jubilee.html
+++ b/ships/carnival/jubilee.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/mardi-gras.html
+++ b/ships/carnival/mardi-gras.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/tropicale.html
+++ b/ships/carnival/tropicale.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/unnamed-project-ace-1.html
+++ b/ships/carnival/unnamed-project-ace-1.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/unnamed-project-ace-2.html
+++ b/ships/carnival/unnamed-project-ace-2.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/carnival/unnamed-project-ace-3.html
+++ b/ships/carnival/unnamed-project-ace-3.html
@@ -397,7 +397,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/celebrity-cruises/celebrity-ascent.html
+++ b/ships/celebrity-cruises/celebrity-ascent.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/celebrity-cruises/celebrity-beyond.html
+++ b/ships/celebrity-cruises/celebrity-beyond.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/celebrity-cruises/celebrity-century.html
+++ b/ships/celebrity-cruises/celebrity-century.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-compass.html
+++ b/ships/celebrity-cruises/celebrity-compass.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-constellation.html
+++ b/ships/celebrity-cruises/celebrity-constellation.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-eclipse.html
+++ b/ships/celebrity-cruises/celebrity-eclipse.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-edge.html
+++ b/ships/celebrity-cruises/celebrity-edge.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/celebrity-cruises/celebrity-equinox.html
+++ b/ships/celebrity-cruises/celebrity-equinox.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-flora.html
+++ b/ships/celebrity-cruises/celebrity-flora.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-galaxy.html
+++ b/ships/celebrity-cruises/celebrity-galaxy.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-infinity.html
+++ b/ships/celebrity-cruises/celebrity-infinity.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-mercury.html
+++ b/ships/celebrity-cruises/celebrity-mercury.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-millennium.html
+++ b/ships/celebrity-cruises/celebrity-millennium.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-reflection.html
+++ b/ships/celebrity-cruises/celebrity-reflection.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-seeker.html
+++ b/ships/celebrity-cruises/celebrity-seeker.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-silhouette.html
+++ b/ships/celebrity-cruises/celebrity-silhouette.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-solstice.html
+++ b/ships/celebrity-cruises/celebrity-solstice.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-summit.html
+++ b/ships/celebrity-cruises/celebrity-summit.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/celebrity-cruises/celebrity-xpedition.html
+++ b/ships/celebrity-cruises/celebrity-xpedition.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-xperience.html
+++ b/ships/celebrity-cruises/celebrity-xperience.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/celebrity-xploration.html
+++ b/ships/celebrity-cruises/celebrity-xploration.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/horizon.html
+++ b/ships/celebrity-cruises/horizon.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/ss-meridian.html
+++ b/ships/celebrity-cruises/ss-meridian.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/unnamed-edge-class.html
+++ b/ships/celebrity-cruises/unnamed-edge-class.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/unnamed-project-nirvana.html
+++ b/ships/celebrity-cruises/unnamed-project-nirvana.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/unnamed-river-class-x6.html
+++ b/ships/celebrity-cruises/unnamed-river-class-x6.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/celebrity-cruises/zenith.html
+++ b/ships/celebrity-cruises/zenith.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/amsterdam.html
+++ b/ships/holland-america-line/amsterdam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/edam.html
+++ b/ships/holland-america-line/edam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/eurodam.html
+++ b/ships/holland-america-line/eurodam.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/holland-america-line/koningsdam.html
+++ b/ships/holland-america-line/koningsdam.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/holland-america-line/leerdam.html
+++ b/ships/holland-america-line/leerdam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/maartensdijk.html
+++ b/ships/holland-america-line/maartensdijk.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/maasdam.html
+++ b/ships/holland-america-line/maasdam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/nieuw-amsterdam-ii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-ii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/nieuw-amsterdam-iii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/nieuw-amsterdam-iv.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iv.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/nieuw-amsterdam-v.html
+++ b/ships/holland-america-line/nieuw-amsterdam-v.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/nieuw-amsterdam.html
+++ b/ships/holland-america-line/nieuw-amsterdam.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/holland-america-line/nieuw-statendam.html
+++ b/ships/holland-america-line/nieuw-statendam.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/holland-america-line/none-announced.html
+++ b/ships/holland-america-line/none-announced.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/noordam-ii.html
+++ b/ships/holland-america-line/noordam-ii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/noordam-iii.html
+++ b/ships/holland-america-line/noordam-iii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/noordam-iv.html
+++ b/ships/holland-america-line/noordam-iv.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/noordam.html
+++ b/ships/holland-america-line/noordam.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/holland-america-line/oosterdam.html
+++ b/ships/holland-america-line/oosterdam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/p-caland.html
+++ b/ships/holland-america-line/p-caland.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/potsdam.html
+++ b/ships/holland-america-line/potsdam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/prinsendam-i.html
+++ b/ships/holland-america-line/prinsendam-i.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/prinsendam-ii.html
+++ b/ships/holland-america-line/prinsendam-ii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/rijndam-ii.html
+++ b/ships/holland-america-line/rijndam-ii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/rijndam.html
+++ b/ships/holland-america-line/rijndam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/rotterdam-iv.html
+++ b/ships/holland-america-line/rotterdam-iv.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/rotterdam-v.html
+++ b/ships/holland-america-line/rotterdam-v.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/rotterdam-vi.html
+++ b/ships/holland-america-line/rotterdam-vi.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/rotterdam.html
+++ b/ships/holland-america-line/rotterdam.html
@@ -397,7 +397,7 @@
 <header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
 
@@ -406,7 +406,7 @@
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake"/>
       </div>
       <div class="tagline">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">

--- a/ships/holland-america-line/ryndam.html
+++ b/ships/holland-america-line/ryndam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/statendam-ii.html
+++ b/ships/holland-america-line/statendam-ii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/statendam-iii.html
+++ b/ships/holland-america-line/statendam-iii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/statendam.html
+++ b/ships/holland-america-line/statendam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/veendam-ii.html
+++ b/ships/holland-america-line/veendam-ii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/veendam-iii.html
+++ b/ships/holland-america-line/veendam-iii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/veendam-iv.html
+++ b/ships/holland-america-line/veendam-iv.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/veendam.html
+++ b/ships/holland-america-line/veendam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/volendam-ii.html
+++ b/ships/holland-america-line/volendam-ii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/volendam-iii.html
+++ b/ships/holland-america-line/volendam-iii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/volendam.html
+++ b/ships/holland-america-line/volendam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/w-a-scholten.html
+++ b/ships/holland-america-line/w-a-scholten.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/westerdam-i.html
+++ b/ships/holland-america-line/westerdam-i.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/westerdam-ii.html
+++ b/ships/holland-america-line/westerdam-ii.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/holland-america-line/zaandam.html
+++ b/ships/holland-america-line/zaandam.html
@@ -358,7 +358,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/ships/index.html
+++ b/ships/index.html
@@ -561,7 +561,7 @@
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+        <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
         <span class="tiny version-badge">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -607,7 +607,7 @@
     <div class="hero" role="img" aria-label="Ship wake at sunrise">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit"><a class="pill" href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener noreferrer">Photo © Flickers of Majesty</a></div>

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -781,7 +781,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -842,7 +842,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/discovery-class-ship-tbn.html
+++ b/ships/rcl/discovery-class-ship-tbn.html
@@ -390,7 +390,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -451,7 +451,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/icon-class-ship-tbn-2027.html
+++ b/ships/rcl/icon-class-ship-tbn-2027.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/icon-class-ship-tbn-2028.html
+++ b/ships/rcl/icon-class-ship-tbn-2028.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/icon-of-the-seas.html
+++ b/ships/rcl/icon-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -781,7 +781,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -842,7 +842,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/legend-of-the-seas-1995-built.html
+++ b/ships/rcl/legend-of-the-seas-1995-built.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
+++ b/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/legend-of-the-seas.html
+++ b/ships/rcl/legend-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/majesty-of-the-seas.html
+++ b/ships/rcl/majesty-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/monarch-of-the-seas.html
+++ b/ships/rcl/monarch-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/nordic-empress.html
+++ b/ships/rcl/nordic-empress.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/nordic-prince.html
+++ b/ships/rcl/nordic-prince.html
@@ -395,7 +395,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -456,7 +456,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/oasis-class-ship-tbn-2028.html
+++ b/ships/rcl/oasis-class-ship-tbn-2028.html
@@ -435,7 +435,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -496,7 +496,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -522,7 +522,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -583,7 +583,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -781,7 +781,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -842,7 +842,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/song-of-america.html
+++ b/ships/rcl/song-of-america.html
@@ -418,7 +418,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -479,7 +479,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/song-of-norway.html
+++ b/ships/rcl/song-of-norway.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/sovereign-of-the-seas.html
+++ b/ships/rcl/sovereign-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/splendour-of-the-seas.html
+++ b/ships/rcl/splendour-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/star-class-ship-tbn-2028.html
+++ b/ships/rcl/star-class-ship-tbn-2028.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/star-of-the-seas-aug-2025-debut.html
+++ b/ships/rcl/star-of-the-seas-aug-2025-debut.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/star-of-the-seas.html
+++ b/ships/rcl/star-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/sun-viking.html
+++ b/ships/rcl/sun-viking.html
@@ -395,7 +395,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -456,7 +456,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/viking-serenade.html
+++ b/ships/rcl/viking-serenade.html
@@ -418,7 +418,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -479,7 +479,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -726,7 +726,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -787,7 +787,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp" alt="In the Wake" width="560" height="144"/>
+        <img class="logo" src="/assets/logo_wake.png" alt="In the Wake" width="560" height="144"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/solo.html
+++ b/solo.html
@@ -822,7 +822,7 @@
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -869,7 +869,7 @@
     <div class="hero" role="img" aria-label="Ship wake at sunrise">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake">
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake">
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/solo/accessible-cruising.html
+++ b/solo/accessible-cruising.html
@@ -224,7 +224,7 @@
   <header class="hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
         <span class="tiny version-badge">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -267,7 +267,7 @@
     <div class="hero" role="img" aria-label="Ship wake at sunrise">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
     </div>
   </header>

--- a/solo/articles/visiting-the-united-states-before-your-cruise.html
+++ b/solo/articles/visiting-the-united-states-before-your-cruise.html
@@ -81,7 +81,7 @@
   <header class="hero-header">
     <div class="navbar" style="overflow:visible">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.009.024" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.009.024" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
         <span class="tiny version-badge" aria-label="Version">v3.009.024</span>
       </div>
 
@@ -119,7 +119,7 @@
     <div class="hero" role="img" aria-label="Ship wake at sunrise">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.009.024" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.009.024" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.009.024" width="560" height="144" alt="In the Wake" decoding="async"/>
         <div class="tagline">A Cruise Traveler’s Logbook</div>
       </div>
       <div class="hero-credit">

--- a/solo/freedom-of-your-own-wake.html
+++ b/solo/freedom-of-your-own-wake.html
@@ -563,7 +563,7 @@ header, .hero-header, .navbar { position: relative; z-index: 1000; }
   <header class="hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.030" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.030" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
         <span class="tiny version-badge">v3.010.030</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -611,7 +611,7 @@ header, .hero-header, .navbar { position: relative; z-index: 1000; }
     <div class="hero" role="img" aria-label="Ship wake at sunrise">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.030" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.030" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.030" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline">A Cruise Traveler’s Logbook</div>
       <div class="hero-credit">

--- a/solo/visiting-the-united-states-before-your-cruise.html
+++ b/solo/visiting-the-united-states-before-your-cruise.html
@@ -503,7 +503,7 @@ figure figcaption { text-align:inherit; }
   <header class="hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.022" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.022" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
         <span class="tiny version-badge">v3.010.022</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -551,7 +551,7 @@ figure figcaption { text-align:inherit; }
     <div class="hero" role="img" aria-label="Ship wake at sunrise">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.022" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.022" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.022" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline">A Cruise Traveler’s Logbook</div>
       <div class="hero-credit">

--- a/solo/why-i-started-solo-cruising.html
+++ b/solo/why-i-started-solo-cruising.html
@@ -464,7 +464,7 @@
   <header class="hero-header">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.031" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.031" alt="In the Wake wordmark" width="256" height="64" decoding="async"/>
         <span class="tiny version-badge">v3.010.031</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -512,7 +512,7 @@
     <div class="hero" role="img" aria-label="Ship wake at sunrise">
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.031" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.031" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.031" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <div class="tagline">A Cruise Traveler’s Logbook</div>
       <div class="hero-credit">

--- a/stateroom-check.html
+++ b/stateroom-check.html
@@ -842,7 +842,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       
 
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Tool version 1.000 alpha">v1.000.α</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -903,7 +903,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">

--- a/terms.html
+++ b/terms.html
@@ -394,7 +394,7 @@
 <body>
 <div class="navbar">
   <div class="brand">
-    <img src="/assets/logo_wake.webp" alt="In the Wake logo" width="116" height="28" decoding="async"/>
+    <img src="/assets/logo_wake.png" alt="In the Wake logo" width="116" height="28" decoding="async"/>
     <span class="tiny version-badge">v3.010.300</span>
   </div>
   <nav class="nav" aria-label="Main site navigation">

--- a/travel.html
+++ b/travel.html
@@ -1128,7 +1128,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake.webp?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
@@ -1177,7 +1177,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
       <div class="latlon-grid" aria-hidden="true"></div>
       <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake.webp?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
+        <img class="logo" src="/assets/logo_wake.png?v=3.010.300" width="560" height="144" alt="In the Wake" decoding="async"/>
       </div>
       <p class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</p>
       <div class="hero-credit">


### PR DESCRIPTION
Replace all logo_wake.webp references with logo_wake.png across entire site. WebP doesn't handle transparency well for logos with subtle edges.

Changed 406+ references across all HTML files (excluding /vendors/). Logo now displays properly with transparent background throughout site.