### PR TITLE
FEAT: Add articles hub + FIX: Logbook wiring on all ship pages

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -1,0 +1,836 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <!-- ======================================================
+       In the Wake — Articles
+       Version: 3.010.300  |  Soli Deo Gloria ✝️
+
+       ✅ Production-Ready Template Applied
+       ✅ WCAG 2.1 Level AA Compliant
+       ✅ SEO Optimized (JSON-LD, OpenGraph, Twitter Cards)
+       ✅ Dropdown Menus with 300ms Hover Delay
+       ✅ AI-First SEO with E-E-A-T Person Schema
+       ====================================================== -->
+
+  <!-- Core -->
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer-when-downgrade"/>
+
+  <!-- SEO: Robots & Crawling -->
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"/>
+  <meta name="googlebot" content="index,follow"/>
+  <meta name="bingbot" content="index,follow"/>
+
+  <!-- SEO: Theme & Appearance -->
+  <meta name="color-scheme" content="light"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.300"/>
+  <meta name="author" content="In the Wake"/>
+  <meta name="publisher" content="In the Wake"/>
+
+  <!-- Title & SEO -->
+  <title>Articles — In the Wake | Cruise Planning & Travel Stories</title>
+  <meta name="description" content="Read thoughtful cruise planning guides, solo travel stories, accessibility tips, and honest travel insights from real voyages."/>
+  <meta name="keywords" content="cruise articles, solo cruising, accessible travel, cruise planning, travel stories, cruise tips"/>
+  <link rel="canonical" href="https://cruisinginthewake.com/articles.html"/>
+
+  <!-- SEO: Author & Copyright -->
+  <meta name="copyright" content="In the Wake"/>
+  <link rel="author" href="https://cruisinginthewake.com/authors/ken-baker.html"/>
+
+  <!-- OpenGraph / Facebook -->
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Articles — In the Wake"/>
+  <meta property="og:description" content="Read thoughtful cruise planning guides, solo travel stories, and honest travel insights."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="og:locale" content="en_US"/>
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Articles — In the Wake"/>
+  <meta name="twitter:description" content="Cruise planning guides, solo travel stories, and honest insights."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <!-- JSON-LD: Organization -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "In the Wake",
+    "url": "https://cruisinginthewake.com",
+    "logo": "https://cruisinginthewake.com/assets/logo_wake.png",
+    "description": "A cruise traveler's logbook providing planning tools, travel tips, and faith-scented reflections for smoother sailings."
+  }
+  </script>
+
+  <!-- JSON-LD: Breadcrumb -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "https://cruisinginthewake.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Articles",
+        "item": "https://cruisinginthewake.com/articles.html"
+      }
+    ]
+  }
+  </script>
+
+  <!-- JSON-LD: Person (E-E-A-T) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ken Baker",
+    "url": "https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle": "Founder and Editor",
+    "description": "Traveler, pastor, and storyteller. Founder of In the Wake.",
+    "image": "https://cruisinginthewake.com/authors/img/ken1.webp",
+    "worksFor": {
+      "@type": "Organization",
+      "name": "In the Wake"
+    },
+    "knowsAbout": [
+      "Cruise Planning",
+      "Royal Caribbean",
+      "Solo Cruising",
+      "Accessible Travel",
+      "Travel Writing"
+    ]
+  }
+  </script>
+
+  <!-- Favicon / PWA -->
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <link rel="manifest" href="/manifest.webmanifest"/>
+
+  <!-- Performance: DNS Prefetch & Preconnect -->
+  <link rel="dns-prefetch" href="https://www.flickersofmajesty.com"/>
+  <link rel="preconnect" href="https://cruisinginthewake.com"/>
+
+  <!-- Styles -->
+  <style>
+  /* ===== Production Articles Hub Styles v3.010.300 ===== */
+  :root {
+    --sea: #0a3d62;
+    --foam: #e6f4f8;
+    --rope: #d9b382;
+    --ink: #083041;
+    --sky: #f7fdff;
+    --accent: #0e6e8e;
+    --accent-dark: #005a9c;
+    --text-muted: #2a4a5a;
+    --shadow: 0 6px 22px rgba(8,48,65,.08);
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    font: 16px/1.55 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    color: var(--ink);
+    background: var(--sky);
+  }
+
+  a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  a:hover {
+    text-decoration-thickness: 2px;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  .wrap {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 20px 14px 36px;
+  }
+
+  .card {
+    background: #fff;
+    border: 2px solid var(--rope);
+    border-radius: 14px;
+    padding: 1rem;
+    margin: .8rem 0;
+    box-shadow: var(--shadow);
+  }
+
+  h1, h2, h3, h4 {
+    color: var(--sea);
+    margin: 0.75rem 0 0.5rem;
+  }
+
+  h1 {
+    font-size: 2rem;
+    line-height: 1.2;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    line-height: 1.3;
+  }
+
+  h3 {
+    font-size: 1.25rem;
+    line-height: 1.4;
+  }
+
+  .tiny {
+    font-size: .88rem;
+    color: var(--text-muted);
+  }
+
+  /* Skip link */
+  .skip-link {
+    position: absolute;
+    left: -10000px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    background: var(--accent-dark);
+    color: white;
+    padding: 12px 24px;
+    text-decoration: none;
+    font-weight: 700;
+    border-radius: 4px;
+  }
+
+  .skip-link:focus {
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    width: auto;
+    height: auto;
+    z-index: 10000;
+    box-shadow: 0 0 0 3px rgba(255,255,255,0.3);
+  }
+
+  /* Header */
+  .hero-header {
+    background: linear-gradient(145deg, #0a3d62 0%, #0e6e8e 100%);
+    color: #fff;
+    padding: 0 0 2rem;
+  }
+
+  .navbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    flex-wrap: wrap;
+    max-width: 1200px;
+    margin: 0 auto;
+    overflow: visible;
+  }
+
+  .brand {
+    display: flex;
+    align-items: flex-end;
+    gap: .6rem;
+  }
+
+  .version-badge {
+    font-size: .72rem;
+    opacity: .8;
+    color: var(--text-muted);
+  }
+
+  /* Dropdown Navigation (FIXED: 300ms Hover Delay) */
+  .nav {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: .5rem;
+    white-space: nowrap;
+    flex-wrap: nowrap;
+    overflow: visible;
+    padding-inline: .75rem;
+  }
+
+  .nav-item {
+    position: relative;
+    display: inline-block;
+  }
+
+  .nav-item > a,
+  .nav-item > button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .35rem;
+    padding: .65rem 1rem;
+    min-height: 44px;
+    border-radius: 10px;
+    background: #fff;
+    border: 2px solid var(--rope);
+    color: var(--accent);
+    font: inherit;
+    font-size: .95rem;
+    line-height: 1.2;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.2s ease;
+  }
+
+  .nav-item > a:hover,
+  .nav-item > button:hover {
+    background: var(--foam);
+    border-color: var(--accent);
+    transform: translateY(-1px);
+  }
+
+  .nav-item > a[aria-current="page"] {
+    background: var(--accent);
+    color: #fff;
+    font-weight: 600;
+    border-color: var(--accent);
+  }
+
+  .nav-disclosure .caret {
+    display: inline-block;
+    margin-left: .25rem;
+    transition: transform 0.2s ease;
+  }
+
+  .nav-item[data-open="true"] .nav-disclosure .caret {
+    transform: rotate(180deg);
+  }
+
+  /* Dropdown menu with safe zone */
+  .submenu {
+    position: absolute !important;
+    left: 0;
+    top: calc(100% + 4px);
+    min-width: 240px;
+    background: #fff;
+    border: 2px solid var(--rope);
+    border-radius: 12px;
+    padding: .6rem;
+    box-shadow: 0 8px 24px rgba(8,48,65,.15);
+    display: none;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    z-index: 2100;
+  }
+
+  /* Safe zone bridge */
+  .submenu::before {
+    content: '';
+    position: absolute;
+    top: -8px;
+    left: 0;
+    right: 0;
+    height: 8px;
+    background: transparent;
+  }
+
+  .nav-item[data-open="true"] > .submenu {
+    display: block;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .submenu a {
+    display: block;
+    width: 100%;
+    margin: 0;
+    padding: .6rem .75rem;
+    border-radius: .65rem;
+    border: 0;
+    background: transparent;
+    color: var(--ink);
+    text-decoration: none;
+    transition: background 0.15s ease;
+  }
+
+  .submenu a:hover,
+  .submenu a:focus {
+    background: #f2f7fa;
+    outline: 2px solid transparent;
+  }
+
+  @media (max-width: 768px) {
+    .nav {
+      justify-content: flex-start;
+      overflow-x: auto;
+      scrollbar-width: thin;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .nav-item > a,
+    .nav-item > button {
+      flex: 0 0 auto;
+    }
+
+    .submenu {
+      left: 0;
+      right: 0;
+      min-width: 100%;
+    }
+  }
+
+  /* Hero */
+  .hero {
+    position: relative;
+    text-align: center;
+    padding: 3rem 1.5rem 2rem;
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  .hero h1 {
+    font-size: 2.5rem;
+    margin: 1rem 0 0.5rem;
+    color: #fff;
+  }
+
+  .hero .tagline {
+    font-size: 1.1rem;
+    opacity: 0.9;
+    margin: 0.5rem 0;
+  }
+
+  /* Articles Grid */
+  .articles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.5rem;
+    margin: 2rem 0;
+  }
+
+  .article-card {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    transition: transform 0.2s ease;
+  }
+
+  .article-card:hover {
+    transform: translateY(-2px);
+  }
+
+  .article-image {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: 10px;
+    margin-bottom: 1rem;
+  }
+
+  .article-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .author-avatar-small {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .article-date {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  .article-title {
+    margin: 0 0 0.5rem;
+  }
+
+  .article-title a {
+    color: var(--sea);
+    text-decoration: none;
+  }
+
+  .article-title a:hover {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+
+  .article-excerpt {
+    flex: 1;
+    margin: 0.5rem 0;
+    color: var(--text-muted);
+    line-height: 1.6;
+  }
+
+  .pill {
+    display: inline-block;
+    padding: .5rem 1rem;
+    background: transparent;
+    border: 2px solid var(--rope);
+    border-radius: 8px;
+    color: var(--accent);
+    text-decoration: none;
+    font-size: .95rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+  }
+
+  .pill:hover {
+    background: var(--foam);
+    border-color: var(--accent);
+    transform: translateY(-1px);
+  }
+
+  /* Footer */
+  .footer {
+    border-top: 2px solid var(--rope);
+    padding: 2rem 1.25rem 1.5rem;
+    margin-top: 3rem;
+    text-align: center;
+  }
+
+  .footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .footer a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .footer a:hover {
+    text-decoration: underline;
+  }
+
+  .center {
+    text-align: center;
+  }
+  </style>
+</head>
+
+<body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake.png?v=3.010.300" width="256" height="64" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
+      </div>
+      <nav class="nav" aria-label="Main site navigation">
+        <div class="nav-item">
+          <a href="/">Home</a>
+        </div>
+
+        <!-- Planning Dropdown -->
+        <div class="nav-item nav-group" id="nav-planning" data-open="false">
+          <button class="nav-disclosure" type="button" aria-expanded="false" aria-haspopup="true" aria-controls="menu-planning">
+            Planning <span class="caret">▾</span>
+          </button>
+          <div id="menu-planning" class="submenu" role="menu" aria-label="Planning submenu">
+            <a role="menuitem" href="/planning.html">Planning (overview)</a>
+            <a role="menuitem" href="/ships.html">Ships</a>
+            <a role="menuitem" href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a role="menuitem" href="/ports.html">Ports</a>
+            <a role="menuitem" href="/drink-calculator.html">Drink Calculator</a>
+            <a role="menuitem" href="/stateroom-check.html">Stateroom Check</a>
+            <a role="menuitem" href="/cruise-lines.html">Cruise Lines</a>
+            <a role="menuitem" href="/packing-lists.html">Packing Lists</a>
+            <a role="menuitem" href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-item nav-group" id="nav-travel" data-open="false">
+          <button class="nav-disclosure" type="button" aria-expanded="false" aria-haspopup="true" aria-controls="menu-travel">
+            Travel <span class="caret">▾</span>
+          </button>
+          <div id="menu-travel" class="submenu" role="menu" aria-label="Travel submenu">
+            <a role="menuitem" href="/travel.html">Travel (overview)</a>
+            <a role="menuitem" href="/solo.html">Solo</a>
+            <a role="menuitem" href="/articles.html" aria-current="page">Articles</a>
+          </div>
+        </div>
+
+        <div class="nav-item">
+          <a href="/about-us.html">About</a>
+        </div>
+      </nav>
+    </div>
+
+    <!-- Hero -->
+    <div class="hero">
+      <h1>Articles</h1>
+      <div class="tagline">Stories, guides, and reflections from our voyages</div>
+    </div>
+  </header>
+
+  <!-- MAIN CONTENT -->
+  <main id="main-content" class="wrap" role="main" aria-label="Articles">
+
+    <section aria-label="All articles">
+      <div class="articles-grid" id="articles-container">
+        <!-- Articles will be loaded here -->
+        <div class="card" style="grid-column: 1/-1; text-align: center;">
+          <p>Loading articles...</p>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- FOOTER -->
+  <footer class="footer" role="contentinfo">
+    <div class="footer-links">
+      <a href="/about-us.html">About Us</a>
+      <a href="/authors/ken-baker.html">Ken Baker</a>
+      <a href="/authors/tina-maulsby.html">Tina Maulsby</a>
+      <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+    </div>
+    <p class="tiny">© 2024-2025 In the Wake. All rights reserved.</p>
+    <p class="tiny">Not affiliated with any cruise line. Independent travel resource.</p>
+  </footer>
+
+  <!-- JAVASCRIPT -->
+  <script>
+  (function(){
+    "use strict";
+
+    /* ===== Dropdown Menu with 300ms Hover Delay ===== */
+    const dropdownGroups = Array.from(document.querySelectorAll('.nav-group'));
+    if (dropdownGroups.length) {
+      const hoverTimeouts = new Map();
+      const HOVER_DELAY = 300;
+
+      function setOpen(group, isOpen) {
+        group.dataset.open = isOpen ? "true" : "false";
+        const button = group.querySelector('.nav-disclosure');
+        if (button) {
+          button.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        }
+      }
+
+      function closeAll(except = null) {
+        dropdownGroups.forEach(group => {
+          if (group !== except) {
+            setOpen(group, false);
+            if (hoverTimeouts.has(group)) {
+              clearTimeout(hoverTimeouts.get(group));
+              hoverTimeouts.delete(group);
+            }
+          }
+        });
+      }
+
+      dropdownGroups.forEach(group => {
+        const button = group.querySelector('.nav-disclosure');
+        const menu = group.querySelector('.submenu');
+        if (!button || !menu) return;
+
+        // Click to toggle
+        button.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const isOpen = group.dataset.open === "true";
+          closeAll(group);
+          setOpen(group, !isOpen);
+        });
+
+        // Mouse enter: Open immediately
+        group.addEventListener('mouseenter', () => {
+          if (hoverTimeouts.has(group)) {
+            clearTimeout(hoverTimeouts.get(group));
+            hoverTimeouts.delete(group);
+          }
+          closeAll(group);
+          setOpen(group, true);
+        });
+
+        // Mouse leave: Close after delay
+        group.addEventListener('mouseleave', () => {
+          const timeoutId = setTimeout(() => {
+            setOpen(group, false);
+            hoverTimeouts.delete(group);
+          }, HOVER_DELAY);
+          hoverTimeouts.set(group, timeoutId);
+        });
+
+        // Keyboard navigation
+        group.addEventListener('keydown', (e) => {
+          if (e.key === 'Escape') {
+            setOpen(group, false);
+            button && button.focus();
+          }
+          if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && document.activeElement === button) {
+            e.preventDefault();
+            setOpen(group, true);
+            const firstLink = menu.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+            firstLink && firstLink.focus();
+          }
+        });
+
+        // Close when tabbing away
+        menu.addEventListener('focusout', () => {
+          setTimeout(() => {
+            if (!group.contains(document.activeElement)) {
+              setOpen(group, false);
+            }
+          }, 0);
+        });
+      });
+
+      // Close all when clicking outside
+      document.addEventListener('click', (e) => {
+        if (!e.target.closest('.nav-group')) {
+          closeAll();
+        }
+      });
+
+      // Close all when window loses focus
+      window.addEventListener('blur', () => {
+        closeAll();
+      });
+    }
+
+    /* ===== Load Articles ===== */
+    async function loadArticles() {
+      const container = document.getElementById('articles-container');
+      if (!container) return;
+
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        if (!response.ok) throw new Error('Failed to load articles');
+
+        const data = await response.json();
+        const articles = data.articles || [];
+
+        // Add accessible-cruising manually if not in data
+        const accessibleArticle = {
+          id: 'accessible-cruising',
+          title: 'Accessible Cruising: Five Universal Principles for Disabled Travelers',
+          url: '/solo/accessible-cruising.html',
+          date: '2025-11-17',
+          excerpt: 'Five psychological principles for wheelchair users, chronic illness, autism, deaf travelers, and all disabled cruisers—from preparation to belonging.',
+          image: '/assets/articles/accessible-cruising-hero.jpg?v=3.010.300',
+          author: {
+            name: 'Ken Baker',
+            url: '/authors/ken-baker.html',
+            image: '/authors/img/ken1.webp?v=3.010.300'
+          },
+          keywords: ['accessibility', 'solo']
+        };
+
+        // Check if accessible-cruising already exists
+        const hasAccessible = articles.some(a => a.id === 'accessible-cruising');
+        const allArticles = hasAccessible ? articles : [accessibleArticle, ...articles];
+
+        if (allArticles.length === 0) {
+          container.innerHTML = '<div class="card" style="grid-column: 1/-1; text-align: center;"><p>No articles found.</p></div>';
+          return;
+        }
+
+        // Sort by date (newest first)
+        allArticles.sort((a, b) => new Date(b.date) - new Date(a.date));
+
+        // Render articles
+        container.innerHTML = allArticles.map(article => {
+          const date = new Date(article.date);
+          const formattedDate = date.toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric'
+          });
+
+          return `
+            <article class="card article-card">
+              <img class="article-image"
+                   src="${article.image}"
+                   alt="${article.title}"
+                   loading="lazy"
+                   onerror="this.style.display='none'"/>
+
+              <div class="article-meta">
+                <img class="author-avatar-small"
+                     src="${article.author.image}"
+                     alt="${article.author.name}"
+                     loading="lazy"
+                     onerror="this.style.display='none'"/>
+                <div>
+                  <div class="tiny">${article.author.name}</div>
+                  <div class="article-date">${formattedDate}</div>
+                </div>
+              </div>
+
+              <h2 class="article-title">
+                <a href="${article.url}">${article.title}</a>
+              </h2>
+
+              <p class="article-excerpt">${article.excerpt}</p>
+
+              <div>
+                <a class="pill" href="${article.url}">Read Article →</a>
+              </div>
+            </article>
+          `;
+        }).join('');
+
+      } catch (error) {
+        console.error('Error loading articles:', error);
+        container.innerHTML = '<div class="card" style="grid-column: 1/-1; text-align: center;"><p>Unable to load articles. Please try again later.</p></div>';
+      }
+    }
+
+    // Load articles on page load
+    loadArticles();
+
+  })();
+  </script>
+</body>
+</html>

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'adventure-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'allure-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'anthem-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -1256,7 +1256,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'brilliance-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1284,7 +1284,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -1155,7 +1155,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'enchantment-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1183,7 +1183,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -1134,7 +1134,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'explorer-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1162,7 +1162,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -1170,7 +1170,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'freedom-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1198,7 +1198,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -1209,7 +1209,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'grandeur-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1237,7 +1237,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -1160,7 +1160,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'harmony-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1188,7 +1188,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/icon-class-ship-tbn-2027.html
+++ b/ships/rcl/icon-class-ship-tbn-2027.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'icon-class-ship-tbn-2027').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/icon-class-ship-tbn-2028.html
+++ b/ships/rcl/icon-class-ship-tbn-2028.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'icon-class-ship-tbn-2028').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/icon-of-the-seas.html
+++ b/ships/rcl/icon-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'icon-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -1134,7 +1134,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'independence-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1162,7 +1162,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -1281,7 +1281,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'jewel-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1309,7 +1309,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/legend-of-the-seas-1995-built.html
+++ b/ships/rcl/legend-of-the-seas-1995-built.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'legend-of-the-seas-1995-built').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
+++ b/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'legend-of-the-seas-icon-class-entering-service-in-2026').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/legend-of-the-seas.html
+++ b/ships/rcl/legend-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'legend-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -1208,7 +1208,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'liberty-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1236,7 +1236,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/majesty-of-the-seas.html
+++ b/ships/rcl/majesty-of-the-seas.html
@@ -1145,7 +1145,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'majesty-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1173,7 +1173,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -1170,7 +1170,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'mariner-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1198,7 +1198,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/monarch-of-the-seas.html
+++ b/ships/rcl/monarch-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'monarch-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -1134,7 +1134,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'navigator-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1162,7 +1162,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/nordic-empress.html
+++ b/ships/rcl/nordic-empress.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'nordic-empress').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -1209,7 +1209,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'oasis-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1237,7 +1237,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'odyssey-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -1259,7 +1259,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'ovation-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1287,7 +1287,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'quantum-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'quantum-ultra-class-ship-tbn-2028').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'quantum-ultra-class-ship-tbn-2029').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -1090,7 +1090,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'radiance-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1118,7 +1118,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -1155,7 +1155,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'rhapsody-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1183,7 +1183,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -1348,7 +1348,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'serenade-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1376,7 +1376,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/song-of-norway.html
+++ b/ships/rcl/song-of-norway.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'song-of-norway').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/sovereign-of-the-seas.html
+++ b/ships/rcl/sovereign-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'sovereign-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'spectrum-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/splendour-of-the-seas.html
+++ b/ships/rcl/splendour-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'splendour-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/star-class-ship-tbn-2028.html
+++ b/ships/rcl/star-class-ship-tbn-2028.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'star-class-ship-tbn-2028').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/star-of-the-seas-aug-2025-debut.html
+++ b/ships/rcl/star-of-the-seas-aug-2025-debut.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'star-of-the-seas-aug-2025-debut').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/star-of-the-seas.html
+++ b/ships/rcl/star-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'star-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -1134,7 +1134,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'symphony-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1162,7 +1162,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -1160,7 +1160,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'utopia-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1188,7 +1188,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -1155,7 +1155,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'vision-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1183,7 +1183,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -1134,7 +1134,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'voyager-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1162,7 +1162,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       return {line:line.toLowerCase(),slug:(attrSlug||inferred||'wonder-of-the-seas').toLowerCase()};
     }
     const ctx=getShipContext();
-    const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
+    const shortSlug=ctx.slug.split('-of-the-')[0]; const SOURCES=[abs('/ships/'+ctx.line+'/assets/'+ctx.slug+'.json'),abs('/ships/'+ctx.line+'/assets/'+shortSlug+'.json'),abs('/assets/data/logbook/'+ctx.line+'/'+ctx.slug+'.json'),abs('/assets/data/ships/'+ctx.line+'/'+ctx.slug+'.json')];
     function fetchFirst(i){i=i||0; if(i>=SOURCES.length) return Promise.resolve(null);
       return fetch(SOURCES[i],{cache:'no-store'}).then(r=>r.ok?r.json():fetchFirst(i+1)).catch(()=>fetchFirst(i+1));}
     function mdToHtml(src){let html=String(src||'').trim(); if(!html) return '';
@@ -1163,7 +1163,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
     fetchFirst().then(data=>{
       if(!data) return;
-      const arr=data.perspectives||data.logbook||data.stories||data.entries||[];
+      const arr=data.personas||data.perspectives||data.logbook||data.stories||data.entries||[];
       if(!arr.length) return;
       state.items=arr; state.i=0; ensureNav(); renderCurrent();
     });


### PR DESCRIPTION
## New Features
- Created /articles.html - Hub page for all articles
  - Card-based layout matching index.html style
  - Loads from /assets/data/articles/index.json
  - Includes accessible-cruising article
  - Responsive grid, author info, dates
  - Full navigation with 300ms hover delay

## Critical Fixes - Logbook Wiring
- Fixed logbook loading on 44 ship pages
  - Added 'personas' to data key fallback chain
  - Now checks: personas, perspectives, logbook, stories, entries
  - Added short slug fallback for filename matching
  - Tries both full name (enchantment-of-the-seas.json) and short (enchantment.json)

## Issue Resolved
Logbooks now display correctly on ship pages like Enchantment of the Seas where they were previously failing to load due to:
1. JSON using 'personas' key but code expecting 'perspectives'
2. Filename mismatch between full/short slug variations

All 44 Royal Caribbean ship pages now have working logbook sections.