### PR TITLE
WIP: Fix ship page structure (15/50 ships)

### DIFF
--- a/fix_ship_structure.py
+++ b/fix_ship_structure.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Fix all ship pages to match proper Radiance/ships.html ICP-Lite structure.
+Standardizes: H1, answer-line, fit-guidance, key-facts, FAQ with details tags.
+"""
+
+import re
+from pathlib import Path
+
+SHIPS_DIR = Path('/home/user/InTheWake/ships/rcl')
+
+def fix_ship_page(filepath):
+    """Apply proper ICP-Lite structure to a ship page."""
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    original = content
+    ship_name = extract_ship_name(content)
+
+    print(f"Processing {ship_name}...")
+
+    # 1. Fix answer-line structure (if exists with wrong format)
+    # OLD: <p class="answer-line"><strong>Quick Answer:</strong> ...
+    # NEW: <p class="answer-line"><span class="answer-q">What this page covers</span><span class="answer-a">...
+
+    answer_pattern = r'<p class="answer-line"><strong>Quick Answer:</strong>\s*([^<]+)</p>'
+    if re.search(answer_pattern, content):
+        content = re.sub(
+            answer_pattern,
+            r'<p class="answer-line">\n      <span class="answer-q">What this page covers</span>\n      <span class="answer-a">\1</span>\n    </p>',
+            content
+        )
+
+    # 2. Fix fit-guidance: <div> → <section>
+    content = re.sub(
+        r'<div class="fit-guidance">',
+        '<section class="fit-guidance">',
+        content
+    )
+    content = re.sub(
+        r'</div>\s*\n\s*<div class="key-facts">',
+        '</section>\n\n    <section class="key-facts card">',
+        content
+    )
+
+    # 3. Fix key-facts: <div> → <section class="key-facts card">
+    content = re.sub(
+        r'<div class="key-facts">',
+        '<section class="key-facts card">',
+        content
+    )
+    content = re.sub(
+        r'</ul>\s*\n\s*</div>\s*\n\s*</section>\s*\n\s*<!-- Row 1',
+        '</ul>\n    </section>\n  </section>\n\n  <!-- Row 1',
+        content
+    )
+
+    # 4. Add sr-only h2 to fit-guidance if missing
+    if '<section class="fit-guidance">' in content and '<h2 class="sr-only">' not in content:
+        content = re.sub(
+            r'(<section class="fit-guidance">)\s*\n\s*(<h2>)',
+            r'\1\n      <h2 class="sr-only">Who This Page Is For</h2>\n      <h2>',
+            content
+        )
+        # Or if there's no h2 at all, add it
+        content = re.sub(
+            r'(<section class="fit-guidance">)\s*\n\s*(<p>)',
+            r'\1\n      <h2 class="sr-only">Who This Page Is For</h2>\n      \2',
+            content
+        )
+
+    # 5. Fix FAQ section: <div class="faq-item"> → <details>
+    # Replace faq-item divs with details/summary
+    faq_item_pattern = r'<div class="faq-item">\s*<h3>([^<]+)</h3>\s*<p>([^<]+)</p>\s*</div>'
+
+    def replace_faq_item(match):
+        question = match.group(1)
+        answer = match.group(2)
+        return f'''<details>
+        <summary>{question}</summary>
+        <p>{answer}</p>
+      </details>'''
+
+    content = re.sub(faq_item_pattern, replace_faq_item, content, flags=re.DOTALL)
+
+    if content != original:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(content)
+        return True
+
+    return False
+
+def extract_ship_name(content):
+    """Extract ship name from content."""
+    match = re.search(r'<h1[^>]*>([^<]+)</h1>', content)
+    if match:
+        return match.group(1).split('—')[0].strip()
+    return "Unknown Ship"
+
+def main():
+    """Main execution."""
+    print("Fixing ship page structure to match proper ICP-Lite...\n")
+
+    fixed_count = 0
+    ship_files = sorted(SHIPS_DIR.glob('*.html'))
+
+    for filepath in ship_files:
+        if fix_ship_page(filepath):
+            fixed_count += 1
+
+    print(f"\n✓ Fixed {fixed_count} ship files")
+
+if __name__ == '__main__':
+    main()

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Adventure of the Seas</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Adventure of the Seas is a Voyager Class ship (137,276 GT, 3,114 guests, launched 2001) featuring the signature Royal Promenade indoor boulevard, ice skating rink, rock climbing wall, and diverse worldwide itineraries.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Adventure of the Seas is a Voyager Class ship (137,276 GT, 3,114 guests, launched 2001) featuring the signature Royal Promenade indoor boulevard, ice skating rink, rock climbing wall, and diverse worldwide itineraries.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Adventure Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Adventure Right for You?</h2>
         <p>Adventure of the Seas invites cruisers who want active, engaging days without stepping foot onto a mega-ship. The revolutionary Voyager Class design brings an indoor boulevard (the Royal Promenade) lined with shops, cafes, and parades, creating a lively town square atmosphere that's unique to this ship class.</p>
         <p>Perfect for active families, couples seeking variety, and travelers who appreciate iconic cruise features like ice skating shows and rock climbing without the overwhelming scale of newer mega-ships. If you want that "sweet spot" between intimate smaller vessels and the newest giants, Adventure delivers adventure with a manageable, engaging layout across worldwide destinations from Alaska to Australia.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Voyager Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Features:</strong> Royal Promenade boulevard, ice skating rink, rock climbing wall</li>
           <li><strong>Best For:</strong> Active families and worldwide adventure seekers</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1076,25 +1080,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Adventure of the Seas?</h3>
+      <details>
+        <summary>What class is Adventure of the Seas?</summary>
         <p>Adventure of the Seas is a Voyager Class ship, featuring the signature Royal Promenade indoor boulevard, ice skating rink, and rock climbing wall.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How many passengers does Adventure of the Seas hold?</h3>
+      <details>
+        <summary>How many passengers does Adventure of the Seas hold?</summary>
         <p>Adventure of the Seas holds 3,114 guests at double occupancy, offering a larger ship experience with diverse activities and entertainment options.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When was Adventure of the Seas built?</h3>
+      <details>
+        <summary>When was Adventure of the Seas built?</summary>
         <p>Adventure of the Seas entered service in 2001 as part of the revolutionary Voyager Class and has been refurbished to maintain modern amenities.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What are the signature features of Adventure of the Seas?</h3>
+      <details>
+        <summary>What are the signature features of Adventure of the Seas?</summary>
         <p>Adventure features the iconic Royal Promenade with shops and restaurants, full-size ice skating rink, rock climbing wall, mini-golf course, and diverse worldwide itineraries from Alaska to Australia.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->

--- a/ships/rcl/discovery-class-ship-tbn.html
+++ b/ships/rcl/discovery-class-ship-tbn.html
@@ -544,15 +544,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Discovery Class Ship (TBN)</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> The Discovery Class Ship (TBN) is an upcoming Royal Caribbean vessel representing a new ship class. Details about capacity, features, and debut date will be announced as the ship design is finalized.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">The Discovery Class Ship (TBN) is an upcoming Royal Caribbean vessel representing a new ship class. Details about capacity, features, and debut date will be announced as the ship design is finalized.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>What We Know About the Discovery Class</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>What We Know About the Discovery Class</h2>
         <p>Royal Caribbean's Discovery Class represents a new chapter in the cruise line's innovative fleet expansion. While specific details remain under wraps, this new class signals Royal Caribbean's ongoing commitment to pushing boundaries and creating extraordinary experiences at sea.</p>
         <p>As a future-focused ship class, the Discovery Class will likely incorporate lessons learned from Royal Caribbean's newest vessels while introducing fresh innovations tailored to evolving guest preferences. We'll update this page with deck plans, dining options, and amenities as soon as Royal Caribbean makes official announcements.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Discovery Class (new class)</li>
@@ -615,25 +619,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What is the Discovery Class?</h3>
+      <details>
+        <summary>What is the Discovery Class?</summary>
         <p>The Discovery Class represents a new ship class in Royal Caribbean's fleet. Details will be announced by Royal Caribbean as the ship design is finalized.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When will the Discovery Class ship enter service?</h3>
+      <details>
+        <summary>When will the Discovery Class ship enter service?</summary>
         <p>The service date for the Discovery Class ship has not yet been publicly announced. Check back for updates as Royal Caribbean releases more information.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What features will the Discovery Class have?</h3>
+      <details>
+        <summary>What features will the Discovery Class have?</summary>
         <p>Specific features have not been announced yet. This page will be updated with deck plans, dining venues, and amenities as Royal Caribbean reveals the ship's design.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How can I stay updated on Discovery Class news?</h3>
+      <details>
+        <summary>How can I stay updated on Discovery Class news?</summary>
         <p>Bookmark this page and check Royal Caribbean's official announcements. In the Wake will update this page as soon as new details become available.</p>
-      </div>
+      </details>
     </section>
   </main>
 

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Enchantment of the Seas</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Enchantment of the Seas is a Vision Class ship (82,910 GT, ~2,250 guests, launched 1997) featuring panoramic ocean views through signature glass walls and worldwide itineraries.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Enchantment of the Seas is a Vision Class ship (82,910 GT, ~2,250 guests, launched 1997) featuring panoramic ocean views through signature glass walls and worldwide itineraries.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Enchantment Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Enchantment Right for You?</h2>
         <p>Enchantment of the Seas welcomes cruisers seeking a mid-sized ship with an intimate atmosphere and beautiful ocean views. Her Vision Class design features floor-to-ceiling glass walls throughout public spaces, bringing the sea and sky into your cruise experience in a way larger ships simply can't match.</p>
         <p>Perfect for first-time cruisers and families who want the Royal Caribbean experience without feeling overwhelmed, Enchantment offers enough activities and dining to keep everyone happy while maintaining an easier-to-navigate layout. If you're drawn to shorter cruise getaways or worldwide adventures with a more relaxed, less-crowded vibe, Enchantment could be your ideal match.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Vision Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Feature:</strong> Floor-to-ceiling glass walls for panoramic ocean views</li>
           <li><strong>Best For:</strong> First-time cruisers and those seeking intimate ship experience</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1096,25 +1100,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Enchantment of the Seas?</h3>
+      <details>
+        <summary>What class is Enchantment of the Seas?</summary>
         <p>Enchantment of the Seas is a Vision Class ship, one of Royal Caribbean's mid-sized vessels featuring signature glass walls for panoramic ocean views.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How many passengers does Enchantment of the Seas hold?</h3>
+      <details>
+        <summary>How many passengers does Enchantment of the Seas hold?</summary>
         <p>Enchantment of the Seas holds approximately 2,250 guests, offering a more intimate cruising experience compared to Royal Caribbean's mega-ships.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When was Enchantment of the Seas built?</h3>
+      <details>
+        <summary>When was Enchantment of the Seas built?</summary>
         <p>Enchantment of the Seas entered service in 1997 and has been refurbished to maintain modern amenities while preserving her signature Vision Class design.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What makes Enchantment of the Seas special?</h3>
+      <details>
+        <summary>What makes Enchantment of the Seas special?</summary>
         <p>Enchantment is known for her floor-to-ceiling glass walls offering stunning ocean views, mid-size intimacy perfect for first-time cruisers, and diverse worldwide itineraries including short getaways.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Grandeur of the Seas</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Grandeur of the Seas is a Vision Class ship (73,817 GT, 1,996 guests, launched 1996) featuring panoramic ocean views through signature glass walls and worldwide itineraries.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Grandeur of the Seas is a Vision Class ship (73,817 GT, 1,996 guests, launched 1996) featuring panoramic ocean views through signature glass walls and worldwide itineraries.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Grandeur Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Grandeur Right for You?</h2>
         <p>Grandeur of the Seas welcomes cruisers who appreciate a more intimate ship experience with fewer crowds, stunning ocean views through floor-to-ceiling windows, and diverse itineraries. The Vision Class design brings the sea closer through panoramic glass walls in public spaces, creating an airy, light-filled atmosphere perfect for those who love to watch the waves.</p>
         <p>With her mid-size profile, Grandeur offers the right balance: enough venues and activities to stay engaged, yet small enough to never feel overwhelming. If you value easier navigation, shorter lines, and a relaxed pace over non-stop entertainment and massive water parks, Grandeur might be your sweet spot.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Vision Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Feature:</strong> Floor-to-ceiling glass walls for panoramic ocean views</li>
           <li><strong>Best For:</strong> Cruisers seeking intimate ship experience and diverse itineraries</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1146,25 +1150,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Grandeur of the Seas?</h3>
+      <details>
+        <summary>What class is Grandeur of the Seas?</summary>
         <p>Grandeur of the Seas is a Vision Class ship, one of Royal Caribbean's mid-sized vessels featuring signature glass walls for panoramic ocean views.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How many passengers does Grandeur of the Seas hold?</h3>
+      <details>
+        <summary>How many passengers does Grandeur of the Seas hold?</summary>
         <p>Grandeur of the Seas holds 1,996 guests at double occupancy, offering a more intimate cruising experience compared to Royal Caribbean's mega-ships.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When was Grandeur of the Seas built?</h3>
+      <details>
+        <summary>When was Grandeur of the Seas built?</summary>
         <p>Grandeur of the Seas entered service in 1996 and has been refurbished to maintain modern amenities while preserving her signature Vision Class design.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What are the best features of Grandeur of the Seas?</h3>
+      <details>
+        <summary>What are the best features of Grandeur of the Seas?</summary>
         <p>Grandeur of the Seas is known for its panoramic ocean views through floor-to-ceiling glass walls, intimate ship size that feels less crowded, and diverse worldwide itineraries.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->

--- a/ships/rcl/icon-class-ship-tbn-2027.html
+++ b/ships/rcl/icon-class-ship-tbn-2027.html
@@ -880,15 +880,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Icon Class Ship (TBN 2027)</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Icon Class Ship TBN 2027 is Royal Caribbean's third Icon Class vessel, expected to debut in 2027 with the same revolutionary features as Icon and Star of the Seas, including Thrill Island aqua park, AquaDome, eight neighborhoods, and 40+ dining venues.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Icon Class Ship TBN 2027 is Royal Caribbean's third Icon Class vessel, expected to debut in 2027 with the same revolutionary features as Icon and Star of the Seas, including Thrill Island aqua park, AquaDome, eight neighborhoods, and 40+ dining venues.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is the Icon Class Ship TBN 2027 Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is the Icon Class Ship TBN 2027 Right for You?</h2>
         <p>As the third ship in Royal Caribbean's groundbreaking Icon Class, this 2027 addition continues the legacy of Icon and Star of the Seas. Imagine the same record-breaking Thrill Island waterpark, the stunning AquaDome entertainment venue with its three-story glass canopy, and eight distinct neighborhoods designed for every travel style.</p>
         <p>Perfect for families who want the newest innovations at sea, active travelers seeking endless activities and dining options, and anyone drawn to having the absolute latest in cruise ship design. With lessons learned from Icon and Star's first years, this third Icon Class ship promises to deliver the refined Icon Class experience when she debuts in 2027.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Icon Class (third ship)</li>
@@ -898,10 +902,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Features:</strong> Thrill Island, AquaDome, eight neighborhoods, 40+ dining venues</li>
           <li><strong>Best For:</strong> Families and variety-seekers wanting Icon Class innovations</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1075,25 +1079,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is the Icon Class Ship TBN 2027?</h3>
+      <details>
+        <summary>What class is the Icon Class Ship TBN 2027?</summary>
         <p>This is the third Icon Class ship from Royal Caribbean, following Icon of the Seas and Star of the Seas, featuring Thrill Island, AquaDome, and eight distinct neighborhoods.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When will Icon Class Ship TBN 2027 debut?</h3>
+      <details>
+        <summary>When will Icon Class Ship TBN 2027 debut?</summary>
         <p>This Icon Class vessel is expected to enter service in 2027. Specific dates will be announced by Royal Caribbean as the ship nears completion.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What features will Icon Class Ship TBN 2027 have?</h3>
+      <details>
+        <summary>What features will Icon Class Ship TBN 2027 have?</summary>
         <p>As an Icon Class ship, it will feature Thrill Island aqua park, AquaDome entertainment venue, eight neighborhoods, 40+ dining options, and the same revolutionary multi-level design as Icon and Star of the Seas.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How does Icon Class Ship TBN 2027 compare to Icon of the Seas?</h3>
+      <details>
+        <summary>How does Icon Class Ship TBN 2027 compare to Icon of the Seas?</summary>
         <p>As the third Icon Class ship, it will share the same platform with similar capacity (~5,600 guests), neighborhoods, and signature features, with potential refinements based on Icon and Star's operational experience.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->

--- a/ships/rcl/icon-class-ship-tbn-2028.html
+++ b/ships/rcl/icon-class-ship-tbn-2028.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Icon Class Ship TBN 2028</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Icon Class Ship TBN 2028 is an upcoming Icon Class vessel expected to debut in 2028, featuring Thrill Island aqua park, AquaDome, eight neighborhoods, 40+ dining venues.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Icon Class Ship TBN 2028 is an upcoming Icon Class vessel expected to debut in 2028, featuring Thrill Island aqua park, AquaDome, eight neighborhoods, 40+ dining venues.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Icon Class Ship TBN 2028 Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Icon Class Ship TBN 2028 Right for You?</h2>
         <p>As a Icon Class ship, Icon Class Ship TBN 2028 will build on Royal Caribbean's proven design while incorporating the latest innovations. With an expected debut in 2028, this vessel promises to deliver the signature Icon Class experience that cruisers have come to love.</p>
         <p>Perfect for travelers seeking Royal Caribbean's proven Icon Class design with modern updates. Details will be announced as the ship nears completion.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Icon Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Features:</strong> Thrill Island aqua park, AquaDome, eight neighborhoods, 40+ dining venues</li>
           <li><strong>Status:</strong> To Be Named - details forthcoming</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1075,25 +1079,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Icon Class Ship TBN 2028?</h3>
+      <details>
+        <summary>What class is Icon Class Ship TBN 2028?</summary>
         <p>Icon Class Ship TBN 2028 is a Icon Class ship from Royal Caribbean, representing the fourth Icon Class vessel.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When will Icon Class Ship TBN 2028 debut?</h3>
+      <details>
+        <summary>When will Icon Class Ship TBN 2028 debut?</summary>
         <p>This vessel is expected to enter service in 2028. Specific dates will be announced by Royal Caribbean as the ship nears completion.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What features will Icon Class Ship TBN 2028 have?</h3>
+      <details>
+        <summary>What features will Icon Class Ship TBN 2028 have?</summary>
         <p>As a Icon Class ship, it is expected to feature Thrill Island aqua park, AquaDome, eight neighborhoods, 40+ dining venues.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What is the size and capacity of Icon Class Ship TBN 2028?</h3>
+      <details>
+        <summary>What is the size and capacity of Icon Class Ship TBN 2028?</summary>
         <p>Expected size is ~250,000 GT with capacity for approximately ~5,600 guests based on Icon Class specifications.</p>
-      </div>
+      </details>
     </section>
 
   </section>

--- a/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
+++ b/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
@@ -880,15 +880,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Legend of the Seas (Icon Class 2026)</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Legend of the Seas (Icon Class 2026) is Royal Caribbean's next Icon Class ship, expected to enter service in 2026 with cutting-edge amenities, expanded neighborhoods, Thrill Island aqua park, and revolutionary design features building on Icon of the Seas' success.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Legend of the Seas (Icon Class 2026) is Royal Caribbean's next Icon Class ship, expected to enter service in 2026 with cutting-edge amenities, expanded neighborhoods, Thrill Island aqua park, and revolutionary design features building on Icon of the Seas' success.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Legend of the Seas (Icon Class 2026) Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Legend of the Seas (Icon Class 2026) Right for You?</h2>
         <p>Legend of the Seas (Icon Class 2026) represents Royal Caribbean's latest leap forward in cruise innovation. As the second ship in the groundbreaking Icon Class, she builds on the revolutionary multi-neighborhood design, bringing together distinct zones for families, adults, and thrill-seekers under one magnificent roof.</p>
         <p>Perfect for families seeking unmatched variety, adventure enthusiasts craving next-level thrills, and travelers who want the newest amenities Royal Caribbean has to offer. If you're drawn to Thrill Island's record-breaking waterpark, the AquaDome's immersive entertainment, or the vast selection of dining and activities, Legend will be your floating paradise when she debuts in 2026.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Icon Class</li>
@@ -898,10 +902,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Features:</strong> Thrill Island aqua park, AquaDome, multi-neighborhood design</li>
           <li><strong>Best For:</strong> Families and thrill-seekers wanting the newest Royal Caribbean has to offer</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1075,25 +1079,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Legend of the Seas (Icon Class 2026)?</h3>
+      <details>
+        <summary>What class is Legend of the Seas (Icon Class 2026)?</summary>
         <p>Legend of the Seas (Icon Class 2026) is an Icon Class ship, Royal Caribbean's newest and most innovative class featuring multi-level neighborhoods, advanced entertainment venues, and the Thrill Island aqua park.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When will Legend of the Seas (Icon Class 2026) enter service?</h3>
+      <details>
+        <summary>When will Legend of the Seas (Icon Class 2026) enter service?</summary>
         <p>Legend of the Seas (Icon Class 2026) is scheduled to enter service in 2026 as part of Royal Caribbean's Icon Class expansion.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What are the signature features of Icon Class ships?</h3>
+      <details>
+        <summary>What are the signature features of Icon Class ships?</summary>
         <p>Icon Class ships feature Thrill Island (the largest waterpark at sea), AquaDome entertainment venue, multiple neighborhood zones, innovative dining concepts, and cutting-edge technology throughout the ship.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How does Legend of the Seas (Icon Class 2026) compare to Icon of the Seas?</h3>
+      <details>
+        <summary>How does Legend of the Seas (Icon Class 2026) compare to Icon of the Seas?</summary>
         <p>Legend of the Seas (Icon Class 2026) follows the revolutionary Icon of the Seas design, building on the same Icon Class platform with similar capacity, neighborhoods, and signature features while potentially incorporating refinements based on Icon's first year at sea.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->

--- a/ships/rcl/majesty-of-the-seas.html
+++ b/ships/rcl/majesty-of-the-seas.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Majesty of the Seas</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Majesty of the Seas is a classic Sovereign Class ship (73,941 GT, 2,350 guests, launched 1992) offering short Caribbean getaways and Royal Caribbean's signature cruise experience in a more intimate, traditional setting.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Majesty of the Seas is a classic Sovereign Class ship (73,941 GT, 2,350 guests, launched 1992) offering short Caribbean getaways and Royal Caribbean's signature cruise experience in a more intimate, traditional setting.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Majesty Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Majesty Right for You?</h2>
         <p>Majesty of the Seas brings classic cruise charm to Caribbean waters, perfect for travelers who appreciate traditional elegance over trendy mega-ship features. As one of Royal Caribbean's time-tested vessels, she offers a more relaxed, intimate atmosphere where you can actually remember where your cabin is and never feel lost in endless corridors.</p>
         <p>Ideal for first-time cruisers testing the waters with short getaways, couples seeking quick romantic escapes, and experienced cruisers who prefer proven classics over flashy innovations. If you value personal service, easier navigation, and traditional cruise warmth, Majesty delivers that vintage Royal Caribbean magic at an accessible price point.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Sovereign Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Feature:</strong> Classic cruise charm with short Caribbean itineraries</li>
           <li><strong>Best For:</strong> First-timers, short getaways, and traditional cruise lovers</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1086,25 +1090,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Majesty of the Seas?</h3>
+      <details>
+        <summary>What class is Majesty of the Seas?</summary>
         <p>Majesty of the Seas is a Sovereign Class ship, one of Royal Caribbean's classic vessels offering traditional cruise experiences with mid-sized intimacy.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How many passengers does Majesty of the Seas hold?</h3>
+      <details>
+        <summary>How many passengers does Majesty of the Seas hold?</summary>
         <p>Majesty of the Seas holds 2,350 guests at double occupancy, offering a more intimate cruising experience perfect for first-timers and those seeking classic cruise charm.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When was Majesty of the Seas built?</h3>
+      <details>
+        <summary>When was Majesty of the Seas built?</summary>
         <p>Majesty of the Seas entered service in 1992 and has been refurbished to maintain modern amenities while preserving her classic charm.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What kind of cruises does Majesty of the Seas offer?</h3>
+      <details>
+        <summary>What kind of cruises does Majesty of the Seas offer?</summary>
         <p>Majesty specializes in short Caribbean getaways, making her perfect for quick escapes, first-time cruisers, and those who prefer traditional cruise experiences over mega-ship energy.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Quantum Ultra Class Ship TBN 2028</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Quantum Ultra Class Ship TBN 2028 is an upcoming Quantum Ultra Class vessel expected to debut in 2028, featuring North Star observation capsule, RipCord by iFLY, SeaPlex, Two70 entertainment venue.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Quantum Ultra Class Ship TBN 2028 is an upcoming Quantum Ultra Class vessel expected to debut in 2028, featuring North Star observation capsule, RipCord by iFLY, SeaPlex, Two70 entertainment venue.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Quantum Ultra Class Ship TBN 2028 Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Quantum Ultra Class Ship TBN 2028 Right for You?</h2>
         <p>As a Quantum Ultra Class ship, Quantum Ultra Class Ship TBN 2028 will build on Royal Caribbean's proven design while incorporating the latest innovations. With an expected debut in 2028, this vessel promises to deliver the signature Quantum Ultra Class experience that cruisers have come to love.</p>
         <p>Perfect for travelers seeking Royal Caribbean's proven Quantum Ultra Class design with modern updates. Details will be announced as the ship nears completion.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Quantum Ultra Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Features:</strong> North Star observation capsule, RipCord by iFLY, SeaPlex, Two70 entertainment venue</li>
           <li><strong>Status:</strong> To Be Named - details forthcoming</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1075,25 +1079,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Quantum Ultra Class Ship TBN 2028?</h3>
+      <details>
+        <summary>What class is Quantum Ultra Class Ship TBN 2028?</summary>
         <p>Quantum Ultra Class Ship TBN 2028 is a Quantum Ultra Class ship from Royal Caribbean, representing the Quantum Ultra Class vessel.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When will Quantum Ultra Class Ship TBN 2028 debut?</h3>
+      <details>
+        <summary>When will Quantum Ultra Class Ship TBN 2028 debut?</summary>
         <p>This vessel is expected to enter service in 2028. Specific dates will be announced by Royal Caribbean as the ship nears completion.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What features will Quantum Ultra Class Ship TBN 2028 have?</h3>
+      <details>
+        <summary>What features will Quantum Ultra Class Ship TBN 2028 have?</summary>
         <p>As a Quantum Ultra Class ship, it is expected to feature North Star observation capsule, RipCord by iFLY, SeaPlex, Two70 entertainment venue.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What is the size and capacity of Quantum Ultra Class Ship TBN 2028?</h3>
+      <details>
+        <summary>What is the size and capacity of Quantum Ultra Class Ship TBN 2028?</summary>
         <p>Expected size is ~169,000 GT with capacity for approximately ~4,900 guests based on Quantum Ultra Class specifications.</p>
-      </div>
+      </details>
     </section>
 
   </section>

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Quantum Ultra Class Ship TBN 2029</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Quantum Ultra Class Ship TBN 2029 is an upcoming Quantum Ultra Class vessel expected to debut in 2029, featuring North Star observation capsule, RipCord by iFLY, SeaPlex, Two70 entertainment venue.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Quantum Ultra Class Ship TBN 2029 is an upcoming Quantum Ultra Class vessel expected to debut in 2029, featuring North Star observation capsule, RipCord by iFLY, SeaPlex, Two70 entertainment venue.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Quantum Ultra Class Ship TBN 2029 Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Quantum Ultra Class Ship TBN 2029 Right for You?</h2>
         <p>As a Quantum Ultra Class ship, Quantum Ultra Class Ship TBN 2029 will build on Royal Caribbean's proven design while incorporating the latest innovations. With an expected debut in 2029, this vessel promises to deliver the signature Quantum Ultra Class experience that cruisers have come to love.</p>
         <p>Perfect for travelers seeking Royal Caribbean's proven Quantum Ultra Class design with modern updates. Details will be announced as the ship nears completion.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Quantum Ultra Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Features:</strong> North Star observation capsule, RipCord by iFLY, SeaPlex, Two70 entertainment venue</li>
           <li><strong>Status:</strong> To Be Named - details forthcoming</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1075,25 +1079,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Quantum Ultra Class Ship TBN 2029?</h3>
+      <details>
+        <summary>What class is Quantum Ultra Class Ship TBN 2029?</summary>
         <p>Quantum Ultra Class Ship TBN 2029 is a Quantum Ultra Class ship from Royal Caribbean, representing the Quantum Ultra Class vessel.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When will Quantum Ultra Class Ship TBN 2029 debut?</h3>
+      <details>
+        <summary>When will Quantum Ultra Class Ship TBN 2029 debut?</summary>
         <p>This vessel is expected to enter service in 2029. Specific dates will be announced by Royal Caribbean as the ship nears completion.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What features will Quantum Ultra Class Ship TBN 2029 have?</h3>
+      <details>
+        <summary>What features will Quantum Ultra Class Ship TBN 2029 have?</summary>
         <p>As a Quantum Ultra Class ship, it is expected to feature North Star observation capsule, RipCord by iFLY, SeaPlex, Two70 entertainment venue.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What is the size and capacity of Quantum Ultra Class Ship TBN 2029?</h3>
+      <details>
+        <summary>What is the size and capacity of Quantum Ultra Class Ship TBN 2029?</summary>
         <p>Expected size is ~169,000 GT with capacity for approximately ~4,900 guests based on Quantum Ultra Class specifications.</p>
-      </div>
+      </details>
     </section>
 
   </section>

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Rhapsody of the Seas</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Rhapsody of the Seas is a Vision Class ship (78,878 GT, 2,026 guests, launched 1997) offering panoramic ocean views through signature glass walls and global itineraries spanning Alaska to Australia.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Rhapsody of the Seas is a Vision Class ship (78,878 GT, 2,026 guests, launched 1997) offering panoramic ocean views through signature glass walls and global itineraries spanning Alaska to Australia.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Rhapsody Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Rhapsody Right for You?</h2>
         <p>Rhapsody of the Seas invites travelers who crave worldwide adventures without sacrificing comfort or feeling lost in a floating city. Her Vision Class design showcases floor-to-ceiling glass walls that transform public spaces into ocean-view galleries, perfect for those who find peace watching the sea roll by.</p>
         <p>With mid-sized intimacy and global reach spanning Alaska to Australia, Rhapsody offers the best of both worlds: diverse itineraries that take you far from home, and a ship small enough to feel like home while you're there. Ideal for couples, mature cruisers, and anyone seeking a balanced cruise experience with genuine ocean connection.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Vision Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Feature:</strong> Panoramic glass walls and global itineraries</li>
           <li><strong>Best For:</strong> Worldwide travelers seeking mid-size ship intimacy</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1096,25 +1100,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Rhapsody of the Seas?</h3>
+      <details>
+        <summary>What class is Rhapsody of the Seas?</summary>
         <p>Rhapsody of the Seas is a Vision Class ship, one of Royal Caribbean's mid-sized vessels featuring signature glass walls for panoramic ocean views.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How many passengers does Rhapsody of the Seas hold?</h3>
+      <details>
+        <summary>How many passengers does Rhapsody of the Seas hold?</summary>
         <p>Rhapsody of the Seas holds 2,026 guests at double occupancy, offering a more intimate cruising experience compared to Royal Caribbean's mega-ships.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When was Rhapsody of the Seas built?</h3>
+      <details>
+        <summary>When was Rhapsody of the Seas built?</summary>
         <p>Rhapsody of the Seas entered service in 1997 and has been refurbished to maintain modern amenities while preserving her signature Vision Class design.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What itineraries does Rhapsody of the Seas sail?</h3>
+      <details>
+        <summary>What itineraries does Rhapsody of the Seas sail?</summary>
         <p>Rhapsody offers diverse global itineraries ranging from Alaska to Australia, making her ideal for travelers seeking worldwide adventures on a mid-sized ship with panoramic ocean views.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->

--- a/ships/rcl/star-class-ship-tbn-2028.html
+++ b/ships/rcl/star-class-ship-tbn-2028.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Star Class Ship TBN 2028</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Star Class Ship TBN 2028 is an upcoming Star Class vessel expected to debut in 2028, featuring Details to be announced.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Star Class Ship TBN 2028 is an upcoming Star Class vessel expected to debut in 2028, featuring Details to be announced.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Star Class Ship TBN 2028 Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Star Class Ship TBN 2028 Right for You?</h2>
         <p>As a Star Class ship, Star Class Ship TBN 2028 will build on Royal Caribbean's proven design while incorporating the latest innovations. With an expected debut in 2028, this vessel promises to deliver the signature Star Class experience that cruisers have come to love.</p>
         <p>Perfect for travelers seeking Royal Caribbean's proven Star Class design with modern updates. Details will be announced as the ship nears completion.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Star Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Features:</strong> Details to be announced</li>
           <li><strong>Status:</strong> To Be Named - details forthcoming</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1075,25 +1079,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Star Class Ship TBN 2028?</h3>
+      <details>
+        <summary>What class is Star Class Ship TBN 2028?</summary>
         <p>Star Class Ship TBN 2028 is a Star Class ship from Royal Caribbean, representing the new Star Class vessel.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When will Star Class Ship TBN 2028 debut?</h3>
+      <details>
+        <summary>When will Star Class Ship TBN 2028 debut?</summary>
         <p>This vessel is expected to enter service in 2028. Specific dates will be announced by Royal Caribbean as the ship nears completion.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What features will Star Class Ship TBN 2028 have?</h3>
+      <details>
+        <summary>What features will Star Class Ship TBN 2028 have?</summary>
         <p>As a Star Class ship, it is expected to feature Details to be announced.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What is the size and capacity of Star Class Ship TBN 2028?</h3>
+      <details>
+        <summary>What is the size and capacity of Star Class Ship TBN 2028?</summary>
         <p>Expected size is TBA with capacity for approximately TBA based on Star Class specifications.</p>
-      </div>
+      </details>
     </section>
 
   </section>

--- a/ships/rcl/star-of-the-seas-aug-2025-debut.html
+++ b/ships/rcl/star-of-the-seas-aug-2025-debut.html
@@ -880,15 +880,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Star of the Seas (August 2025 Debut)</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Star of the Seas debuts in August 2025 as Royal Caribbean's second Icon Class ship (248,663 GT, 5,610 guests) featuring Thrill Island waterpark, AquaDome entertainment venue, eight neighborhoods, and over 40 dining options across a revolutionary multi-level design.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Star of the Seas debuts in August 2025 as Royal Caribbean's second Icon Class ship (248,663 GT, 5,610 guests) featuring Thrill Island waterpark, AquaDome entertainment venue, eight neighborhoods, and over 40 dining options across a revolutionary multi-level design.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Star of the Seas Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Star of the Seas Right for You?</h2>
         <p>Star of the Seas brings the Icon Class revolution to life with unmatched variety and scale. Imagine a ship where every member of your family finds their perfect space: families splash through Thrill Island's record-breaking waterpark, adults unwind at exclusive Hideaway Beach, and everyone gathers under the AquaDome's stunning three-story glass canopy for breathtaking shows.</p>
         <p>Perfect for multi-generational families, active travelers seeking endless activities, and anyone who wants the absolute newest and most innovative cruise experience. If you're drawn to having 40+ dining options, distinct neighborhood zones, cutting-edge entertainment, and amenities you can't find anywhere else at sea, Star of the Seas is your floating wonderland debuting August 2025.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Icon Class</li>
@@ -898,10 +902,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Features:</strong> Thrill Island, AquaDome, eight neighborhoods, 40+ dining venues</li>
           <li><strong>Best For:</strong> Families and variety-seekers wanting the newest cruise innovations</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1075,25 +1079,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Star of the Seas?</h3>
+      <details>
+        <summary>What class is Star of the Seas?</summary>
         <p>Star of the Seas is an Icon Class ship, the second in Royal Caribbean's revolutionary new class featuring Thrill Island waterpark, AquaDome entertainment venue, and multi-neighborhood design.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When does Star of the Seas debut?</h3>
+      <details>
+        <summary>When does Star of the Seas debut?</summary>
         <p>Star of the Seas debuts in August 2025 as the second Icon Class ship, bringing Royal Caribbean's latest innovations to cruisers worldwide.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How many passengers does Star of the Seas hold?</h3>
+      <details>
+        <summary>How many passengers does Star of the Seas hold?</summary>
         <p>Star of the Seas holds 5,610 guests at double occupancy, with a maximum capacity of around 7,600 guests, offering a massive ship experience with incredible variety.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What are the signature features of Star of the Seas?</h3>
+      <details>
+        <summary>What are the signature features of Star of the Seas?</summary>
         <p>Star features Thrill Island (the largest waterpark at sea), the AquaDome multi-level entertainment venue, eight distinct neighborhoods, over 40 dining options, and innovative entertainment including live performances and immersive experiences.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->

--- a/ships/rcl/star-of-the-seas.html
+++ b/ships/rcl/star-of-the-seas.html
@@ -880,15 +880,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Star of the Seas</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Star of the Seas is Royal Caribbean's second Icon Class ship (248,663 GT, 5,610 guests, launched 2025) featuring Thrill Island waterpark, AquaDome entertainment venue, eight neighborhoods, and over 40 dining options across a revolutionary multi-level design.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Star of the Seas is Royal Caribbean's second Icon Class ship (248,663 GT, 5,610 guests, launched 2025) featuring Thrill Island waterpark, AquaDome entertainment venue, eight neighborhoods, and over 40 dining options across a revolutionary multi-level design.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Star of the Seas Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Star of the Seas Right for You?</h2>
         <p>Star of the Seas brings the Icon Class revolution to life with unmatched variety and scale. Imagine a ship where every member of your family finds their perfect space: families splash through Thrill Island's record-breaking waterpark, adults unwind at exclusive Hideaway Beach, and everyone gathers under the AquaDome's stunning three-story glass canopy for breathtaking shows.</p>
         <p>Perfect for multi-generational families, active travelers seeking endless activities, and anyone who wants the absolute newest and most innovative cruise experience. If you're drawn to having 40+ dining options, distinct neighborhood zones, cutting-edge entertainment, and amenities you can't find anywhere else at sea, Star of the Seas is your floating wonderland.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Icon Class</li>
@@ -898,10 +902,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Features:</strong> Thrill Island, AquaDome, eight neighborhoods, 40+ dining venues</li>
           <li><strong>Best For:</strong> Families and variety-seekers wanting the newest cruise innovations</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1075,25 +1079,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Star of the Seas?</h3>
+      <details>
+        <summary>What class is Star of the Seas?</summary>
         <p>Star of the Seas is an Icon Class ship, the second in Royal Caribbean's revolutionary new class featuring Thrill Island waterpark, AquaDome entertainment venue, and multi-neighborhood design.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How many passengers does Star of the Seas hold?</h3>
+      <details>
+        <summary>How many passengers does Star of the Seas hold?</summary>
         <p>Star of the Seas holds 5,610 guests at double occupancy, with a maximum capacity of around 7,600 guests, offering a massive ship experience with incredible variety.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When was Star of the Seas built?</h3>
+      <details>
+        <summary>When was Star of the Seas built?</summary>
         <p>Star of the Seas entered service in 2025 as the second Icon Class ship, building on the innovations introduced by Icon of the Seas.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What are the signature features of Star of the Seas?</h3>
+      <details>
+        <summary>What are the signature features of Star of the Seas?</summary>
         <p>Star features Thrill Island (the largest waterpark at sea), the AquaDome multi-level entertainment venue, eight distinct neighborhoods, over 40 dining options, and innovative entertainment including live performances and immersive experiences.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -881,15 +881,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="ship-name">
       <h1 id="ship-name">Vision of the Seas</h1>
-      <p class="answer-line"><strong>Quick Answer:</strong> Vision of the Seas is a Vision Class ship (78,717 GT, 2,036 guests, launched 1998) featuring panoramic ocean views through signature glass walls and worldwide itineraries.</p>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Vision of the Seas is a Vision Class ship (78,717 GT, 2,036 guests, launched 1998) featuring panoramic ocean views through signature glass walls and worldwide itineraries.</span>
+    </p>
 
-      <div class="fit-guidance">
-        <h2>Is Vision Right for You?</h2>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Vision Right for You?</h2>
         <p>Vision of the Seas lives up to her name through expansive floor-to-ceiling windows that frame the ocean in every direction. If you're drawn to ships where natural light pours in and sea views take center stage, Vision's signature glass architecture creates an experience that larger, newer ships can't replicate.</p>
         <p>This mid-sized beauty is ideal for cruisers who value a more relaxed, intimate atmosphere over non-stop mega-ship energy. With easier navigation, shorter lines, and a welcoming size that never feels overwhelming, Vision offers Royal Caribbean's quality and service in a package that feels personal. Perfect for couples, mature travelers, and anyone who appreciates watching the horizon roll by.</p>
-      </div>
+      </section>
 
-      <div class="key-facts">
+    <section class="key-facts card">
         <h2>Key Facts at a Glance</h2>
         <ul>
           <li><strong>Class:</strong> Vision Class</li>
@@ -899,10 +903,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <li><strong>Signature Feature:</strong> Panoramic floor-to-ceiling glass walls throughout</li>
           <li><strong>Best For:</strong> Cruisers seeking ocean views and intimate ship experience</li>
         </ul>
-      </div>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
@@ -1096,25 +1100,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="card faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions</h2>
 
-      <div class="faq-item">
-        <h3>What class is Vision of the Seas?</h3>
+      <details>
+        <summary>What class is Vision of the Seas?</summary>
         <p>Vision of the Seas is a Vision Class ship, one of Royal Caribbean's mid-sized vessels featuring signature glass walls for panoramic ocean views.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>How many passengers does Vision of the Seas hold?</h3>
+      <details>
+        <summary>How many passengers does Vision of the Seas hold?</summary>
         <p>Vision of the Seas holds 2,036 guests at double occupancy, offering a more intimate cruising experience compared to Royal Caribbean's mega-ships.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>When was Vision of the Seas built?</h3>
+      <details>
+        <summary>When was Vision of the Seas built?</summary>
         <p>Vision of the Seas entered service in 1998 and has been refurbished to maintain modern amenities while preserving her signature Vision Class design.</p>
-      </div>
+      </details>
 
-      <div class="faq-item">
-        <h3>What makes Vision of the Seas unique?</h3>
+      <details>
+        <summary>What makes Vision of the Seas unique?</summary>
         <p>Vision's namesake glass walls offer unparalleled ocean views throughout the ship, creating an airy, light-filled atmosphere. Her mid-size layout is perfect for cruisers who want Royal Caribbean quality without overwhelming crowds.</p>
-      </div>
+      </details>
     </section>
 
     <!-- Attribution -->


### PR DESCRIPTION
Updated 15 ship pages to use proper ICP-Lite structure:
- Fixed answer-line to use answer-q/answer-a spans
- Changed fit-guidance and key-facts from div to section tags
- Added sr-only h2 to fit-guidance sections
- Converted FAQ div.faq-item to details/summary tags

Ships fixed: Adventure, Discovery TBN, Enchantment, Grandeur, Icon TBN 2027/2028, Legend Icon-class 2026, Majesty, Quantum Ultra TBN 2028/2029, Rhapsody, Star class TBN 2028, Star of the Seas variants, Vision

Remaining: 35 ships still need full ICP-Lite structure applied