### PR TITLE
FEAT: Apply proper ICP-Lite structure to 31 additional ships (46/49 c…

### DIFF
--- a/add_missing_icp_headers.py
+++ b/add_missing_icp_headers.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Add ICP-Lite headers to ships that are completely missing them.
+"""
+
+import re
+import json
+from pathlib import Path
+
+SHIPS_DIR = Path('/home/user/InTheWake/ships/rcl')
+
+SHIPS_NEEDING_HEADERS = [
+    'nordic-prince.html',
+    'oasis-class-ship-tbn-2028.html',
+    'quantum-of-the-seas.html',
+    'sovereign-of-the-seas.html',
+    'spectrum-of-the-seas.html',
+    'sun-viking.html',
+    'symphony-of-the-seas.html',
+    'utopia-of-the-seas.html',
+    'voyager-of-the-seas.html',
+    'wonder-of-the-seas.html'
+]
+
+# Ship class information for context
+SHIP_CLASSES = {
+    'nordic-prince': ('Vision Class', 1971, '23,000 GT', '~1,000'),
+    'sovereign': ('Sovereign Class', 1988, '73,192 GT', '~2,278'),
+    'sun-viking': ('Classic', 1972, '18,000 GT', '~800'),
+    'oasis-class-ship-tbn-2028': ('Oasis Class', 2028, 'TBD', 'TBD'),
+    'quantum': ('Quantum Class', 2014, '168,666 GT', '~4,180'),
+    'spectrum': ('Quantum Ultra Class', 2019, '168,666 GT', '~4,246'),
+    'symphony': ('Oasis Class', 2018, '228,081 GT', '~5,518'),
+    'utopia': ('Oasis Class', 2024, '236,473 GT', '~5,668'),
+    'voyager': ('Voyager Class', 1999, '137,276 GT', '~3,114'),
+    'wonder': ('Oasis Class', 2022, '236,857 GT', '~5,734')
+}
+
+def extract_ship_name_from_title(content):
+    """Extract ship name from title tag."""
+    title_match = re.search(r'<title>([^—]+)', content)
+    if title_match:
+        return title_match.group(1).strip()
+    return "Unknown Ship"
+
+def get_ship_class_info(slug):
+    """Get ship class info from lookup table."""
+    for key, info in SHIP_CLASSES.items():
+        if key in slug:
+            return info
+    return ('Unknown Class', 'TBD', 'TBD GT', 'TBD')
+
+def create_icp_header(ship_name, slug):
+    """Create complete ICP-Lite header section."""
+    ship_class, year, tonnage, capacity = get_ship_class_info(slug)
+    
+    # Create answer text based on ship class
+    if 'oasis' in slug.lower():
+        answer_text = f"{ship_name} is an Oasis Class megaship ({tonnage}, {capacity} guests) featuring seven distinct neighborhoods, extensive dining and entertainment options, and Royal Caribbean's signature innovation."
+        fit_text = f"{ship_name} welcomes cruisers seeking grand-scale experiences with neighborhood layouts, multiple pools, zip lines, and world-class entertainment. Perfect for families and groups who want everything under one hull."
+    elif 'quantum' in slug.lower() or 'spectrum' in slug.lower():
+        answer_text = f"{ship_name} is a Quantum Class ship ({tonnage}, {capacity} guests) featuring groundbreaking technology including North Star observation capsule, RipCord by iFLY skydiving simulator, and transforming entertainment venues."
+        fit_text = f"{ship_name} suits tech-savvy cruisers and families seeking innovation with traditional Royal Caribbean service. Ideal for those who want cutting-edge experiences like robot bartenders and virtual balconies."
+    elif 'voyager' in slug.lower():
+        answer_text = f"{ship_name} is a Voyager Class ship ({tonnage}, {capacity} guests) featuring the iconic Royal Promenade, ice skating rink, and rock climbing wall that revolutionized cruising."
+        fit_text = f"{ship_name} welcomes cruisers seeking the sweet spot between intimacy and amenities. Perfect for families wanting Royal Caribbean classics without Oasis-class scale."
+    else:
+        answer_text = f"{ship_name} is a Royal Caribbean ship ({tonnage}, {capacity} guests, launched {year}) offering deck plans, live tracking, dining venues, and cruise planning resources."
+        fit_text = f"{ship_name} welcomes cruisers exploring Royal Caribbean's fleet. This page provides deck plans, current location tracking, and dining information to help plan your voyage."
+    
+    return f'''
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">{ship_name}</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">{answer_text}</span>
+    </p>
+
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is {ship_name} Right for You?</h2>
+        <p>{fit_text}</p>
+      </section>
+
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> {ship_class}</li>
+          <li><strong>Year Built:</strong> {year}</li>
+          <li><strong>Size:</strong> {tonnage}</li>
+          <li><strong>Capacity:</strong> {capacity}</li>
+        </ul>
+    </section>
+  </section>
+
+'''
+
+def add_icp_header(filepath):
+    """Add ICP-Lite header to a ship page that's missing it."""
+    print(f"Adding header to {filepath.name}...")
+    
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    # Check if already has icp-header
+    if 'icp-header' in content:
+        print(f"  ✓ {filepath.name} already has ICP header")
+        return False
+    
+    # Extract ship info
+    ship_name = extract_ship_name_from_title(content)
+    slug = filepath.stem
+    
+    # Create header
+    new_header = create_icp_header(ship_name, slug)
+    
+    # Find the main content start and inject header
+    main_pattern = r'(<main class="wrap" id="main-content"[^>]*>)\s*\n\s*(<!-- Row 1)'
+    
+    if re.search(main_pattern, content):
+        content = re.sub(
+            main_pattern,
+            r'\1\n' + new_header + r'\n  \2',
+            content
+        )
+        
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(content)
+        
+        print(f"  ✓ Added ICP header to {ship_name}")
+        return True
+    else:
+        print(f"  ⚠️  Could not find insertion point")
+        return False
+
+def main():
+    """Main execution."""
+    print("Adding ICP-Lite headers to ships missing them...\n")
+    
+    added_count = 0
+    
+    for filename in SHIPS_NEEDING_HEADERS:
+        filepath = SHIPS_DIR / filename
+        if filepath.exists():
+            if add_icp_header(filepath):
+                added_count += 1
+        else:
+            print(f"⚠️  {filename} not found")
+    
+    print(f"\n✓ Added headers to {added_count} ships")
+
+if __name__ == '__main__':
+    main()

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Allure of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Allure of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Allure of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Allure of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Allure of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Allure of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Allure of the Seas tends to suit travelers who appreciate grand-scale cruising with seven distinct neighborhoods including Central Park (featuring over 12,000 live plants and trees), the Boardwalk with its hand-carved carousel, and the dramatic AquaTheater.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Allure of the Seas Right for You?</h2>
+        <p>Allure of the Seas tends to suit travelers who appreciate grand-scale cruising with seven distinct neighborhoods including Central Park (featuring over 12,000 live plants and trees), the Boardwalk with its hand-carved carousel, and the dramatic AquaTheater.
         It's ideal if you want one of the world's largest cruise ships with up to 6,780 guests, extensive dining and entertainment options, and the space to explore something new each day.
-        If you're seeking a more intimate ship or prefer newer Icon-class innovations, you may want to explore Quantum-class or Icon of the Seas instead.
-      </p>
-    </section>
+        If you're seeking a more intimate ship or prefer newer Icon-class innovations, you may want to explore Quantum-class or Icon of the Seas instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Oasis Class</li><li><strong>Year Built:</strong> 2010</li><li><strong>Size:</strong> 225,282 GT</li><li><strong>Capacity:</strong> 6,780 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Anthem of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Anthem of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Anthem of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Anthem of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Anthem of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Anthem of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Anthem of the Seas tends to suit travelers who appreciate modern technology and innovative features like the North Star capsule rising 300 feet above sea level, SeaPlex (bumper cars and sports), and Two70's transforming entertainment space.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Anthem of the Seas Right for You?</h2>
+        <p>Anthem of the Seas tends to suit travelers who appreciate modern technology and innovative features like the North Star capsule rising 300 feet above sea level, SeaPlex (bumper cars and sports), and Two70's transforming entertainment space.
         It's ideal if you want Quantum-class innovations with about 4,180 guests at double occupancy — more intimate than Oasis class yet packed with high-tech experiences.
-        If you're looking for the classic neighborhood layout or the largest ships afloat, you may want to explore Oasis or Icon class instead.
-      </p>
-    </section>
+        If you're looking for the classic neighborhood layout or the largest ships afloat, you may want to explore Oasis or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Quantum Class</li><li><strong>Year Built:</strong> 2015</li><li><strong>Size:</strong> 168,666 GT</li><li><strong>Capacity:</strong> 4,180 (double) ~4,905 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Brilliance of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Brilliance of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Brilliance of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Brilliance of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Brilliance of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Brilliance of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Brilliance of the Seas tends to suit travelers who prefer mid-sized ships with panoramic ocean views and glass-wall design.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Brilliance of the Seas Right for You?</h2>
+        <p>Brilliance of the Seas tends to suit travelers who prefer mid-sized ships with panoramic ocean views and glass-wall design.
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
-        If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
-      </p>
-    </section>
+        If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Radiance Class</li><li><strong>Year Built:</strong> 2002</li><li><strong>Size:</strong> 90,090 GT</li><li><strong>Capacity:</strong> 2,145 (double) ~2,543 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Explorer of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Explorer of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Explorer of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Explorer of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Explorer of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Explorer of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Explorer of the Seas tends to suit travelers who appreciate Voyager-class innovations like the Royal Promenade (an indoor street with shops and dining), ice skating rink, and rock climbing wall.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Explorer of the Seas Right for You?</h2>
+        <p>Explorer of the Seas tends to suit travelers who appreciate Voyager-class innovations like the Royal Promenade (an indoor street with shops and dining), ice skating rink, and rock climbing wall.
         It's ideal if you want about 3,114 guests at double occupancy — offering a balance of activities and space without the massive scale of Oasis or Icon class ships.
-        If you're seeking the newest features or prefer a larger ship, you may want to explore Quantum, Oasis, or Icon class instead.
-      </p>
-    </section>
+        If you're seeking the newest features or prefer a larger ship, you may want to explore Quantum, Oasis, or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Voyager Class</li><li><strong>Year Built:</strong> 2000</li><li><strong>Size:</strong> 137,308 GT</li><li><strong>Capacity:</strong> 3,286 (double) ~4,290 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Freedom of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Freedom of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Freedom of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Freedom of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Freedom of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Freedom of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Freedom of the Seas tends to suit travelers who appreciate active amenities like the FlowRider surf simulator and water park alongside classic Royal Caribbean features.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Freedom of the Seas Right for You?</h2>
+        <p>Freedom of the Seas tends to suit travelers who appreciate active amenities like the FlowRider surf simulator and water park alongside classic Royal Caribbean features.
         It's ideal if you want up to 4,515 guests — larger than Voyager class but more intimate than Oasis or Icon class.
-        If you're seeking seven neighborhoods or the newest innovations, you may want to explore Oasis or Icon class instead.
-      </p>
-    </section>
+        If you're seeking seven neighborhoods or the newest innovations, you may want to explore Oasis or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Freedom Class</li><li><strong>Year Built:</strong> 2006</li><li><strong>Size:</strong> 156,271 GT</li><li><strong>Capacity:</strong> 3,634 (double) ~3,782 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Harmony of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Harmony of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Harmony of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Harmony of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Harmony of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Harmony of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Harmony of the Seas tends to suit travelers who appreciate grand-scale cruising with seven distinct neighborhoods including Central Park, the Ultimate Abyss slide, and the Bionic Bar.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Harmony of the Seas Right for You?</h2>
+        <p>Harmony of the Seas tends to suit travelers who appreciate grand-scale cruising with seven distinct neighborhoods including Central Park, the Ultimate Abyss slide, and the Bionic Bar.
         It's ideal if you want one of the world's largest cruise ships with up to 6,780 guests and extensive dining and entertainment options.
-        If you're seeking a more intimate ship or prefer Icon-class innovations, you may want to explore Quantum-class or Icon of the Seas instead.
-      </p>
-    </section>
+        If you're seeking a more intimate ship or prefer Icon-class innovations, you may want to explore Quantum-class or Icon of the Seas instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Oasis Class</li><li><strong>Year Built:</strong> 2016</li><li><strong>Size:</strong> 226,963 GT</li><li><strong>Capacity:</strong> 5,479 (double) ~6,700 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/icon-of-the-seas.html
+++ b/ships/rcl/icon-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Icon of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Icon of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Icon of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Icon of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Icon of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Icon of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Icon of the Seas tends to suit travelers who want the newest and largest cruise ship afloat with Category 6 water park, Thrill Island, and eight neighborhoods.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Icon of the Seas Right for You?</h2>
+        <p>Icon of the Seas tends to suit travelers who want the newest and largest cruise ship afloat with Category 6 water park, Thrill Island, and eight neighborhoods.
         It's ideal if you want cutting-edge features and up to 7,600 guests on the world's most innovative cruise ship.
-        If you prefer a smaller ship or classic Royal Caribbean designs, you may want to explore Voyager, Freedom, Quantum, or Oasis class instead.
-      </p>
-    </section>
+        If you prefer a smaller ship or classic Royal Caribbean designs, you may want to explore Voyager, Freedom, Quantum, or Oasis class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Icon Class</li><li><strong>Year Built:</strong> 2024</li><li><strong>Size:</strong> 248,663 GT</li><li><strong>Capacity:</strong> 5,610 (double) ~7,600 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Independence of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Independence of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Independence of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Independence of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Independence of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Independence of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Independence of the Seas tends to suit travelers who appreciate active amenities like the FlowRider surf simulator and water park alongside classic Royal Caribbean features.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Independence of the Seas Right for You?</h2>
+        <p>Independence of the Seas tends to suit travelers who appreciate active amenities like the FlowRider surf simulator and water park alongside classic Royal Caribbean features.
         It's ideal if you want up to 4,515 guests — larger than Voyager class but more intimate than Oasis or Icon class.
-        If you're seeking seven neighborhoods or the newest innovations, you may want to explore Oasis or Icon class instead.
-      </p>
-    </section>
+        If you're seeking seven neighborhoods or the newest innovations, you may want to explore Oasis or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Freedom Class</li><li><strong>Year Built:</strong> 2008</li><li><strong>Size:</strong> 155,889 GT</li><li><strong>Capacity:</strong> 3,634 (double) ~4,375 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Jewel of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Jewel of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Jewel of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Jewel of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Jewel of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Jewel of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Jewel of the Seas tends to suit travelers who prefer mid-sized ships with panoramic ocean views and glass-wall design.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Jewel of the Seas Right for You?</h2>
+        <p>Jewel of the Seas tends to suit travelers who prefer mid-sized ships with panoramic ocean views and glass-wall design.
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
-        If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
-      </p>
-    </section>
+        If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Radiance Class</li><li><strong>Year Built:</strong> 2004</li><li><strong>Size:</strong> 90,090 GT</li><li><strong>Capacity:</strong> 2,110 (double) ~2,573 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/legend-of-the-seas-1995-built.html
+++ b/ships/rcl/legend-of-the-seas-1995-built.html
@@ -853,20 +853,30 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Legend of the Seas (1995 Built) overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Legend of the Seas (1995 Built) — Historical Information &amp; Legacy</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Legend of the Seas (1995 Built)</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers the history, legacy, and details of Legend of the Seas (1995 Built), a historic Royal Caribbean vessel.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Legend of the Seas (1995 Built) information?</strong>
-        <span>This page covers the history, legacy, and details of Legend of the Seas (1995 Built), a historic Royal Caribbean vessel.</span>
-      </p>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Legend of the Seas (1995 Built) Right for You?</h2>
+        <p>Legend of the Seas (built 1995) suits travelers who appreciate mid-sized ships with about 1,804 guests at double occupancy. It offers Vision-class glass-wrapped design with panoramic views, balancing intimacy with modern amenities. Ideal if you want Viking Crown Lounge views and solarium relaxation without mega-ship crowds. If you prefer larger vessels with more dining and entertainment options, consider Quantum, Oasis, or Icon class instead.</p>
+      </section>
 
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Legend of the Seas (built 1995) suits travelers who appreciate mid-sized ships with about 1,804 guests at double occupancy. It offers Vision-class glass-wrapped design with panoramic views, balancing intimacy with modern amenities. Ideal if you want Viking Crown Lounge views and solarium relaxation without mega-ship crowds. If you prefer larger vessels with more dining and entertainment options, consider Quantum, Oasis, or Icon class instead.
-      </p>
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Legend Class</li><li><strong>Year Built:</strong> TBD</li><li><strong>Size:</strong> TBD</li><li><strong>Capacity:</strong> TBD</li>
+        </ul>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/legend-of-the-seas.html
+++ b/ships/rcl/legend-of-the-seas.html
@@ -853,20 +853,30 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Legend of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Legend of the Seas — Historical Information &amp; Legacy</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Legend of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers the history, legacy, and details of Legend of the Seas, a historic Royal Caribbean vessel.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Legend of the Seas information?</strong>
-        <span>This page covers the history, legacy, and details of Legend of the Seas, a historic Royal Caribbean vessel.</span>
-      </p>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Legend of the Seas Right for You?</h2>
+        <p>Legend of the Seas suits travelers who appreciate mid-sized ships with about 1,804 guests at double occupancy. It offers Vision-class glass-wrapped design with panoramic views, balancing intimacy with modern amenities. Ideal if you want Viking Crown Lounge views and solarium relaxation without mega-ship crowds. If you prefer larger vessels with more dining and entertainment options, consider Quantum, Oasis, or Icon class instead.</p>
+      </section>
 
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Legend of the Seas suits travelers who appreciate mid-sized ships with about 1,804 guests at double occupancy. It offers Vision-class glass-wrapped design with panoramic views, balancing intimacy with modern amenities. Ideal if you want Viking Crown Lounge views and solarium relaxation without mega-ship crowds. If you prefer larger vessels with more dining and entertainment options, consider Quantum, Oasis, or Icon class instead.
-      </p>
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Legend Class</li><li><strong>Year Built:</strong> TBD</li><li><strong>Size:</strong> TBD</li><li><strong>Capacity:</strong> TBD</li>
+        </ul>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Liberty of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Liberty of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Liberty of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Liberty of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Liberty of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Liberty of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Liberty of the Seas tends to suit travelers who appreciate active amenities like the FlowRider surf simulator and water park alongside classic Royal Caribbean features.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Liberty of the Seas Right for You?</h2>
+        <p>Liberty of the Seas tends to suit travelers who appreciate active amenities like the FlowRider surf simulator and water park alongside classic Royal Caribbean features.
         It's ideal if you want up to 4,960 guests — larger than Voyager class but more intimate than Oasis or Icon class.
-        If you're seeking seven neighborhoods or the newest innovations, you may want to explore Oasis or Icon class instead.
-      </p>
-    </section>
+        If you're seeking seven neighborhoods or the newest innovations, you may want to explore Oasis or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Freedom Class</li><li><strong>Year Built:</strong> 2007</li><li><strong>Size:</strong> 155,889 GT</li><li><strong>Capacity:</strong> 3,634 (double) ~4,375 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Mariner of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Mariner of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Mariner of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Mariner of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Mariner of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Mariner of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Mariner of the Seas tends to suit travelers who appreciate Voyager-class innovations like the Royal Promenade, ice skating rink, and rock climbing wall.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Mariner of the Seas Right for You?</h2>
+        <p>Mariner of the Seas tends to suit travelers who appreciate Voyager-class innovations like the Royal Promenade, ice skating rink, and rock climbing wall.
         It's ideal if you want about 3,114 guests at double occupancy — offering a balance of activities and space without the massive scale of Oasis or Icon class ships.
-        If you're seeking the newest features or prefer a larger ship, you may want to explore Quantum, Oasis, or Icon class instead.
-      </p>
-    </section>
+        If you're seeking the newest features or prefer a larger ship, you may want to explore Quantum, Oasis, or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Voyager Class</li><li><strong>Year Built:</strong> 2003</li><li><strong>Size:</strong> 139,863 GT</li><li><strong>Capacity:</strong> 3,344 (double) ~4,252 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/monarch-of-the-seas.html
+++ b/ships/rcl/monarch-of-the-seas.html
@@ -871,23 +871,33 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Monarch of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Monarch of the Seas — Historical Information &amp; Legacy</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Monarch of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers the history, legacy, and details of Monarch of the Seas, a classic Sovereign-class ship that served Royal Caribbean from 1991 to 2013.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Monarch of the Seas information?</strong>
-        <span>This page covers the history, legacy, and details of Monarch of the Seas, a classic Sovereign-class ship that served Royal Caribbean from 1991 to 2013.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Monarch of the Seas represented Royal Caribbean's early fleet, offering classic cruising with about 2,744 guests at double occupancy.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Monarch of the Seas Right for You?</h2>
+        <p>Monarch of the Seas represented Royal Caribbean's early fleet, offering classic cruising with about 2,744 guests at double occupancy.
         It suited travelers who appreciated the more intimate experience of Sovereign-class ships compared to today's mega-vessels.
         The ship was sold to Pullmantur in 2013 and later ceased operations in 2020, but its legacy remains an important part of Royal Caribbean's history.
-        If you're looking for currently sailing ships, explore Royal Caribbean's modern fleet including Oasis, Quantum, or Icon class vessels.
-      </p>
-    </section>
+        If you're looking for currently sailing ships, explore Royal Caribbean's modern fleet including Oasis, Quantum, or Icon class vessels.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Sovereign Class</li><li><strong>Year Built:</strong> TBD</li><li><strong>Size:</strong> TBD</li><li><strong>Capacity:</strong> TBD</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Navigator of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Navigator of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Navigator of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Navigator of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Navigator of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Navigator of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Navigator of the Seas tends to suit travelers who appreciate Voyager-class innovations like the Royal Promenade, ice skating rink, and rock climbing wall.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Navigator of the Seas Right for You?</h2>
+        <p>Navigator of the Seas tends to suit travelers who appreciate Voyager-class innovations like the Royal Promenade, ice skating rink, and rock climbing wall.
         It's ideal if you want about 3,114 guests at double occupancy — offering a balance of activities and space without the massive scale of Oasis or Icon class ships.
-        If you're seeking the newest features or prefer a larger ship, you may want to explore Quantum, Oasis, or Icon class instead.
-      </p>
-    </section>
+        If you're seeking the newest features or prefer a larger ship, you may want to explore Quantum, Oasis, or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Voyager Class</li><li><strong>Year Built:</strong> 2002</li><li><strong>Size:</strong> 139,999 GT</li><li><strong>Capacity:</strong> 3,368 (double) ~4,000 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/nordic-empress.html
+++ b/ships/rcl/nordic-empress.html
@@ -853,20 +853,30 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Nordic Empress overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Nordic Empress — Historical Information &amp; Legacy</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Nordic Empress</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers the history, legacy, and details of Nordic Empress, a historic Royal Caribbean vessel.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Nordic Empress information?</strong>
-        <span>This page covers the history, legacy, and details of Nordic Empress, a historic Royal Caribbean vessel.</span>
-      </p>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Nordic Empress Right for You?</h2>
+        <p>Nordic Empress (later Empress of the Seas) served Royal Caribbean from 1990 to 2008, offering short Caribbean cruises with about 1,840 guests at double occupancy. The ship was known for pioneering Royal Caribbean's short-cruise market from Miami. After being sold to Pullmantur in 2008, it continued sailing until 2020. This page preserves its Royal Caribbean legacy.</p>
+      </section>
 
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Nordic Empress (later Empress of the Seas) served Royal Caribbean from 1990 to 2008, offering short Caribbean cruises with about 1,840 guests at double occupancy. The ship was known for pioneering Royal Caribbean's short-cruise market from Miami. After being sold to Pullmantur in 2008, it continued sailing until 2020. This page preserves its Royal Caribbean legacy.
-      </p>
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Nordic Class</li><li><strong>Year Built:</strong> TBD</li><li><strong>Size:</strong> TBD</li><li><strong>Capacity:</strong> TBD</li>
+        </ul>
     </section>
+  </section>
 
-    <!-- Row 1: First Look + Dining -->
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Oasis of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Oasis of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Oasis of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Oasis of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Oasis of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Oasis of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Oasis of the Seas tends to suit travelers who prefer mega-ship variety with seven distinct neighborhoods offering something for everyone — from Central Park's tranquil tree-lined paths to the Boardwalk's carousel and outdoor AquaTheater.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Oasis of the Seas Right for You?</h2>
+        <p>Oasis of the Seas tends to suit travelers who prefer mega-ship variety with seven distinct neighborhoods offering something for everyone — from Central Park's tranquil tree-lined paths to the Boardwalk's carousel and outdoor AquaTheater.
         It's ideal if you want maximum dining, entertainment, and activity options in one sailing, with space for 5,400+ guests without feeling crowded.
-        If you're looking for a more intimate, quiet ship experience or prefer classic ocean-view focused design, you may want to explore Radiance or Voyager class instead.
-      </p>
-    </section>
+        If you're looking for a more intimate, quiet ship experience or prefer classic ocean-view focused design, you may want to explore Radiance or Voyager class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Oasis Class</li><li><strong>Year Built:</strong> 2009</li><li><strong>Size:</strong> 225,282 GT</li><li><strong>Capacity:</strong> 5,400 (double) ~6,771 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Odyssey of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Odyssey of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Odyssey of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Odyssey of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Odyssey of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Odyssey of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Odyssey of the Seas tends to suit travelers who appreciate high-tech entertainment and modern innovations like the SeaPlex (indoor bumper cars and sports), iFly skydiving simulator, and North Star observation capsule.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Odyssey of the Seas Right for You?</h2>
+        <p>Odyssey of the Seas tends to suit travelers who appreciate high-tech entertainment and modern innovations like the SeaPlex (indoor bumper cars and sports), iFly skydiving simulator, and North Star observation capsule.
         It's ideal if you want Quantum-class technology and activities with about 4,198 guests at double occupancy — more intimate than Oasis class but packed with unique experiences.
-        If you're looking for the classic neighborhood layout or the largest ships afloat, you may want to explore Oasis or Icon class instead.
-      </p>
-    </section>
+        If you're looking for the classic neighborhood layout or the largest ships afloat, you may want to explore Oasis or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Quantum Ultra Class</li><li><strong>Year Built:</strong> 2021</li><li><strong>Size:</strong> 167,704 GT</li><li><strong>Capacity:</strong> 4,198 (double) ~5,510 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Ovation of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Ovation of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Ovation of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Ovation of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Ovation of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Ovation of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Ovation of the Seas tends to suit travelers who appreciate modern technology and innovative features like the North Star capsule rising 300 feet above sea level, SeaPlex (bumper cars and sports), and Two70's transforming entertainment space.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Ovation of the Seas Right for You?</h2>
+        <p>Ovation of the Seas tends to suit travelers who appreciate modern technology and innovative features like the North Star capsule rising 300 feet above sea level, SeaPlex (bumper cars and sports), and Two70's transforming entertainment space.
         It's ideal if you want Quantum-class innovations with about 4,180 guests at double occupancy — more intimate than Oasis class yet packed with high-tech experiences.
-        If you're looking for the classic neighborhood layout or the largest ships afloat, you may want to explore Oasis or Icon class instead.
-      </p>
-    </section>
+        If you're looking for the classic neighborhood layout or the largest ships afloat, you may want to explore Oasis or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Quantum Class</li><li><strong>Year Built:</strong> 2016</li><li><strong>Size:</strong> 168,666 GT</li><li><strong>Capacity:</strong> 4,180 (double) ~4,819 (max)</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -798,7 +798,34 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">
-    <!-- Row 1: First Look + Dining -->
+
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Quantum of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Quantum of the Seas is a Quantum Class ship (168,666 GT, ~4,180 guests) featuring groundbreaking technology including North Star observation capsule, RipCord by iFLY skydiving simulator, and transforming entertainment venues.</span>
+    </p>
+
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Quantum of the Seas Right for You?</h2>
+        <p>Quantum of the Seas suits tech-savvy cruisers and families seeking innovation with traditional Royal Caribbean service. Ideal for those who want cutting-edge experiences like robot bartenders and virtual balconies.</p>
+      </section>
+
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Quantum Class</li>
+          <li><strong>Year Built:</strong> 2014</li>
+          <li><strong>Size:</strong> 168,666 GT</li>
+          <li><strong>Capacity:</strong> ~4,180</li>
+        </ul>
+    </section>
+  </section>
+
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -871,22 +871,32 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Serenade of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Serenade of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Serenade of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Serenade of the Seas.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Serenade of the Seas planning info?</strong>
-        <span>This page covers deck plans, live ship tracking, dining venues, and video tours to help you plan your Royal Caribbean cruise aboard Serenade of the Seas.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Serenade of the Seas tends to suit travelers who prefer mid-sized ships with panoramic ocean views and glass-wall design.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Serenade of the Seas Right for You?</h2>
+        <p>Serenade of the Seas tends to suit travelers who prefer mid-sized ships with panoramic ocean views and glass-wall design.
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
-        If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
-      </p>
-    </section>
+        If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Radiance Class</li><li><strong>Year Built:</strong> 2003</li><li><strong>Size:</strong> 90,090 GT</li><li><strong>Capacity:</strong> 2,490</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/song-of-america.html
+++ b/ships/rcl/song-of-america.html
@@ -551,20 +551,30 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Song of America overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Song of America — Historical Information &amp; Legacy</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Song of America</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers the history, legacy, and details of Song of America, a historic Royal Caribbean vessel.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Song of America information?</strong>
-        <span>This page covers the history, legacy, and details of Song of America, a historic Royal Caribbean vessel.</span>
-      </p>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Song of America Right for You?</h2>
+        <p>Song of America served Royal Caribbean from 1982 to 1999, offering mid-sized cruising with about 1,402 guests at double occupancy. The ship featured classic Royal Caribbean amenities and itineraries before being sold to Sun Cruises. Though no longer sailing, Song of America represents an important chapter in Royal Caribbean's growth during the 1980s and 1990s.</p>
+      </section>
 
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Song of America served Royal Caribbean from 1982 to 1999, offering mid-sized cruising with about 1,402 guests at double occupancy. The ship featured classic Royal Caribbean amenities and itineraries before being sold to Sun Cruises. Though no longer sailing, Song of America represents an important chapter in Royal Caribbean's growth during the 1980s and 1990s.
-      </p>
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Song of America Class</li><li><strong>Year Built:</strong> 1982</li><li><strong>Size:</strong> 37,700 GT</li><li><strong>Capacity:</strong> 1,575</li>
+        </ul>
     </section>
+  </section>
 
-    <!-- Row 1: Ship Overview + Stats -->
+  <!-- Row 1: Ship Overview + Stats -->
     <section class="grid-2">
       <!-- Ship Overview -->
       <section class="card" aria-labelledby="ship-overview">

--- a/ships/rcl/song-of-norway.html
+++ b/ships/rcl/song-of-norway.html
@@ -855,23 +855,33 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Song of Norway overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Song of Norway — Historical Information &amp; Legacy</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Song of Norway</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers the history, legacy, and details of Song of Norway, Royal Caribbean's first ship that launched the line in 1970.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Song of Norway information?</strong>
-        <span>This page covers the history, legacy, and details of Song of Norway, Royal Caribbean's first ship that launched the line in 1970.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Song of Norway was Royal Caribbean's inaugural vessel, offering classic Caribbean cruising from 1970.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Song of Norway Right for You?</h2>
+        <p>Song of Norway was Royal Caribbean's inaugural vessel, offering classic Caribbean cruising from 1970.
         The ship represented the line's pioneering spirit with about 724 guests at double occupancy.
         It was later sold to Sun Cruises and eventually scrapped, but its legacy as the vessel that launched Royal Caribbean makes it historically significant.
-        If you're researching the origins of Royal Caribbean or comparing the evolution of cruise ships, this page preserves that founding story.
-      </p>
-    </section>
+        If you're researching the origins of Royal Caribbean or comparing the evolution of cruise ships, this page preserves that founding story.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Song Class</li><li><strong>Year Built:</strong> TBD</li><li><strong>Size:</strong> TBD</li><li><strong>Capacity:</strong> TBD</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/sovereign-of-the-seas.html
+++ b/ships/rcl/sovereign-of-the-seas.html
@@ -798,7 +798,34 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">
-    <!-- Row 1: First Look + Dining -->
+
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Sovereign of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Sovereign of the Seas is a Royal Caribbean ship (73,192 GT, ~2,278 guests, launched 1988) offering deck plans, live tracking, dining venues, and cruise planning resources.</span>
+    </p>
+
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Sovereign of the Seas Right for You?</h2>
+        <p>Sovereign of the Seas welcomes cruisers exploring Royal Caribbean's fleet. This page provides deck plans, current location tracking, and dining information to help plan your voyage.</p>
+      </section>
+
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Sovereign Class</li>
+          <li><strong>Year Built:</strong> 1988</li>
+          <li><strong>Size:</strong> 73,192 GT</li>
+          <li><strong>Capacity:</strong> ~2,278</li>
+        </ul>
+    </section>
+  </section>
+
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -798,7 +798,34 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">
-    <!-- Row 1: First Look + Dining -->
+
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Spectrum of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Spectrum of the Seas is a Quantum Class ship (168,666 GT, ~4,246 guests) featuring groundbreaking technology including North Star observation capsule, RipCord by iFLY skydiving simulator, and transforming entertainment venues.</span>
+    </p>
+
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Spectrum of the Seas Right for You?</h2>
+        <p>Spectrum of the Seas suits tech-savvy cruisers and families seeking innovation with traditional Royal Caribbean service. Ideal for those who want cutting-edge experiences like robot bartenders and virtual balconies.</p>
+      </section>
+
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Quantum Ultra Class</li>
+          <li><strong>Year Built:</strong> 2019</li>
+          <li><strong>Size:</strong> 168,666 GT</li>
+          <li><strong>Capacity:</strong> ~4,246</li>
+        </ul>
+    </section>
+  </section>
+
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/splendour-of-the-seas.html
+++ b/ships/rcl/splendour-of-the-seas.html
@@ -871,23 +871,33 @@ updated: 2025-11-18
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Splendour of the Seas overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Splendour of the Seas — Historical Information &amp; Legacy</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Splendour of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers the history, legacy, and details of Splendour of the Seas, a Vision-class ship that served Royal Caribbean from 1996 to 2017 and now sails as Marella Discovery.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Splendour of the Seas information?</strong>
-        <span>This page covers the history, legacy, and details of Splendour of the Seas, a Vision-class ship that served Royal Caribbean from 1996 to 2017 and now sails as Marella Discovery.</span>
-      </p>
-
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Splendour of the Seas offered the signature Vision-class experience with panoramic glass walls and about 1,804 guests at double occupancy.
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Splendour of the Seas Right for You?</h2>
+        <p>Splendour of the Seas offered the signature Vision-class experience with panoramic glass walls and about 1,804 guests at double occupancy.
         It suited travelers who appreciated the view-focused, intimate design of Royal Caribbean's mid-sized ships.
         The ship was sold to TUI/Marella Cruises in 2017 and continues sailing as Marella Discovery, preserving the distinctive glass-wrapped architecture.
-        If you're looking for currently sailing Royal Caribbean ships, explore Vision-class sisters like Grandeur, Rhapsody, Vision, and Enchantment, or modern Radiance, Quantum, and Icon class vessels.
-      </p>
-    </section>
+        If you're looking for currently sailing Royal Caribbean ships, explore Vision-class sisters like Grandeur, Rhapsody, Vision, and Enchantment, or modern Radiance, Quantum, and Icon class vessels.</p>
+      </section>
 
-    <!-- Row 1: First Look + Dining -->
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Vision Class</li><li><strong>Year Built:</strong> TBD</li><li><strong>Size:</strong> TBD</li><li><strong>Capacity:</strong> TBD</li>
+        </ul>
+    </section>
+  </section>
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -798,7 +798,34 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">
-    <!-- Row 1: First Look + Dining -->
+
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Symphony of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Symphony of the Seas is a Royal Caribbean ship (228,081 GT, ~5,518 guests, launched 2018) offering deck plans, live tracking, dining venues, and cruise planning resources.</span>
+    </p>
+
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Symphony of the Seas Right for You?</h2>
+        <p>Symphony of the Seas welcomes cruisers exploring Royal Caribbean's fleet. This page provides deck plans, current location tracking, and dining information to help plan your voyage.</p>
+      </section>
+
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Oasis Class</li>
+          <li><strong>Year Built:</strong> 2018</li>
+          <li><strong>Size:</strong> 228,081 GT</li>
+          <li><strong>Capacity:</strong> ~5,518</li>
+        </ul>
+    </section>
+  </section>
+
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -798,7 +798,34 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">
-    <!-- Row 1: First Look + Dining -->
+
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Utopia of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Utopia of the Seas is a Royal Caribbean ship (236,473 GT, ~5,668 guests, launched 2024) offering deck plans, live tracking, dining venues, and cruise planning resources.</span>
+    </p>
+
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Utopia of the Seas Right for You?</h2>
+        <p>Utopia of the Seas welcomes cruisers exploring Royal Caribbean's fleet. This page provides deck plans, current location tracking, and dining information to help plan your voyage.</p>
+      </section>
+
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Oasis Class</li>
+          <li><strong>Year Built:</strong> 2024</li>
+          <li><strong>Size:</strong> 236,473 GT</li>
+          <li><strong>Capacity:</strong> ~5,668</li>
+        </ul>
+    </section>
+  </section>
+
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/viking-serenade.html
+++ b/ships/rcl/viking-serenade.html
@@ -551,20 +551,30 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap" id="main-content" role="main" tabindex="-1">
 
     <!-- ICP-Lite: Page Intro -->
-    <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;" aria-label="Viking Serenade overview">
-      <h1 style="font-size: clamp(1.6rem, 3vw, 2.1rem); color: var(--sea); margin: 0.75rem 0 0.5rem;">Viking Serenade — Historical Information &amp; Legacy</h1>
+    
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Viking Serenade</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">This page covers the history, legacy, and details of Viking Serenade, a historic Royal Caribbean vessel.</span>
+    </p>
 
-      <p style="margin: 0.5rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope); background: #f7fdff; border-radius: 8px; font-size: 0.95rem; color: #134;">
-        <strong style="display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: #567; margin-bottom: 0.15rem;">Looking for Viking Serenade information?</strong>
-        <span>This page covers the history, legacy, and details of Viking Serenade, a historic Royal Caribbean vessel.</span>
-      </p>
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Viking Serenade Right for You?</h2>
+        <p>Viking Serenade served Royal Caribbean from 1990 to 2002, offering Alaska and Caribbean itineraries with about 1,512 guests at double occupancy. The ship featured classic Royal Caribbean amenities before being sold. Though no longer sailing with RCL, Viking Serenade contributed to the line's growth in the 1990s.</p>
+      </section>
 
-      <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        Viking Serenade served Royal Caribbean from 1990 to 2002, offering Alaska and Caribbean itineraries with about 1,512 guests at double occupancy. The ship featured classic Royal Caribbean amenities before being sold. Though no longer sailing with RCL, Viking Serenade contributed to the line's growth in the 1990s.
-      </p>
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Viking Serenade Class</li><li><strong>Year Built:</strong> 1990 (RCL)</li><li><strong>Size:</strong> 40,132 GT</li><li><strong>Capacity:</strong> 1,870</li>
+        </ul>
     </section>
+  </section>
 
-    <!-- Row 1: Ship Overview + Stats -->
+  <!-- Row 1: Ship Overview + Stats -->
     <section class="grid-2">
       <!-- Ship Overview -->
       <section class="card" aria-labelledby="ship-overview">

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -798,7 +798,34 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">
-    <!-- Row 1: First Look + Dining -->
+
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Voyager of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Voyager of the Seas is a Voyager Class ship (137,276 GT, ~3,114 guests) featuring the iconic Royal Promenade, ice skating rink, and rock climbing wall that revolutionized cruising.</span>
+    </p>
+
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Voyager of the Seas Right for You?</h2>
+        <p>Voyager of the Seas welcomes cruisers seeking the sweet spot between intimacy and amenities. Perfect for families wanting Royal Caribbean classics without Oasis-class scale.</p>
+      </section>
+
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Voyager Class</li>
+          <li><strong>Year Built:</strong> 1999</li>
+          <li><strong>Size:</strong> 137,276 GT</li>
+          <li><strong>Capacity:</strong> ~3,114</li>
+        </ul>
+    </section>
+  </section>
+
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -798,7 +798,34 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">
-    <!-- Row 1: First Look + Dining -->
+
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">Wonder of the Seas</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">Wonder of the Seas is a Royal Caribbean ship (236,857 GT, ~5,734 guests, launched 2022) offering deck plans, live tracking, dining venues, and cruise planning resources.</span>
+    </p>
+
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is Wonder of the Seas Right for You?</h2>
+        <p>Wonder of the Seas welcomes cruisers exploring Royal Caribbean's fleet. This page provides deck plans, current location tracking, and dining information to help plan your voyage.</p>
+      </section>
+
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Class:</strong> Oasis Class</li>
+          <li><strong>Year Built:</strong> 2022</li>
+          <li><strong>Size:</strong> 236,857 GT</li>
+          <li><strong>Capacity:</strong> ~5,734</li>
+        </ul>
+    </section>
+  </section>
+
+
+  <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">

--- a/transform_ship_pages.py
+++ b/transform_ship_pages.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Transform remaining 34 ship pages to proper ICP-Lite structure.
+Converts page-intro sections to icp-header with answer-line, fit-guidance, key-facts.
+"""
+
+import re
+import json
+from pathlib import Path
+
+SHIPS_DIR = Path('/home/user/InTheWake/ships/rcl')
+
+# Ships to transform (excluding radiance-of-the-seas.html)
+SHIPS_TO_FIX = [
+    'allure-of-the-seas.html', 'anthem-of-the-seas.html', 'brilliance-of-the-seas.html',
+    'explorer-of-the-seas.html', 'freedom-of-the-seas.html', 'harmony-of-the-seas.html',
+    'icon-of-the-seas.html', 'independence-of-the-seas.html', 'jewel-of-the-seas.html',
+    'legend-of-the-seas-1995-built.html', 'legend-of-the-seas.html', 'liberty-of-the-seas.html',
+    'mariner-of-the-seas.html', 'monarch-of-the-seas.html', 'navigator-of-the-seas.html',
+    'nordic-empress.html', 'nordic-prince.html', 'oasis-class-ship-tbn-2028.html',
+    'oasis-of-the-seas.html', 'odyssey-of-the-seas.html', 'ovation-of-the-seas.html',
+    'quantum-of-the-seas.html', 'serenade-of-the-seas.html', 'song-of-america.html',
+    'song-of-norway.html', 'sovereign-of-the-seas.html', 'spectrum-of-the-seas.html',
+    'splendour-of-the-seas.html', 'sun-viking.html', 'symphony-of-the-seas.html',
+    'utopia-of-the-seas.html', 'viking-serenade.html', 'voyager-of-the-seas.html',
+    'wonder-of-the-seas.html'
+]
+
+def extract_ship_stats(content):
+    """Extract ship stats from JSON fallback."""
+    stats_match = re.search(r'<script type="application/json" id="ship-stats-fallback">\s*({[^}]+})', content, re.DOTALL)
+    if stats_match:
+        try:
+            stats = json.loads(stats_match.group(1))
+            return stats
+        except:
+            pass
+    return None
+
+def extract_ship_name(content):
+    """Extract clean ship name from H1."""
+    h1_match = re.search(r'<h1[^>]*>([^<—]+)', content)
+    if h1_match:
+        return h1_match.group(1).strip()
+    return "Unknown Ship"
+
+def create_key_facts(stats, ship_name):
+    """Create key-facts section from stats."""
+    if not stats:
+        return ""
+
+    facts = []
+    if stats.get('class'):
+        facts.append(f"<li><strong>Class:</strong> {stats['class']}</li>")
+    if stats.get('entered_service'):
+        facts.append(f"<li><strong>Year Built:</strong> {stats['entered_service']}</li>")
+    if stats.get('gt'):
+        facts.append(f"<li><strong>Size:</strong> {stats['gt']}</li>")
+    if stats.get('guests'):
+        facts.append(f"<li><strong>Capacity:</strong> {stats['guests']}</li>")
+
+    if not facts:
+        return ""
+
+    return f"""
+    <section class="key-facts card">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          {''.join(facts)}
+        </ul>
+    </section>"""
+
+def transform_page_intro(content, ship_name, stats):
+    """Transform page-intro section to proper ICP-Lite structure."""
+
+    # Extract the page-intro section content
+    intro_pattern = r'<section class="page-intro"[^>]*>(.*?)</section>\s*\n\s*<!-- Row 1'
+    intro_match = re.search(intro_pattern, content, re.DOTALL)
+
+    if not intro_match:
+        print(f"  ⚠️  No page-intro section found")
+        return content
+
+    intro_content = intro_match.group(1)
+
+    # Extract the descriptive paragraphs
+    para_pattern = r'<p style="[^"]*">\s*<strong[^>]*>[^<]*</strong>\s*<span>([^<]+)</span>\s*</p>\s*<p style="[^"]*">([^<]+)</p>'
+    para_match = re.search(para_pattern, intro_content, re.DOTALL)
+
+    if not para_match:
+        print(f"  ⚠️  Could not extract paragraphs")
+        return content
+
+    answer_text = para_match.group(1).strip()
+    fit_text = para_match.group(2).strip()
+
+    # Build new ICP-Lite structure
+    new_structure = f'''
+    <!-- ICP-Lite v1.0: Answer-First Content -->
+    <section class="icp-header" aria-labelledby="ship-name">
+      <h1 id="ship-name">{ship_name}</h1>
+      <p class="answer-line">
+      <span class="answer-q">What this page covers</span>
+      <span class="answer-a">{answer_text}</span>
+    </p>
+
+      <section class="fit-guidance">
+      <h2 class="sr-only">Who This Page Is For</h2>
+      <h2>Is {ship_name} Right for You?</h2>
+        <p>{fit_text}</p>
+      </section>
+{create_key_facts(stats, ship_name)}
+  </section>
+
+  <!-- Row 1'''
+
+    # Replace the old section
+    content = re.sub(intro_pattern, new_structure, content, flags=re.DOTALL)
+
+    return content
+
+def transform_ship_page(filepath):
+    """Transform a single ship page."""
+    print(f"Transforming {filepath.name}...")
+
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    original = content
+
+    # Extract ship info
+    ship_name = extract_ship_name(content)
+    stats = extract_ship_stats(content)
+
+    # Transform page-intro to icp-header
+    content = transform_page_intro(content, ship_name, stats)
+
+    if content != original:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(content)
+        print(f"  ✓ Transformed {ship_name}")
+        return True
+    else:
+        print(f"  - No changes for {ship_name}")
+        return False
+
+def main():
+    """Main execution."""
+    print("Transforming ship pages to proper ICP-Lite structure...\n")
+    print(f"Processing {len(SHIPS_TO_FIX)} ships (excluding radiance-of-the-seas.html)\n")
+
+    transformed_count = 0
+
+    for filename in SHIPS_TO_FIX:
+        filepath = SHIPS_DIR / filename
+        if filepath.exists():
+            if transform_ship_page(filepath):
+                transformed_count += 1
+        else:
+            print(f"⚠️  {filename} not found")
+
+    print(f"\n✓ Transformed {transformed_count} ship pages")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
…omplete)

Transformed ship pages to standardized ICP-Lite structure:
- Converted page-intro sections to icp-header with proper semantic markup
- Added answer-line with answer-q/answer-a spans
- Created fit-guidance sections with sr-only h2
- Generated key-facts sections from ship stats
- Added ICP headers from scratch for 7 ships that were completely missing them

Ships updated (31 total):
- Allure, Anthem, Brilliance, Explorer, Freedom, Harmony, Icon
- Independence, Jewel, Legend (both), Liberty, Mariner, Monarch
- Navigator, Nordic Empress, Oasis, Odyssey, Ovation, Quantum
- Serenade, Song of America/Norway, Sovereign, Spectrum, Splendour
- Symphony, Utopia, Viking Serenade, Voyager, Wonder

Status: 46/49 ships (excluding Radiance) now have proper ICP-Lite structure
Remaining: nordic-prince, oasis-class-ship-tbn-2028, sun-viking (3 ships)