### PR TITLE
ADD: Comprehensive Royal Caribbean port content to ports.html

### DIFF
--- a/ports.html
+++ b/ports.html
@@ -54,23 +54,23 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <meta name="publisher" content="In the Wake"/>
 
   <!-- Title & SEO -->
-  <title>Ports — Cruise Port Guides & Travel Tips | In the Wake</title>
+  <title>Royal Caribbean Ports — 300+ Destinations Guide | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ports.html"/>
-  <meta name="description" content="Explore cruise port guides from In the Wake — authentic snapshots, accessibility notes, and honest travel insight for cruise travelers."/>
+  <meta name="description" content="Complete guide to Royal Caribbean's 300+ cruise destinations across all seven continents — from Perfect Day at CocoCay to Antarctica, with deployment info and port highlights."/>
 
   <!-- OpenGraph -->
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
-  <meta property="og:title" content="Ports — Cruise Port Guides & Travel Tips"/>
-  <meta property="og:description" content="Cruise ports coming soon — authentic snapshots and accessibility insights for travelers."/>
+  <meta property="og:title" content="Royal Caribbean Ports — 300+ Destinations Guide"/>
+  <meta property="og:description" content="Complete guide to Royal Caribbean's 300+ cruise destinations across all seven continents — from Perfect Day at CocoCay to Antarctica."/>
   <meta property="og:url" content="https://cruisinginthewake.com/ports.html"/>
   <meta property="og:locale" content="en_US"/>
   <meta property="og:image" content="https://cruisinginthewake.com/assets/index_hero.jpg"/>
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:title" content="Ports — Cruise Port Guides"/>
-  <meta name="twitter:description" content="Cruise ports coming soon — authentic snapshots and accessibility insights."/>
+  <meta name="twitter:title" content="Royal Caribbean Ports — 300+ Destinations"/>
+  <meta name="twitter:description" content="Complete guide to Royal Caribbean's cruise destinations across all seven continents, with ship deployments and port highlights."/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/index_hero.jpg"/>
 
   <!-- Google Analytics -->
@@ -728,18 +728,20 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> This page provides cruise planning resources for Ports. Use the information below to help plan your cruise vacation.
+        <strong>Quick Answer:</strong> Royal Caribbean visits 300+ destinations across all seven continents. This guide covers every region — from private islands like Perfect Day at CocoCay to Antarctica expeditions — with ship deployment info and port highlights.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching ports, comparing options, and gathering information for trip planning.
+        <strong>Best For:</strong> Cruisers researching Royal Caribbean itineraries, comparing regions, and planning which ports to prioritize on their voyage.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Topic:</strong> Ports</li>
-          <li><strong>Purpose:</strong> Cruise planning resource</li>
+          <li><strong>Destinations:</strong> 300+ ports across 7 continents</li>
+          <li><strong>Private Islands:</strong> Perfect Day at CocoCay, Labadee</li>
+          <li><strong>Coverage:</strong> Caribbean, Alaska, Europe, Asia-Pacific, Australia/NZ, South America, Antarctica</li>
+          <li><strong>Updated:</strong> 2023-2027 deployment info included</li>
         </ul>
       </div>
     </section>
@@ -747,196 +749,535 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section aria-label="Ports content">
       <!-- Intro -->
       <article class="card">
-        <h1>Destination Ports</h1>
+        <h1>Royal Caribbean Destination Ports</h1>
         <p style="font-size:1.05rem;line-height:1.7;color:#134;">
-          These are the places your ship visits — the ports of call where you'll spend a few hours exploring, shopping, or just soaking in a new place. Looking for where to <em>start</em> your cruise? Check out the <a href="/planning.html#state-port-selector">departure ports on our Planning page</a>.
+          Royal Caribbean visits over 300 destinations across all seven continents. These are the ports of call where you'll spend hours exploring, from private island paradises to ancient cities. Looking for where to <em>start</em> your cruise? Check out the <a href="/planning.html#state-port-selector">departure ports on our Planning page</a>.
         </p>
         <p style="font-size:0.95rem;color:#456;">
-          Jump to: <a href="#caribbean">Caribbean</a> · <a href="#alaska">Alaska</a> · <a href="#mexico">Mexico</a> · <a href="#mediterranean">Mediterranean</a> · <a href="#northern-europe">Northern Europe</a> · <a href="#other">Other Regions</a>
+          Jump to: <a href="#private-destinations">Private Destinations</a> · <a href="#caribbean">Caribbean</a> · <a href="#alaska">Alaska</a> · <a href="#canada-new-england">Canada/New England</a> · <a href="#hawaii">Hawaii</a> · <a href="#mexico">Mexican Riviera</a> · <a href="#mediterranean">Mediterranean</a> · <a href="#northern-europe">Northern Europe</a> · <a href="#asia-pacific">Asia-Pacific</a> · <a href="#australia-nz">Australia/NZ</a> · <a href="#south-pacific">South Pacific</a> · <a href="#south-america">South America</a> · <a href="#world-cruise">World Cruise</a>
         </p>
+      </article>
+
+      <!-- Private & Exclusive Destinations -->
+      <article class="card" id="private-destinations">
+        <h2>Private &amp; Exclusive Destinations</h2>
+        <p>Royal Caribbean's crown jewels — private islands and beach clubs designed exclusively for their guests.</p>
+
+        <h3>Perfect Day at CocoCay (Bahamas)</h3>
+        <p>Royal Caribbean's $250 million private island destination, transformed in 2019.</p>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Thrill Waterpark</strong> — Daredevil's Peak (135 ft slide), wave pool, kids' areas</li>
+          <li><strong>Oasis Lagoon</strong> — Largest freshwater pool in the Caribbean, swim-up bar</li>
+          <li><strong>Coco Beach Club</strong> — Over-water cabanas, infinity pool, upscale experience</li>
+          <li><strong>Up, Up and Away</strong> — Helium balloon 450 ft above island</li>
+          <li><strong>Zip Line</strong> — 1,600 ft across the island</li>
+          <li><strong>South Beach</strong> — Free beach area, volleyball, floating mats</li>
+          <li><strong>Chill Island</strong> — Quieter beach, hammocks, cabana rentals</li>
+          <li><strong>Snorkel Beach</strong> — Calm waters, equipment rentals</li>
+        </ul>
+        <p class="tiny">Note: No tenders required — ships dock directly. Most Oasis and Quantum-class ships visit.</p>
+
+        <h3>Labadee (Haiti)</h3>
+        <p>Royal Caribbean's original private destination on Haiti's secluded north coast since 1986.</p>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Dragon's Breath</strong> — World's longest zip line over water (2,600 ft)</li>
+          <li><strong>Dragon's Tail Coaster</strong> — Alpine coaster down the mountain</li>
+          <li><strong>Arawak Aqua Park</strong> — Floating trampolines, slides in the bay</li>
+          <li><strong>Columbus Cove</strong> — Calmer beach, better for families</li>
+          <li><strong>Barefoot Beach</strong> — Main beach with chair rentals</li>
+          <li><strong>Nellie's Beach</strong> — Exclusive cabanas, butler service</li>
+          <li><strong>Artisan's Market</strong> — Local Haitian crafts and art</li>
+        </ul>
+        <p class="tiny">Tip: Book Dragon's Breath early — it sells out. Labadee is fenced and secure; you won't interact with Haiti beyond.</p>
+
+        <h3>Royal Beach Club Collection (Coming 2025-2027)</h3>
+        <p>New premium beach club destinations expanding the private experience.</p>
+        <ul>
+          <li><strong>Royal Beach Club Paradise Island</strong> (Nassau, Bahamas) — Opening 2025, partnership with Bahamas government</li>
+          <li><strong>Royal Beach Club Cozumel</strong> (Mexico) — Announced for 2026</li>
+          <li><strong>Royal Beach Club Antigua</strong> — In development</li>
+        </ul>
+        <p class="tiny">Beach clubs offer day-pass access with pools, beaches, food &amp; beverage — a hybrid between port call and private island.</p>
       </article>
 
       <!-- Caribbean -->
       <article class="card" id="caribbean">
-        <h2>Caribbean</h2>
-        <p>The most popular cruise destination — warm water, easy beaches, and familiar US dollar in many ports.</p>
+        <h2>Caribbean &amp; Bahamas</h2>
+        <p>Royal Caribbean's bread and butter — year-round sailings from Florida, Texas, and beyond. Ships deployed: Wonder, Utopia, Harmony, Allure, Symphony, Freedom, Liberty, Independence, Mariner, Navigator, Voyager, Grandeur, Vision, Enchantment, Radiance, Brilliance, and more.</p>
 
-        <h3>Private Islands</h3>
+        <h3>Bahamas</h3>
         <ul style="columns:2;column-gap:2rem;">
-          <li><strong>CocoCay</strong> (Royal Caribbean) — Thrill Waterpark, Coco Beach Club, no tenders</li>
-          <li><strong>Labadee</strong> (Royal Caribbean) — Haiti's north coast, Dragon's Breath zip line</li>
-          <li><strong>Perfect Day at CocoCay</strong> — Full-day destination with Oasis Lagoon</li>
-          <li><strong>Half Moon Cay</strong> (Holland America/Carnival) — Low-key beach day</li>
-          <li><strong>Princess Cays</strong> (Princess) — Eleuthera, Bahamas</li>
-          <li><strong>Castaway Cay</strong> (Disney) — Family-focused, character meet-and-greets</li>
+          <li><strong>Nassau</strong> — Atlantis day passes, downtown shopping, Junkanoo Beach</li>
+          <li><strong>Freeport/Lucaya</strong> — Port Lucaya Marketplace, Garden of the Groves</li>
+          <li><strong>Bimini</strong> — Close to Miami, excellent fishing, Resorts World</li>
         </ul>
 
         <h3>Eastern Caribbean</h3>
         <ul style="columns:2;column-gap:2rem;">
-          <li><strong>Nassau, Bahamas</strong> — Walking distance shops, Atlantis day passes available</li>
-          <li><strong>St. Thomas, USVI</strong> — Duty-free shopping, Magens Bay beach</li>
-          <li><strong>St. Maarten</strong> — Dutch/French sides, Maho Beach plane spotting</li>
-          <li><strong>San Juan, Puerto Rico</strong> — Old San Juan forts, no passport needed</li>
-          <li><strong>Tortola, BVI</strong> — The Baths at Virgin Gorda (excursion)</li>
+          <li><strong>St. Thomas, USVI</strong> — Charlotte Amalie duty-free shopping, Magens Bay</li>
+          <li><strong>St. John, USVI</strong> — Trunk Bay, Virgin Islands National Park</li>
+          <li><strong>St. Croix, USVI</strong> — Christiansted, Buck Island snorkeling</li>
+          <li><strong>St. Maarten/St. Martin</strong> — Philipsburg (Dutch), Marigot (French), Maho Beach</li>
+          <li><strong>San Juan, Puerto Rico</strong> — Old San Juan forts, no passport needed, home port</li>
+          <li><strong>Tortola, BVI</strong> — The Baths at Virgin Gorda, Cane Garden Bay</li>
+          <li><strong>Virgin Gorda, BVI</strong> — The Baths granite boulders</li>
+          <li><strong>St. Kitts</strong> — Brimstone Hill Fortress, scenic railway</li>
+          <li><strong>Antigua</strong> — Nelson's Dockyard, 365 beaches, Shirley Heights</li>
+          <li><strong>St. Lucia</strong> — The Pitons, drive-in volcano, mud baths</li>
+          <li><strong>Barbados</strong> — Harrison's Cave, Mount Gay rum, Bridgetown</li>
+          <li><strong>Martinique</strong> — French culture, Mount Pelée, rum distilleries</li>
+          <li><strong>Guadeloupe</strong> — Butterfly-shaped island, La Soufrière volcano</li>
+          <li><strong>Dominica</strong> — Nature isle, waterfalls, Boiling Lake hike</li>
         </ul>
 
         <h3>Western Caribbean</h3>
         <ul style="columns:2;column-gap:2rem;">
-          <li><strong>Cozumel, Mexico</strong> — Snorkeling, Mayan ruins (Tulum excursion)</li>
-          <li><strong>Costa Maya, Mexico</strong> — Beach clubs, less crowded than Cozumel</li>
-          <li><strong>Roatán, Honduras</strong> — Affordable excursions, sloth sanctuaries</li>
-          <li><strong>Belize City</strong> — Tender port, Mayan ruins at Altun Ha</li>
-          <li><strong>George Town, Grand Cayman</strong> — Stingray City, Seven Mile Beach</li>
-          <li><strong>Falmouth, Jamaica</strong> — Dunn's River Falls, newer cruise pier</li>
+          <li><strong>Cozumel, Mexico</strong> — Snorkeling capital, Mayan ruins, multiple piers</li>
+          <li><strong>Costa Maya, Mexico</strong> — Beach clubs, quieter than Cozumel, Mayan ruins</li>
+          <li><strong>Progreso, Mexico</strong> — Gateway to Mérida and Chichén Itzá</li>
+          <li><strong>Roatán, Honduras</strong> — Affordable excursions, sloth sanctuaries, West Bay Beach</li>
+          <li><strong>Belize City</strong> — Tender port, Mayan ruins at Altun Ha, cave tubing</li>
+          <li><strong>Harvest Caye, Belize</strong> — NCL private destination (not RCL)</li>
+          <li><strong>George Town, Grand Cayman</strong> — Stingray City, Seven Mile Beach, tender port</li>
+          <li><strong>Ocho Rios, Jamaica</strong> — Dunn's River Falls, Mystic Mountain</li>
+          <li><strong>Falmouth, Jamaica</strong> — RCL-built pier, Georgian architecture, Dunn's River accessible</li>
+          <li><strong>Montego Bay, Jamaica</strong> — Hip Strip shopping, Doctor's Cave Beach</li>
         </ul>
 
         <h3>Southern Caribbean</h3>
+        <p>Deeper sailings from San Juan or Barbados — typically 7+ nights reaching the ABC islands and South America.</p>
         <ul style="columns:2;column-gap:2rem;">
-          <li><strong>Aruba</strong> — Eagle Beach, consistent weather, easy walking</li>
-          <li><strong>Curaçao</strong> — Colorful Willemstad, great snorkeling</li>
-          <li><strong>Bonaire</strong> — World-class diving, flamingo sanctuary</li>
-          <li><strong>Barbados</strong> — Harrison's Cave, rum tours</li>
-          <li><strong>St. Lucia</strong> — The Pitons, drive-in volcano</li>
-          <li><strong>Grenada</strong> — Spice island, Grand Anse Beach</li>
+          <li><strong>Aruba</strong> — Eagle Beach, Natural Pool, consistent weather</li>
+          <li><strong>Curaçao</strong> — Colorful Willemstad (UNESCO), Hato Caves</li>
+          <li><strong>Bonaire</strong> — World-class diving/snorkeling, flamingo sanctuary</li>
+          <li><strong>Grenada</strong> — Spice island, Grand Anse Beach, nutmeg tours</li>
+          <li><strong>Trinidad</strong> — Pitch Lake, Port of Spain, Carnival culture</li>
+          <li><strong>Tobago</strong> — Pigeon Point, rainforest, quieter sibling</li>
+          <li><strong>Cartagena, Colombia</strong> — Walled city (UNESCO), vibrant culture</li>
+          <li><strong>Santa Marta, Colombia</strong> — Gateway to Tayrona Park</li>
+          <li><strong>Kralendijk, Bonaire</strong> — Shore diving capital</li>
         </ul>
+
+        <p class="tiny">Deployment note: Utopia of the Seas (2024) joins Wonder in Port Canaveral. Freedom, Liberty, Independence rotate Galveston/Port Canaveral. Grandeur operates shorter Bahamas runs from Baltimore.</p>
       </article>
 
       <!-- Alaska -->
       <article class="card" id="alaska">
         <h2>Alaska</h2>
-        <p>Glacier viewing, wildlife, and small-town charm. Most sailings run May through September.</p>
+        <p>May through September season. Ships deployed: Ovation of the Seas (Seattle), Quantum of the Seas, Radiance of the Seas (Vancouver), Serenade of the Seas (Vancouver/Seward), Brilliance of the Seas.</p>
 
-        <h3>Popular Ports</h3>
-        <ul>
-          <li><strong>Juneau</strong> — State capital, Mendenhall Glacier, whale watching. No roads in/out — arrive by air or sea only.</li>
-          <li><strong>Ketchikan</strong> — "Salmon Capital," totem poles, Creek Street boardwalk. Rainiest city in Alaska.</li>
-          <li><strong>Skagway</strong> — Gold Rush history, White Pass Railway. Small town with big character.</li>
-          <li><strong>Sitka</strong> — Russian heritage, Raptor Center, less touristy feel.</li>
-          <li><strong>Icy Strait Point</strong> — Hoonah village, world's largest zip line, whale watching.</li>
+        <h3>Primary Ports</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Juneau</strong> — State capital, Mendenhall Glacier, whale watching. No roads in/out.</li>
+          <li><strong>Ketchikan</strong> — "Salmon Capital," totem poles, Creek Street. Rainiest Alaska city.</li>
+          <li><strong>Skagway</strong> — Gold Rush history, White Pass &amp; Yukon Railway, walkable town.</li>
+          <li><strong>Sitka</strong> — Russian heritage, Raptor Center, less crowded feel.</li>
+          <li><strong>Victoria, BC</strong> — Butchart Gardens, afternoon tea, British charm.</li>
+          <li><strong>Icy Strait Point</strong> — Hoonah village, world's largest zip line (ZipRider), whale watching.</li>
           <li><strong>Haines</strong> — Eagles, bears, less crowded alternative to Skagway.</li>
+        </ul>
+
+        <h3>Turnaround Ports (Embark/Debark)</h3>
+        <ul>
+          <li><strong>Seattle, Washington</strong> — Year-round home port, Space Needle, Pike Place</li>
+          <li><strong>Vancouver, BC</strong> — Canada Place pier, Stanley Park, diverse food scene</li>
+          <li><strong>Seward, Alaska</strong> — For Anchorage cruisetours, Kenai Fjords access</li>
         </ul>
 
         <h3>Scenic Cruising (No Dock)</h3>
         <ul>
-          <li><strong>Glacier Bay</strong> — National Park, rangers board ship, calving glaciers</li>
-          <li><strong>Hubbard Glacier</strong> — Largest tidewater glacier, ship gets close</li>
-          <li><strong>Tracy Arm Fjord</strong> — Twin Sawyer glaciers, steep fjord walls</li>
-          <li><strong>College Fjord</strong> — Multiple glaciers named after colleges</li>
+          <li><strong>Glacier Bay</strong> — National Park, rangers board ship, Margerie Glacier calving</li>
+          <li><strong>Hubbard Glacier</strong> — Largest tidewater glacier in North America, spectacular calving</li>
+          <li><strong>Tracy Arm/Endicott Arm</strong> — Twin Sawyer glaciers, steep fjord walls, icebergs</li>
+          <li><strong>Inside Passage</strong> — Protected waterway, wildlife spotting, forest scenery</li>
         </ul>
 
-        <p class="tiny">Tip: Book excursions early for Alaska — popular tours like helicopter glacier landings sell out months ahead.</p>
+        <h3>Cruisetour Extensions</h3>
+        <p>Royal Caribbean offers land packages before/after Alaska sailings:</p>
+        <ul>
+          <li><strong>Denali National Park</strong> — Mt. Denali (20,310 ft), wildlife tours</li>
+          <li><strong>Fairbanks</strong> — Gold panning, pipeline viewing, northern lights (shoulder season)</li>
+          <li><strong>Anchorage</strong> — Urban Alaska, museums, day trip options</li>
+        </ul>
+
+        <p class="tiny">Tip: Book excursions early — helicopter glacier landings and bear viewing sell out months ahead. Ovation offers the newest ship experience from Seattle.</p>
+      </article>
+
+      <!-- Canada & New England -->
+      <article class="card" id="canada-new-england">
+        <h2>Canada &amp; New England</h2>
+        <p>Fall foliage season (September–October) is prime time. Ships deployed: Serenade of the Seas, Brilliance of the Seas, Adventure of the Seas from Cape Liberty/Boston/Quebec.</p>
+
+        <h3>New England Ports</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Boston, Massachusetts</strong> — Freedom Trail, Faneuil Hall, home port</li>
+          <li><strong>Bar Harbor, Maine</strong> — Acadia National Park, lobster, tender port</li>
+          <li><strong>Portland, Maine</strong> — Foodie scene, lighthouses, Old Port district</li>
+          <li><strong>Newport, Rhode Island</strong> — Gilded Age mansions, sailing heritage</li>
+          <li><strong>Cape Cod (Provincetown)</strong> — Pilgrim Monument, whale watching</li>
+          <li><strong>Martha's Vineyard</strong> — Gingerbread cottages, tender port</li>
+        </ul>
+
+        <h3>Canadian Maritimes</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Halifax, Nova Scotia</strong> — Peggy's Cove, Titanic cemetery, maritime museums</li>
+          <li><strong>Saint John, New Brunswick</strong> — Reversing Falls, Bay of Fundy tides</li>
+          <li><strong>Sydney, Nova Scotia</strong> — Big Fiddle, Cabot Trail gateway</li>
+          <li><strong>Charlottetown, PEI</strong> — Anne of Green Gables, lobster suppers</li>
+        </ul>
+
+        <h3>St. Lawrence River</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Quebec City</strong> — Château Frontenac, Old Quebec (UNESCO), French Canada</li>
+          <li><strong>Montreal</strong> — Mount Royal, Notre-Dame Basilica, bagels vs. NYC</li>
+          <li><strong>Saguenay</strong> — Fjord scenery, whale watching</li>
+        </ul>
+
+        <p class="tiny">Tip: Fall foliage peaks mid-September in Quebec, early October in New England. Pack layers — temperatures can vary 30°F between ports.</p>
+      </article>
+
+      <!-- Hawaii -->
+      <article class="card" id="hawaii">
+        <h2>Hawaii</h2>
+        <p>Royal Caribbean visits Hawaii on longer Pacific voyages and repositioning cruises — typically 14–18 nights from the West Coast. Not to be confused with NCL's inter-island Hawaii cruises.</p>
+
+        <h3>Major Ports</h3>
+        <ul>
+          <li><strong>Honolulu, Oahu</strong> — Waikiki Beach, Pearl Harbor, Diamond Head</li>
+          <li><strong>Maui (Lahaina/Kahului)</strong> — Road to Hana, Haleakala sunrise, whale watching (seasonal)</li>
+          <li><strong>Kona, Big Island</strong> — Coffee farms, active volcanoes, manta ray night dives</li>
+          <li><strong>Hilo, Big Island</strong> — Rainbow Falls, Hawaii Volcanoes National Park access</li>
+          <li><strong>Kauai (Nawiliwili)</strong> — Na Pali Coast, Waimea Canyon, Garden Isle</li>
+        </ul>
+
+        <p class="tiny">Note: Jones Act requires foreign-flagged ships to visit a non-US port (like Ensenada) on round-trip voyages from the mainland. Most Hawaii cruises are one-way repositioning sailings.</p>
       </article>
 
       <!-- Mexico (non-Caribbean) -->
       <article class="card" id="mexico">
         <h2>Mexican Riviera</h2>
-        <p>Pacific coast cruises from California ports — different vibe from Caribbean Mexico.</p>
+        <p>Pacific coast cruises primarily from Los Angeles. Ships deployed seasonally: Navigator of the Seas operates year-round from LA with some Mexican Riviera sailings.</p>
 
-        <ul>
-          <li><strong>Cabo San Lucas</strong> — El Arco rock formation, tender port, beach clubs</li>
-          <li><strong>Puerto Vallarta</strong> — Malecón boardwalk, old town charm, zip lines</li>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Cabo San Lucas</strong> — El Arco rock formation, tender port, beach clubs, whale watching</li>
+          <li><strong>Puerto Vallarta</strong> — Malecón boardwalk, old town, zip lines, Marietas Islands</li>
           <li><strong>Mazatlán</strong> — Historic centro, cliff divers, Golden Zone beaches</li>
-          <li><strong>Ensenada</strong> — Wine country, La Bufadora blowhole, short cruises from LA</li>
+          <li><strong>Ensenada</strong> — Wine country (Valle de Guadalupe), La Bufadora blowhole</li>
         </ul>
+
+        <p class="tiny">Deployment note: Mexican Riviera sailings are often 3–5 night "short getaways" from LA. Panama Canal repositioning cruises may also call at Huatulco and Puerto Chiapas.</p>
       </article>
 
       <!-- Mediterranean -->
       <article class="card" id="mediterranean">
         <h2>Mediterranean</h2>
-        <p>History, culture, and cuisine. Longer port days mean more time to explore — but crowds at major sites can be intense.</p>
+        <p>April through November season. Ships deployed: Allure of the Seas (Barcelona), Odyssey of the Seas (Rome), Brilliance of the Seas, Rhapsody of the Seas. History, culture, cuisine — and intense crowds at major sites.</p>
 
         <h3>Western Mediterranean</h3>
         <ul style="columns:2;column-gap:2rem;">
-          <li><strong>Barcelona, Spain</strong> — Sagrada Familia, La Rambla, Gaudí architecture</li>
-          <li><strong>Civitavecchia (Rome)</strong> — 90-min transfer to Rome, book early</li>
-          <li><strong>Naples, Italy</strong> — Pompeii, Amalfi Coast, pizza's birthplace</li>
-          <li><strong>Livorno (Florence/Pisa)</strong> — Long drive to Florence, Pisa closer</li>
-          <li><strong>Marseille, France</strong> — Old port, Provence day trips</li>
-          <li><strong>Palma de Mallorca</strong> — Cathedral, old town, beach day option</li>
+          <li><strong>Barcelona, Spain</strong> — Sagrada Familia, La Rambla, Gaudí architecture, major home port</li>
+          <li><strong>Civitavecchia (Rome)</strong> — 90-min transfer to Rome, Vatican, Colosseum — book early</li>
+          <li><strong>Naples, Italy</strong> — Pompeii, Amalfi Coast, original pizza, Sorrento</li>
+          <li><strong>Livorno (Florence/Pisa)</strong> — 90-min to Florence, 30-min to Pisa's tower</li>
+          <li><strong>La Spezia, Italy</strong> — Cinque Terre gateway, train to five villages</li>
+          <li><strong>Genoa, Italy</strong> — Columbus' birthplace, aquarium, Portofino nearby</li>
+          <li><strong>Marseille, France</strong> — Old port, Provence lavender fields</li>
+          <li><strong>Nice/Villefranche, France</strong> — French Riviera, Monaco day trip</li>
+          <li><strong>Cannes, France</strong> — Film festival site, tender port</li>
+          <li><strong>Palma de Mallorca, Spain</strong> — Gothic cathedral, old town, beach day</li>
+          <li><strong>Ibiza, Spain</strong> — Old town (Dalt Vila), beaches, nightlife</li>
+          <li><strong>Málaga, Spain</strong> — Picasso museum, Marbella day trips</li>
+          <li><strong>Cartagena, Spain</strong> — Roman theater, tapas, walkable</li>
+          <li><strong>Cádiz, Spain</strong> — Ancient city, cathedral, fried fish</li>
+          <li><strong>Gibraltar, UK</strong> — The Rock, Barbary macaques, duty-free</li>
         </ul>
 
-        <h3>Eastern Mediterranean</h3>
+        <h3>Eastern Mediterranean &amp; Greek Isles</h3>
         <ul style="columns:2;column-gap:2rem;">
-          <li><strong>Santorini, Greece</strong> — Tender port, cable car/donkeys up caldera</li>
-          <li><strong>Mykonos, Greece</strong> — Windmills, white buildings, party scene</li>
-          <li><strong>Athens (Piraeus)</strong> — Acropolis, Parthenon, walkable from port</li>
-          <li><strong>Dubrovnik, Croatia</strong> — Game of Thrones filming, walled city</li>
-          <li><strong>Kotor, Montenegro</strong> — Stunning fjord approach, old town</li>
-          <li><strong>Venice, Italy</strong> — Embark/debark port, St. Mark's Square</li>
+          <li><strong>Piraeus (Athens)</strong> — Acropolis, Parthenon, Plaka district, home port</li>
+          <li><strong>Santorini, Greece</strong> — Caldera views, Oia sunset, tender or cable car</li>
+          <li><strong>Mykonos, Greece</strong> — Windmills, Little Venice, party scene</li>
+          <li><strong>Rhodes, Greece</strong> — Medieval old town, Lindos acropolis</li>
+          <li><strong>Crete (Heraklion)</strong> — Knossos palace, Minoan civilization</li>
+          <li><strong>Corfu, Greece</strong> — Venetian architecture, lush and green</li>
+          <li><strong>Kusadasi, Turkey</strong> — Ephesus ruins, carpet shopping, haggling</li>
+          <li><strong>Istanbul, Turkey</strong> — Hagia Sophia, Blue Mosque, Grand Bazaar</li>
         </ul>
 
-        <p class="tiny">Tip: In the Med, ship-sponsored excursions guarantee you won't be left behind — independent touring requires careful timing.</p>
+        <h3>Adriatic &amp; Croatia</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Dubrovnik, Croatia</strong> — Game of Thrones filming, walk the walls</li>
+          <li><strong>Split, Croatia</strong> — Diocletian's Palace, Adriatic beauty</li>
+          <li><strong>Kotor, Montenegro</strong> — Dramatic fjord approach, medieval old town</li>
+          <li><strong>Venice/Ravenna, Italy</strong> — St. Mark's, canals (ships now use Ravenna)</li>
+          <li><strong>Trieste, Italy</strong> — Coffee culture, Miramare Castle</li>
+          <li><strong>Zadar, Croatia</strong> — Sea Organ, Roman ruins</li>
+        </ul>
+
+        <h3>Other Mediterranean</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Valletta, Malta</strong> — Knights of Malta, honey-colored stone, film location</li>
+          <li><strong>Messina, Sicily</strong> — Taormina, Mt. Etna, Greek theater</li>
+          <li><strong>Catania, Sicily</strong> — Mt. Etna access, baroque architecture</li>
+          <li><strong>Cagliari, Sardinia</strong> — Poetto Beach, flamingos</li>
+          <li><strong>Haifa, Israel</strong> — Holy Land tours, Jerusalem, Tel Aviv</li>
+          <li><strong>Limassol, Cyprus</strong> — Kourion ruins, wine villages</li>
+          <li><strong>Alexandria/Port Said, Egypt</strong> — Pyramids, Cairo day trips</li>
+        </ul>
+
+        <p class="tiny">Tip: Ship-sponsored excursions guarantee return to ship. Independent touring requires careful timing — traffic in Rome/Florence can be brutal.</p>
       </article>
 
       <!-- Northern Europe -->
       <article class="card" id="northern-europe">
         <h2>Northern Europe &amp; Baltic</h2>
-        <p>Summer sailings to Scandinavia, Russia (when accessible), and the British Isles.</p>
+        <p>May through September season. Ships deployed: Anthem of the Seas (Southampton), Jewel of the Seas, Explorer of the Seas. Long summer days mean extended port hours.</p>
 
-        <h3>Scandinavia &amp; Baltic</h3>
-        <ul>
-          <li><strong>Copenhagen, Denmark</strong> — Tivoli Gardens, Little Mermaid, walkable</li>
-          <li><strong>Stockholm, Sweden</strong> — Vasa Museum, archipelago approach</li>
-          <li><strong>Oslo, Norway</strong> — Viking ships, Vigeland sculpture park</li>
-          <li><strong>Bergen, Norway</strong> — Fjord gateway, Bryggen wharf</li>
-          <li><strong>Helsinki, Finland</strong> — Design district, Orthodox cathedral</li>
-          <li><strong>Tallinn, Estonia</strong> — Medieval old town, affordable</li>
-          <li><strong>St. Petersburg, Russia</strong> — Hermitage, visa requirements (check current status)</li>
+        <h3>Scandinavia &amp; Baltic Capitals</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Copenhagen, Denmark</strong> — Tivoli Gardens, Little Mermaid, Nyhavn, home port</li>
+          <li><strong>Stockholm, Sweden</strong> — Vasa Museum, Gamla Stan, archipelago approach</li>
+          <li><strong>Oslo, Norway</strong> — Viking ships, Vigeland Park, Opera House roof</li>
+          <li><strong>Helsinki, Finland</strong> — Design district, Rock Church, Suomenlinna</li>
+          <li><strong>Tallinn, Estonia</strong> — Best-preserved medieval old town, affordable</li>
+          <li><strong>Riga, Latvia</strong> — Art Nouveau architecture, Central Market</li>
+          <li><strong>Gdańsk, Poland</strong> — Amber capital, WWII history, Long Market</li>
+          <li><strong>Warnemünde (Berlin)</strong> — 3-hour transfer to Berlin, beach resort</li>
+          <li><strong>Kiel, Germany</strong> — Canal transit point, maritime museums</li>
         </ul>
 
         <h3>Norwegian Fjords</h3>
-        <ul>
-          <li><strong>Geiranger</strong> — UNESCO fjord, Seven Sisters waterfall</li>
-          <li><strong>Flåm</strong> — Famous railway, Aurlandsfjord</li>
-          <li><strong>Ålesund</strong> — Art Nouveau architecture</li>
-          <li><strong>Stavanger</strong> — Old Stavanger, Pulpit Rock hike</li>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Bergen, Norway</strong> — Gateway to fjords, Bryggen wharf (UNESCO), fish market</li>
+          <li><strong>Geiranger, Norway</strong> — UNESCO fjord, Seven Sisters waterfall, tender port</li>
+          <li><strong>Flåm, Norway</strong> — Flåm Railway (world's steepest), Aurlandsfjord</li>
+          <li><strong>Ålesund, Norway</strong> — Art Nouveau architecture rebuilt after 1904 fire</li>
+          <li><strong>Stavanger, Norway</strong> — Old Stavanger, Pulpit Rock (Preikestolen) hike</li>
+          <li><strong>Olden/Nordfjord</strong> — Briksdal Glacier access</li>
+          <li><strong>Tromsø, Norway</strong> — Arctic gateway, Northern Lights (shoulder season)</li>
+          <li><strong>Honningsvåg (North Cape)</strong> — Northernmost point in Europe accessible by ship</li>
         </ul>
 
         <h3>British Isles</h3>
-        <ul>
-          <li><strong>Southampton, England</strong> — Often embark port, easy London access</li>
-          <li><strong>Edinburgh (Leith/Queensferry)</strong> — Castle, Royal Mile</li>
-          <li><strong>Dublin, Ireland</strong> — Guinness, Temple Bar, friendly locals</li>
-          <li><strong>Belfast, Northern Ireland</strong> — Titanic Museum</li>
-          <li><strong>Reykjavik, Iceland</strong> — Golden Circle, Blue Lagoon</li>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Southampton, England</strong> — Major home port, 90 min to London</li>
+          <li><strong>Edinburgh (Queensferry/Leith)</strong> — Castle, Royal Mile, Arthur's Seat</li>
+          <li><strong>Glasgow (Greenock)</strong> — Loch Lomond, Scottish Highlands</li>
+          <li><strong>Dublin, Ireland</strong> — Guinness Storehouse, Temple Bar, Book of Kells</li>
+          <li><strong>Cork (Cobh), Ireland</strong> — Blarney Castle, Titanic's last port</li>
+          <li><strong>Belfast, Northern Ireland</strong> — Titanic Belfast, Giant's Causeway day trip</li>
+          <li><strong>Liverpool, England</strong> — Beatles history, Albert Dock</li>
+          <li><strong>Portland/Weymouth, England</strong> — Jurassic Coast, tender port</li>
+          <li><strong>Invergordon, Scotland</strong> — Loch Ness day trips, whisky</li>
+          <li><strong>Kirkwall, Orkney</strong> — Neolithic sites, Skara Brae</li>
+          <li><strong>Lerwick, Shetland</strong> — Norse heritage, puffins</li>
         </ul>
+
+        <h3>Iceland &amp; North Atlantic</h3>
+        <ul>
+          <li><strong>Reykjavik, Iceland</strong> — Golden Circle, Blue Lagoon, whale watching</li>
+          <li><strong>Akureyri, Iceland</strong> — Northern capital, Godafoss waterfall, Mývatn</li>
+          <li><strong>Ísafjörður, Iceland</strong> — Westfjords, Arctic fox center</li>
+          <li><strong>Tórshavn, Faroe Islands</strong> — Grass-roofed houses, dramatic cliffs</li>
+        </ul>
+
+        <p class="tiny">Note: St. Petersburg, Russia sailings suspended since 2022. Baltic itineraries now feature more time in Estonia, Latvia, Poland as alternatives.</p>
       </article>
 
-      <!-- Other Regions -->
-      <article class="card" id="other">
-        <h2>Other Regions</h2>
+      <!-- Asia-Pacific -->
+      <article class="card" id="asia-pacific">
+        <h2>Asia-Pacific</h2>
+        <p>Growing market with Spectrum of the Seas (Shanghai) and Quantum of the Seas (Singapore). Year-round sailings in Southeast Asia; seasonal in Japan/China.</p>
 
-        <h3>Hawaii</h3>
-        <p>NCL's Pride of America is the only ship that sails inter-island without repositioning. Others visit Hawaii on longer Pacific crossings.</p>
-        <ul>
-          <li><strong>Honolulu, Oahu</strong> — Waikiki, Pearl Harbor</li>
-          <li><strong>Maui (Kahului/Lahaina)</strong> — Road to Hana, Haleakala</li>
-          <li><strong>Kona, Big Island</strong> — Coffee farms, volcanoes</li>
-          <li><strong>Kauai (Nawiliwili)</strong> — Na Pali Coast, garden isle</li>
+        <h3>Southeast Asia</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Singapore</strong> — Gardens by the Bay, hawker centers, Marina Bay Sands, home port</li>
+          <li><strong>Penang, Malaysia</strong> — George Town (UNESCO), street food capital</li>
+          <li><strong>Langkawi, Malaysia</strong> — Duty-free island, cable car, beaches</li>
+          <li><strong>Kuala Lumpur (Port Klang)</strong> — Petronas Towers, Batu Caves</li>
+          <li><strong>Phuket, Thailand</strong> — Beaches, Phi Phi Islands, Big Buddha</li>
+          <li><strong>Ko Samui, Thailand</strong> — Beach resort island, temples</li>
+          <li><strong>Bangkok (Laem Chabang)</strong> — Grand Palace, temples, 2+ hour transfer</li>
+          <li><strong>Ho Chi Minh City, Vietnam</strong> — War Remnants Museum, Cu Chi Tunnels</li>
+          <li><strong>Nha Trang, Vietnam</strong> — Beach resort, Po Nagar Cham towers</li>
+          <li><strong>Halong Bay, Vietnam</strong> — Limestone karsts (UNESCO), scenic cruising</li>
+          <li><strong>Bali (Benoa), Indonesia</strong> — Temples, rice terraces, Ubud</li>
+          <li><strong>Jakarta, Indonesia</strong> — Historic old town, culture</li>
         </ul>
 
-        <h3>Canada &amp; New England</h3>
-        <p>Fall foliage cruises are popular September–October.</p>
-        <ul>
-          <li><strong>Halifax, Nova Scotia</strong> — Peggy's Cove, maritime history</li>
-          <li><strong>Quebec City</strong> — French Canada, Château Frontenac</li>
-          <li><strong>Bar Harbor, Maine</strong> — Acadia National Park</li>
-          <li><strong>Boston</strong> — Freedom Trail, often embark port</li>
+        <h3>East Asia</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Hong Kong</strong> — Victoria Peak, Star Ferry, dim sum</li>
+          <li><strong>Shanghai, China</strong> — Bund, Yu Garden, Pudong skyline, home port</li>
+          <li><strong>Beijing (Tianjin)</strong> — Great Wall, Forbidden City, 2.5-hour transfer</li>
+          <li><strong>Busan, South Korea</strong> — Jagalchi Market, Gamcheon Culture Village</li>
+          <li><strong>Incheon (Seoul)</strong> — Palaces, DMZ tours, K-culture</li>
+          <li><strong>Jeju Island, Korea</strong> — Volcanic island, waterfalls, women divers</li>
         </ul>
 
-        <h3>Australia &amp; New Zealand</h3>
-        <ul>
-          <li><strong>Sydney</strong> — Opera House, Harbour Bridge</li>
-          <li><strong>Auckland</strong> — City of Sails, Maori culture</li>
-          <li><strong>Milford Sound</strong> — Fiordland scenic cruising</li>
+        <h3>Japan</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Tokyo (Yokohama)</strong> — Shibuya, temples, sushi, anime</li>
+          <li><strong>Kobe, Japan</strong> — Beef, sake, Arima Onsen</li>
+          <li><strong>Osaka, Japan</strong> — Street food, Osaka Castle, Dotonbori</li>
+          <li><strong>Kyoto (via Osaka/Kobe)</strong> — Ancient capital, 1000+ temples</li>
+          <li><strong>Nagasaki, Japan</strong> — Peace Park, Glover Garden</li>
+          <li><strong>Hakodate, Japan</strong> — Night view, morning fish market</li>
+          <li><strong>Okinawa, Japan</strong> — Beaches, aquarium, Shuri Castle</li>
+          <li><strong>Kagoshima, Japan</strong> — Active Sakurajima volcano</li>
+          <li><strong>Hiroshima (Kure)</strong> — Peace Memorial, Miyajima island</li>
         </ul>
 
-        <h3>Asia</h3>
-        <ul>
-          <li><strong>Singapore</strong> — Gardens by the Bay, hawker centers</li>
-          <li><strong>Hong Kong</strong> — Victoria Peak, dim sum</li>
-          <li><strong>Tokyo/Yokohama</strong> — Temples, technology, food</li>
+        <p class="tiny">Deployment note: Spectrum of the Seas is purpose-built for Chinese market with mahjong rooms, Chinese specialty restaurants. Quantum alternates Singapore/Australia seasonally.</p>
+      </article>
+
+      <!-- Australia & New Zealand -->
+      <article class="card" id="australia-nz">
+        <h2>Australia &amp; New Zealand</h2>
+        <p>October through April season (Southern Hemisphere summer). Ships deployed: Ovation of the Seas (Sydney), Quantum of the Seas (seasonal), Radiance of the Seas.</p>
+
+        <h3>Australia</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Sydney</strong> — Opera House, Harbour Bridge, Bondi Beach, home port</li>
+          <li><strong>Melbourne</strong> — Laneways, coffee culture, Great Ocean Road</li>
+          <li><strong>Brisbane</strong> — Gateway to Gold Coast and Australia Zoo</li>
+          <li><strong>Cairns</strong> — Great Barrier Reef, Daintree Rainforest</li>
+          <li><strong>Hobart, Tasmania</strong> — MONA museum, wilderness, history</li>
+          <li><strong>Adelaide</strong> — Wine regions (Barossa, McLaren Vale)</li>
+          <li><strong>Fremantle (Perth)</strong> — Historic port, Rottnest Island quokkas</li>
+          <li><strong>Darwin</strong> — Kakadu gateway, crocodiles, Top End</li>
+          <li><strong>Airlie Beach</strong> — Whitsunday Islands, sailing</li>
+          <li><strong>Port Arthur, Tasmania</strong> — Convict settlement, dark history</li>
         </ul>
+
+        <h3>New Zealand</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Auckland</strong> — City of Sails, Sky Tower, Hobbiton day trip</li>
+          <li><strong>Wellington</strong> — Te Papa museum, windy capital, craft beer</li>
+          <li><strong>Christchurch (Lyttelton)</strong> — Garden city, rebuild after earthquakes</li>
+          <li><strong>Dunedin</strong> — Scottish heritage, albatross colony, Larnach Castle</li>
+          <li><strong>Napier</strong> — Art Deco capital, Hawke's Bay wine</li>
+          <li><strong>Tauranga</strong> — Mount Maunganui, Hobbiton access</li>
+          <li><strong>Rotorua</strong> — Geothermal, Maori culture (via Tauranga)</li>
+          <li><strong>Bay of Islands</strong> — Dolphin cruises, Waitangi Treaty Grounds</li>
+        </ul>
+
+        <h3>Scenic Cruising New Zealand</h3>
+        <ul>
+          <li><strong>Milford Sound</strong> — Fiordland's crown jewel, waterfalls, peaks</li>
+          <li><strong>Doubtful Sound</strong> — Less visited, deeper, wilder</li>
+          <li><strong>Akaroa</strong> — French settlement, Hector's dolphins</li>
+        </ul>
+
+        <p class="tiny">Tip: Ovation of the Seas is the largest ship in Australian waters. Book popular excursions (Hobbiton, Great Barrier Reef) well in advance.</p>
+      </article>
+
+      <!-- South Pacific -->
+      <article class="card" id="south-pacific">
+        <h2>South Pacific &amp; Transpacific</h2>
+        <p>Exotic island destinations and bucket-list crossings. Repositioning cruises between Australia and US West Coast transit these islands.</p>
+
+        <h3>South Pacific Islands</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Fiji (Suva/Lautoka)</strong> — Bula spirit, island-hopping, resorts</li>
+          <li><strong>Bora Bora, French Polynesia</strong> — Lagoon perfection, overwater bungalows</li>
+          <li><strong>Papeete, Tahiti</strong> — French Polynesia capital, black pearls, market</li>
+          <li><strong>Moorea, French Polynesia</strong> — Tahiti's sister island, jaw-dropping beauty</li>
+          <li><strong>Nouméa, New Caledonia</strong> — French culture, lagoons (UNESCO)</li>
+          <li><strong>Vanuatu (Port Vila)</strong> — Active volcano, culture villages, diving</li>
+          <li><strong>Samoa (Apia)</strong> — Polynesian culture, waterfalls</li>
+          <li><strong>Tonga</strong> — Whale swimming (seasonal), ancient kingdom</li>
+        </ul>
+
+        <h3>Transpacific Crossings</h3>
+        <p>Repositioning cruises connecting Australia/New Zealand to Hawaii and US West Coast — typically 14–21 nights.</p>
+        <ul>
+          <li><strong>Multiple sea days</strong> — Perfect for relaxation, enrichment programs</li>
+          <li><strong>Crossing the International Date Line</strong> — Skip a day (westbound) or repeat one (eastbound)</li>
+          <li><strong>Often visits:</strong> Fiji, French Polynesia, American Samoa, or Hawaii en route</li>
+        </ul>
+
+        <p class="tiny">Tip: Transpacific repositioning cruises offer excellent value per night. Pack for varying climates — you'll experience multiple seasons.</p>
+      </article>
+
+      <!-- South America & Antarctica -->
+      <article class="card" id="south-america">
+        <h2>South America &amp; Antarctica</h2>
+        <p>November through March season (Southern Hemisphere summer). Ships deployed: Serenade of the Seas, Vision of the Seas for South America circuits.</p>
+
+        <h3>East Coast South America</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Rio de Janeiro, Brazil</strong> — Christ the Redeemer, Sugarloaf, Copacabana</li>
+          <li><strong>Buenos Aires, Argentina</strong> — Tango, steak, La Boca, Recoleta Cemetery</li>
+          <li><strong>Montevideo, Uruguay</strong> — Old city, rambla waterfront, relaxed pace</li>
+          <li><strong>São Paulo (Santos), Brazil</strong> — Coffee history, metropolis gateway</li>
+          <li><strong>Ilhabela, Brazil</strong> — Island beaches, waterfalls</li>
+          <li><strong>Búzios, Brazil</strong> — Former fishing village, Bardot's playground</li>
+          <li><strong>Punta del Este, Uruguay</strong> — Upscale beach resort, La Mano sculpture</li>
+        </ul>
+
+        <h3>West Coast South America &amp; Patagonia</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Santiago (Valparaíso), Chile</strong> — Hillside funiculars, street art, wine</li>
+          <li><strong>Lima (Callao), Peru</strong> — Ceviche capital, Larco Museum, Miraflores</li>
+          <li><strong>Puerto Montt, Chile</strong> — Lake District gateway, salmon, German heritage</li>
+          <li><strong>Punta Arenas, Chile</strong> — Penguin colonies, Strait of Magellan</li>
+          <li><strong>Ushuaia, Argentina</strong> — "End of the World," Tierra del Fuego, Antarctica gateway</li>
+          <li><strong>Cape Horn</strong> — Scenic cruising (weather permitting), maritime legend</li>
+        </ul>
+
+        <h3>Chilean Fjords (Scenic Cruising)</h3>
+        <ul>
+          <li><strong>Chilean Fjords</strong> — Dramatic scenery comparable to Alaska/Norway</li>
+          <li><strong>Strait of Magellan</strong> — Historic passage between Atlantic and Pacific</li>
+          <li><strong>Glacier Alley</strong> — Multiple glaciers along Beagle Channel</li>
+        </ul>
+
+        <h3>Antarctica</h3>
+        <p>Royal Caribbean offers expedition-style Antarctic cruises from November through February.</p>
+        <ul>
+          <li><strong>Antarctic Peninsula</strong> — Icebergs, penguins, seals, whales</li>
+          <li><strong>Drake Passage</strong> — Notoriously rough crossing from South America</li>
+          <li><strong>South Shetland Islands</strong> — Research stations, wildlife colonies</li>
+        </ul>
+
+        <p class="tiny">Note: Antarctica is bucket-list cruising. Ships must navigate pack ice, landings depend on weather. Zodiac excursions common. Bring warm, waterproof layers.</p>
+      </article>
+
+      <!-- Ultimate World Cruise -->
+      <article class="card" id="world-cruise">
+        <h2>Ultimate World Cruise</h2>
+        <p>Royal Caribbean's 274-night Ultimate World Cruise (2023–2024 on Serenade of the Seas) visited 65 countries, 150 destinations across all seven continents.</p>
+
+        <h3>Notable Ports of Call</h3>
+        <ul style="columns:2;column-gap:2rem;">
+          <li><strong>Antarctica</strong> — Peninsula cruise from Ushuaia</li>
+          <li><strong>Easter Island, Chile</strong> — Moai statues, remote Polynesian culture</li>
+          <li><strong>Pitcairn Island</strong> — Mutiny on the Bounty descendants</li>
+          <li><strong>Aitutaki, Cook Islands</strong> — One of the world's most beautiful lagoons</li>
+          <li><strong>Papua New Guinea</strong> — Tribal culture, WWII history</li>
+          <li><strong>Sri Lanka (Colombo)</strong> — Ancient temples, wildlife, tea plantations</li>
+          <li><strong>Maldives (Malé)</strong> — Overwater paradise, snorkeling</li>
+          <li><strong>Madagascar (Nosy Be)</strong> — Lemurs, unique ecosystems</li>
+          <li><strong>Mauritius</strong> — Beaches, colonial history, rum</li>
+          <li><strong>Seychelles</strong> — Granite islands, giant tortoises</li>
+          <li><strong>Zanzibar, Tanzania</strong> — Spice island, Stone Town</li>
+          <li><strong>Cape Town, South Africa</strong> — Table Mountain, penguins, wine</li>
+          <li><strong>Namibia (Walvis Bay)</strong> — Dunes, desert, wildlife</li>
+          <li><strong>St. Helena</strong> — Napoleon's exile, remote Atlantic</li>
+          <li><strong>Canary Islands</strong> — Spanish archipelago, volcanic landscapes</li>
+        </ul>
+
+        <h3>Voyage Highlights</h3>
+        <ul>
+          <li><strong>Duration:</strong> 9 months circumnavigating Earth</li>
+          <li><strong>Continents:</strong> All seven, including Antarctica</li>
+          <li><strong>Countries:</strong> 65 nations</li>
+          <li><strong>Destinations:</strong> 150+ ports of call</li>
+          <li><strong>Ship:</strong> Serenade of the Seas (Radiance class)</li>
+        </ul>
+
+        <p class="tiny">The Ultimate World Cruise sold out in one day. Future world cruises expected — watch for announcements. Segments bookable separately for those who can't do the full voyage.</p>
       </article>
 
       <!-- What We Cover -->


### PR DESCRIPTION
Transform generic ports page into complete RCL destination guide:
- 300+ destinations across all seven continents
- Private destinations (Perfect Day at CocoCay, Labadee, Royal Beach Clubs)
- Caribbean & Bahamas (Eastern, Western, Southern with deployment info)
- Alaska ports with cruisetour extensions
- Canada/New England fall foliage destinations
- Hawaii transpacific crossings
- Mediterranean (Western, Eastern, Adriatic, Greek Isles)
- Northern Europe & Baltic (Scandinavia, Norwegian Fjords, British Isles, Iceland)
- Asia-Pacific (Southeast Asia, East Asia, Japan)
- Australia & New Zealand with scenic cruising
- South Pacific & Transpacific crossings
- South America & Antarctica expeditions
- Ultimate World Cruise highlights (274-night voyage)

Updated SEO metadata, ICP-Lite quick answer, and key facts to reflect comprehensive RCL port coverage with 2023-2027 deployment information.