### PR TITLE
ADD: Asia-Pacific port pages (Singapore, Sydney, Brisbane)

### DIFF
--- a/ports/brisbane.html
+++ b/ports/brisbane.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Brisbane Cruise Port Guide – In the Wake</title>
+  <meta name="description" content="First-person guide to Brisbane cruise port: South Bank beach, Lone Pine Koala Sanctuary, CityCat ferry, and why it's Australia's most relaxed port." />
+  <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="/assets/css/common.css" />
+  <link rel="stylesheet" href="/assets/css/articles.css" />
+  <style>
+    .poignant-highlight{background:linear-gradient(135deg,#f8f4e9 60%,#e6f0e8 100%);border-left:5px solid #2a9d8f;padding:1.5rem 1.75rem;margin:2rem 0;border-radius:10px;font-size:1.08rem;line-height:1.75}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://inthewake.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Ports", "item": "https://inthewake.io/ports.html" },
+      { "@type": "ListItem", "position": 3, "name": "Brisbane" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="/" class="logo" aria-label="In the Wake home"><strong>In the Wake</strong></a>
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" />
+      <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+      <ul class="nav-links">
+        <li><a href="/ships.html">Ships</a></li>
+        <li><a href="/cruise-lines.html">Cruise Lines</a></li>
+        <li><a href="/ports.html">Ports</a></li>
+        <li><a href="/planning.html">Planning</a></li>
+        <li><a href="/news.html">News</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/search.html" aria-label="Search"><img src="/assets/images/search.svg" alt="Search" style="width:20px;vertical-align:middle;" /></a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="article-container">
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/">Home</a> &rsaquo;
+      <a href="/ports.html">Ports</a> &rsaquo;
+      <span aria-current="page">Brisbane</span>
+    </nav>
+
+    <article>
+      <header class="article-header">
+        <h1>Brisbane Cruise Port Guide</h1>
+        <p class="subtitle">My Relaxed River City Surprise</p>
+      </header>
+
+      <!-- Quick Answer -->
+      <section class="quick-answer" style="background:#e6f7f5;border-left:5px solid #2a9d8f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>Quick&nbsp;Answer:</strong> Brisbane scores 4.8 stars with its warm, sunny, laid-back vibe. Must-dos: South Bank Streets Beach, CityCat ferry ride, Lone Pine Koala Sanctuary (cuddle koalas!), and sunset at Mount Coot-tha lookout.</p>
+      </section>
+
+      <!-- Logbook Entry -->
+      <section>
+        <h2>My Brisbane Day – A First-Person Account</h2>
+        <p>Brisbane has become a regular on South Pacific and repositioning cruises, and I adore its warm, sunny, laid-back vibe – 4.8 average lately.</p>
+
+        <p>My perfect day: off the ship at Portside and straight to South Bank for the man-made Streets Beach lagoon, the Wheel of Brisbane, and the epic Epicurious garden. Then a CityCat ferry up the river (best $5 you'll ever spend), Lone Pine Koala Sanctuary to cuddle koalas and hand-feed kangaroos, and Mount Coot-tha lookout at sunset.</p>
+
+        <div class="poignant-highlight">
+          <strong>The moment that stays with me:</strong> Holding a sleepy koala at Lone Pine while kangaroos hop lazily around my feet – Brisbane doesn't try to impress you with grand monuments, it just hands you a furry friend and lets the sunshine do the rest.
+        </div>
+
+        <p>XXXX Brewery tour and a steak at Breakfast Creek Hotel are classics. The subtropical warmth wraps around you like a hug, and Queenslanders are genuinely some of the friendliest people I've met anywhere in the world.</p>
+      </section>
+
+      <!-- Navigation -->
+      <section>
+        <h2>Getting Around</h2>
+        <p>The new <strong>Brisbane International Cruise Terminal</strong> sits at the river mouth – 20–30 minutes by shuttle or taxi to city center. The CityCat ferry system is cheap, scenic, and connects all the major attractions along the river.</p>
+      </section>
+
+      <!-- Word of Warning -->
+      <section style="background:#fef9e7;border-left:5px solid #f4d03f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>A Positively Worded Word of Warning:</strong> The subtropical warmth and friendly Queenslander smiles are contagious – slow down, grab a cold one, and let Brisbane's easy pace give you the most relaxed day of your cruise.</p>
+      </section>
+
+      <!-- FAQ -->
+      <section>
+        <h2>Frequently Asked Questions</h2>
+        <details><summary>Can I actually hold a koala at Lone Pine?</summary><p>Yes! Queensland is one of the few Australian states where you can cuddle koalas. Book your koala photo early in the day as slots fill up. Hand-feeding kangaroos is included with admission.</p></details>
+        <details><summary>Is South Bank Streets Beach actually nice?</summary><p>It's surprisingly great – a clean, free, man-made lagoon with lifeguards, surrounded by restaurants and parkland. Perfect for families or just cooling off.</p></details>
+        <details><summary>How do I get to Lone Pine Koala Sanctuary?</summary><p>Take a taxi/Uber (25–30 minutes, $40–50) or the scenic Mirimar cruise boat from South Bank. The boat ride adds to the experience.</p></details>
+      </section>
+
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 In the Wake. All rights reserved.</p>
+    <p><a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a></p>
+  </footer>
+
+  <script src="/assets/js/common.js"></script>
+</body>
+</html>

--- a/ports/singapore.html
+++ b/ports/singapore.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Singapore Cruise Port Guide – In the Wake</title>
+  <meta name="description" content="First-person guide to Singapore cruise port: Gardens by the Bay, Marina Bay Sands, hawker centers, and why it's Asia's top-rated port." />
+  <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="/assets/css/common.css" />
+  <link rel="stylesheet" href="/assets/css/articles.css" />
+  <style>
+    .poignant-highlight{background:linear-gradient(135deg,#f8f4e9 60%,#e6f0e8 100%);border-left:5px solid #2a9d8f;padding:1.5rem 1.75rem;margin:2rem 0;border-radius:10px;font-size:1.08rem;line-height:1.75}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://inthewake.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Ports", "item": "https://inthewake.io/ports.html" },
+      { "@type": "ListItem", "position": 3, "name": "Singapore" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="/" class="logo" aria-label="In the Wake home"><strong>In the Wake</strong></a>
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" />
+      <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+      <ul class="nav-links">
+        <li><a href="/ships.html">Ships</a></li>
+        <li><a href="/cruise-lines.html">Cruise Lines</a></li>
+        <li><a href="/ports.html">Ports</a></li>
+        <li><a href="/planning.html">Planning</a></li>
+        <li><a href="/news.html">News</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/search.html" aria-label="Search"><img src="/assets/images/search.svg" alt="Search" style="width:20px;vertical-align:middle;" /></a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="article-container">
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/">Home</a> &rsaquo;
+      <a href="/ports.html">Ports</a> &rsaquo;
+      <span aria-current="page">Singapore</span>
+    </nav>
+
+    <article>
+      <header class="article-header">
+        <h1>Singapore Cruise Port Guide</h1>
+        <p class="subtitle">My Futuristic Garden City That Blows My Mind Every Time</p>
+      </header>
+
+      <!-- Quick Answer -->
+      <section class="quick-answer" style="background:#e6f7f5;border-left:5px solid #2a9d8f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>Quick&nbsp;Answer:</strong> Singapore consistently ranks #1 or #2 in Asia-Pacific for Royal Caribbean passengers (4.9–5.0 stars). Must-dos: Gardens by the Bay Cloud Forest, chili crab at Jumbo Seafood, and the Marina Bay Sands light show. The MRT is spotless, cheap, and gets you everywhere.</p>
+      </section>
+
+      <!-- Logbook Entry -->
+      <section>
+        <h2>My Singapore Day – A First-Person Account</h2>
+        <p>Every single time our Royal Caribbean ship sails through the Strait of Singapore at dawn and the skyline of Marina Bay Sands, the Supertrees, and that incredible skyline appear like something out of a sci-fi movie, I actually tear up a little. Singapore is consistently ranked the #1 or #2 port in all of Asia-Pacific by Royal passengers (4.9–5.0 average 2023–2025), and I get it completely.</p>
+
+        <p>My perfect day starts the second we dock: I'm off the ship and on the MRT (spotless, cheap, air-conditioned) straight to Gardens by the Bay for the first entry into the Cloud Forest dome – that 35-meter indoor waterfall and mist-shrouded mountain take my breath away every single time. Then the Flower Dome, the Supertree Grove light show at night, and the OCBC Skyway for panoramic views.</p>
+
+        <div class="poignant-highlight">
+          <strong>The moment that stays with me:</strong> Standing on the OCBC Skyway at sunset, watching the Supertrees light up one by one while the Marina Bay Sands laser show starts across the water – Singapore feels like the future we were all promised, and somehow it's even better than I imagined.
+        </div>
+
+        <p>Lunch is always chili crab and black pepper crab at Jumbo Seafood or No Signboard on the East Coast – messy, expensive, and the best seafood I've ever had. Afternoon options: Sentosa Island (Universal Studios, S.E.A. Aquarium, or just the beaches), the Singapore Zoo Night Safari (feed hyenas at 7 p.m.!), or shopping on Orchard Road and Haji Lane's colorful street art.</p>
+
+        <p>I always do the Singapore Flyer or a bumboat ride on the river at sunset to see the Merlion and the laser show at Marina Bay. Hawker centers like Lau Pa Sat for satay and laksa are non-negotiable. Singapore is clean, safe, green, and mind-blowingly efficient – it feels like the future we were all promised.</p>
+      </section>
+
+      <!-- Navigation -->
+      <section>
+        <h2>Getting Around</h2>
+        <p><strong>Spectrum</strong> and <strong>Icon of the Seas</strong> dock at the brand-new Marina Bay Cruise Centre (5–10 minutes by taxi to Gardens by the Bay, $15–20), while smaller ships sometimes use the older HarbourFront – both have direct MRT stations underneath. Grab rides are cheap and instant.</p>
+      </section>
+
+      <!-- Word of Warning -->
+      <section style="background:#fef9e7;border-left:5px solid #f4d03f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>A Positively Worded Word of Warning:</strong> The famous Singapore rules and efficiency are simply the city's way of giving you the smoothest, safest, most hassle-free day imaginable – embrace the order and you'll have time for three perfect activities instead of one.</p>
+      </section>
+
+      <!-- FAQ -->
+      <section>
+        <h2>Frequently Asked Questions</h2>
+        <details><summary>What's the best way to get from the cruise terminal to Gardens by the Bay?</summary><p>Take the MRT from the station directly beneath the Marina Bay Cruise Centre – it's spotless, air-conditioned, and costs just a few dollars. Or grab a taxi/Grab for $15–20 (5–10 minutes).</p></details>
+        <details><summary>Is the chili crab worth the price?</summary><p>Absolutely. Jumbo Seafood and No Signboard are famous for a reason – messy, expensive ($60–80 for two), but genuinely the best seafood experience in Asia.</p></details>
+        <details><summary>Can I do both Gardens by the Bay and Sentosa in one day?</summary><p>Yes, but it's rushed. I recommend picking one for a relaxed experience. Gardens in the morning, then hawker centers and Marina Bay at night is my perfect Singapore day.</p></details>
+      </section>
+
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 In the Wake. All rights reserved.</p>
+    <p><a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a></p>
+  </footer>
+
+  <script src="/assets/js/common.js"></script>
+</body>
+</html>

--- a/ports/sydney.html
+++ b/ports/sydney.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sydney Cruise Port Guide – In the Wake</title>
+  <meta name="description" content="First-person guide to Sydney cruise port: Opera House, Harbour Bridge, Bondi Beach, and why it's Australia's highest-rated port." />
+  <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="/assets/css/common.css" />
+  <link rel="stylesheet" href="/assets/css/articles.css" />
+  <style>
+    .poignant-highlight{background:linear-gradient(135deg,#f8f4e9 60%,#e6f0e8 100%);border-left:5px solid #2a9d8f;padding:1.5rem 1.75rem;margin:2rem 0;border-radius:10px;font-size:1.08rem;line-height:1.75}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://inthewake.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Ports", "item": "https://inthewake.io/ports.html" },
+      { "@type": "ListItem", "position": 3, "name": "Sydney" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="/" class="logo" aria-label="In the Wake home"><strong>In the Wake</strong></a>
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" />
+      <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+      <ul class="nav-links">
+        <li><a href="/ships.html">Ships</a></li>
+        <li><a href="/cruise-lines.html">Cruise Lines</a></li>
+        <li><a href="/ports.html">Ports</a></li>
+        <li><a href="/planning.html">Planning</a></li>
+        <li><a href="/news.html">News</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/search.html" aria-label="Search"><img src="/assets/images/search.svg" alt="Search" style="width:20px;vertical-align:middle;" /></a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="article-container">
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/">Home</a> &rsaquo;
+      <a href="/ports.html">Ports</a> &rsaquo;
+      <span aria-current="page">Sydney</span>
+    </nav>
+
+    <article>
+      <header class="article-header">
+        <h1>Sydney Cruise Port Guide</h1>
+        <p class="subtitle">My Harbour City That Feels Like Home</p>
+      </header>
+
+      <!-- Quick Answer -->
+      <section class="quick-answer" style="background:#e6f7f5;border-left:5px solid #2a9d8f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>Quick&nbsp;Answer:</strong> Sydney is Australia's highest-rated port (4.9–5.0 stars) with the most spectacular harbour entrance on earth. Must-dos: Opera House tour, Manly Ferry, Bondi-to-Bronte coastal walk, and sunset drinks at Opera Bar.</p>
+      </section>
+
+      <!-- Logbook Entry -->
+      <section>
+        <h2>My Sydney Day – A First-Person Account</h2>
+        <p>Sailing under the Sydney Harbour Bridge at sunrise with the Opera House glowing pink is one of cruising's all-time greatest moments – hands down the most spectacular port entrance on earth. Sydney is the highest-rated Australian port (4.9–5.0 stars).</p>
+
+        <p>My perfect day: off the ship at Circular Quay or White Bay and straight onto the first ferry to Manly for the beach and that iconic harbour crossing. Then the Opera House guided tour (book ahead), climbing the Harbour Bridge if I'm feeling brave, Bondi Beach for the coastal walk to Bronte (best views ever), and lunch at Icebergs or just fish & chips on the sand.</p>
+
+        <div class="poignant-highlight">
+          <strong>The moment that stays with me:</strong> Sailing under the Harbour Bridge at dawn, watching the Opera House sails turn from grey to pink to gold as the sun rises – in that moment, Sydney isn't just a port, it's a promise that some places really are as beautiful as the postcards say.
+        </div>
+
+        <p>Afternoon in The Rocks for history and pubs, Darling Harbour for the aquarium and fireworks if it's Saturday. Sunset drinks at Opera Bar with the bridge and sails right there is perfection.</p>
+      </section>
+
+      <!-- Navigation -->
+      <section>
+        <h2>Getting Around</h2>
+        <p><strong>Ovation</strong> and <strong>Quantum</strong> dock at Circular Quay (step off and you're at the Opera House) or White Bay (15-minute shuttle or ferry). Everything is walkable or quick ferry.</p>
+      </section>
+
+      <!-- Word of Warning -->
+      <section style="background:#fef9e7;border-left:5px solid #f4d03f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>A Positively Worded Word of Warning:</strong> The jaw-dropping views from every angle are Sydney's gift – let the sunshine and laid-back Aussie vibe turn every moment into a postcard you're living inside.</p>
+      </section>
+
+      <!-- FAQ -->
+      <section>
+        <h2>Frequently Asked Questions</h2>
+        <details><summary>Should I book the Opera House tour in advance?</summary><p>Yes, definitely book ahead – tours fill up quickly on cruise ship days. The guided tour is worth it to see backstage and learn the incredible construction story.</p></details>
+        <details><summary>Is the Harbour Bridge climb worth it?</summary><p>If you're not afraid of heights and have the budget ($150–300+), it's unforgettable. The views are spectacular and you get a great photo at the top.</p></details>
+        <details><summary>How do I get to Bondi Beach from the cruise terminal?</summary><p>From Circular Quay, take a bus (30–40 minutes) or taxi/Uber ($30–40). The Bondi to Bronte coastal walk is free and absolutely stunning.</p></details>
+      </section>
+
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 In the Wake. All rights reserved.</p>
+    <p><a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a></p>
+  </footer>
+
+  <script src="/assets/js/common.js"></script>
+</body>
+</html>


### PR DESCRIPTION
First-person logbook guides with ICP-Lite compliance for Singapore (Gardens by the Bay, Marina Bay), Sydney (Opera House, Harbour Bridge), and Brisbane (South Bank, Lone Pine Koala Sanctuary).