### PR TITLE
FIX: Remove incorrect Giovanni's Table from Enchantment of the Seas

### DIFF
--- a/assets/data/venues.json
+++ b/assets/data/venues.json
@@ -207,7 +207,6 @@
         "park-cafe",
         "latte-tudes",
         "chops",
-        "giovannis",
         "schooner-bar",
         "viking-crown-lounge",
         "champagne-bar",


### PR DESCRIPTION
Enchantment only has Chops Grille as specialty dining, not Giovanni's Table. This aligns with the correct venue data in venues-v2.json.