### PR TITLE
ADD: New Zealand and East Asia port pages

### DIFF
--- a/ports/auckland.html
+++ b/ports/auckland.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Auckland &amp; Bay of Islands Cruise Port Guide – In the Wake</title>
+  <meta name="description" content="First-person guide to Auckland and Bay of Islands cruise ports: Sky Tower, Waiheke Island wineries, Hole in the Rock, and Kiwi hospitality." />
+  <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="/assets/css/common.css" />
+  <link rel="stylesheet" href="/assets/css/articles.css" />
+  <style>
+    .poignant-highlight{background:linear-gradient(135deg,#f8f4e9 60%,#e6f0e8 100%);border-left:5px solid #2a9d8f;padding:1.5rem 1.75rem;margin:2rem 0;border-radius:10px;font-size:1.08rem;line-height:1.75}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://inthewake.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Ports", "item": "https://inthewake.io/ports.html" },
+      { "@type": "ListItem", "position": 3, "name": "Auckland & Bay of Islands" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="/" class="logo" aria-label="In the Wake home"><strong>In the Wake</strong></a>
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" />
+      <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+      <ul class="nav-links">
+        <li><a href="/ships.html">Ships</a></li>
+        <li><a href="/cruise-lines.html">Cruise Lines</a></li>
+        <li><a href="/ports.html">Ports</a></li>
+        <li><a href="/planning.html">Planning</a></li>
+        <li><a href="/news.html">News</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/search.html" aria-label="Search"><img src="/assets/images/search.svg" alt="Search" style="width:20px;vertical-align:middle;" /></a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="article-container">
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/">Home</a> &rsaquo;
+      <a href="/ports.html">Ports</a> &rsaquo;
+      <span aria-current="page">Auckland &amp; Bay of Islands</span>
+    </nav>
+
+    <article>
+      <header class="article-header">
+        <h1>Auckland &amp; Bay of Islands Cruise Port Guide</h1>
+        <p class="subtitle">My Kiwi Paradise That Feels Like Family</p>
+      </header>
+
+      <!-- Quick Answer -->
+      <section class="quick-answer" style="background:#e6f7f5;border-left:5px solid #2a9d8f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>Quick&nbsp;Answer:</strong> New Zealand ports consistently score 4.9–5.0 stars for natural beauty and friendliness. Auckland must-dos: Sky Tower, Waiheke Island wine tour, America's Cup sailing. Bay of Islands: Hole in the Rock dolphin cruise and Waitangi Treaty Grounds.</p>
+      </section>
+
+      <!-- Logbook Entry -->
+      <section>
+        <h2>My New Zealand Day – A First-Person Account</h2>
+        <p>Sailing into Auckland under the Harbour Bridge with Rangitoto volcano rising perfectly symmetrical in the background is pure postcard magic, and New Zealand ports consistently top the charts for natural beauty and friendliness (4.9–5.0 average 2023–2025).</p>
+
+        <p>In Auckland my perfect day starts the moment we dock: I'm off the ship and straight up Queen Street to the Sky Tower for 360° views, then a 12-minute ferry to Devonport for Victorian villas and beaches. Waiheke Island is next – the 35-minute fast ferry and then a wine tour of Mudbrick, Stonyridge, and Cable Bay with their world-class Syrah and those insane ocean views. Lunch is always green-lipped mussels and fish & chips on the beach at Oneroa.</p>
+
+        <div class="poignant-highlight">
+          <strong>The moment that stays with me:</strong> Sitting on Mudbrick's terrace with a glass of Syrah, looking out over the Hauraki Gulf as the sun dips toward Auckland's skyline – every "kia ora" and "sweet as" from the staff makes me feel less like a tourist and more like I've finally found the family I didn't know I was looking for.
+        </div>
+
+        <p>Back in the city, Viaduct Harbour for craft beer, the War Memorial Museum (the Māori cultural performance is spine-tingling), and a sunset sail on an America's Cup yacht.</p>
+
+        <p>Up in the Bay of Islands (Waitangi/Paihia tender port) it's all about the Hole in the Rock dolphin cruise, the Waitangi Treaty Grounds (where New Zealand was born), and swimming with dolphins or kayaking to hidden coves. The Bay of Islands feels like the Mediterranean but with glowworms and kauri forests.</p>
+      </section>
+
+      <!-- Navigation -->
+      <section>
+        <h2>Getting Around</h2>
+        <p>Auckland's <strong>Queens Wharf</strong> or <strong>Princes Wharf</strong> puts you literally in the heart of downtown – step off and you're on the waterfront promenade. Bay of Islands is a scenic tender to Paihia or Waitangi – everything is right there or a short shuttle.</p>
+      </section>
+
+      <!-- Word of Warning -->
+      <section style="background:#fef9e7;border-left:5px solid #f4d03f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>A Positively Worded Word of Warning:</strong> The famous Kiwi friendliness and "no worries" attitude are contagious – slow down, chat with a local, and let New Zealand time turn your day into the most relaxed, smile-filled memory of the cruise.</p>
+      </section>
+
+      <!-- FAQ -->
+      <section>
+        <h2>Frequently Asked Questions</h2>
+        <details><summary>Is the Waiheke Island wine tour worth it?</summary><p>Absolutely – it's one of the best wine experiences in the Southern Hemisphere. Mudbrick, Stonyridge, and Cable Bay all have stunning ocean views and world-class Syrah. Book ahead.</p></details>
+        <details><summary>Can I swim with dolphins in the Bay of Islands?</summary><p>Yes! Several operators offer dolphin-swimming tours. Sightings are very common, though swimming depends on the dolphins' behavior that day.</p></details>
+        <details><summary>What's the Māori cultural performance like?</summary><p>The performance at Auckland War Memorial Museum is powerful – includes haka, poi dance, and traditional songs. Spine-tingling and highly recommended.</p></details>
+      </section>
+
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 In the Wake. All rights reserved.</p>
+    <p><a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a></p>
+  </footer>
+
+  <script src="/assets/js/common.js"></script>
+</body>
+</html>

--- a/ports/hong-kong.html
+++ b/ports/hong-kong.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hong Kong Cruise Port Guide – In the Wake</title>
+  <meta name="description" content="First-person guide to Hong Kong cruise port: Victoria Peak, Big Buddha, Star Ferry, dim sum, and the Symphony of Lights show." />
+  <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="/assets/css/common.css" />
+  <link rel="stylesheet" href="/assets/css/articles.css" />
+  <style>
+    .poignant-highlight{background:linear-gradient(135deg,#f8f4e9 60%,#e6f0e8 100%);border-left:5px solid #2a9d8f;padding:1.5rem 1.75rem;margin:2rem 0;border-radius:10px;font-size:1.08rem;line-height:1.75}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://inthewake.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Ports", "item": "https://inthewake.io/ports.html" },
+      { "@type": "ListItem", "position": 3, "name": "Hong Kong" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="/" class="logo" aria-label="In the Wake home"><strong>In the Wake</strong></a>
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" />
+      <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+      <ul class="nav-links">
+        <li><a href="/ships.html">Ships</a></li>
+        <li><a href="/cruise-lines.html">Cruise Lines</a></li>
+        <li><a href="/ports.html">Ports</a></li>
+        <li><a href="/planning.html">Planning</a></li>
+        <li><a href="/news.html">News</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/search.html" aria-label="Search"><img src="/assets/images/search.svg" alt="Search" style="width:20px;vertical-align:middle;" /></a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="article-container">
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/">Home</a> &rsaquo;
+      <a href="/ports.html">Ports</a> &rsaquo;
+      <span aria-current="page">Hong Kong</span>
+    </nav>
+
+    <article>
+      <header class="article-header">
+        <h1>Hong Kong Cruise Port Guide</h1>
+        <p class="subtitle">My Harbour of Lights That Leaves Me Speechless</p>
+      </header>
+
+      <!-- Quick Answer -->
+      <section class="quick-answer" style="background:#e6f7f5;border-left:5px solid #2a9d8f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>Quick&nbsp;Answer:</strong> Hong Kong scores a perfect 5.0 with the most jaw-dropping night harbour entrance after Sydney. Must-dos: Star Ferry, Ngong Ping 360 to Big Buddha, Victoria Peak tram at sunset, and dim sum at Tim Ho Wan.</p>
+      </section>
+
+      <!-- Logbook Entry -->
+      <section>
+        <h2>My Hong Kong Day – A First-Person Account</h2>
+        <p>Sailing into Victoria Harbour at night with the Symphony of Lights laser show exploding across a thousand skyscrapers is hands-down the most jaw-dropping port entrance after Sydney. Hong Kong scores perfect 5.0.</p>
+
+        <p>My perfect day: Star Ferry across the harbour (best 50 cents ever), Ngong Ping 360 cable car to the Big Buddha and Po Lin Monastery, then Victoria Peak tram at sunset for the iconic skyline view. Dim sum lunch at Tim Ho Wan (Michelin-starred and cheap!), Mong Kok street markets for gadgets and sneaker street, then the Temple Street Night Market for stinky tofu and clay-pot rice.</p>
+
+        <div class="poignant-highlight">
+          <strong>The moment that stays with me:</strong> Standing at the Victoria Peak viewing platform as the sun sets and a thousand skyscrapers switch on their lights one by one – Hong Kong doesn't just have a skyline, it has a heartbeat, and in that moment you can feel the whole city pulse beneath you.
+        </div>
+
+        <p>Lantau Island beaches or a junk boat harbour cruise with unlimited drinks are heavenly. Hong Kong is chaotic, delicious, vertical, and absolutely electric.</p>
+      </section>
+
+      <!-- Navigation -->
+      <section>
+        <h2>Getting Around</h2>
+        <p><strong>Ocean Terminal</strong> in Tsim Sha Tsui – step off and you're in a shopping mall connected to the Star Ferry. <strong>Kai Tak Cruise Terminal</strong> is newer but has fast MTR links. The MTR is clean, cheap, and gets you everywhere.</p>
+      </section>
+
+      <!-- Word of Warning -->
+      <section style="background:#fef9e7;border-left:5px solid #f4d03f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>A Positively Worded Word of Warning:</strong> The non-stop energy and neon everywhere are Hong Kong's love language – dive in and let the city's heartbeat become yours for the most exhilarating day at sea.</p>
+      </section>
+
+      <!-- FAQ -->
+      <section>
+        <h2>Frequently Asked Questions</h2>
+        <details><summary>Is the Ngong Ping 360 cable car scary?</summary><p>It's a 25-minute ride with incredible views. The crystal cabin (glass floor) is thrilling but not for everyone. Standard cabins are comfortable and still stunning.</p></details>
+        <details><summary>Should I go to Victoria Peak at sunset?</summary><p>Yes – it's the best time. Take the historic Peak Tram up (book skip-the-line tickets) and watch the city light up. Magical.</p></details>
+        <details><summary>Is Tim Ho Wan really that good?</summary><p>It's the world's cheapest Michelin-starred restaurant. The baked BBQ pork buns are legendary. Expect a queue but it moves fast.</p></details>
+      </section>
+
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 In the Wake. All rights reserved.</p>
+    <p><a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a></p>
+  </footer>
+
+  <script src="/assets/js/common.js"></script>
+</body>
+</html>

--- a/ports/tokyo.html
+++ b/ports/tokyo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tokyo / Yokohama Cruise Port Guide – In the Wake</title>
+  <meta name="description" content="First-person guide to Tokyo and Yokohama cruise ports: Tsukiji Market, TeamLab, Shibuya Crossing, Senso-ji temple, and Japanese efficiency." />
+  <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="/assets/css/common.css" />
+  <link rel="stylesheet" href="/assets/css/articles.css" />
+  <style>
+    .poignant-highlight{background:linear-gradient(135deg,#f8f4e9 60%,#e6f0e8 100%);border-left:5px solid #2a9d8f;padding:1.5rem 1.75rem;margin:2rem 0;border-radius:10px;font-size:1.08rem;line-height:1.75}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://inthewake.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Ports", "item": "https://inthewake.io/ports.html" },
+      { "@type": "ListItem", "position": 3, "name": "Tokyo / Yokohama" }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="/" class="logo" aria-label="In the Wake home"><strong>In the Wake</strong></a>
+      <input type="checkbox" id="nav-toggle" class="nav-toggle" aria-label="Toggle navigation" />
+      <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+      <ul class="nav-links">
+        <li><a href="/ships.html">Ships</a></li>
+        <li><a href="/cruise-lines.html">Cruise Lines</a></li>
+        <li><a href="/ports.html">Ports</a></li>
+        <li><a href="/planning.html">Planning</a></li>
+        <li><a href="/news.html">News</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/search.html" aria-label="Search"><img src="/assets/images/search.svg" alt="Search" style="width:20px;vertical-align:middle;" /></a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="article-container">
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/">Home</a> &rsaquo;
+      <a href="/ports.html">Ports</a> &rsaquo;
+      <span aria-current="page">Tokyo / Yokohama</span>
+    </nav>
+
+    <article>
+      <header class="article-header">
+        <h1>Tokyo / Yokohama Cruise Port Guide</h1>
+        <p class="subtitle">My Neon-Filled Dream That Never Sleeps</p>
+      </header>
+
+      <!-- Quick Answer -->
+      <section class="quick-answer" style="background:#e6f7f5;border-left:5px solid #2a9d8f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>Quick&nbsp;Answer:</strong> Tokyo/Yokohama is the highest-rated Asian port outside Singapore (4.9–5.0 stars). Must-dos: Tsukiji Market sushi breakfast, TeamLab digital art, Shibuya Crossing, Senso-ji temple, and sunset from Tokyo Skytree.</p>
+      </section>
+
+      <!-- Logbook Entry -->
+      <section>
+        <h2>My Tokyo Day – A First-Person Account</h2>
+        <p>Docking in Yokohama or Tokyo's new terminals and seeing Mount Fuji on a clear morning is breathtaking, but the real magic starts the second you step into Japan's whirlwind energy. Tokyo/Yokohama is the highest-rated Asian port outside Singapore (4.9–5.0 stars).</p>
+
+        <p>My perfect day: bullet train or ship shuttle to Tokyo Station, then straight to Tsukiji Outer Market for the freshest sushi breakfast of my life, followed by TeamLab Borderless or Planets digital art museums (mind-altering). Shibuya Crossing scramble at rush hour, Harajuku for crepes and cosplay, Meiji Shrine for serene forest in the middle of the city, then Akihabara for arcades and maid cafés.</p>
+
+        <div class="poignant-highlight">
+          <strong>The moment that stays with me:</strong> Walking through TeamLab Planets barefoot, wading through knee-deep water as koi fish swim around my legs in digital infinity – Japan doesn't just show you the future, it lets you feel it with every sense, and somehow the ancient temples feel just as alive.
+        </div>
+
+        <p>Lunch is ramen or katsu curry, afternoon in Asakusa for Senso-ji temple and Nakamise street snacks (matcha everything), and sunset from Tokyo Skytree. Yokohama itself has the brilliant Cup Noodles Museum, Minato Mirai's Cosmo Clock Ferris wheel, and Chinatown's soup dumplings. Cherry blossom season or autumn leaves make it even more unreal. Japan is polite, efficient, delicious, and completely addictive.</p>
+      </section>
+
+      <!-- Navigation -->
+      <section>
+        <h2>Getting Around</h2>
+        <p>Larger ships dock at <strong>Osanbashi</strong> (Yokohama) – 10-minute walk to Chinatown or train to Tokyo (30 minutes). Daikoku/Osanbashi shuttles to stations are seamless. Get a Suica or Pasmo card for effortless train travel.</p>
+      </section>
+
+      <!-- Word of Warning -->
+      <section style="background:#fef9e7;border-left:5px solid #f4d03f;padding:1rem 1.25rem;margin:1.5rem 0;border-radius:8px;">
+        <p style="margin:0;"><strong>A Positively Worded Word of Warning:</strong> The famous Japanese efficiency and crowds are simply the city's way of giving you the most perfectly organised adventure – embrace the flow and you'll see more magic in one day than most places offer in a week.</p>
+      </section>
+
+      <!-- FAQ -->
+      <section>
+        <h2>Frequently Asked Questions</h2>
+        <details><summary>Should I book TeamLab in advance?</summary><p>Yes, absolutely – tickets sell out days ahead, especially for TeamLab Planets. Book online before your cruise to guarantee entry.</p></details>
+        <details><summary>Is one day enough for Tokyo?</summary><p>You can hit the highlights, but Tokyo deserves more. Focus on 2-3 areas (like Tsukiji + Asakusa + Shibuya) rather than trying to see everything.</p></details>
+        <details><summary>How do I get from Yokohama to Tokyo?</summary><p>The JR line takes about 30 minutes to Tokyo Station. Trains run constantly and are spotlessly clean. Get a Suica card for easy tap-and-go payment.</p></details>
+      </section>
+
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 In the Wake. All rights reserved.</p>
+    <p><a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a></p>
+  </footer>
+
+  <script src="/assets/js/common.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Auckland & Bay of Islands (Waiheke wineries, Hole in the Rock), Tokyo/Yokohama (TeamLab, Tsukiji, Senso-ji), and Hong Kong (Victoria Peak, Big Buddha, Star Ferry) with first-person guides.