### PR TITLE
FIX: Clean up venues-v2.json data quality issues

### DIFF
--- a/assets/data/venues-v2.json
+++ b/assets/data/venues-v2.json
@@ -1539,7 +1539,12 @@
         "surfside",
         "the-pearl",
         "lost-dunes",
-        "crowns-edge"
+        "crowns-edge",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar",
+        "solarium",
+        "whirlpools"
       ]
     },
     "star-of-the-seas": {
@@ -1555,7 +1560,7 @@
         "el-loco-fresh",
         "chops",
         "giovannis-italian-kitchen",
-        "izumi",
+        "izumi-in-the-park",
         "chefs-table",
         "empire-supper-club",
         "lincoln-park-supper-club",
@@ -1591,7 +1596,13 @@
         "central-park",
         "surfside",
         "suite-enclave",
-        "lost-dunes"
+        "lost-dunes",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar",
+        "solarium",
+        "whirlpools",
+        "thrill-island"
       ]
     },
     "harmony-of-the-seas": {
@@ -1637,7 +1648,7 @@
         "perfect-storm",
         "zip-line",
         "flowrider",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "vitality-spa",
         "arcade",
@@ -1646,7 +1657,10 @@
         "whirlpools",
         "boardwalk",
         "central-park",
-        "royal-promenade"
+        "royal-promenade",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "allure-of-the-seas": {
@@ -1694,7 +1708,7 @@
         "perfect-storm",
         "zip-line",
         "flowrider",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "vitality-spa",
         "arcade",
@@ -1703,7 +1717,10 @@
         "whirlpools",
         "boardwalk",
         "central-park",
-        "royal-promenade"
+        "royal-promenade",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "oasis-of-the-seas": {
@@ -1747,7 +1764,7 @@
         "perfect-storm",
         "zip-line",
         "flowrider",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "vitality-spa",
         "arcade",
@@ -1756,7 +1773,10 @@
         "whirlpools",
         "boardwalk",
         "central-park",
-        "royal-promenade"
+        "royal-promenade",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "anthem-of-the-seas": {
@@ -1793,12 +1813,15 @@
         "flowrider",
         "ripcord",
         "north-star",
-        "rock-climbing",
+        "rock-climbing-wall",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
         "whirlpools",
-        "splashaway-bay"
+        "splashaway-bay",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "quantum-of-the-seas": {
@@ -1834,12 +1857,15 @@
         "flowrider",
         "ripcord",
         "north-star",
-        "rock-climbing",
+        "rock-climbing-wall",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
         "whirlpools",
-        "splashaway-bay"
+        "splashaway-bay",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "freedom-of-the-seas": {
@@ -1869,12 +1895,15 @@
         "studio-b",
         "flowrider",
         "perfect-storm",
-        "rock-climbing",
+        "rock-climbing-wall",
         "freedom-fairways",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
-        "whirlpools"
+        "whirlpools",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "independence-of-the-seas": {
@@ -1905,12 +1934,15 @@
         "studio-b",
         "flowrider",
         "perfect-storm",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
-        "whirlpools"
+        "whirlpools",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "liberty-of-the-seas": {
@@ -1940,12 +1972,15 @@
         "studio-b",
         "flowrider",
         "perfect-storm",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
-        "whirlpools"
+        "whirlpools",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "navigator-of-the-seas": {
@@ -1978,12 +2013,15 @@
         "studio-b",
         "flowrider",
         "perfect-storm",
-        "rock-climbing",
+        "rock-climbing-wall",
         "navigator-dunes",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
-        "whirlpools"
+        "whirlpools",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "mariner-of-the-seas": {
@@ -2017,12 +2055,15 @@
         "studio-b",
         "flowrider",
         "perfect-storm",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
-        "whirlpools"
+        "whirlpools",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "explorer-of-the-seas": {
@@ -2050,12 +2091,15 @@
         "royal-theater",
         "studio-b",
         "flowrider",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
-        "whirlpools"
+        "whirlpools",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "adventure-of-the-seas": {
@@ -2086,12 +2130,14 @@
         "royal-theater",
         "studio-b",
         "flowrider",
-        "rock-climbing",
+        "rock-climbing-wall",
         "adventure-dunes",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
-        "whirlpools"
+        "whirlpools",
+        "room-service",
+        "latte-tudes"
       ]
     },
     "voyager-of-the-seas": {
@@ -2122,12 +2168,15 @@
         "la-scala-theatre",
         "studio-b",
         "flowrider",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
-        "whirlpools"
+        "whirlpools",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "serenade-of-the-seas": {
@@ -2138,7 +2187,7 @@
         "reflections-dining-room",
         "windjammer",
         "park-cafe",
-        "cafe-latte-tudes",
+        "latte-tudes",
         "izumi",
         "chops",
         "giovannis",
@@ -2158,14 +2207,16 @@
         "vintages",
         "tropical-theater",
         "casino-royale",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "vitality-spa",
         "arcade",
         "adventure-ocean",
         "solarium",
         "whirlpools",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "champagne-bar"
       ]
     },
     "jewel-of-the-seas": {
@@ -2176,7 +2227,7 @@
         "tides-dining-room",
         "windjammer",
         "solarium-cafe",
-        "cafe-latte-tudes",
+        "latte-tudes",
         "izumi",
         "chops",
         "giovannis",
@@ -2189,14 +2240,16 @@
         "vintages",
         "royal-theater",
         "casino-royale",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "vitality-spa",
         "arcade",
         "adventure-ocean",
         "solarium",
         "whirlpools",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "champagne-bar"
       ]
     },
     "brilliance-of-the-seas": {
@@ -2207,7 +2260,7 @@
         "minstrel-dining-room",
         "windjammer",
         "park-cafe",
-        "cafe-latte-tudes",
+        "latte-tudes",
         "izumi",
         "chops",
         "giovannis",
@@ -2224,14 +2277,15 @@
         "vintages",
         "pacifica-theater",
         "casino-royale",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "vitality-spa",
         "arcade",
         "adventure-ocean",
         "solarium",
         "whirlpools",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service"
       ]
     },
     "radiance-of-the-seas": {
@@ -2242,7 +2296,7 @@
         "cascades-dining-room",
         "windjammer",
         "park-cafe",
-        "cafe-latte-tudes",
+        "latte-tudes",
         "dog-house",
         "izumi",
         "chops",
@@ -2261,13 +2315,14 @@
         "casino-royale",
         "vintages",
         "aurora-theater",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "vitality-spa",
         "adventure-ocean",
         "solarium",
         "whirlpools",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service"
       ]
     },
     "enchantment-of-the-seas": {
@@ -2278,7 +2333,7 @@
         "my-fair-lady-dining-room",
         "windjammer",
         "park-cafe",
-        "cafe-latte-tudes",
+        "latte-tudes",
         "chops",
         "chefs-table",
         "schooner-bar",
@@ -2291,14 +2346,16 @@
         "viking-crown-lounge",
         "orpheum-theater",
         "casino-royale",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "vitality-spa",
         "adventure-ocean",
         "solarium",
         "whirlpools",
         "bungee-trampoline",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "champagne-bar"
       ]
     },
     "vision-of-the-seas": {
@@ -2309,7 +2366,7 @@
         "aquarius-dining-room",
         "windjammer",
         "park-cafe",
-        "cafe-latte-tudes",
+        "latte-tudes",
         "izumi",
         "chops",
         "giovannis",
@@ -2324,12 +2381,14 @@
         "vortex",
         "masquerade-theater",
         "casino-royale",
-        "rock-climbing",
+        "rock-climbing-wall",
         "vitality-spa",
         "adventure-ocean",
         "solarium",
         "whirlpools",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "champagne-bar"
       ]
     },
     "rhapsody-of-the-seas": {
@@ -2344,7 +2403,7 @@
         "izumi",
         "chefs-table",
         "park-cafe",
-        "cafe-latte-tudes",
+        "latte-tudes",
         "ben-and-jerrys",
         "r-bar",
         "schooner-bar",
@@ -2354,7 +2413,7 @@
         "solarium-bar",
         "broadway-melodies-theatre",
         "casino-royale",
-        "rock-climbing",
+        "rock-climbing-wall",
         "vitality-spa",
         "arcade",
         "adventure-ocean",
@@ -2362,7 +2421,9 @@
         "whirlpools",
         "golf-simulator",
         "jogging-track",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "champagne-bar"
       ]
     },
     "grandeur-of-the-seas": {
@@ -2376,7 +2437,7 @@
         "giovannis",
         "izumi",
         "chefs-table",
-        "cafe-latte-tudes",
+        "latte-tudes",
         "park-cafe",
         "r-bar",
         "schooner-bar",
@@ -2387,14 +2448,16 @@
         "concierge-lounge",
         "the-palladium",
         "casino-royale",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "vitality-spa",
         "arcade",
         "adventure-ocean",
         "solarium",
         "whirlpools",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "champagne-bar"
       ]
     },
     "utopia-of-the-seas": {
@@ -2411,7 +2474,7 @@
         "sorrentos",
         "cafe-promenade",
         "boardwalk-dog-house",
-        "vitality-cafe",
+        "vitality-spa",
         "johnny-rockets",
         "sugar-beach",
         "sprinkles",
@@ -2448,7 +2511,7 @@
         "perfect-storm",
         "ultimate-abyss",
         "zip-line",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "adventure-ocean",
         "social-100",
@@ -2456,7 +2519,10 @@
         "solarium",
         "whirlpools",
         "splashaway-bay",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "wonder-of-the-seas": {
@@ -2473,7 +2539,7 @@
         "sorrentos",
         "cafe-promenade",
         "boardwalk-dog-house",
-        "vitality-cafe",
+        "vitality-spa",
         "johnny-rockets",
         "sprinkles",
         "izumi",
@@ -2507,7 +2573,7 @@
         "perfect-storm",
         "ultimate-abyss",
         "zip-line",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "adventure-ocean",
         "social-100",
@@ -2515,7 +2581,10 @@
         "solarium",
         "whirlpools",
         "splashaway-bay",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "symphony-of-the-seas": {
@@ -2532,7 +2601,7 @@
         "sorrentos",
         "cafe-promenade",
         "boardwalk-dog-house",
-        "vitality-cafe",
+        "vitality-spa",
         "johnny-rockets",
         "sprinkles",
         "izumi",
@@ -2564,7 +2633,7 @@
         "perfect-storm",
         "ultimate-abyss",
         "zip-line",
-        "rock-climbing",
+        "rock-climbing-wall",
         "mini-golf",
         "laser-tag",
         "adventure-ocean",
@@ -2573,7 +2642,10 @@
         "solarium",
         "whirlpools",
         "splashaway-bay",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "odyssey-of-the-seas": {
@@ -2611,14 +2683,17 @@
         "flowrider",
         "ripcord",
         "north-star",
-        "rock-climbing",
+        "rock-climbing-wall",
         "adventure-ocean",
         "social-100",
         "vitality-spa",
         "solarium",
         "whirlpools",
         "splashaway-bay",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "spectrum-of-the-seas": {
@@ -2654,13 +2729,16 @@
         "ripcord",
         "north-star",
         "seaplex",
-        "rock-climbing",
+        "rock-climbing-wall",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
         "whirlpools",
         "splashaway-bay",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     },
     "ovation-of-the-seas": {
@@ -2697,13 +2775,16 @@
         "ripcord",
         "north-star",
         "seaplex",
-        "rock-climbing",
+        "rock-climbing-wall",
         "adventure-ocean",
         "vitality-spa",
         "solarium",
         "whirlpools",
         "splashaway-bay",
-        "skylight-chapel"
+        "skylight-chapel",
+        "room-service",
+        "latte-tudes",
+        "champagne-bar"
       ]
     }
   }


### PR DESCRIPTION
- Fixed 38 invalid slug references:
  - rock-climbing -> rock-climbing-wall (27 ships)
  - cafe-latte-tudes -> latte-tudes (8 ships)
  - vitality-cafe -> vitality-spa (3 ships)
- Added missing standard amenities to all 29 ships:
  - room-service, latte-tudes, champagne-bar
- Added solarium and whirlpools to Icon Class ships
- Fixed Star-of-the-seas: izumi -> izumi-in-the-park
- Added thrill-island to Star-of-the-seas
- Added aurora-theater to Radiance of the Seas

All venue references now valid. All ships have core entertainment.