### PR TITLE
ADD: Asia-Pacific ports to site-wide search index

### DIFF
--- a/assets/data/search-index.json
+++ b/assets/data/search-index.json
@@ -2655,5 +2655,183 @@
       "reykjavik",
       "british isles"
     ]
+  },
+  {
+    "title": "Singapore",
+    "url": "/ports/singapore.html",
+    "description": "Asia's top-rated cruise port with Gardens by the Bay, Marina Bay Sands, and world-class hawker food.",
+    "cta": "First-person logbook guide to Singapore with tips for Gardens by the Bay and chili crab.",
+    "category": "port",
+    "keywords": [
+      "singapore",
+      "asia",
+      "gardens by the bay",
+      "marina bay sands",
+      "hawker",
+      "chili crab",
+      "sentosa",
+      "supertrees",
+      "southeast asia"
+    ]
+  },
+  {
+    "title": "Sydney, Australia",
+    "url": "/ports/sydney.html",
+    "description": "Australia's highest-rated port with the Opera House, Harbour Bridge, and Bondi Beach.",
+    "cta": "First-person logbook guide to Sydney with tips for the Opera House and harbour experiences.",
+    "category": "port",
+    "keywords": [
+      "sydney",
+      "australia",
+      "opera house",
+      "harbour bridge",
+      "bondi beach",
+      "circular quay",
+      "manly",
+      "down under"
+    ]
+  },
+  {
+    "title": "Brisbane, Australia",
+    "url": "/ports/brisbane.html",
+    "description": "Queensland's relaxed river city with South Bank beach, Lone Pine Koala Sanctuary, and CityCat ferries.",
+    "cta": "First-person logbook guide to Brisbane with tips for koala encounters and South Bank.",
+    "category": "port",
+    "keywords": [
+      "brisbane",
+      "australia",
+      "queensland",
+      "south bank",
+      "lone pine",
+      "koala",
+      "citycat",
+      "mount coot-tha"
+    ]
+  },
+  {
+    "title": "Auckland & Bay of Islands, New Zealand",
+    "url": "/ports/auckland.html",
+    "description": "New Zealand's City of Sails with Sky Tower, Waiheke Island wineries, and Bay of Islands dolphin cruises.",
+    "cta": "First-person logbook guide to Auckland and Bay of Islands with wine and wildlife tips.",
+    "category": "port",
+    "keywords": [
+      "auckland",
+      "new zealand",
+      "bay of islands",
+      "waiheke",
+      "sky tower",
+      "maori",
+      "kiwi",
+      "dolphins",
+      "waitangi"
+    ]
+  },
+  {
+    "title": "Tokyo / Yokohama, Japan",
+    "url": "/ports/tokyo.html",
+    "description": "Japan's dazzling capital with TeamLab digital art, Tsukiji Market sushi, and ancient temples.",
+    "cta": "First-person logbook guide to Tokyo with tips for TeamLab, Shibuya, and Senso-ji.",
+    "category": "port",
+    "keywords": [
+      "tokyo",
+      "yokohama",
+      "japan",
+      "teamlab",
+      "tsukiji",
+      "shibuya",
+      "senso-ji",
+      "sushi",
+      "ramen",
+      "asia"
+    ]
+  },
+  {
+    "title": "Hong Kong",
+    "url": "/ports/hong-kong.html",
+    "description": "Victoria Harbour's stunning skyline with Big Buddha, Victoria Peak, and legendary dim sum.",
+    "cta": "First-person logbook guide to Hong Kong with tips for Peak Tram and dim sum.",
+    "category": "port",
+    "keywords": [
+      "hong kong",
+      "victoria peak",
+      "big buddha",
+      "ngong ping",
+      "star ferry",
+      "dim sum",
+      "symphony of lights",
+      "asia"
+    ]
+  },
+  {
+    "title": "Shanghai, China",
+    "url": "/ports/shanghai.html",
+    "description": "China's futuristic megacity with The Bund, Shanghai Tower, Yu Garden, and xiaolongbao dumplings.",
+    "cta": "First-person logbook guide to Shanghai with tips for The Bund and French Concession.",
+    "category": "port",
+    "keywords": [
+      "shanghai",
+      "china",
+      "the bund",
+      "pudong",
+      "yu garden",
+      "xiaolongbao",
+      "french concession",
+      "asia"
+    ]
+  },
+  {
+    "title": "Bangkok / Laem Chabang, Thailand",
+    "url": "/ports/bangkok.html",
+    "description": "Thailand's chaotic capital with Grand Palace, Wat Arun, legendary street food, and rooftop bars.",
+    "cta": "First-person logbook guide to Bangkok with tips for temples and street food.",
+    "category": "port",
+    "keywords": [
+      "bangkok",
+      "laem chabang",
+      "thailand",
+      "grand palace",
+      "wat arun",
+      "street food",
+      "pad thai",
+      "floating market",
+      "asia"
+    ]
+  },
+  {
+    "title": "Bali / Benoa, Indonesia",
+    "url": "/ports/bali.html",
+    "description": "Indonesia's Island of the Gods with Uluwatu temple, Ubud rice terraces, and Jimbaran beach seafood.",
+    "cta": "First-person logbook guide to Bali with tips for temples, rice terraces, and beach clubs.",
+    "category": "port",
+    "keywords": [
+      "bali",
+      "benoa",
+      "indonesia",
+      "uluwatu",
+      "ubud",
+      "rice terraces",
+      "monkey forest",
+      "jimbaran",
+      "asia"
+    ]
+  },
+  {
+    "title": "South Pacific Islands",
+    "url": "/ports/south-pacific.html",
+    "description": "Paradise islands including Bora Bora, Tahiti, Fiji, Vanuatu, and New Caledonia with turquoise lagoons.",
+    "cta": "First-person logbook guide to South Pacific islands with tips for lagoon tours and kava.",
+    "category": "port",
+    "keywords": [
+      "south pacific",
+      "bora bora",
+      "tahiti",
+      "fiji",
+      "moorea",
+      "vanuatu",
+      "new caledonia",
+      "french polynesia",
+      "lagoon",
+      "overwater"
+    ]
   }
 ]


### PR DESCRIPTION
Singapore, Sydney, Brisbane, Auckland, Tokyo, Hong Kong, Shanghai, Bangkok, Bali, and South Pacific Islands now searchable with keywords and descriptions for site-wide search.