### PR TITLE
UPDATE: Switch site-wide from venues.json to venues-v2.json

### DIFF
--- a/assets/js/rcl.page.js
+++ b/assets/js/rcl.page.js
@@ -79,7 +79,7 @@ function bindSearch(){
   try {
     const [A,B,C]=await Promise.all([
       loadJSON('https://www.cruisinginthewake.com/assets/data/ships.json'),
-      loadJSON('https://www.cruisinginthewake.com/assets/data/venues.json'),
+      loadJSON('https://www.cruisinginthewake.com/assets/data/venues-v2.json'),
       loadJSON('https://www.cruisinginthewake.com/assets/data/experiences.json')
     ]);
     SHIPS=A; VENUES=B; EXPS=C;

--- a/assets/js/venue-boot.js
+++ b/assets/js/venue-boot.js
@@ -9,8 +9,8 @@
 
   // Configuration
   const CONFIG = {
-    version: '2.257',
-    venueDataPath: '/assets/data/venues.json',
+    version: '2.258',
+    venueDataPath: '/assets/data/venues-v2.json',
     shipDataPath: '/assets/data/fleets_index.json'
   };
 

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -1021,7 +1021,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -953,7 +953,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -951,7 +951,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -948,7 +948,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -873,7 +873,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const res=await fetch('/assets/data/venues.json',{cache:'no-store'});
+      const res=await fetch('/assets/data/venues-v2.json',{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();
 

--- a/restaurants/chops.html
+++ b/restaurants/chops.html
@@ -913,7 +913,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const res=await fetch('/assets/data/venues.json',{cache:'no-store'});
+      const res=await fetch('/assets/data/venues-v2.json',{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();
 

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -892,7 +892,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -923,7 +923,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -979,7 +979,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -944,7 +944,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -999,7 +999,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -1014,7 +1014,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL = (location.origin||'').replace(/\/$/,'') + '/assets/data/venues.json';
+      const DATA_URL = (location.origin||'').replace(/\/$/,'') + '/assets/data/venues-v2.json';
       const res = await fetch(DATA_URL, {cache:'no-store'});
       if (!res.ok) throw new Error('HTTP '+res.status);
       const db = await res.json();

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -991,7 +991,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -935,7 +935,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/room-service.html
+++ b/restaurants/room-service.html
@@ -933,7 +933,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const res=await fetch(`${location.origin}/assets/data/venues.json`,{cache:'no-store'});
+      const res=await fetch(`${location.origin}/assets/data/venues-v2.json`,{cache:'no-store'});
       if(!res.ok)throw new Error(res.status);
       const db=await res.json();
       const ships=Object.entries(db.ships||{}).filter(([slug,p])=>{

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -899,7 +899,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const res=await fetch('/assets/data/venues.json',{cache:'no-store'});
+      const res=await fetch('/assets/data/venues-v2.json',{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();
 

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -857,7 +857,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -997,7 +997,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL = (location.origin||'').replace(/\/$/,'') + '/assets/data/venues.json';
+      const DATA_URL = (location.origin||'').replace(/\/$/,'') + '/assets/data/venues-v2.json';
       const res = await fetch(DATA_URL, {cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db = await res.json();

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -974,7 +974,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -916,7 +916,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -888,7 +888,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -1057,7 +1057,7 @@
 
   async function hydrateShipList(listEl){
     try{
-      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues.json';
+      const DATA_URL=(location.origin||'').replace(/\/$/,'')+'/assets/data/venues-v2.json';
       const res=await fetch(DATA_URL,{cache:'no-store'});
       if(!res.ok) throw new Error('HTTP '+res.status);
       const db=await res.json();

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -1002,7 +1002,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"adventure-of-the-seas","aliases":["Adventure of the Seas","Adventure Of The Seas","Adventure"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"adventure-of-the-seas","aliases":["Adventure of the Seas","Adventure Of The Seas","Adventure"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -994,7 +994,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"allure-of-the-seas","aliases":["Allure of the Seas","Allure Of The Seas","Allure"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"allure-of-the-seas","aliases":["Allure of the Seas","Allure Of The Seas","Allure"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -1002,7 +1002,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"anthem-of-the-seas","aliases":["Anthem of the Seas","Anthem Of The Seas","Anthem"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"anthem-of-the-seas","aliases":["Anthem of the Seas","Anthem Of The Seas","Anthem"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -1012,7 +1012,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"brilliance-of-the-seas","aliases":["Brilliance of the Seas","Brilliance Of The Seas","Brilliance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"brilliance-of-the-seas","aliases":["Brilliance of the Seas","Brilliance Of The Seas","Brilliance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -1033,7 +1033,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"enchantment-of-the-seas","aliases":["Enchantment of the Seas","Enchantment Of The Seas","Enchantment"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"enchantment-of-the-seas","aliases":["Enchantment of the Seas","Enchantment Of The Seas","Enchantment"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -993,7 +993,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"explorer-of-the-seas","aliases":["Explorer of the Seas","Explorer Of The Seas","Explorer"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"explorer-of-the-seas","aliases":["Explorer of the Seas","Explorer Of The Seas","Explorer"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -1024,7 +1024,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"freedom-of-the-seas","aliases":["Freedom of the Seas","Freedom Of The Seas","Freedom"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"freedom-of-the-seas","aliases":["Freedom of the Seas","Freedom Of The Seas","Freedom"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -1072,7 +1072,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"grandeur-of-the-seas","aliases":["Grandeur of the Seas","Grandeur Of The Seas","Grandeur"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"grandeur-of-the-seas","aliases":["Grandeur of the Seas","Grandeur Of The Seas","Grandeur"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -1016,7 +1016,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"harmony-of-the-seas","aliases":["Harmony of the Seas","Harmony Of The Seas","Harmony"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"harmony-of-the-seas","aliases":["Harmony of the Seas","Harmony Of The Seas","Harmony"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/icon-class-ship-tbn-2027.html
+++ b/ships/rcl/icon-class-ship-tbn-2027.html
@@ -988,7 +988,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"icon-class-ship-tbn-2027","aliases":["Icon Class Ship (TBN 2027)","Radiance Of The Seas","Radiance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"icon-class-ship-tbn-2027","aliases":["Icon Class Ship (TBN 2027)","Radiance Of The Seas","Radiance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/icon-class-ship-tbn-2028.html
+++ b/ships/rcl/icon-class-ship-tbn-2028.html
@@ -989,7 +989,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"icon-class-ship-tbn-2028","aliases":["Icon Class Ship (TBN 2028)","Radiance Of The Seas","Radiance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"icon-class-ship-tbn-2028","aliases":["Icon Class Ship (TBN 2028)","Radiance Of The Seas","Radiance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/icon-of-the-seas.html
+++ b/ships/rcl/icon-of-the-seas.html
@@ -1011,7 +1011,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"icon-of-the-seas","aliases":["Icon of the Seas","Icon Of The Seas","Icon"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"icon-of-the-seas","aliases":["Icon of the Seas","Icon Of The Seas","Icon"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -991,7 +991,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"independence-of-the-seas","aliases":["Independence of the Seas","Independence Of The Seas","Independence"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"independence-of-the-seas","aliases":["Independence of the Seas","Independence Of The Seas","Independence"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -1034,7 +1034,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"jewel-of-the-seas","aliases":["Jewel of the Seas","Jewel Of The Seas","Jewel"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"jewel-of-the-seas","aliases":["Jewel of the Seas","Jewel Of The Seas","Jewel"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/legend-of-the-seas-1995-built.html
+++ b/ships/rcl/legend-of-the-seas-1995-built.html
@@ -968,7 +968,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"legend-of-the-seas-1995-built","aliases":["Legend of the Seas (1995)","Radiance Of The Seas","Radiance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"legend-of-the-seas-1995-built","aliases":["Legend of the Seas (1995)","Radiance Of The Seas","Radiance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
+++ b/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
@@ -988,7 +988,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"legend-of-the-seas-icon-class-entering-service-in-2026","aliases":["Legend of the Seas (Icon Class 2026)","Radiance Of The Seas","Radiance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"legend-of-the-seas-icon-class-entering-service-in-2026","aliases":["Legend of the Seas (Icon Class 2026)","Radiance Of The Seas","Radiance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/legend-of-the-seas.html
+++ b/ships/rcl/legend-of-the-seas.html
@@ -976,7 +976,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"legend-of-the-seas","aliases":["Legend of the Seas","Legend Of The Seas","Legend"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"legend-of-the-seas","aliases":["Legend of the Seas","Legend Of The Seas","Legend"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -1061,7 +1061,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"liberty-of-the-seas","aliases":["Liberty of the Seas","Liberty Of The Seas","Liberty"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"liberty-of-the-seas","aliases":["Liberty of the Seas","Liberty Of The Seas","Liberty"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/majesty-of-the-seas.html
+++ b/ships/rcl/majesty-of-the-seas.html
@@ -991,7 +991,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"majesty-of-the-seas","aliases":["Majesty of the Seas","Majesty Of The Seas","Majesty"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"majesty-of-the-seas","aliases":["Majesty of the Seas","Majesty Of The Seas","Majesty"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -1026,7 +1026,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"mariner-of-the-seas","aliases":["Mariner of the Seas","Mariner Of The Seas","Mariner"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"mariner-of-the-seas","aliases":["Mariner of the Seas","Mariner Of The Seas","Mariner"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/monarch-of-the-seas.html
+++ b/ships/rcl/monarch-of-the-seas.html
@@ -973,7 +973,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"monarch-of-the-seas","aliases":["Monarch of the Seas","Monarch Of The Seas","Monarch"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"monarch-of-the-seas","aliases":["Monarch of the Seas","Monarch Of The Seas","Monarch"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -993,7 +993,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"navigator-of-the-seas","aliases":["Navigator of the Seas","Navigator Of The Seas","Navigator"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"navigator-of-the-seas","aliases":["Navigator of the Seas","Navigator Of The Seas","Navigator"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/nordic-empress.html
+++ b/ships/rcl/nordic-empress.html
@@ -956,7 +956,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"nordic-empress","aliases":["Nordic Empress","Nordic Empress Of The Seas","Nordic Empress"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"nordic-empress","aliases":["Nordic Empress","Nordic Empress Of The Seas","Nordic Empress"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -1064,7 +1064,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"oasis-of-the-seas","aliases":["Oasis of the Seas","Oasis Of The Seas","Oasis"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"oasis-of-the-seas","aliases":["Oasis of the Seas","Oasis Of The Seas","Oasis"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -993,7 +993,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"odyssey-of-the-seas","aliases":["Odyssey of the Seas","Odyssey Of The Seas","Odyssey"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"odyssey-of-the-seas","aliases":["Odyssey of the Seas","Odyssey Of The Seas","Odyssey"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -1111,7 +1111,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"ovation-of-the-seas","aliases":["Ovation of the Seas","Ovation Of The Seas","Ovation"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"ovation-of-the-seas","aliases":["Ovation of the Seas","Ovation Of The Seas","Ovation"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -969,7 +969,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"quantum-of-the-seas","aliases":["Quantum of the Seas","Quantum Of The Seas","Quantum"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"quantum-of-the-seas","aliases":["Quantum of the Seas","Quantum Of The Seas","Quantum"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
@@ -988,7 +988,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"quantum-ultra-class-ship-tbn-2028","aliases":["Quantum Ultra Class Ship (TBN 2028)","Radiance Of The Seas","Radiance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"quantum-ultra-class-ship-tbn-2028","aliases":["Quantum Ultra Class Ship (TBN 2028)","Radiance Of The Seas","Radiance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
@@ -988,7 +988,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"quantum-ultra-class-ship-tbn-2029","aliases":["Quantum Ultra Class Ship (TBN 2029)","Radiance Of The Seas","Radiance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"quantum-ultra-class-ship-tbn-2029","aliases":["Quantum Ultra Class Ship (TBN 2029)","Radiance Of The Seas","Radiance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -837,7 +837,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"radiance-of-the-seas","aliases":["Radiance of the Seas","Radiance Of The Seas","Radiance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"radiance-of-the-seas","aliases":["Radiance of the Seas","Radiance Of The Seas","Radiance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -1023,7 +1023,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"rhapsody-of-the-seas","aliases":["Rhapsody of the Seas","Rhapsody Of The Seas","Rhapsody"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"rhapsody-of-the-seas","aliases":["Rhapsody of the Seas","Rhapsody Of The Seas","Rhapsody"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -1100,7 +1100,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"serenade-of-the-seas","aliases":["Serenade of the Seas","Serenade Of The Seas","Serenade"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"serenade-of-the-seas","aliases":["Serenade of the Seas","Serenade Of The Seas","Serenade"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/song-of-norway.html
+++ b/ships/rcl/song-of-norway.html
@@ -971,7 +971,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"song-of-norway","aliases":["Song of Norway","Song Of The Seas","Song"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"song-of-norway","aliases":["Song of Norway","Song Of The Seas","Song"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/sovereign-of-the-seas.html
+++ b/ships/rcl/sovereign-of-the-seas.html
@@ -950,7 +950,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"sovereign-of-the-seas","aliases":["Sovereign of the Seas","Sovereign Of The Seas","Sovereign"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"sovereign-of-the-seas","aliases":["Sovereign of the Seas","Sovereign Of The Seas","Sovereign"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -970,7 +970,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"spectrum-of-the-seas","aliases":["Spectrum of the Seas","Spectrum Of The Seas","Spectrum"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"spectrum-of-the-seas","aliases":["Spectrum of the Seas","Spectrum Of The Seas","Spectrum"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/splendour-of-the-seas.html
+++ b/ships/rcl/splendour-of-the-seas.html
@@ -995,7 +995,7 @@ updated: 2025-11-18
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"splendour-of-the-seas","aliases":["Splendour of the Seas","Splendour Of The Seas","Splendour"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"splendour-of-the-seas","aliases":["Splendour of the Seas","Splendour Of The Seas","Splendour"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/star-class-ship-tbn-2028.html
+++ b/ships/rcl/star-class-ship-tbn-2028.html
@@ -988,7 +988,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"star-class-ship-tbn-2028","aliases":["Star Class Ship (TBN 2028)","Radiance Of The Seas","Radiance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"star-class-ship-tbn-2028","aliases":["Star Class Ship (TBN 2028)","Radiance Of The Seas","Radiance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/star-of-the-seas-aug-2025-debut.html
+++ b/ships/rcl/star-of-the-seas-aug-2025-debut.html
@@ -987,7 +987,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"star-of-the-seas-aug-2025-debut","aliases":["Star of the Seas (August 2025)","Radiance Of The Seas","Radiance"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"star-of-the-seas-aug-2025-debut","aliases":["Star of the Seas (August 2025)","Radiance Of The Seas","Radiance"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/star-of-the-seas.html
+++ b/ships/rcl/star-of-the-seas.html
@@ -1001,7 +1001,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"star-of-the-seas","aliases":["Star of the Seas","Star Of The Seas","Star"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"star-of-the-seas","aliases":["Star of the Seas","Star Of The Seas","Star"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -971,7 +971,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"symphony-of-the-seas","aliases":["Symphony of the Seas","Symphony Of The Seas","Symphony"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"symphony-of-the-seas","aliases":["Symphony of the Seas","Symphony Of The Seas","Symphony"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -993,7 +993,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"utopia-of-the-seas","aliases":["Utopia of the Seas","Utopia Of The Seas","Utopia"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"utopia-of-the-seas","aliases":["Utopia of the Seas","Utopia Of The Seas","Utopia"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -1023,7 +1023,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"vision-of-the-seas","aliases":["Vision of the Seas","Vision Of The Seas","Vision"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"vision-of-the-seas","aliases":["Vision of the Seas","Vision Of The Seas","Vision"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -970,7 +970,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"voyager-of-the-seas","aliases":["Voyager of the Seas","Voyager Of The Seas","Voyager"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"voyager-of-the-seas","aliases":["Voyager of the Seas","Voyager Of The Seas","Voyager"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -971,7 +971,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="dining-content" id="dining-content" aria-live="polite"></div>
 
         <!-- normalize dining data source to venues.json on this origin -->
-        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues.json","ship_slug":"wonder-of-the-seas","aliases":["Wonder of the Seas","Wonder Of The Seas","Wonder"]}</script>
+        <script type="application/json" id="dining-data-source">{"provider":"rcl","json":"/assets/data/venues-v2.json","ship_slug":"wonder-of-the-seas","aliases":["Wonder of the Seas","Wonder Of The Seas","Wonder"]}</script>
         <script>
         (function fixDiningJSON(){
           function run(){

--- a/travel.html
+++ b/travel.html
@@ -1656,7 +1656,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
   <script>
   (function(){async function warm(){try{await Promise.all([
     SiteCache.getJSON('/assets/data/fleet_index.json',{ttlDays:7,versionPath:['version']}),
-    SiteCache.getJSON('/assets/data/venues.json',{ttlDays:7,versionPath:['meta','version']}),
+    SiteCache.getJSON('/assets/data/venues-v2.json',{ttlDays:7,versionPath:['meta','version']}),
     SiteCache.getJSON('/assets/data/personas/index.json',{ttlDays:7,versionPath:['version']}),
     SiteCache.getJSON('/assets/data/articles/index.json',{ttlDays:7,versionPath:['version']})
   ]);}catch(_){}} if(document.readyState==='loading'){


### PR DESCRIPTION
Updated all references to use the new verified venue data structure:

Core JS files:
- venue-boot.js (v2.258)
- dining-card.js (v2.247) - updated category logic for subcategory support
- rcl.page.js

Pages updated:
- 44 ship pages
- 22 restaurant pages
- travel.html

The dining-card.js now correctly handles both v1 (category) and v2 (category/subcategory) structures for backward compatibility.