### PR TITLE
ADD: Restaurant category SVG placeholder images (pilot)

### DIFF
--- a/assets/images/restaurants/asian-cuisine.svg
+++ b/assets/images/restaurants/asian-cuisine.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <!-- Asian cuisine icon with maritime theme -->
+  <defs>
+    <linearGradient id="oceanGradAsian" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a3d62;stop-opacity:0.08" />
+      <stop offset="100%" style="stop-color:#0e6e8e;stop-opacity:0.12" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="400" height="300" fill="#f7fdff"/>
+
+  <!-- Subtle wave pattern -->
+  <g opacity="0.06">
+    <path d="M0,100 Q50,90 100,100 T200,100 T300,100 T400,100" fill="none" stroke="#0a3d62" stroke-width="1"/>
+    <path d="M0,120 Q50,110 100,120 T200,120 T300,120 T400,120" fill="none" stroke="#0a3d62" stroke-width="1"/>
+    <path d="M0,140 Q50,130 100,140 T200,140 T300,140 T400,140" fill="none" stroke="#0a3d62" stroke-width="1"/>
+  </g>
+
+  <!-- Main icon: Chopsticks and bowl -->
+  <g transform="translate(200, 140)">
+    <!-- Bowl -->
+    <ellipse cx="0" cy="20" rx="50" ry="12" fill="url(#oceanGradAsian)"/>
+    <path d="M-50,20 Q-50,0 -30,-15 Q0,-25 30,-15 Q50,0 50,20"
+          fill="none" stroke="#0e6e8e" stroke-width="2.5" stroke-linecap="round"/>
+
+    <!-- Chopsticks -->
+    <g transform="translate(20, -30) rotate(25)">
+      <rect x="-2" y="-30" width="2" height="60" fill="#d9b382" rx="1"/>
+      <rect x="3" y="-30" width="2" height="60" fill="#d9b382" rx="1"/>
+    </g>
+
+    <!-- Decorative circle elements -->
+    <circle cx="-35" cy="-5" r="2" fill="#0e6e8e" opacity="0.4"/>
+    <circle cx="0" cy="-10" r="2" fill="#0e6e8e" opacity="0.4"/>
+    <circle cx="35" cy="-5" r="2" fill="#0e6e8e" opacity="0.4"/>
+  </g>
+
+  <!-- Text -->
+  <text x="200" y="260" font-family="Georgia, serif" font-size="14" fill="#0a3d62" text-anchor="middle" opacity="0.7">
+    Asian Cuisine
+  </text>
+</svg>

--- a/assets/images/restaurants/bar-lounge.svg
+++ b/assets/images/restaurants/bar-lounge.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <!-- Bar/Lounge icon with maritime theme -->
+  <defs>
+    <linearGradient id="oceanGradBar" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a3d62;stop-opacity:0.08" />
+      <stop offset="100%" style="stop-color:#0e6e8e;stop-opacity:0.12" />
+    </linearGradient>
+    <linearGradient id="glassGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#0e6e8e;stop-opacity:0.2" />
+      <stop offset="50%" style="stop-color:#0e6e8e;stop-opacity:0.05" />
+      <stop offset="100%" style="stop-color:#0e6e8e;stop-opacity:0.2" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="400" height="300" fill="#f7fdff"/>
+
+  <!-- Decorative wave (subtle) -->
+  <g opacity="0.06">
+    <path d="M0,200 Q100,190 200,200 T400,200" fill="none" stroke="#0a3d62" stroke-width="2"/>
+    <path d="M0,210 Q100,200 200,210 T400,210" fill="none" stroke="#0a3d62" stroke-width="1.5"/>
+  </g>
+
+  <!-- Main icon: Cocktail glass -->
+  <g transform="translate(200, 130)">
+    <!-- Glass -->
+    <path d="M-35,-40 L35,-40 L25,0 L-25,0 Z" fill="url(#glassGrad)" stroke="#0e6e8e" stroke-width="2.5"/>
+
+    <!-- Stem -->
+    <rect x="-3" y="0" width="6" height="40" fill="#0e6e8e" rx="3"/>
+
+    <!-- Base -->
+    <ellipse cx="0" cy="45" rx="20" ry="5" fill="url(#oceanGradBar)" stroke="#0e6e8e" stroke-width="2"/>
+
+    <!-- Garnish (olive with pick) -->
+    <circle cx="0" cy="-25" r="4" fill="#d9b382"/>
+    <line x1="0" y1="-40" x2="0" y2="-21" stroke="#d9b382" stroke-width="1.5"/>
+
+    <!-- Bubbles -->
+    <circle cx="-10" cy="-15" r="2" fill="#0e6e8e" opacity="0.3"/>
+    <circle cx="8" cy="-20" r="1.5" fill="#0e6e8e" opacity="0.3"/>
+    <circle cx="5" cy="-10" r="1.5" fill="#0e6e8e" opacity="0.3"/>
+  </g>
+
+  <!-- Text -->
+  <text x="200" y="260" font-family="Georgia, serif" font-size="14" fill="#0a3d62" text-anchor="middle" opacity="0.7">
+    Bar &amp; Lounge
+  </text>
+</svg>

--- a/assets/images/restaurants/italian-cuisine.svg
+++ b/assets/images/restaurants/italian-cuisine.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <!-- Italian cuisine icon with maritime theme -->
+  <defs>
+    <linearGradient id="oceanGradItalian" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a3d62;stop-opacity:0.08" />
+      <stop offset="100%" style="stop-color:#0e6e8e;stop-opacity:0.12" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="400" height="300" fill="#f7fdff"/>
+
+  <!-- Decorative rope pattern -->
+  <g opacity="0.06">
+    <circle cx="80" cy="80" r="15" fill="none" stroke="#d9b382" stroke-width="2"/>
+    <circle cx="320" cy="80" r="15" fill="none" stroke="#d9b382" stroke-width="2"/>
+    <circle cx="80" cy="220" r="15" fill="none" stroke="#d9b382" stroke-width="2"/>
+    <circle cx="320" cy="220" r="15" fill="none" stroke="#d9b382" stroke-width="2"/>
+  </g>
+
+  <!-- Main icon: Fork and pasta -->
+  <g transform="translate(200, 150)">
+    <!-- Plate -->
+    <ellipse cx="0" cy="15" rx="55" ry="13" fill="url(#oceanGradItalian)"/>
+    <ellipse cx="0" cy="15" rx="55" ry="13" fill="none" stroke="#0e6e8e" stroke-width="2"/>
+
+    <!-- Pasta/spaghetti on plate -->
+    <g opacity="0.7">
+      <path d="M-20,10 Q-15,0 -10,10 Q-5,20 0,10 Q5,0 10,10 Q15,20 20,10"
+            fill="none" stroke="#d9b382" stroke-width="2" stroke-linecap="round"/>
+      <path d="M-15,5 Q-10,-5 -5,5 Q0,15 5,5 Q10,-5 15,5"
+            fill="none" stroke="#d9b382" stroke-width="2" stroke-linecap="round"/>
+    </g>
+
+    <!-- Fork -->
+    <g transform="translate(-30, -20)">
+      <!-- Handle -->
+      <rect x="-2" y="-30" width="4" height="50" fill="#0e6e8e" rx="2"/>
+      <!-- Tines -->
+      <rect x="-10" y="15" width="2" height="12" fill="#0e6e8e" rx="1"/>
+      <rect x="-4" y="15" width="2" height="12" fill="#0e6e8e" rx="1"/>
+      <rect x="2" y="15" width="2" height="12" fill="#0e6e8e" rx="1"/>
+      <rect x="8" y="15" width="2" height="12" fill="#0e6e8e" rx="1"/>
+    </g>
+  </g>
+
+  <!-- Text -->
+  <text x="200" y="260" font-family="Georgia, serif" font-size="14" fill="#0a3d62" text-anchor="middle" opacity="0.7">
+    Italian Cuisine
+  </text>
+</svg>

--- a/assets/images/restaurants/specialty-dining.svg
+++ b/assets/images/restaurants/specialty-dining.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <!-- Elegant specialty dining icon with maritime theme -->
+  <defs>
+    <linearGradient id="oceanGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a3d62;stop-opacity:0.08" />
+      <stop offset="100%" style="stop-color:#0e6e8e;stop-opacity:0.12" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="400" height="300" fill="#f7fdff"/>
+
+  <!-- Decorative compass rose (subtle) -->
+  <g opacity="0.06">
+    <circle cx="200" cy="150" r="80" fill="none" stroke="#0a3d62" stroke-width="1"/>
+    <circle cx="200" cy="150" r="60" fill="none" stroke="#0a3d62" stroke-width="0.5"/>
+    <path d="M200,70 L205,145 L200,150 L195,145 Z" fill="#0a3d62"/>
+    <path d="M200,230 L195,155 L200,150 L205,155 Z" fill="#0a3d62"/>
+    <path d="M120,150 L195,145 L200,150 L195,155 Z" fill="#0a3d62"/>
+    <path d="M280,150 L205,155 L200,150 L205,145 Z" fill="#0a3d62"/>
+  </g>
+
+  <!-- Main icon: Elegant cloche/dome -->
+  <g transform="translate(200, 150)">
+    <!-- Dome -->
+    <ellipse cx="0" cy="20" rx="60" ry="8" fill="#d9b382" opacity="0.3"/>
+    <path d="M-60,20 Q-60,0 -40,-20 Q-20,-35 0,-40 Q20,-35 40,-20 Q60,0 60,20 Z"
+          fill="none" stroke="#0e6e8e" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="0" cy="-40" r="6" fill="#0e6e8e"/>
+
+    <!-- Base plate -->
+    <ellipse cx="0" cy="25" rx="70" ry="10" fill="none" stroke="#0e6e8e" stroke-width="2"/>
+    <ellipse cx="0" cy="25" rx="65" ry="8" fill="url(#oceanGrad)"/>
+  </g>
+
+  <!-- Text -->
+  <text x="200" y="260" font-family="Georgia, serif" font-size="14" fill="#0a3d62" text-anchor="middle" opacity="0.7">
+    Specialty Dining
+  </text>
+</svg>

--- a/assets/images/restaurants/steakhouse.svg
+++ b/assets/images/restaurants/steakhouse.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <!-- Steakhouse icon with maritime theme -->
+  <defs>
+    <linearGradient id="oceanGradSteak" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a3d62;stop-opacity:0.08" />
+      <stop offset="100%" style="stop-color:#0e6e8e;stop-opacity:0.12" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="400" height="300" fill="#f7fdff"/>
+
+  <!-- Decorative anchor pattern (subtle) -->
+  <g opacity="0.05" transform="translate(100, 220)">
+    <path d="M0,-15 L0,15 M-10,10 Q-10,15 -5,15 L0,10 M10,10 Q10,15 5,15 L0,10 M-5,-15 L5,-15"
+          stroke="#0a3d62" stroke-width="2" fill="none" stroke-linecap="round"/>
+  </g>
+  <g opacity="0.05" transform="translate(300, 80)">
+    <path d="M0,-15 L0,15 M-10,10 Q-10,15 -5,15 L0,10 M10,10 Q10,15 5,15 L0,10 M-5,-15 L5,-15"
+          stroke="#0a3d62" stroke-width="2" fill="none" stroke-linecap="round"/>
+  </g>
+
+  <!-- Main icon: Knife and fork crossed -->
+  <g transform="translate(200, 150)">
+    <!-- Plate -->
+    <ellipse cx="0" cy="0" rx="60" ry="15" fill="url(#oceanGradSteak)"/>
+    <ellipse cx="0" cy="0" rx="60" ry="15" fill="none" stroke="#0e6e8e" stroke-width="2.5"/>
+
+    <!-- Knife (left, rotated) -->
+    <g transform="rotate(-45)">
+      <rect x="-3" y="-60" width="6" height="70" fill="#0e6e8e" rx="3"/>
+      <path d="M-3,10 L0,15 L3,10" fill="#0e6e8e"/>
+    </g>
+
+    <!-- Fork (right, rotated) -->
+    <g transform="rotate(45)">
+      <rect x="-2.5" y="-60" width="5" height="65" fill="#d9b382" rx="2.5"/>
+      <rect x="-8" y="0" width="2" height="10" fill="#d9b382" rx="1"/>
+      <rect x="-3" y="0" width="2" height="10" fill="#d9b382" rx="1"/>
+      <rect x="2" y="0" width="2" height="10" fill="#d9b382" rx="1"/>
+      <rect x="7" y="0" width="2" height="10" fill="#d9b382" rx="1"/>
+    </g>
+  </g>
+
+  <!-- Text -->
+  <text x="200" y="260" font-family="Georgia, serif" font-size="14" fill="#0a3d62" text-anchor="middle" opacity="0.7">
+    Steakhouse
+  </text>
+</svg>

--- a/restaurants/jamies-italian.html
+++ b/restaurants/jamies-italian.html
@@ -210,7 +210,7 @@
 <main class="wrap">
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/italian-cuisine.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Jamie's Italian by Jamie Oliver</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -235,7 +235,7 @@
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/italian-cuisine.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -246,7 +246,7 @@
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/italian-cuisine.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -261,7 +261,7 @@
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/italian-cuisine.svg" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -312,7 +312,7 @@
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/italian-cuisine.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/schooner-bar.html
+++ b/restaurants/schooner-bar.html
@@ -210,7 +210,7 @@
 <main class="wrap">
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Schooner Bar</h1>
       <p class="subtitle">Royal Caribbean — Bar & Lounge</p>
@@ -235,7 +235,7 @@
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -246,7 +246,7 @@
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -265,7 +265,7 @@
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -316,7 +316,7 @@
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/wonderland.html
+++ b/restaurants/wonderland.html
@@ -210,7 +210,7 @@
 <main class="wrap">
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Wonderland</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -235,7 +235,7 @@
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -246,7 +246,7 @@
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -260,7 +260,7 @@
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -311,7 +311,7 @@
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://www.cruisinginthewake.com/assets/watermark.png" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>


### PR DESCRIPTION
- Create 5 elegant SVG placeholder images for restaurant categories
  * specialty-dining.svg: Cloche/dome for signature restaurants
  * asian-cuisine.svg: Chopsticks and bowl for Asian venues
  * italian-cuisine.svg: Fork and pasta for Italian restaurants
  * steakhouse.svg: Crossed knife and fork for steakhouses
  * bar-lounge.svg: Cocktail glass for bars and lounges

- Update 5 high-profile restaurant pages to use new SVGs:
  * Wonderland → specialty-dining.svg
  * Izumi → asian-cuisine.svg
  * Jamie's Italian → italian-cuisine.svg
  * Chops Grille → steakhouse.svg
  * Schooner Bar → bar-lounge.svg

- All SVGs feature maritime theme matching site aesthetic
- Replace generic watermark.png with category-specific imagery
- Maintain consistent color palette (ocean blues, rope tan)
- Pilot program for hybrid image approach (Tier 3)