### PR TITLE
ADD: 10 Northern Europe Batch 1 cruise port pages with ICP-Lite v1.0 …

### DIFF
--- a/assets/data/search-index.json
+++ b/assets/data/search-index.json
@@ -4338,5 +4338,154 @@
       "habsburg",
       "miramare castle"
     ]
+  },
+  {
+    "title": "Bergen, Norway",
+    "url": "/ports/bergen.html",
+    "description": "Seven mountains, colorful Hanseatic wharf houses, Mount Fløyen funicular, fish market, gateway to fjords.",
+    "cta": "First-person logbook guide to Bergen with Bryggen wharf and funicular.",
+    "category": "port",
+    "keywords": [
+      "bergen",
+      "norway",
+      "bryggen",
+      "mount floyen",
+      "fjords",
+      "hanseatic"
+    ]
+  },
+  {
+    "title": "Stavanger, Norway",
+    "url": "/ports/stavanger.html",
+    "description": "White wooden houses, Lysefjord cruise with Pulpit Rock views, adventure capital with charm.",
+    "cta": "First-person logbook guide to Stavanger with Pulpit Rock cruise.",
+    "category": "port",
+    "keywords": [
+      "stavanger",
+      "norway",
+      "pulpit rock",
+      "lysefjord",
+      "gamle stavanger"
+    ]
+  },
+  {
+    "title": "Ålesund, Norway",
+    "url": "/ports/alesund.html",
+    "description": "Art Nouveau fairy tale rebuilt after 1904 fire, pastel buildings, Mount Aksla viewpoint, island charm.",
+    "cta": "First-person logbook guide to Ålesund with Art Nouveau architecture.",
+    "category": "port",
+    "keywords": [
+      "alesund",
+      "norway",
+      "art nouveau",
+      "mount aksla",
+      "jugendstil"
+    ]
+  },
+  {
+    "title": "Tromsø, Norway",
+    "url": "/ports/tromso.html",
+    "description": "Arctic capital with midnight sun or northern lights, Arctic Cathedral, cable car viewpoint, reindeer.",
+    "cta": "First-person logbook guide to Tromsø with Arctic experiences.",
+    "category": "port",
+    "keywords": [
+      "tromso",
+      "norway",
+      "arctic",
+      "midnight sun",
+      "northern lights",
+      "arctic cathedral"
+    ]
+  },
+  {
+    "title": "Tallinn, Estonia",
+    "url": "/ports/tallinn.html",
+    "description": "Perfectly preserved Hanseatic fairy tale with orange roofs, church spires, medieval walls from 1450.",
+    "cta": "First-person logbook guide to Tallinn's medieval old town.",
+    "category": "port",
+    "keywords": [
+      "tallinn",
+      "estonia",
+      "medieval",
+      "hanseatic",
+      "toompea",
+      "old town"
+    ]
+  },
+  {
+    "title": "St. Petersburg, Russia",
+    "url": "/ports/st-petersburg.html",
+    "description": "Imperial excess with golden spires, Hermitage museum, Church on Spilled Blood, canal cruises, white nights.",
+    "cta": "First-person logbook guide to St. Petersburg with Hermitage.",
+    "category": "port",
+    "keywords": [
+      "st petersburg",
+      "russia",
+      "hermitage",
+      "church on spilled blood",
+      "white nights",
+      "imperial palaces"
+    ]
+  },
+  {
+    "title": "Riga, Latvia",
+    "url": "/ports/riga.html",
+    "description": "Art Nouveau capital of the world with Hanseatic old town and biggest market halls in Europe.",
+    "cta": "First-person logbook guide to Riga with Art Nouveau district.",
+    "category": "port",
+    "keywords": [
+      "riga",
+      "latvia",
+      "art nouveau",
+      "hanseatic",
+      "central market",
+      "alberta iela"
+    ]
+  },
+  {
+    "title": "Gdansk, Poland",
+    "url": "/ports/gdansk.html",
+    "description": "Amber capital, Solidarity birthplace, perfectly rebuilt Hanseatic façades, phoenix city from ashes.",
+    "cta": "First-person logbook guide to Gdansk with Solidarity history.",
+    "category": "port",
+    "keywords": [
+      "gdansk",
+      "poland",
+      "amber",
+      "solidarity",
+      "hanseatic",
+      "st mary's church"
+    ]
+  },
+  {
+    "title": "Warnemünde, Germany",
+    "url": "/ports/warnemunde.html",
+    "description": "Perfect beach town and gateway to Berlin — Brandenburg Gate, Museum Island, Checkpoint Charlie day trip.",
+    "cta": "First-person logbook guide to Warnemünde with Berlin day trip.",
+    "category": "port",
+    "keywords": [
+      "warnemunde",
+      "germany",
+      "berlin",
+      "brandenburg gate",
+      "checkpoint charlie",
+      "day trip"
+    ]
+  },
+  {
+    "title": "Kiel, Germany",
+    "url": "/ports/kiel.html",
+    "description": "Sailing capital with Olympic harbor, massive Kiel Canal locks, Laboe Naval Memorial, and U-boat museum.",
+    "cta": "First-person logbook guide to Kiel with canal and U-boat.",
+    "category": "port",
+    "keywords": [
+      "kiel",
+      "germany",
+      "kiel canal",
+      "sailing",
+      "laboe",
+      "u-boat",
+      "naval memorial"
+    ]
   }
 ]

--- a/ports/alesund.html
+++ b/ports/alesund.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Ålesund with tips for Art Nouveau architecture, Mount Aksla viewpoint, and canal kayaking."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Ålesund Port Guide — Art Nouveau Fairy Tale on Fjord Islands | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Ålesund, Norway — Art Nouveau fairy tale rebuilt after 1904 fire, pastel buildings, turrets, Mount Aksla viewpoint."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/alesund.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Ålesund", "item": "https://cruisinginthewake.com/ports/alesund.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Ålesund</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Ålesund is pure Art Nouveau fairy tale rebuilt after a 1904 fire – pastel buildings, turrets, and islands scattered like confetti in the fjord.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Ålesund: My Art Nouveau Dream</h1>
+      <div class="logbook-entry">
+        <p>We sailed in at sunrise and the town looked like a watercolor painting – all soft pinks, greens, and turrets reflected perfectly in calm water. We climbed the 418 steps to Mount Aksla at 8 a.m. and had the entire viewpoint to ourselves – 360° of islands, fjords, and snow-capped Sunnmøre Alps turning pink. We had breakfast at a café built in 1905 with original Jugendstil interiors – coffee and svele (thick Norwegian pancakes) with brown cheese that tastes like caramel.</p>
+
+        <p>In the afternoon we went kayaking in the Brosundet canal right through town – paddling between Art Nouveau façades while locals waved from balconies felt surreal. The pros: the most beautiful architecture in Norway and compact enough to see everything. The cons: another set of steps (those 418 again), but the view rewards every single one.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing alone on Aksla while the morning mist lifted off the fjord and revealed island after island after island, each with a tiny red boathouse, until the horizon disappeared in blue haze.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Ålesund</h3>
+        <p>Ship docks literally in the town center – everything is walkable or short water taxi.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The stairs to Aksla are steady but rewarding – take them slowly and stop at the viewpoints; the panorama just keeps getting better.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Ålesund worth it?</strong><br/>A: The prettiest town in Norway – yes!</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Aksla viewpoint at sunrise/golden hour.</p>
+        <p><strong>Q: How long for Aksla?</strong><br/>A: 1.5–2 hours round-trip with photos.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Yes – right into Art Nouveau heaven.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Bergen with tips for Bryggen wharf, Mount Fløyen funicular, and fish market."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Bergen Port Guide — Hanseatic Wharf & Gateway to Fjords | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Bergen, Norway — colorful Bryggen wharf houses, Mount Fløyen funicular, fish market, and gateway to the fjords."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/bergen.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Bergen", "item": "https://cruisinginthewake.com/ports/bergen.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Bergen</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Bergen is seven mountains, colorful Hanseatic wharf houses, and rain that somehow makes everything more beautiful – the gateway to the fjords.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Bergen: My Gateway to the Fjords</h1>
+      <div class="logbook-entry">
+        <p>We sailed into the harbor at dawn with Bryggen's crooked wooden façades glowing like gingerbread against the mist. The funicular up Mount Fløyen was waiting – ten minutes later we stood above the cloud layer watching the city sparkle below while goats grazed on the roof of the station restaurant. Back down we wandered the UNESCO-listed Bryggen alleys – timber beams creaking, the smell of tar and salt, tiny galleries tucked between 300-year-old warehouses.</p>
+
+        <p>We had lunch at the fish market – the freshest salmon sashimi of my life eaten standing up, washed down with Aquavit that tasted like Christmas. In the afternoon we went back to the Fløibanen because we couldn't resist, this time hiking the ridge trail through pine forest that smelled like gin. Bergen rains a lot (it did, three times), but every shower left rainbows over the fjord and made the colors pop even more. The pros: compact, ridiculously pretty, and genuinely Norwegian. The cons: that rain is real, but Norwegians just smile and keep walking.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing on Fløyen in complete silence while low cloud poured over the ridge like dry ice and the first sunbeam hit Bryggen far below, turning the whole city gold for exactly thirty perfect seconds.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Bergen</h3>
+        <p>Ship docks 5-minute walk from the fish market and Bryggen. Everything is walkable or quick funicular ride.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>Bergen's weather changes every ten minutes – a light rain jacket lives in my day bag and has never once been unnecessary.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Bergen worth it?</strong><br/>A: The prettiest city in Norway, full stop.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Fløibanen funicular + Bryggen wander.</p>
+        <p><strong>Q: How long on Fløyen?</strong><br/>A: 2–3 hours including short hike.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Yes – right into the postcard.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/gdansk.html
+++ b/ports/gdansk.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Gdansk with tips for Hanseatic old town, Solidarity museum, amber, St. Mary's Church."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Gdansk Port Guide — Amber, Solidarity & Phoenix City | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Gdansk, Poland — amber capital, Solidarity birthplace, perfectly rebuilt Hanseatic façades along Motława River."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/gdansk.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Gdansk", "item": "https://cruisinginthewake.com/ports/gdansk.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Gdansk</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Gdansk is amber, solidarity, and perfectly rebuilt Hanseatic façades along the Motława River – the phoenix city that rose from ashes.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Gdansk: My Phoenix City</h1>
+      <div class="logbook-entry">
+        <p>We walked off into Dlugi Targ and the colorful merchants' houses looked freshly painted – hard to believe 95% were rubble in 1945. The Amber Museum inside a medieval gate tower showed insects trapped 40 million years ago still perfect. St. Mary's Church climb (408 steps) gave us views over red roofs to the shipyards where Solidarity began.</p>
+
+        <p>We had lunch at a milk bar – pierogi ruskie and żurek soup in rye bread bowls that tasted like grandma's hug. In the afternoon we went to Oliwa Cathedral for the organ concert – 7,000 pipes playing Bach while wooden angels danced on cables. The pros: beautiful, meaningful, and incredibly warm people. The cons: some post-war architecture, but the rebuilt center is flawless.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing in the Gdańsk Shipyard at the Solidarity monument while an old worker quietly told us "we changed the world here" – history still breathing.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Gdansk</h3>
+        <p>Ship docks 20-minute walk or quick tram to old town.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The cobblestones are authentically medieval – comfortable shoes make wandering even more enjoyable.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Gdansk worth it?</strong><br/>A: The most beautiful and important Polish port city.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Main town + Solidarity center.</p>
+        <p><strong>Q: How long for old town?</strong><br/>A: 5–6 hours perfect.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Pleasant 20-minute stroll.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/kiel.html
+++ b/ports/kiel.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Kiel with tips for Kiel Canal, Olympic harbor, Laboe Naval Memorial and U-boat."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Kiel Port Guide — Sailing Capital & Kiel Canal Locks | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Kiel, Germany — sailing capital with Olympic harbor, massive Kiel Canal locks, Laboe Naval Memorial and U-boat museum."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/kiel.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Kiel", "item": "https://cruisinginthewake.com/ports/kiel.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Kiel</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Kiel is the sailing capital of Germany – Olympic harbor, massive locks, and the world's busiest canal right at your gangway.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Kiel: My Sailing Capital</h1>
+      <div class="logbook-entry">
+        <p>We watched the ship squeeze through the Kiel Canal locks from the top deck – inches from the walls, engineers waving like it was normal. The maritime quarter is pure sailing porn – German frigates, classic tall ships, and the Olympic rings still painted on the harbor from 1936/1972. Laboe Naval Memorial 20 minutes away – the U-boat museum inside is claustrophobic and humbling.</p>
+
+        <p>We had lunch at the fish market – rollmops and Labskaus (corned beef mash that tastes better than it sounds) while watching sailing teams practice in the fjord. In the afternoon we walked the Kiellinie promenade – 4 km of parks, beaches, and views of million-dollar yachts. The pros: genuine working maritime city with almost no cruise crowds. The cons: industrial in parts, but that's authentic Kiel.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing inside U-995 submarine listening to the audio guide describe diving while imagining 50 men living in that steel tube for months – respect doesn't begin to cover it.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Kiel</h3>
+        <p>Ship docks right in town center – everything walkable or quick bus to Laboe.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The maritime museums have lots of stairs and ladders – curiosity and careful steps make the history come alive.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Kiel worth it?</strong><br/>A: The most authentic German maritime port.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Kiel Canal experience + Laboe U-boat.</p>
+        <p><strong>Q: How long for Laboe?</strong><br/>A: 3 hours round-trip.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Yes – right into sailing central.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/riga.html
+++ b/ports/riga.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Riga with tips for Art Nouveau district, Central Market, Hanseatic old town."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Riga Port Guide — Art Nouveau Capital & Hanseatic Charm | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Riga, Latvia — Art Nouveau capital of the world with Hanseatic old town and biggest market halls in Europe."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/riga.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Riga", "item": "https://cruisinginthewake.com/ports/riga.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Riga</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Riga is the Art Nouveau capital of the world wrapped in a Hanseatic old town with the biggest market halls in Europe.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Riga: My Art Nouveau Capital</h1>
+      <div class="logbook-entry">
+        <p>We walked off into Vecrīga and the cobblestones immediately started singing – every building a different pastel color, church spires competing for attention. Alberta iela at 9 a.m. was pure Art Nouveau porn – facades covered in screaming faces, naked ladies, and mythical beasts. The Central Market inside five zeppelin hangars was sensory overload – black balsamic vinegar aged 25 years, smoked sprats, and hemp butter that tastes like nostalgia.</p>
+
+        <p>We had lunch at a milk bar – Soviet-era canteen serving cold beet soup and piragi bacon buns for pocket change. House of the Blackheads rebuilt perfectly after WWII – the detail is insane. The pros: beautiful, affordable, and genuinely friendly. The cons: some Soviet concrete on the outskirts, but the old town is perfect.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing alone on the corner of Alberta and Strēlnieku watching the morning sun light up ten different Art Nouveau masterpieces at once – Riga really is the world capital.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Riga</h3>
+        <p>Ship docks 15-minute walk or quick tram to old town.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The market halls are enormous – comfortable shoes make hunting for black balsam and amber even more fun.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Riga worth it?</strong><br/>A: The most beautiful and underrated Baltic capital.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Art Nouveau district + Central Market.</p>
+        <p><strong>Q: How long for Art Nouveau?</strong><br/>A: 2–3 hours of pure joy.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Easy 15-minute stroll.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/st-petersburg.html
+++ b/ports/st-petersburg.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to St. Petersburg with tips for Hermitage, Church on Spilled Blood, canal cruises, white nights."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>St. Petersburg Port Guide — Imperial Palaces & White Nights | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to St. Petersburg, Russia — imperial excess with golden spires, Hermitage museum, Church on Spilled Blood mosaics, canal cruises."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/st-petersburg.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "St. Petersburg", "item": "https://cruisinginthewake.com/ports/st-petersburg.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">St. Petersburg</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> St. Petersburg is imperial excess on steroids – golden spires, canals, and palaces that make Versailles look modest.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>St. Petersburg: My Imperial Dream</h1>
+      <div class="logbook-entry">
+        <p>We arrived at dawn and the city was already glowing – the Peter & Paul Fortress spire catching first light across the Neva. We arrived at the Hermitage early and had the Gold Room almost to ourselves – Fabergé eggs and Scythian gold glittering in perfect silence. The Church on Spilled Blood at 9 a.m. was empty enough to hear the mosaics whisper – every inch covered in biblical scenes that look wet.</p>
+
+        <p>In the evening we took a canal boat ride under the bridges while the sun set at 11 p.m. – white nights turning the sky lavender and gold. We had dinner at a Georgian restaurant – khinkali soup dumplings and khachapuri that ruined cheese bread for life. The pros: the most beautiful city ever built by autocrats. The cons: visa bureaucracy and crowds later in the day, but early entry solves everything.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing alone in the Hermitage's Jordan Staircase at opening while sunlight poured through the windows and turned the entire marble palace gold – Catherine the Great's ghost felt very close.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around St. Petersburg</h3>
+        <p>Ship-organized visa and transport required – hydrofoil or bus to city center.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>Early-entry tickets are pure gold – they turn overwhelming crowds into private palace moments.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is St. Petersburg worth it?</strong><br/>A: The single most spectacular port in northern Europe.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Early Hermitage + canal cruise.</p>
+        <p><strong>Q: How long in Hermitage?</strong><br/>A: 4 hours minimum, lifetime not enough.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: No – organized transport only.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/stavanger.html
+++ b/ports/stavanger.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Stavanger with tips for Gamle Stavanger, Lysefjord cruise, and Pulpit Rock views."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Stavanger Port Guide — White Houses & Gateway to Pulpit Rock | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Stavanger, Norway — white wooden houses, street art, Lysefjord cruise with Pulpit Rock views, adventure capital charm."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/stavanger.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Stavanger", "item": "https://cruisinginthewake.com/ports/stavanger.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Stavanger</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Stavanger is white wooden houses, street art, and the gateway to Pulpit Rock and Lysefjord – Norway's adventure capital with surprising charm.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Stavanger: My Adventure Capital</h1>
+      <div class="logbook-entry">
+        <p>We walked off straight into Gamle Stavanger – 173 perfectly preserved 18th-century white houses with roses climbing the walls and cats sleeping on every doorstep. The petroleum museum is surprisingly cool – interactive oil-platform exhibits that make you feel like a roughneck. We had lunch at Fisketorget – fish soup so rich it should be illegal, eaten on the harbor while gulls circled overhead.</p>
+
+        <p>The real magic was the three-hour fjord cruise to Lysefjord – the captain nosed right up to Vagabonds' Cave and cut the engines under Pulpit Rock towering 604 m straight above us. The cliff face is so sheer it looks Photoshopped. We saw mountain goats on impossible ledges and waterfalls that fall for hundreds of meters. The pros: perfect mix of cute town and dramatic nature. The cons: Pulpit Rock hike itself is too long for a port day, but the boat view is arguably better anyway.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Drifting in complete silence under Preikestolen while a waterfall roared beside the boat and a single sunbeam lit the entire rock face like a stage – I actually whispered "no way this is real."
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Stavanger</h3>
+        <p>Ship docks 10-minute walk from old town and harbor. Fjord cruises leave right in front of the ship.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The wind in Lysefjord can be fierce – a warm layer and windproof jacket make the dramatic scenery even more enjoyable.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Stavanger worth it?</strong><br/>A: Best fjord access without overnighting.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Lysefjord cruise with Pulpit Rock view.</p>
+        <p><strong>Q: How long for fjord cruise?</strong><br/>A: 3–4 hours is perfect.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Yes – straight into Gamle Stavanger.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/tallinn.html
+++ b/ports/tallinn.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Tallinn with tips for medieval old town, Toompea Hill, Alexander Nevsky Cathedral."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Tallinn Port Guide — Perfectly Preserved Hanseatic Fairy Tale | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Tallinn, Estonia — perfectly preserved Hanseatic fairy tale with orange roofs, church spires, medieval walls."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/tallinn.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Tallinn", "item": "https://cruisinginthewake.com/ports/tallinn.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Tallinn</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Tallinn is a perfectly preserved Hanseatic fairy tale – orange roofs, church spires, and medieval walls that make you feel like you've time-traveled to 1450.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Tallinn: My Medieval Time Machine</h1>
+      <div class="logbook-entry">
+        <p>We walked off straight through the Viru Gates into a Disney movie – cobblestones, pastel merchants' houses, nuns in habits buying flowers. Alexander Nevsky Cathedral's onion domes glowed in the sun, incense and chanting spilling out the doors. We climbed Toompea Hill to the viewing platforms – the entire lower town spread below like a medieval model village, red roofs as far as the eye could see.</p>
+
+        <p>We had lunch at Olde Hansa – candlelit, serving bear stew and spiced beer in clay mugs while musicians played lute. In the afternoon we explored the secret St. Catherine's Passage – artisans blowing glass and weaving exactly like 500 years ago. The pros: the best-preserved medieval city in northern Europe and surprisingly affordable. The cons: cruise crowds mid-day, but they disappear into the labyrinthine alleys if you wander.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing alone in St. Catherine's Passage while a glassblower created a tiny green horse in flames and the only sound was medieval music drifting from a hidden courtyard.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Tallinn</h3>
+        <p>Ship docks 10-minute walk from old town gates.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The old town cobblestones are authentically uneven – comfortable shoes make exploring the fairy tale even more magical.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Tallinn worth it?</strong><br/>A: The most beautiful Baltic capital.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Just wander Toompea and lower town.</p>
+        <p><strong>Q: How long needed?</strong><br/>A: 5–6 hours of pure joy.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Yes – straight into the Middle Ages.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/tromso.html
+++ b/ports/tromso.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Tromsø with tips for midnight sun, Arctic Cathedral, cable car viewpoint, and reindeer."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Tromsø Port Guide — Arctic Capital of Midnight Sun & Northern Lights | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Tromsø, Norway — Arctic capital with midnight sun or northern lights, reindeer sledding, stunning Arctic Cathedral."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/tromso.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Tromsø", "item": "https://cruisinginthewake.com/ports/tromso.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Tromsø</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Tromsø is the Arctic capital – midnight sun or northern lights, reindeer sledding, and the stunning Arctic Cathedral glowing across the fjord.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Tromsø: My Arctic Capital</h1>
+      <div class="logbook-entry">
+        <p>We arrived in summer under 24-hour daylight and the city felt like it never slept – people kayaking at 11 p.m., the sun just dipping behind mountains but never setting. The cable car up Storsteinen gave us views over islands stretching to infinity while reindeer grazed below. The Arctic Cathedral at midnight looked like a frozen aurora made of concrete and glass – we attended an actual midnight sun concert inside with organ music echoing off the triangular windows.</p>
+
+        <p>Lunch was reindeer steak at Emma's Drømmekjøkken – tastes like lean, gamey beef and felt appropriately Arctic. In the evening we went on a husky wagon visit (summer wheels instead of sleds) – 120 barking Alaskan huskies all desperate for cuddles. The pros: genuine Arctic city with big-city amenities. The cons: expensive (everything is), but the experiences are once-in-a-lifetime.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing on the Fjellheisen viewpoint at 1 a.m. with the sun sitting on the horizon turning everything peach while the city lights started twinkling on below – day and night existing at the same time.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Tromsø</h3>
+        <p>Ship docks 5-minute walk from city center. Everything reachable by foot or quick bus.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>Even summer nights are cool above the Arctic Circle – a light jacket lets you enjoy the midnight sun in complete comfort.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Tromsø worth it?</strong><br/>A: The coolest Arctic city you can visit by cruise ship.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Fjellheisen cable car + Arctic Cathedral.</p>
+        <p><strong>Q: How long for midnight sun concert?</strong><br/>A: 1 hour of pure magic.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Yes – right into town.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/warnemunde.html
+++ b/ports/warnemunde.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Warnemünde with tips for Berlin day trip, Brandenburg Gate, Checkpoint Charlie."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Warnemünde Port Guide — Gateway to Berlin Day Trip | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Warnemünde, Germany — perfect beach town and gateway to Berlin with Brandenburg Gate, Museum Island, Checkpoint Charlie."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/warnemunde.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Warnemünde", "item": "https://cruisinginthewake.com/ports/warnemunde.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Warnemünde</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Warnemünde is a perfect German beach town, but everyone uses it as the gateway to Berlin – three hours each way for the German capital experience.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Warnemünde: My Gateway to Berlin</h1>
+      <div class="logbook-entry">
+        <p>We took the first train to Berlin at 7:30 a.m. and were at Brandenburg Gate by 10:15 – the city still quiet enough to feel intimate. Walked Unter den Linden to Museum Island, cried at the Pergamon Altar (even reconstructed), then Checkpoint Charlie and the East Side Gallery where the Wall still stands covered in murals. We had currywurst at Curry 36 that tasted exactly like freedom and mustard.</p>
+
+        <p>We arrived back in Warnemünde at golden hour – the beach was full of locals in strandkorb chairs drinking Astra beer while the sun set over the Baltic. The pros: you actually get Berlin in a day. The cons: six hours on trains, but the German rail system makes it painless.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing alone under the Brandenburg Gate at 10:30 a.m. while a street musician played "Imagine" and the whole history of the 20th century washed over me.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Warnemünde</h3>
+        <p>Direct trains every 30 minutes from Warnemünde station (5-minute walk from ship) to Berlin Hbf.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The Berlin day is long but perfectly doable – an early start and comfortable train seat make it one of the best port days possible.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Warnemünde/Berlin worth it?</strong><br/>A: The only realistic way to see Berlin by cruise ship.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Brandenburg Gate + Reichstag dome (pre-book).</p>
+        <p><strong>Q: How long in Berlin?</strong><br/>A: 6–7 hours on ground is perfect.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: To Warnemünde beach yes; Berlin needs train.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -805,6 +805,66 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://www.cruisinginthewake.com/ports/bergen.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/stavanger.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/alesund.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/tromso.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/tallinn.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/st-petersburg.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/riga.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/gdansk.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/warnemunde.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/kiel.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://www.cruisinginthewake.com/privacy.html</loc>
     <lastmod>2025-11-19</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
…format

Created comprehensive port guides for Northern Europe region:
- Bergen, Norway (Bryggen wharf, Mount Fløyen funicular)
- Stavanger, Norway (Lysefjord cruise, Pulpit Rock views)
- Ålesund, Norway (Art Nouveau architecture, Mount Aksla)
- Tromsø, Norway (Arctic capital, midnight sun, Arctic Cathedral)
- Tallinn, Estonia (Medieval old town, Hanseatic fairy tale)
- St. Petersburg, Russia (Hermitage, Church on Spilled Blood)
- Riga, Latvia (Art Nouveau capital, Central Market)
- Gdansk, Poland (Amber, Solidarity, Hanseatic old town)
- Warnemünde, Germany (Berlin day trip gateway)
- Kiel, Germany (Kiel Canal, sailing capital, U-boat museum)

All pages follow ICP-Lite v1.0 protocol with complete sentences, price-agnostic language, first-person logbook entries, and poignant highlights.

Updated search index and sitemap with all 10 new ports.