### PR TITLE
ADD: 10 Northern Europe Batch 2 cruise port pages with ICP-Lite v1.0 …

### DIFF
--- a/assets/data/search-index.json
+++ b/assets/data/search-index.json
@@ -4487,5 +4487,159 @@
       "u-boat",
       "naval memorial"
     ]
+  },
+  {
+    "title": "Zeebrugge/Bruges, Belgium",
+    "url": "/ports/zeebrugge.html",
+    "description": "Gateway to perfectly preserved medieval Bruges with canals, swans, Belfry climb, chocolate shops.",
+    "cta": "First-person logbook guide to Zeebrugge/Bruges with medieval Bruges.",
+    "category": "port",
+    "keywords": [
+      "zeebrugge",
+      "bruges",
+      "belgium",
+      "medieval",
+      "canals",
+      "belfry",
+      "chocolate"
+    ]
+  },
+  {
+    "title": "Le Havre/Paris, France",
+    "url": "/ports/le-havre.html",
+    "description": "Realistic gateway to Paris for Eiffel Tower, Louvre, Montmartre in single (very full) day by train.",
+    "cta": "First-person logbook guide to Le Havre/Paris day trip.",
+    "category": "port",
+    "keywords": [
+      "le havre",
+      "paris",
+      "france",
+      "eiffel tower",
+      "louvre",
+      "montmartre",
+      "day trip"
+    ]
+  },
+  {
+    "title": "Cherbourg, France",
+    "url": "/ports/cherbourg.html",
+    "description": "Largest artificial harbor, Cité de la Mer submarine museum, D-Day beaches, Utah Beach, Normandy charm.",
+    "cta": "First-person logbook guide to Cherbourg with D-Day beaches.",
+    "category": "port",
+    "keywords": [
+      "cherbourg",
+      "france",
+      "normandy",
+      "d-day",
+      "cite de la mer",
+      "submarine",
+      "utah beach"
+    ]
+  },
+  {
+    "title": "Bordeaux, France",
+    "url": "/ports/bordeaux.html",
+    "description": "Wine capital of world with Cité du Vin museum shaped like decanter, Miroir d'Eau, Saint-Émilion village.",
+    "cta": "First-person logbook guide to Bordeaux with Cité du Vin.",
+    "category": "port",
+    "keywords": [
+      "bordeaux",
+      "france",
+      "wine",
+      "cite du vin",
+      "saint-emilion",
+      "port wine"
+    ]
+  },
+  {
+    "title": "Bilbao, Spain",
+    "url": "/ports/bilbao.html",
+    "description": "Frank Gehry's titanium Guggenheim masterpiece, Puppy flower-dog, Richard Serra steel spirals, Basque pintxos.",
+    "cta": "First-person logbook guide to Bilbao with Guggenheim.",
+    "category": "port",
+    "keywords": [
+      "bilbao",
+      "spain",
+      "guggenheim",
+      "basque",
+      "pintxos",
+      "frank gehry"
+    ]
+  },
+  {
+    "title": "La Coruña, Spain",
+    "url": "/ports/la-coruna.html",
+    "description": "City of Glass with 1,900-year-old Tower of Hercules lighthouse still working, glazed galerías, Riazor beach.",
+    "cta": "First-person logbook guide to La Coruña with Tower of Hercules.",
+    "category": "port",
+    "keywords": [
+      "la coruna",
+      "spain",
+      "galicia",
+      "tower of hercules",
+      "lighthouse",
+      "galerias"
+    ]
+  },
+  {
+    "title": "Vigo, Spain",
+    "url": "/ports/vigo.html",
+    "description": "Gateway to Cíes Islands Atlantic paradise with world's best beaches, Rodas Beach, limited daily visitors.",
+    "cta": "First-person logbook guide to Vigo with Cíes Islands.",
+    "category": "port",
+    "keywords": [
+      "vigo",
+      "spain",
+      "galicia",
+      "cies islands",
+      "rodas beach",
+      "paradise"
+    ]
+  },
+  {
+    "title": "Porto (Leixões), Portugal",
+    "url": "/ports/porto.html",
+    "description": "Terracotta roofs cascading to Douro, port wine lodges, São Bento station with 20,000 azulejos tiles.",
+    "cta": "First-person logbook guide to Porto with port wine tasting.",
+    "category": "port",
+    "keywords": [
+      "porto",
+      "portugal",
+      "douro",
+      "port wine",
+      "sao bento",
+      "azulejos",
+      "ribeira"
+    ]
+  },
+  {
+    "title": "Honfleur, France",
+    "url": "/ports/honfleur.html",
+    "description": "Prettiest harbor in Normandy with colorful Vieux Bassin tall houses, birthplace of Impressionism.",
+    "cta": "First-person logbook guide to Honfleur with Vieux Bassin.",
+    "category": "port",
+    "keywords": [
+      "honfleur",
+      "france",
+      "normandy",
+      "vieux bassin",
+      "impressionism",
+      "monet"
+    ]
+  },
+  {
+    "title": "Gothenburg, Sweden",
+    "url": "/ports/gothenburg.html",
+    "description": "Trams, Feskekôrka seafood fish church, car-free southern archipelago islands, Liseberg park, Scandinavian cool.",
+    "cta": "First-person logbook guide to Gothenburg with archipelago.",
+    "category": "port",
+    "keywords": [
+      "gothenburg",
+      "sweden",
+      "feskekorka",
+      "archipelago",
+      "liseberg",
+      "swedish"
+    ]
   }
 ]

--- a/ports/bilbao.html
+++ b/ports/bilbao.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Bilbao with tips for Guggenheim Museum, Puppy sculpture, pintxos crawl."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Bilbao Port Guide — Guggenheim Effect & Basque Pintxos | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Bilbao, Spain — Frank Gehry's titanium Guggenheim masterpiece, Puppy flower-dog, pintxos heaven, Basque cool."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/bilbao.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Bilbao", "item": "https://cruisinginthewake.com/ports/bilbao.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Bilbao</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Bilbao is the Guggenheim effect – Frank Gehry's titanium masterpiece that turned an industrial city into one of Europe's coolest art destinations.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Bilbao: My Guggenheim Dream</h1>
+      <div class="logbook-entry">
+        <p>We walked off straight to the Guggenheim – the building looks different from every angle, like a metallic flower opening to the Nervión River. Puppy the flower-dog greeted us with 40,000 real pansies. Inside, Richard Serra's massive steel spirals made us dizzy in the best way – walking through them feels like being inside a hurricane made of rust.</p>
+
+        <p>We went to Casco Viejo for lunch – pintxos heaven at Víctor Montes: foie gras with apple, txangurro spider crab, and cold txakoli poured from height. In the afternoon we took the funicular up Mount Artxanda for the panoramic view – the entire titanium museum gleaming below like a spaceship. The pros: world-class art in a genuinely lived-in city. The cons: Basque rain is real, but the museum is perfect for wet days.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing alone inside Serra's "The Matter of Time" while the curved steel walls warped the sound of my own footsteps into something alien and beautiful.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Bilbao</h3>
+        <p>Ship docks 15-minute tram from Guggenheim and old town.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The Guggenheim's curves are designed to be walked around – comfortable shoes make discovering every new angle pure joy.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Bilbao worth it?</strong><br/>A: The coolest city transformation in Europe.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Guggenheim exterior + interior + pintxos crawl.</p>
+        <p><strong>Q: How long for Guggenheim?</strong><br/>A: 3–4 hours minimum.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Easy tram ride.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/bordeaux.html
+++ b/ports/bordeaux.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Bordeaux with tips for Cité du Vin wine museum, Miroir d'Eau, Saint-Émilion."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Bordeaux Port Guide — Wine Capital & Cité du Vin Museum | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Bordeaux, France — wine capital of world with Cité du Vin museum, Miroir d'Eau reflecting pool, Saint-Émilion."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/bordeaux.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Bordeaux", "item": "https://cruisinginthewake.com/ports/bordeaux.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Bordeaux</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Bordeaux is golden stone, grand boulevards, and the wine capital of the world – with the stunning Cité du Vin museum shaped like a wine decanter.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Bordeaux: My Wine Capital</h1>
+      <div class="logbook-entry">
+        <p>The ship docks 45 minutes from the city center, but the shuttle drops you at the most beautiful urban waterfront in Europe – the Garonne reflecting 18th-century façades like a mirror. We walked the entire Miroir d'Eau (the world's largest reflecting pool) barefoot while kids splashed and the Place de la Bourse shimmered behind us.</p>
+
+        <p>Cité du Vin is worth every penny – interactive exhibits, smells of oak and blackcurrant, and a tasting on the 8th floor with 360° views over the river. We had lunch at Le Quatrième Mur – Philippe Etchebest's brasserie opposite the opera – duck breast with perfect crispy skin and a glass of Saint-Émilion that tasted like liquid velvet. In the afternoon we took the tram to Saint-Émilion village (45 min) – medieval streets surrounded by actual grand cru vineyards. The pros: wine heaven with zero pretension. The cons: hot in summer, but the river breeze saves you.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing on the Belvédère at Cité du Vin with a glass of 2015 Château Figeac watching the sun set over the Garonne while the entire golden city turned pink.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Bordeaux</h3>
+        <p>Ship shuttle to city center, then excellent tram network.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>Bordeaux stone reflects heat – light clothing and plenty of water make wine tasting even more pleasant.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Bordeaux worth it?</strong><br/>A: The most elegant wine city on Earth.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Cité du Vin + riverfront wander.</p>
+        <p><strong>Q: How long for Cité du Vin?</strong><br/>A: 3–4 hours including tasting.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: No – shuttle required.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/cherbourg.html
+++ b/ports/cherbourg.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Cherbourg with tips for Cité de la Mer submarine museum, D-Day beaches, Utah Beach."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Cherbourg Port Guide — D-Day Beaches & Submarine Museum | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Cherbourg, France — largest artificial harbor, Cité de la Mer submarine museum, D-Day beaches, Normandy charm."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/cherbourg.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Cherbourg", "item": "https://cruisinginthewake.com/ports/cherbourg.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Cherbourg</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Cherbourg is umbrellas on the promenade, the largest artificial harbor in the world, and perfect Normandy charm with D-Day beaches an easy drive away.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Cherbourg: My Normandy Gateway</h1>
+      <div class="logbook-entry">
+        <p>We walked off straight onto the Quai de Normandie – massive art-deco transatlantic terminal where the Titanic stopped and the Queen Mary was built. La Cité de la Mer is brilliant – the Redoutable submarine tour inside a real nuclear sub is mind-blowing, and the Titanic exhibit has actual passenger artifacts that made us tear up.</p>
+
+        <p>In the afternoon we drove to Sainte-Mère-Église (where paratrooper John Steele hung from the church steeple) and Utah Beach – the sand is still there, the bunkers still stare at the sea, and the silence is deafening. We had lunch at a tiny café in town – moules-frites with cider, the mussels so fresh they tasted like the ocean waved hello. The pros: authentic Normandy without the Omaha crowds. The cons: rainy more often than not, but the clouds make the green even greener.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing alone inside the Redoutable submarine's torpedo room while the guide described launching a nuclear missile – the weight of history in a steel tube.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Cherbourg</h3>
+        <p>Ship docks right in town – everything walkable or short taxi to beaches.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>Normandy weather is famously changeable – a light rain jacket keeps the day perfect no matter what.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Cherbourg worth it?</strong><br/>A: Best underrated Normandy port.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Cité de la Mer + Utah Beach.</p>
+        <p><strong>Q: How long for D-Day sites?</strong><br/>A: 5–6 hours round-trip.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Yes – right into town.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/gothenburg.html
+++ b/ports/gothenburg.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Gothenburg with tips for Feskekôrka fish church, southern archipelago islands, Liseberg park."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Gothenburg Port Guide — Seafood, Archipelago & Scandinavian Cool | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Gothenburg, Sweden — trams, Feskekôrka seafood, car-free archipelago islands, friendliest Swedish city."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/gothenburg.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Gothenburg", "item": "https://cruisinginthewake.com/ports/gothenburg.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Gothenburg</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Gothenburg is trams, seafood, and Scandinavian cool – the friendliest big city in Sweden with an archipelago of car-free islands 20 minutes away.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Gothenburg: My Scandinavian Cool</h1>
+      <div class="logbook-entry">
+        <p>We walked off into a city that feels like Copenhagen and Oslo had a baby who smiles more. The Feskekôrka fish church – literally a church-shaped market smelling of fresh shrimp and dill. We had lunch at the counter – räkmacka shrimp mountain on bread so high it needs a fork, eaten while fishermen unloaded the catch behind us.</p>
+
+        <p>In the afternoon we took the ferry to the southern archipelago – car-free islands, red boathouses, and sauna jumps into 18°C water followed by cinnamon buns. We went to Liseberg amusement park at golden hour – the wooden roller coaster Balder gave us butterflies and views over the entire city. The pros: genuinely Swedish without Stockholm prices or attitude. The cons: rain (it did), but Swedes just put on cute raincoats and keep smiling.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Jumping off the sauna dock into the Baltic at 8 p.m. while the sun still hung high and a dozen naked Swedes cheered us on – peak Scandinavian happiness.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Gothenburg</h3>
+        <p>Ship docks 10-minute tram from city center – excellent public transport everywhere.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>Gothenburg's archipelago is pure magic – a light jacket for the boat ride makes island hopping even better.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Gothenburg worth it?</strong><br/>A: The coolest, friendliest Swedish city.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Feskekôrka + southern archipelago ferry.</p>
+        <p><strong>Q: How long for islands?</strong><br/>A: 4–5 hours round-trip.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Easy tram ride.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/honfleur.html
+++ b/ports/honfleur.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Honfleur with tips for Vieux Bassin harbor, Sainte-Catherine church, Impressionism birthplace."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Honfleur Port Guide — Prettiest Normandy Harbor & Impressionism | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Honfleur, France — prettiest harbor in Normandy with colorful Vieux Bassin, birthplace of Impressionism."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/honfleur.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Honfleur", "item": "https://cruisinginthewake.com/ports/honfleur.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Honfleur</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Honfleur is the prettiest harbor in Normandy – colorful tall houses reflected in the Vieux Bassin and the birthplace of Impressionism.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Honfleur: My Impressionist Dream</h1>
+      <div class="logbook-entry">
+        <p>We tendered right into the heart of the Vieux Bassin – slate-roofed houses stacked like macarons around the water, sailboats bobbing, the smell of crêpes and Calvados everywhere. Sainte-Catherine church – built by shipwrights after the Hundred Years' War, entirely of wood with a bell tower across the street like a separate lighthouse.</p>
+
+        <p>We had lunch at SaQuaNa – two Michelin stars of seafood that tasted like the ocean went to culinary school. In the afternoon we walked the Côte de Grâce for views over the Seine estuary that made Monet grab his paintbrush. The pros: feels like a painting you can walk inside. The cons: tiny, so one ship fills it – but the charm wins every time.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Sitting on the harbor wall at golden hour watching the light do exactly what the Impressionists spent their lives chasing while a street accordion played "La Vie en Rose."
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Honfleur</h3>
+        <p>Tender drops you right at the Vieux Bassin.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>Honfleur's charm is in its small size – wandering slowly lets every reflection and flowerbox reveal itself.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Honfleur worth it?</strong><br/>A: The most beautiful tender port in France.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Just sit by the Vieux Bassin and soak.</p>
+        <p><strong>Q: How long needed?</strong><br/>A: 4–5 hours of pure Normandy magic.</p>
+        <p><strong>Q: Walk from tender?</strong><br/>A: Yes – you're already there.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/la-coruna.html
+++ b/ports/la-coruna.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to La Coruña with tips for Tower of Hercules lighthouse, glazed galerías, pulpo a la gallega."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>La Coruña Port Guide — City of Glass & Roman Lighthouse | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to La Coruña, Spain — City of Glass with 1,900-year-old Tower of Hercules lighthouse, glazed galerías, Riazor beach."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/la-coruna.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "La Coruña", "item": "https://cruisinginthewake.com/ports/la-coruna.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">La Coruña</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> La Coruña is the City of Glass – Roman lighthouse still working after 1,900 years, galleries in glazed balconies, and beaches right in the city center.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>La Coruña: My City of Glass</h1>
+      <div class="logbook-entry">
+        <p>We walked off straight to the Tower of Hercules – the oldest functioning lighthouse in the world. Climbing the 242 steps felt like time travel – Celtic, Roman, and medieval graffiti carved into the stones. The Atlantic wind at the top whipped our hair while Africa was theoretically visible on the horizon.</p>
+
+        <p>In the afternoon we wandered the glazed galerías – entire buildings wrapped in glass balconies that make the city sparkle like crystal. We had lunch at A Mundiña – pulpo a la gallega so tender it melted, pimientos de Padrón where one in ten is spicy and perfect. We went to Riazor beach for a swim – city beach with real waves and zero tourists. The pros: authentic Galician soul with almost no cruise crowds. The cons: Atlantic water is cold, but that's why it feels alive.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing at the foot of the Tower of Hercules watching the Atlantic crash exactly where Romans did 1,900 years ago while the lantern still blinked above us.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around La Coruña</h3>
+        <p>Ship docks 10-minute walk from old town and lighthouse.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The path around the Tower is exposed to wind – a light jacket makes the dramatic views even more exhilarating.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is La Coruña worth it?</strong><br/>A: The most underrated Spanish port.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Tower of Hercules + galerías walk.</p>
+        <p><strong>Q: How long for lighthouse?</strong><br/>A: 2 hours including climb.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Yes – right into the action.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/le-havre.html
+++ b/ports/le-havre.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Le Havre/Paris with tips for Paris day trip, Eiffel Tower, Louvre, Montmartre."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Le Havre Port Guide — Gateway to Paris Day Trip | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Le Havre/Paris, France — realistic gateway to Paris for Eiffel Tower, Louvre, Montmartre in single day."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/le-havre.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Le Havre", "item": "https://cruisinginthewake.com/ports/le-havre.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Le Havre</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Le Havre is the realistic gateway to Paris – six hours round-trip on excellent trains for the City of Light in a single (very full) day.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Le Havre: My Gateway to Paris</h1>
+      <div class="logbook-entry">
+        <p>We caught the 7:45 train and were sipping café crème under the Eiffel Tower by 10:30. The Seine sparkled, the chestnut trees were in bloom, and Paris smelled exactly like fresh baguette and romance. We walked from the Louvre (Mona Lisa smaller than expected, Venus de Milo perfect) across the Tuileries to the Orangerie where Monet's water lilies wrapped around us like a hug.</p>
+
+        <p>We had lunch at a tiny Montmartre bistro – steak-frites and a carafe of red while an accordion player outside made us cry into our fries. Quick metro to Sacré-Cœur for the view, then back to Gare St-Lazare with croissants for the train. The pros: you actually get Paris – real Paris – in a day. The cons: it's a long day with trains, but the French rail system is flawless and the memories are priceless.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing under the Eiffel Tower at exactly noon when it started sparkling in the sun and a thousand people gasped at once – pure movie magic made real.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Le Havre/Paris</h3>
+        <p>Direct trains from Le Havre station (5-minute taxi from ship) to Paris St-Lazare every hour.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The Paris day is full but perfectly paced – an early train and pre-booked museum tickets turn rush into pure joy.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Le Havre/Paris worth it?</strong><br/>A: The only realistic way to see Paris by cruise ship.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Eiffel Tower + Louvre express + Montmartre.</p>
+        <p><strong>Q: How long in Paris?</strong><br/>A: 7–8 hours on ground is ideal.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: No – train is essential.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/porto.html
+++ b/ports/porto.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Porto with tips for Douro River, port wine lodges, São Bento azulejos, Dom Luís I bridge."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Porto Port Guide — Port Wine Lodges & Azulejo Train Station | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Porto (Leixões), Portugal — terracotta roofs cascading to Douro, port wine lodges, São Bento station azulejos."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/porto.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Porto", "item": "https://cruisinginthewake.com/ports/porto.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Porto</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Porto is terracotta roofs cascading down to the Douro, port wine lodges, and the most beautiful train station in Europe covered in azulejos.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Porto: My Douro Dream</h1>
+      <div class="logbook-entry">
+        <p>We took the shuttle to the Ribeira and the city hit us like a warm hug – colorful houses tumbling into the river, the Dom Luís I bridge towering above, buskers playing fado. São Bento station at 9 a.m. – 20,000 hand-painted tiles telling Portugal's history while commuters rushed past like nothing. We walked across the bridge to Gaia for port tasting at Ramos Pinto – 10-year tawny that tasted like liquid Christmas.</p>
+
+        <p>We had lunch at Casa Portuguesa do Pastel de Bacalhau – cod cake with molten Serra cheese inside, paired with Vinho Verde that fizzes on the tongue. We watched sunset from the terrace of the monastery above the bridge – the entire city turned golden while church bells rang from every hill. The pros: soulful, walkable, and genuinely welcoming. The cons: those hills are steep, but every climb earns another perfect view.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing on the upper deck of Dom Luís I bridge at blue hour while the city lights started twinkling on below and a fado singer's voice drifted up from the Ribeira.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Porto</h3>
+        <p>Ship shuttle to city center (15 min), then everything walkable or funicular.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>Porto's hills are legendary – comfortable shoes and the occasional funicular make exploring pure pleasure.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Porto worth it?</strong><br/>A: The most beautiful city on the Iberian Atlantic coast.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Ribeira + port lodge tasting + São Bento.</p>
+        <p><strong>Q: How long for port tasting?</strong><br/>A: 2 hours including Gaia visit.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: No – shuttle needed.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/vigo.html
+++ b/ports/vigo.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Vigo with tips for Cíes Islands paradise, Rodas Beach, Galician old town."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Vigo Port Guide — Gateway to Cíes Islands Paradise | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Vigo, Spain — gateway to Cíes Islands Atlantic paradise with world's best beaches, Rodas Beach, Galician charm."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/vigo.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Vigo", "item": "https://cruisinginthewake.com/ports/vigo.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Vigo</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Vigo is the gateway to the Cíes Islands – Atlantic paradise with beaches that regularly top "best in the world" lists and only 2,200 visitors a day.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Vigo: My Gateway to Paradise</h1>
+      <div class="logbook-entry">
+        <p>We caught the 9 a.m. ferry to Cíes (booked months in advance) and stepped onto Rodas Beach – powder-white sand connecting two islands in a perfect crescent, water so clear we saw fish from the ferry. The 3-km hike to Faro da Porta gave views that made us gasp – the entire Ría de Vigo spread below like a map. We had octopus salad and Estrella Galicia on the beach while Atlantic rollers crashed.</p>
+
+        <p>We arrived back in Vigo at golden hour – the old town Casco Vello is all tiny squares and tapas bars smelling of pimientos de Padrón. The pros: you get paradise islands and a working Galician city in one day. The cons: Cíes tickets sell out fast, but the city itself is lovely if you miss them.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Lying on Rodas Beach with zero phone signal and the only sound Atlantic waves and seagulls – the most perfect beach day of my life.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Vigo</h3>
+        <p>Ship docks in city center – ferry terminal 10-minute walk.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>Cíes has a strict daily limit – booking early guarantees one of the best beach days on the planet.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Vigo worth it?</strong><br/>A: For Cíes Islands alone, absolutely.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Ferry to Cíes + Rodas Beach.</p>
+        <p><strong>Q: How long on Cíes?</strong><br/>A: Full day is paradise.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Yes – right to ferry.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/ports/zeebrugge.html
+++ b/ports/zeebrugge.html
@@ -1,0 +1,128 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Zeebrugge/Bruges with tips for medieval Bruges canals, Belfry climb, chocolate shops."/>
+  <meta name="last-reviewed" content="2025-11-21"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Zeebrugge/Bruges Port Guide — Gateway to Medieval Fairy Tale | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Zeebrugge/Bruges, Belgium — gateway to perfectly preserved medieval Bruges with canals, swans, chocolate shops."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/zeebrugge.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Zeebrugge/Bruges", "item": "https://cruisinginthewake.com/ports/zeebrugge.html"}
+    ]
+  }
+  </script>
+  <style>
+    .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
+    .logbook-entry p { margin-bottom: 1.25rem; }
+    .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }
+    .port-section { margin: 2rem 0; padding: 1.25rem; background: #f7fdff; border-radius: 12px; border: 1px solid #e0f0f5; }
+    .port-section h3 { margin-top: 0; color: var(--sea, #0a3d62); }
+  </style>
+</head>
+<body class="page">
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Zeebrugge/Bruges</li></ol></nav>
+
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Zeebrugge is the gateway to Bruges – a perfectly preserved medieval fairy-tale city of canals, swans, and more chocolate shops per square meter than anywhere on Earth.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1 / span 999;">
+    <article class="card">
+      <h1>Zeebrugge/Bruges: My Medieval Fairy Tale</h1>
+      <div class="logbook-entry">
+        <p>We took the first shuttle and were wandering Bruges' cobbled streets by 9 a.m. while the morning mist still hung over the reien canals. The Belfry tower loomed above the Markt like a Gothic wedding cake, and climbing its 366 steps left us breathless in every sense – the carillon bells rang right over our heads at the top. A horse-drawn carriage clip-clopped past as we drifted along the Dijver watching swans glide under stone bridges that haven't changed since the 1400s.</p>
+
+        <p>We had lunch at De Halve Maan brewery – waterzooi cream stew and stoofvlees washed down with fresh Brugse Zot straight from the source. In the afternoon we went on a canal boat ride (the only way to see the city properly) – the captain pointed out the exact spot where Colin Farrell jumped in In Bruges. We finished with hot chocolate so thick the spoon stood up at The Old Chocolate House. The pros: Bruges is the most romantic medieval city still alive. The cons: cruise crowds descend by 10:30, but the back streets stay magically quiet if you wander five minutes off the Markt.</p>
+
+        <div class="poignant-highlight">
+          <strong>The Moment That Stays With Me:</strong> Standing alone on the Rozenhoedkaai at golden hour with the Belfry reflected perfectly in the canal while church bells rang and a swan family swam past like they were paid by the tourism board.
+        </div>
+      </div>
+
+      <section class="port-section">
+        <h3>Getting Around Zeebrugge/Bruges</h3>
+        <p>Ship shuttle or train to Bruges (15–20 min). Once there everything is walkable or canal boat.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Positively Worded Word of Warning</h3>
+        <p>The cobblestones are authentically medieval – comfortable shoes make the fairy tale even more enjoyable.</p>
+      </section>
+
+      <section class="port-section">
+        <h3>Frequently Asked Questions</h3>
+        <p><strong>Q: Is Zeebrugge/Bruges worth it?</strong><br/>A: The single most beautiful day trip in northern Europe.</p>
+        <p><strong>Q: Best thing?</strong><br/>A: Canal boat + Belfry climb + chocolate.</p>
+        <p><strong>Q: How long in Bruges?</strong><br/>A: 6–7 hours is perfect.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: No – shuttle/train required.</p>
+      </section>
+    </article>
+  </div>
+  <aside class="rail" style="grid-column: 2; grid-row: 2;">
+    <section class="card">
+      <h3>About the Author</h3>
+      <div class="author-info" style="display: flex; gap: 1rem; align-items: flex-start;">
+        <a href="/authors/ken-baker.html" style="flex-shrink: 0;">
+          <img src="/authors/img/ken1_96_96.webp" srcset="/authors/img/ken1_96_96.webp 1x, /authors/img/ken1_96_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </a>
+        <div>
+          <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Recent Articles</h3>
+      <div id="recent-rail"></div>
+    </section>
+  </aside>
+
+
+
+    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+  </main>
+  <footer class="wrap" style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #e0e8f0;"><p style="text-align: center; color: #666;">&copy; 2025 In the Wake.</p></footer>
+
+  <script>
+    // Load recent articles
+    (async function() {
+      try {
+        const response = await fetch('/assets/data/articles/index.json');
+        const articles = await response.json();
+        const rail = document.getElementById('recent-rail');
+
+        if (rail && articles && articles.length > 0) {
+          rail.innerHTML = articles.slice(0, 5).map(article => `
+            <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;">
+              <h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;">
+                <a href="${article.url}">${article.title}</a>
+              </h4>
+              <p style="margin: 0; font-size: 0.8rem; color: #666;">${article.date}</p>
+            </div>
+          `).join('');
+        }
+      } catch (err) {
+        console.log('Could not load articles:', err);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -865,6 +865,66 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://www.cruisinginthewake.com/ports/zeebrugge.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/le-havre.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/cherbourg.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/bordeaux.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/bilbao.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/la-coruna.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/vigo.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/porto.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/honfleur.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cruisinginthewake.com/ports/gothenburg.html</loc>
+    <lastmod>2025-11-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://www.cruisinginthewake.com/privacy.html</loc>
     <lastmod>2025-11-19</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
…format

Created comprehensive port guides for Northern Europe region:
- Zeebrugge/Bruges, Belgium (Medieval Bruges canals, Belfry, chocolate)
- Le Havre/Paris, France (Paris day trip gateway - Eiffel Tower, Louvre)
- Cherbourg, France (Cité de la Mer submarine museum, D-Day beaches)
- Bordeaux, France (Wine capital, Cité du Vin, Saint-Émilion)
- Bilbao, Spain (Guggenheim Museum, Puppy, Basque pintxos)
- La Coruña, Spain (Tower of Hercules lighthouse, City of Glass)
- Vigo, Spain (Cíes Islands paradise, Rodas Beach)
- Porto, Portugal (Douro River, port wine lodges, São Bento azulejos)
- Honfleur, France (Vieux Bassin harbor, Impressionism birthplace)
- Gothenburg, Sweden (Feskekôrka, southern archipelago islands)

All pages follow ICP-Lite v1.0 protocol with complete sentences, price-agnostic language, first-person logbook entries, and poignant highlights.

Updated search index and sitemap with all 10 new ports.