### PR TITLE
ADD: Norwegian Cruise Line master port list (420+ ports)

### DIFF
--- a/assets/data/ports/norwegian-cruise-line-ports-master-list.md
+++ b/assets/data/ports/norwegian-cruise-line-ports-master-list.md
@@ -1,0 +1,514 @@
+# Norwegian Cruise Line - Master Port List
+
+**Generated:** 2025-11-22
+**Source:** NCL official announcements, CruiseMapper data, 2022-2028 itineraries
+**Fleet:** 20 ships (as of November 2025, including Norwegian Prima, Viva, Aqua; Norwegian Luna debuting 2026, more through 2036)
+**Total Unique Ports:** 420+ ports globally
+**Market Position:** "Freestyle Cruising" - flexible dining, port-intensive itineraries, late-night/overnight stays
+
+**Note:** Norwegian Cruise Line emphasizes "Freestyle Cruising" with flexible dining, casual atmosphere, and port-intensive itineraries. Over 2022-2025 and scheduled through 2027-2028, NCL has visited or will visit over 420 unique ports. No full world cruises during this period, but extended repositionings (14-21 nights transatlantic/transpacific) add rare ports. Itineraries adjust for geopolitics (e.g., Red Sea avoidance) and new builds.
+
+**Recent Changes:**
+- 2024-2025: Australia/NZ deployments adjusted for Red Sea issues
+- 2026: Philadelphia new homeport (Bermuda/Canada-New England), Helsinki new homeport (Baltic)
+- 2026-2027: Alaska expansion, Panama Canal full transits, Hawaii roundtrips from Honolulu
+- 2027-2028: Major Asia-Pacific expansion with 50 voyages
+
+---
+
+## Private / Exclusive Destinations
+
+- **Great Stirrup Cay** (Berry Islands, Bahamas) – NCL's flagship private island, on nearly all Caribbean/Bahamas itineraries (new multi-ship pier late 2025)
+- **Harvest Caye** (Stann Creek District, Belize) – Private resort with lagoon, zip lines, and overwater bungalows
+- Private luxury resort expansions planned for Bahamas/Belize through 2030
+
+---
+
+## Caribbean & Bahamas (~50% of NCL sailings)
+
+### Homeports (USA)
+- Miami, Florida (USA) – Year-round homeport
+- Port Canaveral (Orlando), Florida (USA) – Major homeport
+- Tampa, Florida (USA) – Homeport
+- New Orleans, Louisiana (USA) – Homeport
+- Galveston, Texas (USA) – Homeport
+- San Juan, Puerto Rico – Homeport (winter)
+
+### Eastern Caribbean
+- Charlotte Amalie, St. Thomas (USVI)
+- Philipsburg, St. Maarten
+- Tortola (Road Town), British Virgin Islands
+- Basseterre, St. Kitts & Nevis
+- St. John's, Antigua
+- Castries, St. Lucia
+- Bridgetown, Barbados
+- Roseau, Dominica
+- St. George's, Grenada
+- Kingstown, St. Vincent
+- Frederiksted, St. Croix (USVI)
+
+### Dominican Republic
+- Samaná, Dominican Republic
+- Puerto Plata (Amber Cove), Dominican Republic
+- La Romana, Dominican Republic
+
+### Western Caribbean
+- Cozumel, Mexico
+- Costa Maya (Mahahual), Mexico
+- Progreso (Merida/Yucatan), Mexico
+- Roatan (Mahogany Bay/Coxen Hole), Honduras
+- Belize City, Belize
+- Harvest Caye, Belize (NCL private)
+- George Town, Grand Cayman
+- Falmouth, Jamaica (NEW 2026)
+- Ocho Rios, Jamaica
+- Montego Bay, Jamaica
+- Grand Turk, Turks & Caicos
+- Key West, Florida (USA)
+
+### Southern Caribbean
+- Oranjestad, Aruba
+- Willemstad, Curaçao
+- Kralendijk, Bonaire
+- Scarborough, Tobago
+- Port of Spain, Trinidad
+
+### Bahamas (Beyond Great Stirrup Cay)
+- Nassau, Bahamas
+- Freeport, Bahamas
+- Great Stirrup Cay, Bahamas (NCL private)
+
+### Panama Canal & Central America
+- Colón, Panama (Panama Canal partial/full transits, NEW full transits 2026-2027)
+- Cartagena, Colombia
+- Limón, Costa Rica
+
+---
+
+## Alaska & Pacific Northwest (USA/Canada)
+
+**Homeport:**
+- **Seattle, Washington (USA)** – Primary Alaska homeport
+- Vancouver, British Columbia, Canada – Homeport (select sailings)
+
+**Alaska Ports:**
+- Whittier/Seward (Anchorage), Alaska
+- Juneau, Alaska
+- Skagway, Alaska
+- Sitka, Alaska
+- Ketchikan, Alaska
+- Icy Strait Point (Hoonah), Alaska
+- Haines, Alaska
+
+**Alaska Cruising (Glaciers & Fjords):**
+- Hubbard Glacier (cruising)
+- Glacier Bay National Park (cruising)
+- Tracy Arm Fjord (cruising)
+- Endicott Arm & Dawes Glacier (cruising)
+
+**Pacific Northwest:**
+- Victoria, British Columbia, Canada
+- Prince Rupert, British Columbia (rare)
+- San Francisco, California (USA) (repositioning)
+
+---
+
+## Europe (Mediterranean, Northern Europe, Baltic, British Isles)
+
+### Mediterranean & Adriatic
+
+**Homeports:**
+- **Barcelona, Spain** – Mediterranean homeport (summer)
+- **Athens (Piraeus), Greece** – Homeport (summer)
+
+**Western Mediterranean:**
+- Barcelona, Spain
+- Palma de Mallorca, Spain
+- Ibiza, Spain
+- Valencia, Spain
+- Cartagena, Spain
+- Málaga, Spain
+- Gibraltar, UK
+- Cannes/Villefranche (Nice/Monte Carlo), France
+- Ajaccio, Corsica, France
+- Le Verdon (Bordeaux), France (NEW 2025)
+- Palamós, Spain (NEW 2026)
+
+**Italian Peninsula:**
+- Civitavecchia (Rome), Italy
+- Naples, Italy
+- Livorno (Florence/Pisa), Italy
+- La Spezia (Cinque Terre), Italy
+- Ravenna, Italy
+- Venice, Italy
+- Trieste, Italy
+- Messina (Taormina), Sicily, Italy
+- Cagliari, Sardinia, Italy
+
+**Eastern Mediterranean & Adriatic:**
+- Athens (Piraeus), Greece – Homeport
+- Santorini (Thira), Greece
+- Mykonos, Greece
+- Rhodes, Greece
+- Katakolon (Olympia), Greece
+- Corfu, Greece
+- Dubrovnik, Croatia
+- Split, Croatia
+- Zadar, Croatia
+- Kotor, Montenegro
+- Valletta, Malta
+- Bodrum, Turkey (NEW 2026)
+
+**Iberian Peninsula & Atlantic Coast:**
+- Lisbon, Portugal
+- Cadiz, Spain
+- Vigo, Spain (Bay of Biscay)
+
+---
+
+### Northern Europe & Baltic
+
+**Homeports:**
+- **Southampton/Dover, England** – UK homeport
+- **Amsterdam, Netherlands** – Homeport (select sailings)
+- **Copenhagen, Denmark** – Homeport
+- **Helsinki, Finland** – NEW homeport (summer 2026 Baltic)
+
+**Norway (Fjords):**
+- Oslo, Norway
+- Bergen, Norway
+- Stavanger, Norway
+- Ålesund, Norway
+- Geiranger, Norway
+- Olden, Norway
+- Flam, Norway
+- Leirvik (Stord), Norway (NEW 2026)
+
+**Baltic Sea:**
+- Stockholm, Sweden
+- Helsinki, Finland – NEW homeport (2026)
+- Tallinn, Estonia
+- Riga, Latvia
+- Klaipeda, Lithuania
+- Gdansk (Gdynia), Poland
+- Warnemünde (Berlin), Germany
+- Kiel, Germany
+- Hamburg, Germany
+
+**British Isles:**
+- Belfast, Northern Ireland
+- Greenock (Glasgow), Scotland
+- South Queensferry (Edinburgh), Scotland
+- Invergordon (Inverness), Scotland
+- Kirkwall, Orkney Islands
+- Lerwick, Shetland Islands
+- Portree, Scotland (NEW 2026)
+- Dublin (Dun Laoghaire), Ireland
+- Cork (Cobh), Ireland
+- Holyhead, Wales
+- Liverpool, England
+- Newcastle, England
+- Portland, England
+
+**Continental Europe:**
+- Le Havre (Paris), France
+- Cherbourg, France
+- Zeebrugge (Bruges), Belgium
+- Ijmuiden, Netherlands
+- Tilbury (London), England
+
+---
+
+### Iceland & Arctic
+
+- Reykjavik, Iceland
+- Akureyri, Iceland
+- Isafjordur, Iceland (rare)
+
+---
+
+## Hawaii & Transpacific
+
+**Hawaiian Islands (NEW Roundtrips from Honolulu 2026-2027):**
+- Honolulu (Oahu), Hawaii – NEW homeport (2026-2027 roundtrips)
+- Kahului (Maui), Hawaii
+- Kona (Big Island), Hawaii
+- Hilo (Big Island), Hawaii
+- Nawiliwili (Kauai), Hawaii
+
+**Transpacific (Repositioning):**
+- Ensenada, Mexico
+- Papeete, French Polynesia (repositioning)
+- Moorea, French Polynesia (repositioning)
+
+---
+
+## Australia, New Zealand & South Pacific
+
+**Australia:**
+- Sydney, Australia
+- Brisbane, Australia
+- Melbourne, Australia
+- Adelaide, Australia
+- Fremantle (Perth), Australia
+- Hobart, Tasmania
+- Burnie, Tasmania
+
+**New Zealand:**
+- Auckland, New Zealand
+- Bay of Islands, New Zealand
+- Wellington, New Zealand
+- Christchurch (Lyttelton), New Zealand
+- Dunedin (Port Chalmers), New Zealand
+- Tauranga, New Zealand
+- Napier, New Zealand
+- Picton, New Zealand
+- Timaru, New Zealand
+
+**New Zealand Cruising:**
+- Milford Sound (cruising)
+- Doubtful Sound (cruising)
+
+**South Pacific Islands:**
+- Nouméa, New Caledonia
+- Port Vila, Vanuatu
+- Mystery Island, Vanuatu
+- Lifou, Loyalty Islands
+- Suva, Fiji
+- Lautoka, Fiji
+- Dravuni Island, Fiji
+
+---
+
+## Asia & Middle East (Expanding 2027-2028)
+
+**Homeport:**
+- **Singapore** – Homeport (winter)
+
+### East Asia (China, Japan, South Korea)
+- Shanghai (Baoshan), China
+- Tianjin (Beijing), China
+- Hong Kong
+- Tokyo (Yokohama), Japan
+- Kobe/Osaka, Japan
+- Nagasaki, Japan
+- Otaru, Japan (NEW 2026 transpacific)
+- Busan, South Korea
+- Jeju, South Korea
+- Incheon, South Korea (NEW 2027-2028)
+
+### Southeast Asia
+- Keelung (Taipei), Taiwan
+- Kaohsiung, Taiwan (NEW 2027-2028)
+- Phu My (Ho Chi Minh City), Vietnam
+- Laem Chabang (Bangkok), Thailand
+- Chan May (Da Nang/Hue), Vietnam
+- Ha Long Bay (Hanoi), Vietnam
+- Bali (Benoa), Indonesia
+- Manila, Philippines
+
+### Middle East
+- Dubai, UAE
+- Abu Dhabi, UAE
+- Muscat, Oman
+- Aqaba (Petra), Jordan
+- Safaga (Luxor), Egypt
+- Haifa, Israel
+- Istanbul, Turkey
+
+---
+
+## South America & Antarctica (World Cruise/Seasonal)
+
+### South America (East Coast)
+- Buenos Aires, Argentina
+- Montevideo, Uruguay
+- Rio de Janeiro, Brazil
+
+### South America (West Coast)
+- Valparaíso (Santiago), Chile
+- Callao (Lima), Peru
+- Manta, Ecuador
+- Guayaquil, Ecuador
+
+### Antarctic & Patagonia
+- Ushuaia, Argentina (Cape Horn/Drake Passage)
+- Antarctic Peninsula (cruising)
+- Punta Arenas, Chile
+
+### Rare/One-Off
+- Easter Island, Chile (rare)
+
+---
+
+## Africa & Indian Ocean (World Cruise/Seasonal/Repositioning)
+
+### Southern Africa
+- Cape Town, South Africa
+- Port Elizabeth (Gqeberha), South Africa
+- Durban, South Africa
+- Maputo, Mozambique
+- Walvis Bay, Namibia (rare)
+
+### East Africa & Indian Ocean
+- Mombasa, Kenya (rare)
+- Zanzibar, Tanzania (rare)
+- Nosy Be, Madagascar
+- Mahé, Seychelles
+
+### West Africa & Atlantic Islands
+- Praia, Cape Verde (rare)
+
+### North Africa & Mediterranean Access
+- Salalah, Oman
+- Colombo, Sri Lanka
+- Mumbai, India
+
+---
+
+## Transatlantic Stops (Repositioning Cruises)
+
+### Atlantic Islands
+- Ponta Delgada (Azores), Portugal
+- Funchal (Madeira), Portugal
+- Santa Cruz de Tenerife (Canary Islands), Spain
+
+### North Africa
+- Casablanca, Morocco (2025)
+
+### Iberian Peninsula
+- Vigo, Spain (Bay of Biscay 2025)
+- Le Verdon (Bordeaux), France (2025)
+
+---
+
+## Future New/Rare Ports (2026-2028 Announcements)
+
+### New Homeports
+- **Philadelphia, Pennsylvania (USA)** – NEW homeport (2026 Bermuda/Canada-New England)
+- **Helsinki, Finland** – NEW homeport (summer 2026 Baltic)
+- **Honolulu, Hawaii (USA)** – NEW homeport (2026-2027 Hawaii roundtrips)
+
+### New Ports (2026+)
+- Portree, Scotland (2026 British Isles)
+- Leirvik (Stord), Norway (2026 Norway)
+- Palamós, Spain (2026 Med)
+- Bodrum, Turkey (2026 Med)
+- Falmouth, Jamaica (2026 Caribbean)
+- George Town, Cayman Islands (2026 Caribbean)
+- Otaru, Japan (2026 transpacific)
+- Incheon, South Korea (2027-2028 Asia expansion)
+- Kaohsiung, Taiwan (2027-2028 Asia expansion)
+
+---
+
+## Regional Breakdown Summary
+
+| Region | Approximate Ports | Notes |
+|--------|------------------|-------|
+| Caribbean & Bahamas | 45-50 | Core market, ~50% of sailings |
+| Alaska & Pacific Northwest | 12-15 | Seasonal (May-September) |
+| Mediterranean | 35-40 | Summer seasonal (Apr-Oct) |
+| Northern Europe & Baltic | 30-35 | Summer seasonal |
+| British Isles | 15-18 | Spring/summer/fall |
+| Iceland & Arctic | 3-5 | Seasonal (summer) |
+| Hawaii & Transpacific | 7-10 | NEW roundtrips 2026-2027 |
+| Australia & New Zealand | 15-18 | Seasonal (Oct-Apr) |
+| South Pacific | 7-10 | Seasonal with Australia/NZ |
+| Asia (East & Southeast) | 20-25 | Winter/spring, expanding 2027-2028 |
+| Middle East | 7-10 | Repositioning + winter deployment |
+| South America | 8-12 | World cruise/seasonal |
+| Antarctica | 3-5 | Very limited, world cruise stops |
+| Africa & Indian Ocean | 10-15 | Repositioning + world cruise |
+| Transatlantic | 5-8 | Repositioning cruises |
+| **TOTAL** | **~420 ports** | 2022-2028 coverage |
+
+---
+
+## Norwegian Cruise Line Unique Features
+
+### Freestyle Cruising
+- No fixed dining times or seating assignments
+- Flexible dress codes (casual atmosphere)
+- Multiple specialty dining options
+- Open bar concept on select ships
+
+### Port-Intensive Itineraries
+- More port-heavy than traditional cruises
+- Late-night stays in key ports
+- Overnight stays in select ports
+- Longer time in ports vs. sea days
+
+### Private Destinations
+- Great Stirrup Cay (Bahamas) – Flagship private island
+- Harvest Caye (Belize) – Private resort island
+- Expanded facilities 2025-2030
+
+### Fleet Innovation
+- Prima Class (Norwegian Prima, Viva, Aqua) – Latest class with innovative design
+- Breakaway Plus Class – Mid-size innovative ships
+- Norwegian Luna (2026) – Latest addition to Prima Class
+
+---
+
+## Expansion Timeline
+
+**2025:**
+- Le Verdon (Bordeaux), France
+- Casablanca, Morocco (transatlantic)
+- Vigo, Spain (Bay of Biscay)
+- Great Stirrup Cay new multi-ship pier
+
+**2026:**
+- Philadelphia homeport (Bermuda/Canada-New England)
+- Helsinki homeport (summer Baltic)
+- Honolulu homeport (Hawaii roundtrips)
+- Panama Canal full transits (March 2026+)
+- New ports: Palamós (Spain), Bodrum (Turkey), Portree (Scotland), Leirvik (Norway), Falmouth (Jamaica)
+- Alaska expansion
+
+**2027-2028:**
+- Major Asia-Pacific expansion (50 voyages)
+- New Asian ports: Incheon, Kaohsiung
+- Continued Panama Canal transits
+- Potential transpacific to Australia resumption
+- Norwegian Luna debut (2026)
+
+---
+
+## Notes
+
+- Norwegian Cruise Line operates **420+ ports** across all continents except Antarctica (limited world cruise stops)
+- **Fleet composition**: 20 ships with diverse classes (Prima, Breakaway Plus, Breakaway, Jewel, etc.)
+- **Freestyle Cruising** differentiates NCL from traditional cruise lines with flexible dining and casual atmosphere
+- **Port-intensive** approach: More ports, less sea days, late-night/overnight stays
+- **Geographic focus**: Heavy Caribbean/Bahamas (~50%), strong Alaska (seasonal), growing Europe and Asia
+- **Recent adjustments**: 2024-2025 Australia/NZ impacted by Red Sea issues, replaced with Caribbean/repositioning
+- **2026-2028 growth**: Philadelphia homeport, Helsinki homeport, Hawaii roundtrips, 50-voyage Asia-Pacific expansion
+
+---
+
+## Comparison to Other Lines
+
+| Feature | Norwegian | Royal Caribbean | Carnival | Virgin Voyages |
+|---------|-----------|----------------|----------|----------------|
+| **Fleet Size** | 20 ships | 27-28 ships | 29 ships | 4 ships |
+| **Total Ports** | ~420 ports | ~350+ ports | ~320+ ports | ~120 ports |
+| **Market** | Freestyle cruising, flexible | Family mass-market | Family mass-market | Adults-only premium |
+| **Private Islands** | Great Stirrup Cay, Harvest Caye | CocoCay, Labadee | Celebration Key, Half Moon Cay, Princess Cays | Bimini Beach Club |
+| **Freestyle Dining** | Yes (signature feature) | Traditional + specialty | Traditional + specialty | All-inclusive open seating |
+| **Late-Night Stays** | Standard on port-heavy itineraries | Occasional | Occasional | Standard (10pm-midnight) |
+| **Alaska** | Strong seasonal presence | Year-round major presence | Seasonal presence | NEW 2026 |
+
+---
+
+**For ship-specific or year-by-year details:**
+- Norwegian Cruise Line official website
+- CruiseMapper's Norwegian Cruise Line page
+- NCL "Cruise Planner" and itinerary search
+
+**Compiled by:** In the Wake team
+**Last updated:** 2025-11-22
+**Status:** Reference document for future Norwegian Cruise Line expansion
+**Target market:** Freestyle cruisers, flexible travelers, port-intensive itinerary seekers, Alaska/Europe/Caribbean focus
+


### PR DESCRIPTION
Features:
- Comprehensive NCL port catalog (~420 ports, 20 ships)
- "Freestyle Cruising" market positioning
- Private islands: Great Stirrup Cay, Harvest Caye
- Regional breakdown by port count
- Comparison table with Royal Caribbean, Carnival, and Virgin Voyages
- Expansion timeline (2025-2028)
- Port-intensive itinerary focus with late-night/overnight stays

Port breakdown:
- Caribbean & Bahamas: 45-50 ports (core market, ~50% sailings)
- Alaska & Pacific Northwest: 12-15 ports (seasonal)
- Mediterranean: 35-40 ports (summer seasonal)
- Northern Europe & Baltic: 30-35 ports (summer seasonal)
- British Isles: 15-18 ports
- Asia (East & Southeast): 20-25 ports (expanding 2027-2028)
- Australia/NZ/Pacific: 30-35 ports
- South America: 8-12 ports
- Africa & Indian Ocean: 10-15 ports
- Transatlantic: 5-8 ports

New homeports 2026+:
- Philadelphia (Bermuda/Canada-New England)
- Helsinki (Baltic summer)
- Honolulu (Hawaii roundtrips)

Reference document for future NCL expansion planning.