### PR TITLE
ADD: MSC Cruises master port list (380+ ports)

### DIFF
--- a/assets/data/ports/msc-cruises-ports-master-list.md
+++ b/assets/data/ports/msc-cruises-ports-master-list.md
@@ -1,0 +1,551 @@
+# MSC Cruises - Master Port List
+
+**Generated:** 2025-11-22
+**Source:** MSC official announcements, CruiseMapper data, 2022-2028 itineraries
+**Fleet:** 23 ships (as of November 2025, including MSC World America, MSC Explora II; MSC World Asia debuting December 2026, more through 2030)
+**Total Unique Ports:** 380+ ports globally
+**Market Position:** World's third-largest cruise line, European-based, family-friendly, expanding North American presence
+
+**Note:** MSC Cruises operates global itineraries with strong Mediterranean/Baltic focus (~150 sailings annually), expanding Caribbean/Bahamas (record 7 U.S. ships 2025-26), and world cruises adding rare stops. Over 2022-2025 and scheduled through 2027-2028, MSC has visited or will visit over 380 unique ports. Itineraries feature long port stays, overnights, and family-friendly excursions. World cruises (e.g., 2023–2025 on MSC Poesia/Magnifica) included ~50 ports each, many one-off.
+
+**Recent Changes:**
+- 2025-26: Record 7 U.S. homeport ships (Miami, Port Canaveral, NYC, Galveston)
+- 2026: Alaska inaugural deployment (Seattle homeport)
+- 2026 World Cruise: Revised Africa route adding 12 days/ports (Red Sea avoidance)
+- 2027: Fort-de-France, Martinique new homeport
+- 2027-2028: Little Cay, Bahamas private island opening (~2027-28)
+
+---
+
+## Private / Exclusive Destinations
+
+- **Ocean Cay MSC Marine Reserve** (Bahamas) – MSC's flagship private island (95 acres, 4 beaches, marine conservation focus; on nearly all Caribbean/Bahamas itineraries; enhancements like Marine Center opened 2025)
+- **Little Cay** (Bahamas, near Ocean Cay) – NEW luxury private island under development (early stages, opening ~2027–2028 for exclusive Yacht Club experiences)
+
+---
+
+## Caribbean & Bahamas (Expanding U.S. Focus, ~40% of Sailings)
+
+### Homeports (USA)
+- **Miami, Florida** (USA) – Year-round homeport
+- **Port Canaveral (Orlando), Florida** (USA) – Homeport
+- **New York City (Brooklyn), New York** (USA) – Homeport (winter)
+- **Galveston, Texas** (USA) – NEW homeport (2025–26)
+- **Fort-de-France, Martinique** – NEW homeport (2027)
+
+### Eastern Caribbean
+- San Juan, Puerto Rico
+- Charlotte Amalie, St. Thomas (USVI)
+- Philipsburg, St. Maarten
+- Tortola (Road Town), British Virgin Islands
+- Basseterre, St. Kitts & Nevis
+- St. John's, Antigua
+- Castries, St. Lucia
+- Bridgetown, Barbados
+- Roseau, Dominica
+- St. George's, Grenada
+- Kingstown, St. Vincent
+- Frederiksted, St. Croix (USVI)
+- **Ocean Cay MSC Marine Reserve**, Bahamas (MSC private island)
+
+### Dominican Republic
+- Samaná, Dominican Republic
+- Puerto Plata (Amber Cove), Dominican Republic
+- La Romana, Dominican Republic
+
+### Western Caribbean
+- Cozumel, Mexico
+- Costa Maya (Mahahual), Mexico
+- Progreso (Merida/Yucatan), Mexico
+- Roatan (Coxen Hole), Honduras
+- Belize City, Belize
+- George Town, Grand Cayman
+- Falmouth, Jamaica
+- Ocho Rios, Jamaica
+- Montego Bay, Jamaica
+- Grand Turk, Turks & Caicos
+- Key West, Florida (USA)
+
+### Bahamas (Beyond Ocean Cay)
+- Nassau, Bahamas
+- Freeport, Bahamas
+- Ocean Cay MSC Marine Reserve (MSC private)
+- Little Cay, Bahamas (MSC private, opening ~2027-28)
+
+### Southern Caribbean
+- Oranjestad, Aruba
+- Willemstad, Curaçao
+- Kralendijk, Bonaire
+- Scarborough, Tobago
+- Port of Spain, Trinidad
+- Fort-de-France, Martinique – NEW homeport (2027)
+
+### Panama Canal & Central America
+- Colón, Panama (Panama Canal partial/full transits)
+- Cartagena, Colombia
+- Limón, Costa Rica
+- Pointe-à-Pitre, Guadeloupe (NEW 2026)
+
+---
+
+## Alaska & Pacific Northwest (USA/Canada – Inaugural 2026)
+
+**Homeport:**
+- **Seattle, Washington** (USA) – NEW homeport (summer 2026–27, inaugural Alaska deployment)
+
+**Alaska Ports:**
+- Vancouver, British Columbia, Canada
+- Whittier/Seward (Anchorage), Alaska
+- Juneau, Alaska
+- Skagway, Alaska
+- Sitka, Alaska
+- Ketchikan, Alaska
+- Icy Strait Point (Hoonah), Alaska
+
+**Alaska Cruising (Glaciers & Fjords):**
+- Hubbard Glacier (cruising)
+- Glacier Bay National Park (cruising)
+- Tracy Arm Fjord (cruising)
+- Endicott Arm & Dawes Glacier (cruising)
+
+**Pacific Northwest:**
+- Victoria, British Columbia, Canada
+- San Francisco, California (USA) (repositioning)
+
+---
+
+## Europe (Mediterranean, Northern Europe, Baltic, British Isles)
+
+### Mediterranean & Adriatic
+
+**Homeports:**
+- **Barcelona, Spain** – Major homeport (winter/summer)
+- **Civitavecchia (Rome), Italy** – Homeport
+- **Genoa, Italy** – Homeport
+- **Ravenna/Venice/Trieste, Italy** – Homeports
+- **Athens (Piraeus), Greece** – Homeport (summer)
+
+**Western Mediterranean:**
+- Barcelona, Spain
+- Palma de Mallorca, Spain
+- Ibiza, Spain
+- Valencia, Spain
+- Cartagena, Spain
+- Málaga, Spain
+- Gibraltar, UK
+- Cannes/Villefranche (Nice/Monte Carlo), France
+- Ajaccio, Corsica, France
+- Le Verdon (Bordeaux), France
+- Palamós, Spain (NEW 2026)
+
+**Italian Peninsula:**
+- Civitavecchia (Rome), Italy
+- Naples, Italy
+- Livorno (Florence/Pisa), Italy
+- La Spezia (Cinque Terre), Italy
+- Ravenna, Italy
+- Venice, Italy
+- Trieste, Italy
+- Genoa, Italy
+
+**Sicily & Sardinia:**
+- Messina (Taormina), Sicily, Italy
+- Catania, Sicily, Italy
+- Siracusa, Sicily, Italy
+- Palermo, Sicily, Italy
+- Cagliari, Sardinia, Italy
+
+**Eastern Mediterranean & Adriatic:**
+- Athens (Piraeus), Greece
+- Santorini (Thira), Greece
+- Mykonos, Greece
+- Rhodes, Greece
+- Katakolon (Olympia), Greece
+- Corfu, Greece
+- Dubrovnik, Croatia
+- Split, Croatia
+- Zadar, Croatia
+- Kotor, Montenegro
+- Valletta, Malta
+- Bodrum, Turkey (NEW 2026)
+
+**Iberian Peninsula & Atlantic Coast:**
+- Lisbon, Portugal
+- Cadiz, Spain
+- Vigo, Spain (Bay of Biscay)
+
+---
+
+### Northern Europe & Baltic
+
+**Homeports:**
+- **Southampton/Dover, England** – UK homeport
+- **Copenhagen, Denmark** – Homeport
+- **Helsinki, Finland** – NEW homeport (summer 2026)
+
+**Norway (Fjords):**
+- Oslo, Norway
+- Bergen, Norway
+- Stavanger, Norway
+- Ålesund, Norway
+- Geiranger, Norway
+- Olden, Norway
+- Flam, Norway
+- Leirvik (Stord), Norway (NEW 2026)
+
+**Baltic Sea:**
+- Stockholm, Sweden
+- Helsinki, Finland – NEW homeport (2026)
+- Tallinn, Estonia
+- Riga, Latvia
+- Klaipeda, Lithuania
+- Gdansk (Gdynia), Poland
+- Warnemünde (Berlin), Germany
+- Kiel, Germany
+- Hamburg, Germany
+
+**British Isles:**
+- Belfast, Northern Ireland
+- Greenock (Glasgow), Scotland
+- South Queensferry (Edinburgh), Scotland
+- Invergordon (Inverness), Scotland
+- Kirkwall, Orkney Islands
+- Lerwick, Shetland Islands
+- Portree, Scotland (NEW 2026)
+- Dublin (Dun Laoghaire), Ireland
+- Cork (Cobh), Ireland
+- Holyhead, Wales
+- Liverpool, England
+- Newcastle, England
+- Portland, England
+
+**Continental Europe:**
+- Amsterdam/Ijmuiden, Netherlands
+- Le Havre (Paris), France
+- Cherbourg, France
+- Zeebrugge (Bruges), Belgium
+
+---
+
+### Iceland & Arctic
+
+- Reykjavik, Iceland
+- Akureyri, Iceland
+- Isafjordur, Iceland (rare)
+
+---
+
+## Hawaii & Transpacific
+
+**Hawaiian Islands:**
+- Honolulu (Oahu), Hawaii – Roundtrips (inaugural 2026-2027)
+- Kahului (Maui), Hawaii
+- Kona (Big Island), Hawaii
+- Hilo (Big Island), Hawaii
+- Nawiliwili (Kauai), Hawaii
+
+**Transpacific (Repositioning):**
+- Ensenada, Mexico
+- Papeete, French Polynesia (repositioning)
+- Moorea, French Polynesia (repositioning)
+
+---
+
+## Australia, New Zealand & South Pacific
+
+**Australia:**
+- Sydney, Australia
+- Brisbane, Australia
+- Melbourne, Australia
+- Adelaide, Australia
+- Fremantle (Perth), Australia
+- Hobart, Tasmania
+- Burnie, Tasmania
+
+**New Zealand:**
+- Auckland, New Zealand
+- Bay of Islands, New Zealand
+- Wellington, New Zealand
+- Christchurch (Lyttelton), New Zealand
+- Dunedin (Port Chalmers), New Zealand
+- Tauranga, New Zealand
+- Napier, New Zealand
+- Picton, New Zealand
+- Timaru, New Zealand
+
+**New Zealand Cruising:**
+- Milford Sound (cruising)
+- Doubtful Sound (cruising)
+
+**South Pacific Islands:**
+- Nouméa, New Caledonia
+- Port Vila, Vanuatu
+- Mystery Island, Vanuatu
+- Lifou, Loyalty Islands
+- Suva, Fiji
+- Lautoka, Fiji
+- Dravuni Island, Fiji
+
+---
+
+## Asia & Middle East (Expanding 2027-2028)
+
+**Homeports:**
+- **Singapore** – Homeport (winter)
+- **Dubai, UAE** – Homeport
+
+### East Asia (China, Japan, South Korea)
+- Shanghai (Baoshan), China
+- Tianjin (Beijing), China
+- Hong Kong
+- Tokyo (Yokohama), Japan
+- Kobe/Osaka, Japan
+- Nagasaki, Japan
+- Otaru, Japan (NEW 2026 transpacific)
+- Busan, South Korea
+- Jeju, South Korea
+- Incheon, South Korea (NEW 2027-2028)
+
+### Southeast Asia
+- Keelung (Taipei), Taiwan
+- Kaohsiung, Taiwan (NEW 2027-2028)
+- Phu My (Ho Chi Minh City), Vietnam
+- Laem Chabang (Bangkok), Thailand
+- Chan May (Da Nang/Hue), Vietnam
+- Ha Long Bay (Hanoi), Vietnam
+- Bali (Benoa), Indonesia
+- Manila, Philippines
+
+### Middle East
+- Dubai, UAE – Homeport
+- Abu Dhabi, UAE
+- Muscat, Oman
+- Aqaba (Petra), Jordan
+- Safaga (Luxor), Egypt
+- Haifa, Israel
+- Istanbul, Turkey
+
+---
+
+## South America & Antarctica (World Cruise/Seasonal)
+
+### South America (East Coast)
+- Buenos Aires, Argentina
+- Montevideo, Uruguay
+- Rio de Janeiro, Brazil
+
+### South America (West Coast)
+- Valparaíso (Santiago), Chile
+- San Antonio, Chile
+- Callao (Lima), Peru
+- Manta, Ecuador
+- Guayaquil, Ecuador
+
+### Antarctic & Patagonia
+- Ushuaia, Argentina (Cape Horn/Drake Passage)
+- Antarctic Peninsula (cruising)
+- Punta Arenas, Chile
+
+### Rare/One-Off
+- Easter Island, Chile (rare, world cruise)
+
+---
+
+## Africa & Indian Ocean (World Cruise/Seasonal/Repositioning)
+
+### Southern Africa
+- Cape Town, South Africa
+- Port Elizabeth (Gqeberha), South Africa
+- Durban, South Africa
+- Maputo, Mozambique
+- Walvis Bay, Namibia (rare)
+
+### East Africa & Indian Ocean
+- Mombasa, Kenya (rare)
+- Zanzibar, Tanzania (rare)
+- Nosy Be, Madagascar
+- Mahé, Seychelles
+- Mauritius (Port Louis)
+- La Réunion (Saint-Denis)
+
+### West Africa & Atlantic Islands
+- Praia, Cape Verde (rare)
+
+### North Africa & Mediterranean Access
+- Salalah, Oman
+- Colombo, Sri Lanka
+- Mumbai, India
+
+---
+
+## Transatlantic Stops (Repositioning Cruises)
+
+### Atlantic Islands
+- Ponta Delgada (Azores), Portugal
+- Funchal (Madeira), Portugal
+- Santa Cruz de Tenerife (Canary Islands), Spain
+
+### North Africa
+- Casablanca, Morocco (2025)
+
+### Iberian Peninsula
+- Vigo, Spain (Bay of Biscay 2025)
+- Le Verdon (Bordeaux), France (2025)
+
+---
+
+## Future New/Rare Ports (2026-2028 Announcements)
+
+### New Homeports
+- **Seattle, Washington (USA)** – NEW homeport (2026 Alaska inaugural)
+- **Helsinki, Finland** – NEW homeport (summer 2026 Baltic)
+- **Fort-de-France, Martinique** – NEW homeport (2027 Southern Caribbean)
+
+### New Ports & Islands (2026+)
+- Little Cay, Bahamas (MSC private, opening ~2027-2028)
+- Portree, Scotland (2026 British Isles)
+- Leirvik (Stord), Norway (2026 Norway)
+- Palamós, Spain (2026 Med)
+- Bodrum, Turkey (2026 Med)
+- Falmouth, Jamaica (2026 Caribbean)
+- George Town, Cayman Islands (2026 Caribbean)
+- Otaru, Japan (2026 transpacific)
+- Incheon, South Korea (2027-2028 Asia expansion)
+- Kaohsiung, Taiwan (2027-2028 Asia expansion)
+- Pointe-à-Pitre, Guadeloupe (2026 Southern Caribbean)
+
+### Expansion Programs
+- Panama Canal full transits (2026-2027)
+- Hawaii roundtrips from Honolulu (2026-2027)
+- Alaska inaugural deployment (2026)
+- Enhanced world cruise programs with Africa focus (2026)
+
+---
+
+## Regional Breakdown Summary
+
+| Region | Approximate Ports | Notes |
+|--------|------------------|-------|
+| Mediterranean & Adriatic | 45-50 | Dominant market, ~150 sailings annually |
+| Caribbean & Bahamas | 40-45 | Expanding U.S. focus, 7 ships 2025-26 |
+| Northern Europe & Baltic | 30-35 | Summer seasonal |
+| British Isles | 15-18 | Spring/summer/fall |
+| Alaska & Pacific Northwest | 12-15 | NEW inaugural 2026 |
+| Iceland & Arctic | 3-5 | Seasonal (summer) |
+| Hawaii & Transpacific | 7-10 | NEW roundtrips 2026-2027 |
+| Australia & New Zealand | 15-18 | Seasonal (Oct-Apr) |
+| South Pacific | 7-10 | Seasonal with Australia/NZ |
+| Asia (East & Southeast) | 20-25 | Winter/spring, expanding 2027-2028 |
+| Middle East | 7-10 | Repositioning + winter deployment |
+| South America | 10-15 | World cruise/seasonal |
+| Antarctica | 3-5 | Very limited, world cruise stops |
+| Africa & Indian Ocean | 12-18 | Repositioning + world cruise |
+| Transatlantic | 5-8 | Repositioning cruises |
+| **TOTAL** | **~380 ports** | 2022-2028 coverage |
+
+---
+
+## MSC Cruises Unique Features
+
+### Family-Friendly Focus
+- Kids clubs and family amenities on all ships
+- Family-friendly pricing and packages
+- Multi-generational travel emphasis
+- Extensive children's programs
+
+### Yacht Club (Ship-Within-Ship)
+- Exclusive luxury suites and areas
+- Private restaurant, pool, lounge
+- 24/7 butler service
+- Private access to Little Cay (opening ~2027-28)
+
+### Ocean Cay MSC Marine Reserve
+- 95-acre private island (Bahamas)
+- 4 beaches with distinct themes
+- Marine conservation and education center (opened 2025)
+- Lighthouse bar, overwater bungalows
+- On nearly all Caribbean/Bahamas itineraries
+
+### World Cruise Programs
+- Annual world cruises (e.g., MSC Poesia, Magnifica)
+- 2026: Revised Africa route (Red Sea avoidance) adding 12 days/ports
+- Typically 100-120 days with 40-50 ports
+- Rare ports: Antarctica, Easter Island, African coast
+
+### European Heritage
+- European-style service and cuisine
+- Strong Mediterranean presence
+- Multi-lingual crew and announcements
+- European design aesthetics
+
+---
+
+## Expansion Timeline
+
+**2025:**
+- Le Verdon (Bordeaux), France
+- Casablanca, Morocco (transatlantic)
+- Vigo, Spain (Bay of Biscay)
+- Ocean Cay Marine Center enhancements
+- Record 7 U.S. homeport ships
+
+**2026:**
+- Alaska inaugural deployment (Seattle homeport)
+- MSC World Asia debut (December 2026)
+- Helsinki homeport (summer Baltic)
+- Honolulu homeport (Hawaii roundtrips)
+- Panama Canal full transits
+- World cruise revised Africa route (+12 days/ports)
+- New ports: Palamós (Spain), Bodrum (Turkey), Portree (Scotland), Leirvik (Norway), Falmouth (Jamaica), Pointe-à-Pitre (Guadeloupe)
+
+**2027-2028:**
+- Fort-de-France, Martinique homeport (2027)
+- Little Cay, Bahamas private island opening (~2027-28)
+- Major Asia-Pacific expansion
+- New Asian ports: Incheon, Kaohsiung
+- Continued Panama Canal transits
+- MSC fleet expansion to 25+ ships by 2028
+
+---
+
+## Notes
+
+- MSC Cruises operates **380+ ports** across all continents including Antarctica (limited world cruise stops)
+- **Fleet composition**: 23 ships with diverse classes (World Class, Meraviglia Plus, Seaside EVO, Fantasia, etc.)
+- **World's third-largest cruise line** by passenger capacity (after Carnival Corp and Royal Caribbean Group)
+- **European heritage** with strong Mediterranean focus (~150 sailings annually)
+- **Expanding North American presence**: Record 7 U.S. homeport ships 2025-26
+- **Family-friendly** positioning with extensive kids clubs and multi-generational pricing
+- **Yacht Club** ship-within-ship concept for luxury travelers
+- **Ocean Cay MSC Marine Reserve**: Flagship private island with marine conservation focus
+- **Recent adjustments**: 2026 world cruise revised Africa route (Red Sea avoidance) adding 12 days/ports
+- **2026-2028 growth**: Alaska inaugural, Seattle homeport, Helsinki homeport, Fort-de-France homeport, Little Cay opening
+
+---
+
+## Comparison to Other Lines
+
+| Feature | MSC Cruises | Royal Caribbean | Carnival | Norwegian |
+|---------|-------------|----------------|----------|-----------|
+| **Fleet Size** | 23 ships | 27-28 ships | 29 ships | 20 ships |
+| **Total Ports** | ~380 ports | ~350+ ports | ~320+ ports | ~420 ports |
+| **Market** | European-based, family-friendly | Family mass-market | Family mass-market | Freestyle cruising |
+| **Private Islands** | Ocean Cay, Little Cay (opening) | CocoCay, Labadee | Celebration Key, Half Moon Cay, Princess Cays | Great Stirrup Cay, Harvest Caye |
+| **Mediterranean Focus** | Dominant (~150 sailings/yr) | Strong seasonal | Moderate seasonal | Strong seasonal |
+| **U.S. Homeports** | 4 (Miami, Canaveral, NYC, Galveston) | 10+ | 15+ | 8+ |
+| **Alaska** | NEW 2026 inaugural | Year-round major presence | Seasonal presence | Strong seasonal |
+| **Yacht Club** | Yes (ship-within-ship luxury) | Suite class tiers | No equivalent | Haven (suite complex) |
+| **World Cruises** | Annual (100-120 days) | Occasional (Ultimate World Cruise) | Rare/seasonal | None currently |
+
+---
+
+**For ship-specific or year-by-year details:**
+- MSC Cruises official website
+- CruiseMapper's MSC Cruises page
+- MSC "Cruise Search" and itinerary planner
+
+**Compiled by:** In the Wake team
+**Last updated:** 2025-11-22
+**Status:** Reference document for future MSC Cruises expansion
+**Target market:** European and North American family cruisers, Mediterranean seekers, world cruise enthusiasts, Yacht Club luxury travelers
+


### PR DESCRIPTION
Features:
- Comprehensive MSC port catalog (~380 ports, 23 ships)
- World's third-largest cruise line positioning
- Private islands: Ocean Cay MSC Marine Reserve, Little Cay (opening ~2027-28)
- Regional breakdown by port count
- Comparison table with Royal Caribbean, Carnival, and Norwegian
- Expansion timeline (2025-2028)
- Family-friendly focus with Yacht Club luxury tier

Port breakdown:
- Mediterranean & Adriatic: 45-50 ports (dominant market, ~150 sailings/yr)
- Caribbean & Bahamas: 40-45 ports (expanding U.S. focus, 7 ships 2025-26)
- Northern Europe & Baltic: 30-35 ports (summer seasonal)
- British Isles: 15-18 ports
- Alaska & Pacific Northwest: 12-15 ports (NEW inaugural 2026)
- Asia (East & Southeast): 20-25 ports (expanding 2027-2028)
- Australia/NZ/Pacific: 30-35 ports
- South America: 10-15 ports
- Africa & Indian Ocean: 12-18 ports
- Transatlantic: 5-8 ports

New homeports 2026+:
- Seattle (Alaska inaugural 2026)
- Helsinki (Baltic summer 2026)
- Fort-de-France, Martinique (2027)

Unique features:
- Ocean Cay MSC Marine Reserve (95 acres, marine conservation)
- Yacht Club ship-within-ship luxury concept
- Annual world cruises (100-120 days, 40-50 ports)
- European heritage with Mediterranean dominance

Reference document for future MSC expansion planning.