### PR TITLE
FIX: Restore hero image vibrancy and correct logo positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,6 +234,7 @@
   <!-- Performance: DNS Prefetch & Preconnect -->
   <link rel="dns-prefetch" href="https://www.flickersofmajesty.com"/>
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
+  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.300" imagesrcset="/assets/index_hero.webp?v=3.010.300" fetchpriority="high"/>
 
   <!-- Styles -->
   <style>
@@ -589,7 +590,7 @@
     position: relative;
     width: 100%;
     min-height: clamp(200px, 24vw, 340px);
-    background: url('/assets/index_hero.webp') 50% 50%/cover no-repeat;
+    background: url('/assets/index_hero.webp?v=3.010.300') 50% 50%/cover no-repeat;
     display: flex;
     align-items: flex-end;
     overflow-x: clip;
@@ -615,8 +616,7 @@
   .hero-title {
     position: absolute;
     left: min(3vw, 1rem);
-    top: 50%;
-    transform: translateY(-50%);
+    bottom: clamp(.6rem, 2vw, 1.4rem);
     z-index: 3;
     display: flex;
     align-items: flex-end;


### PR DESCRIPTION
- Add preload link with cache buster to load current hero image
- Update background URL with ?v=3.010.300 parameter
- Restore bottom-aligned logo positioning to match travel.html