### PR TITLE
FIX: Remove duplicate hero sections and enhance article rail

### DIFF
--- a/admin/audit_and_fix_duplicates.py
+++ b/admin/audit_and_fix_duplicates.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Audit and Fix Duplicate Hero Sections
+
+Checks for and removes duplicate:
+- Hero divs (<div class="hero">)
+- Compass roses (hero-compass images)
+- Logos (logo images)
+- Multiple header elements
+
+Each page should have exactly ONE of each element.
+
+Excludes: /vendors/, /solo/articles/, old-files/, admin/
+"""
+
+import os
+import re
+from pathlib import Path
+from collections import defaultdict
+
+class DuplicateHeroFixer:
+    def __init__(self, base_dir, dry_run=False):
+        self.base_dir = Path(base_dir)
+        self.dry_run = dry_run
+        self.stats = {
+            'files_with_duplicates': 0,
+            'duplicate_heroes': 0,
+            'duplicate_compass': 0,
+            'duplicate_logos': 0,
+            'files_fixed': 0
+        }
+        self.issues = defaultdict(list)
+
+    def should_skip(self, filepath):
+        """Check if file should be excluded."""
+        path_str = str(filepath)
+        skip_patterns = [
+            '/vendors/', 'vendors/',
+            '/solo/articles/',
+            '/old-files/', 'old-files/',
+            '/admin/', 'admin/',
+            'template.html',
+            'invocation_signature.html'
+        ]
+        return any(pattern in path_str for pattern in skip_patterns)
+
+    def audit_file(self, filepath):
+        """Audit a file for duplicate hero elements."""
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                content = f.read()
+        except Exception as e:
+            return None, []
+
+        issues = []
+
+        # Count hero divs (should be exactly 1)
+        hero_divs = len(re.findall(r'<div[^>]*class="hero"', content))
+        if hero_divs > 1:
+            issues.append(f"{hero_divs} hero divs (should be 1)")
+
+        # Count compass roses (should be exactly 1)
+        compass = len(re.findall(r'class="hero-compass"', content))
+        if compass > 1:
+            issues.append(f"{compass} compass roses (should be 1)")
+
+        # Count logos (should be exactly 1)
+        logos = len(re.findall(r'class="logo"[^>]*src="/assets/logo_wake', content))
+        if logos > 1:
+            issues.append(f"{logos} logos (should be 1)")
+
+        return content, issues
+
+    def fix_file(self, filepath, content):
+        """Remove duplicate hero sections from a file."""
+        original_content = content
+        modified = False
+
+        # Strategy: Keep the FIRST hero div, remove subsequent ones
+        # The duplicate hero sections are typically the ones added by the fix script
+        # They have the pattern: <!-- Hero -->\n    <div class="hero">.....</div>
+
+        # Find all hero div blocks
+        # We need to be careful - hero divs can be nested in headers or standalone
+
+        # Pattern for the duplicate hero section added by fix script
+        # It has the comment "<!-- Hero -->" followed by the hero div
+        duplicate_hero_pattern = r'\s*<!-- Hero -->\s*<div class="hero">.*?</div>\s*(?=</header>)'
+
+        matches = list(re.finditer(duplicate_hero_pattern, content, re.DOTALL))
+
+        if matches:
+            # Check if there's already a hero div before this one
+            for match in matches:
+                # Check if there's another hero div before this match
+                before_match = content[:match.start()]
+                if '<div class="hero"' in before_match:
+                    # This is a duplicate, remove it
+                    content = content[:match.start()] + content[match.end():]
+                    modified = True
+                    self.stats['duplicate_heroes'] += 1
+
+        if modified:
+            return content, True
+
+        return original_content, False
+
+    def run(self):
+        """Run the audit and fix on all HTML files."""
+        print("=" * 80)
+        print("DUPLICATE HERO ELEMENT AUDIT AND FIX")
+        print("=" * 80)
+        if self.dry_run:
+            print("\n⚠️  DRY RUN MODE - No files will be modified")
+        print(f"\nBase directory: {self.base_dir}")
+        print("Excluding: /vendors/, /solo/articles/, /old-files/, /admin/\n")
+
+        # Find all HTML files
+        html_files = []
+        for pattern in ['*.html', '**/*.html']:
+            html_files.extend(self.base_dir.glob(pattern))
+
+        # Filter out excluded directories
+        html_files = [f for f in html_files if not self.should_skip(f)]
+
+        print(f"Found {len(html_files)} HTML files to process\n")
+        print("Auditing...\n")
+
+        # First, audit all files
+        for filepath in sorted(html_files):
+            content, issues = self.audit_file(filepath)
+            if issues:
+                rel_path = filepath.relative_to(self.base_dir)
+                self.issues[str(rel_path)] = issues
+                self.stats['files_with_duplicates'] += 1
+
+        # Print audit results
+        if self.issues:
+            print(f"⚠️  Found {len(self.issues)} files with duplicate hero elements:\n")
+            for filepath, issues_list in sorted(self.issues.items()):
+                print(f"  {filepath}")
+                for issue in issues_list:
+                    print(f"    - {issue}")
+            print()
+        else:
+            print("✅ No duplicate hero elements found!\n")
+            return
+
+        if self.dry_run:
+            print("\nDry run complete. Use without --dry-run to fix issues.")
+            return
+
+        # Now fix the files
+        print("=" * 80)
+        print("FIXING FILES")
+        print("=" * 80)
+        print()
+
+        for filepath in sorted(html_files):
+            rel_path = filepath.relative_to(self.base_dir)
+            if str(rel_path) in self.issues:
+                try:
+                    with open(filepath, 'r', encoding='utf-8') as f:
+                        content = f.read()
+
+                    new_content, modified = self.fix_file(filepath, content)
+
+                    if modified:
+                        with open(filepath, 'w', encoding='utf-8') as f:
+                            f.write(new_content)
+                        self.stats['files_fixed'] += 1
+                        print(f"  ✓ Fixed: {rel_path}")
+                except Exception as e:
+                    print(f"  ✗ Error fixing {rel_path}: {e}")
+
+        # Print summary
+        self.print_summary()
+
+    def print_summary(self):
+        """Print summary statistics."""
+        print("\n" + "=" * 80)
+        print("SUMMARY")
+        print("=" * 80)
+        print(f"Files with duplicates found: {self.stats['files_with_duplicates']}")
+        print(f"Files fixed: {self.stats['files_fixed']}")
+        print()
+        print("Duplicates removed:")
+        print(f"  - Duplicate hero divs: {self.stats['duplicate_heroes']}")
+        print(f"  - Duplicate compass roses: {self.stats['duplicate_compass']}")
+        print(f"  - Duplicate logos: {self.stats['duplicate_logos']}")
+
+def main():
+    import sys
+    dry_run = '--dry-run' in sys.argv
+    fixer = DuplicateHeroFixer('/home/user/InTheWake', dry_run=dry_run)
+    fixer.run()
+
+if __name__ == '__main__':
+    main()

--- a/admin/fix_ship_duplicates.py
+++ b/admin/fix_ship_duplicates.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Fix Duplicate Hero Sections in Ship Pages
+
+Removes the pattern where there are two identical hero sections
+with two </header> closing tags.
+
+Pattern to remove:
+</div></header>
+
+    <!-- Hero section -->
+    <div class="hero"...>...</div>
+</header>
+"""
+
+import re
+from pathlib import Path
+
+def fix_duplicate_heroes(filepath):
+    """Remove duplicate hero sections from a ship page."""
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    original = content
+
+    # Pattern: First </header>, then duplicate hero section, then second </header>
+    # We want to keep everything before the first </header> and remove everything between first and second </header>
+
+    # Find pattern: </div></header>\n\n    <!-- Hero section -->\n    <div class="hero"...>...</div>\n</header>
+    pattern = r'(</div></header>)\s*<!-- Hero section -->\s*<div class="hero"[^>]*>.*?</div>\s*</header>'
+
+    # Replace with just the first </header>
+    content = re.sub(pattern, r'\1', content, flags=re.DOTALL)
+
+    if content != original:
+        return content, True
+    return original, False
+
+def main():
+    """Fix all ship pages with duplicate heroes."""
+    base_dir = Path('/home/user/InTheWake')
+
+    # List of files to fix
+    ship_dirs = [
+        'ships/carnival',
+        'ships/celebrity-cruises',
+        'ships/holland-america-line'
+    ]
+
+    stats = {'fixed': 0, 'skipped': 0, 'errors': 0}
+
+    print("=" * 70)
+    print("FIXING DUPLICATE HERO SECTIONS IN SHIP PAGES")
+    print("=" * 70)
+    print()
+
+    for ship_dir in ship_dirs:
+        dir_path = base_dir / ship_dir
+        if not dir_path.exists():
+            continue
+
+        print(f"\nProcessing {ship_dir}...")
+
+        for filepath in sorted(dir_path.glob('*.html')):
+            try:
+                new_content, modified = fix_duplicate_heroes(filepath)
+
+                if modified:
+                    with open(filepath, 'w', encoding='utf-8') as f:
+                        f.write(new_content)
+                    stats['fixed'] += 1
+                    print(f"  ✓ Fixed: {filepath.name}")
+                else:
+                    stats['skipped'] += 1
+            except Exception as e:
+                stats['errors'] += 1
+                print(f"  ✗ Error: {filepath.name}: {e}")
+
+    # Print summary
+    print("\n" + "=" * 70)
+    print("SUMMARY")
+    print("=" * 70)
+    print(f"Files fixed: {stats['fixed']}")
+    print(f"Files skipped: {stats['skipped']}")
+    print(f"Errors: {stats['errors']}")
+
+if __name__ == '__main__':
+    main()

--- a/assets/data/articles/index.json
+++ b/assets/data/articles/index.json
@@ -56,6 +56,34 @@
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
       "keywords": ["travel", "solo", "usa"]
+    },
+    {
+      "id": "in-the-wake-of-grief",
+      "title": "In the Wake of Grief: When Loss Needs Water",
+      "url": "/solo/in-the-wake-of-grief.html",
+      "date": "2024-05-15",
+      "excerpt": "Finding solace and healing in the steady rhythm of the sea.",
+      "image": "/solo/images/flickersofmajesty.jpeg?v=3.009.023",
+      "author": {
+        "name": "Ken Baker",
+        "url": "/authors/ken-baker.html",
+        "image": "/authors/img/ken1.jpg?v=3.009.023"
+      },
+      "keywords": ["solo", "grief", "healing"]
+    },
+    {
+      "id": "accessible-cruising",
+      "title": "Accessible Cruising: Five Universal Principles for Disabled Travelers",
+      "url": "/solo/articles/accessible-cruising.html",
+      "date": "2024-07-10",
+      "excerpt": "Practical guidance for making cruise travel accessible and enjoyable for disabled travelers.",
+      "image": "/solo/images/flickersofmajesty.jpeg?v=3.009.023",
+      "author": {
+        "name": "Ken Baker",
+        "url": "/authors/ken-baker.html",
+        "image": "/authors/img/ken1.jpg?v=3.009.023"
+      },
+      "keywords": ["accessibility", "travel", "solo"]
     }
   ]
 }

--- a/assets/ships/grandeur-of-the-seas.html
+++ b/assets/ships/grandeur-of-the-seas.html
@@ -426,20 +426,7 @@
         <div class="tagline">A Cruise Traveler’s Logbook</div>
       </div>
     
-<div class="hero-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> · <a href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener">Instagram</a></div></div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+<div class="hero-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> · <a href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener">Instagram</a></div></div></header>
   <main class="wrap" id="content">
     
     <div class="lang-switch" style="display:flex;gap:.5rem;justify-content:flex-end;align-items:center;margin:.5rem 0 1rem;">

--- a/authors/ken-baker.html
+++ b/authors/ken-baker.html
@@ -712,20 +712,7 @@
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap page-grid" id="content" role="main">
     <!-- ICP-Lite Content Structure - Right Rail -->

--- a/authors/tina-maulsby.html
+++ b/authors/tina-maulsby.html
@@ -691,20 +691,7 @@
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content" role="main">
     <!-- ICP-Lite Content Structure -->

--- a/cruise-lines.html
+++ b/cruise-lines.html
@@ -753,20 +753,7 @@
              placeholder="Type to filter… (e.g., royal, princess, disney)"
              aria-describedby="search-meta"/>
       <p id="search-meta" class="tiny" aria-live="polite">Showing all cruise lines</p>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main id="content" class="wrap">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/cruise-lines/carnival.html
+++ b/cruise-lines/carnival.html
@@ -719,20 +719,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/cruise-lines/celebrity.html
+++ b/cruise-lines/celebrity.html
@@ -719,20 +719,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/cruise-lines/disney.html
+++ b/cruise-lines/disney.html
@@ -719,20 +719,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/cruise-lines/holland-america.html
+++ b/cruise-lines/holland-america.html
@@ -716,20 +716,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/cruise-lines/msc.html
+++ b/cruise-lines/msc.html
@@ -719,20 +719,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/cruise-lines/norwegian.html
+++ b/cruise-lines/norwegian.html
@@ -725,20 +725,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/cruise-lines/princess.html
+++ b/cruise-lines/princess.html
@@ -721,20 +721,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/cruise-lines/royal-caribbean.html
+++ b/cruise-lines/royal-caribbean.html
@@ -192,20 +192,7 @@ All work on this project is offered as a gift to God.
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite Content Structure -->

--- a/cruise-lines/viking.html
+++ b/cruise-lines/viking.html
@@ -674,20 +674,7 @@ All work on this project is offered as a gift to God.
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -673,20 +673,7 @@ All work on this project is offered as a gift to God.
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content">
     <!-- ICP-Lite v1.0: Answer-First Content -->

--- a/disability-at-sea.html
+++ b/disability-at-sea.html
@@ -600,20 +600,7 @@ ADDENDUM: Facebook Domain Verification v3.008.021
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- Portal root (fixed layer for menus) -->
   <div id="nav-portal" aria-hidden="true"></div>

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -1209,20 +1209,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
   
   <!-- MAIN CONTENT -->
   <main class="wrap calculator-grid" id="content">

--- a/drink-packages.html
+++ b/drink-packages.html
@@ -578,20 +578,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN -->
   <main id="main-content" class="wrap" role="main">

--- a/index.html
+++ b/index.html
@@ -1291,7 +1291,10 @@
 
       <!-- Recent Articles rail -->
       <section style="grid-column: 1; grid-row: 1 / span 999;" class="card" aria-labelledby="recent-rail-title">
-        <h3 id="recent-rail-title">Recent Articles</h3>
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+        </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
@@ -1610,16 +1613,25 @@
       rail.innerHTML = view.map(p=>{
         const title = pick(p,['title','name'],'Article');
         const href  = pick(p,['url','path'],'#');
+        const excerpt = pick(p,['excerpt','description'],'');
         return `
-          <a class="card" style="display:grid;grid-template-columns:72px 1fr;gap:.6rem;align-items:center" href="${href}" aria-label="${title}">
-            <div style="width:72px;height:48px;overflow:hidden;border-radius:10px;background:#eef4f6;border:1px solid #dfe7ea">
-              <img class="article-thumb" alt="" decoding="async" loading="lazy" style="width:100%;height:100%;object-fit:cover">
+          <article class="card" style="display:flex;flex-direction:column;gap:.75rem;padding:.85rem">
+            <div style="display:grid;grid-template-columns:80px 1fr;gap:.75rem;align-items:start">
+              <div style="width:80px;height:60px;overflow:hidden;border-radius:8px;background:#eef4f6;border:1px solid #dfe7ea;flex-shrink:0">
+                <img class="article-thumb" alt="" decoding="async" loading="lazy" style="width:100%;height:100%;object-fit:cover">
+              </div>
+              <div>
+                <h4 style="margin:0 0 .35rem 0;font-size:.9rem;line-height:1.3;font-weight:600">
+                  <a href="${href}" style="color:var(--accent,#0e6e8e);text-decoration:none">${title}</a>
+                </h4>
+                ${excerpt ? `<p class="tiny" style="margin:0;line-height:1.4;color:var(--ink-mid,#3d5a6a)">${excerpt}</p>` : ''}
+              </div>
             </div>
-            <div class="tiny" style="line-height:1.35">${title}</div>
-          </a>`;
+            <a href="${href}" class="pill" style="align-self:flex-start;font-size:.85rem;padding:.45rem .95rem;text-decoration:none">Read Article →</a>
+          </article>`;
       }).join('');
 
-      const cards = [...rail.querySelectorAll('a.card')];
+      const cards = [...rail.querySelectorAll('article.card')];
       cards.forEach((card,i)=>{
         const p = view[i] || {};
         const el = card.querySelector('img.article-thumb');

--- a/offline.html
+++ b/offline.html
@@ -531,20 +531,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ports.html
+++ b/ports.html
@@ -736,20 +736,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">

--- a/privacy.html
+++ b/privacy.html
@@ -335,20 +335,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">

--- a/restaurants.html
+++ b/restaurants.html
@@ -899,20 +899,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">

--- a/restaurants/150-central-park.html
+++ b/restaurants/150-central-park.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/adagio-dining-room.html
+++ b/restaurants/adagio-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/amber-and-oak.html
+++ b/restaurants/amber-and-oak.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/american-icon-grill.html
+++ b/restaurants/american-icon-grill.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -681,20 +681,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
 

--- a/restaurants/aquarium-bar.html
+++ b/restaurants/aquarium-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/aquarius-dining-room.html
+++ b/restaurants/aquarius-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/bamboo-room.html
+++ b/restaurants/bamboo-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -699,20 +699,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/bell-and-barley.html
+++ b/restaurants/bell-and-barley.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/ben-and-jerrys.html
+++ b/restaurants/ben-and-jerrys.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/bionic-bar.html
+++ b/restaurants/bionic-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/boardwalk-dog-house.html
+++ b/restaurants/boardwalk-dog-house.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/boleros.html
+++ b/restaurants/boleros.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/brass-and-bock.html
+++ b/restaurants/brass-and-bock.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/bubbles.html
+++ b/restaurants/bubbles.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/bull-and-bear-pub.html
+++ b/restaurants/bull-and-bear-pub.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -643,20 +643,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
 

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -685,20 +685,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
 

--- a/restaurants/cantina-fresca.html
+++ b/restaurants/cantina-fresca.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/cascades-dining-room.html
+++ b/restaurants/cascades-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/casino-bar.html
+++ b/restaurants/casino-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/celebration-table.html
+++ b/restaurants/celebration-table.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/champagne-bar.html
+++ b/restaurants/champagne-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -649,20 +649,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap" id="main">
   <!-- Overview -->

--- a/restaurants/chic.html
+++ b/restaurants/chic.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/chops.html
+++ b/restaurants/chops.html
@@ -709,20 +709,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/cloud-17.html
+++ b/restaurants/cloud-17.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -642,20 +642,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
 

--- a/restaurants/concierge-lounge.html
+++ b/restaurants/concierge-lounge.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/congo-bar.html
+++ b/restaurants/congo-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/cosmopolitan-club.html
+++ b/restaurants/cosmopolitan-club.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/crown-and-castle-pub.html
+++ b/restaurants/crown-and-castle-pub.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/crown-and-kettle.html
+++ b/restaurants/crown-and-kettle.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/dazzles.html
+++ b/restaurants/dazzles.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/desserted.html
+++ b/restaurants/desserted.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/devinly-decadence.html
+++ b/restaurants/devinly-decadence.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/diamond-club.html
+++ b/restaurants/diamond-club.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -696,20 +696,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/dining-activities.html
+++ b/restaurants/dining-activities.html
@@ -643,20 +643,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main>
 

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -702,20 +702,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/duck-and-dog-pub.html
+++ b/restaurants/duck-and-dog-pub.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/dueling-pianos.html
+++ b/restaurants/dueling-pianos.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/edelweiss-dining-room.html
+++ b/restaurants/edelweiss-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -685,20 +685,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
 

--- a/restaurants/empire-supper-club.html
+++ b/restaurants/empire-supper-club.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/english-pub.html
+++ b/restaurants/english-pub.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/fish-and-ships.html
+++ b/restaurants/fish-and-ships.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/game-reserve.html
+++ b/restaurants/game-reserve.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/giovannis-italian-kitchen.html
+++ b/restaurants/giovannis-italian-kitchen.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/giovannis.html
+++ b/restaurants/giovannis.html
@@ -693,20 +693,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main id="main" class="wrap">
 

--- a/restaurants/globe-and-atlas.html
+++ b/restaurants/globe-and-atlas.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/great-gatsby-dining-room.html
+++ b/restaurants/great-gatsby-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/hooked-seafood.html
+++ b/restaurants/hooked-seafood.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/hot-pot.html
+++ b/restaurants/hot-pot.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/izumi-in-the-park.html
+++ b/restaurants/izumi-in-the-park.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/izumi.html
+++ b/restaurants/izumi.html
@@ -358,20 +358,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
   <header>
     <h1>Izumi Sushi & Hibachi — Japanese Flavors at Sea</h1>
     <p>Experience two distinct takes on Japanese dining: the serene precision of Izumi Sushi and the fiery flair of Izumi Hibachi.</p>

--- a/restaurants/jamies-italian.html
+++ b/restaurants/jamies-italian.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/johnny-rockets.html
+++ b/restaurants/johnny-rockets.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -681,20 +681,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/leaf-and-bean.html
+++ b/restaurants/leaf-and-bean.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/lime-and-coconut.html
+++ b/restaurants/lime-and-coconut.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/lincoln-park-supper-club.html
+++ b/restaurants/lincoln-park-supper-club.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/lobby-bar.html
+++ b/restaurants/lobby-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/lous-jazz-n-blues.html
+++ b/restaurants/lous-jazz-n-blues.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/mason-jar.html
+++ b/restaurants/mason-jar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -679,20 +679,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/minstrel-dining-room.html
+++ b/restaurants/minstrel-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/my-fair-lady-dining-room.html
+++ b/restaurants/my-fair-lady-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/north-star-bar.html
+++ b/restaurants/north-star-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/oasis-bar.html
+++ b/restaurants/oasis-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/olive-or-twist.html
+++ b/restaurants/olive-or-twist.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/on-air.html
+++ b/restaurants/on-air.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -693,20 +693,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -674,20 +674,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
 

--- a/restaurants/pesky-parrot.html
+++ b/restaurants/pesky-parrot.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/pier-7.html
+++ b/restaurants/pier-7.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/pig-and-whistle-pub.html
+++ b/restaurants/pig-and-whistle-pub.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/playmakers.html
+++ b/restaurants/playmakers.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/plaza-bar.html
+++ b/restaurants/plaza-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/pool-bar.html
+++ b/restaurants/pool-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/portside-bbq.html
+++ b/restaurants/portside-bbq.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/quill-and-compass.html
+++ b/restaurants/quill-and-compass.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/r-bar.html
+++ b/restaurants/r-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/reflections-dining-room.html
+++ b/restaurants/reflections-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/rising-tide-bar.html
+++ b/restaurants/rising-tide-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/ritas-cantina.html
+++ b/restaurants/ritas-cantina.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/room-service.html
+++ b/restaurants/room-service.html
@@ -703,20 +703,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main id="main" class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/royal-railway.html
+++ b/restaurants/royal-railway.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/rye-and-bean.html
+++ b/restaurants/rye-and-bean.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/sabor-taqueria.html
+++ b/restaurants/sabor-taqueria.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/sabor.html
+++ b/restaurants/sabor.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -660,20 +660,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap" id="main">
   <!-- Overview -->

--- a/restaurants/sapphire-dining-room.html
+++ b/restaurants/sapphire-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/sapphire-restaurant.html
+++ b/restaurants/sapphire-restaurant.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/schooner-bar.html
+++ b/restaurants/schooner-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/sichuan-red.html
+++ b/restaurants/sichuan-red.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/silk.html
+++ b/restaurants/silk.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/sky-bar.html
+++ b/restaurants/sky-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/solarium-bar.html
+++ b/restaurants/solarium-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -622,20 +622,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
 

--- a/restaurants/solarium-cafe.html
+++ b/restaurants/solarium-cafe.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -708,20 +708,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/sprinkles.html
+++ b/restaurants/sprinkles.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/star-lounge.html
+++ b/restaurants/star-lounge.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/starbucks.html
+++ b/restaurants/starbucks.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/sugar-beach.html
+++ b/restaurants/sugar-beach.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/suite-lounge.html
+++ b/restaurants/suite-lounge.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -691,20 +691,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/swim-and-tonic.html
+++ b/restaurants/swim-and-tonic.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/tavern-bar.html
+++ b/restaurants/tavern-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/the-bamboo-room.html
+++ b/restaurants/the-bamboo-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/the-dining-room.html
+++ b/restaurants/the-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/the-grande.html
+++ b/restaurants/the-grande.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -689,20 +689,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/the-overlook.html
+++ b/restaurants/the-overlook.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/the-pit-stop.html
+++ b/restaurants/the-pit-stop.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/tides-dining-room.html
+++ b/restaurants/tides-dining-room.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/trellis-bar.html
+++ b/restaurants/trellis-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/two70-bar.html
+++ b/restaurants/two70-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/viking-crown-lounge.html
+++ b/restaurants/viking-crown-lounge.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/vintages.html
+++ b/restaurants/vintages.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -674,20 +674,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
     <!-- ICP-Lite Content Structure -->

--- a/restaurants/vortex.html
+++ b/restaurants/vortex.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/wig-and-gavel.html
+++ b/restaurants/wig-and-gavel.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -689,20 +689,7 @@
     <div class="hero-credit">
       <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
     </div>
-  </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+  </div></header>
 
 <main class="wrap">
 

--- a/restaurants/wipeout-bar.html
+++ b/restaurants/wipeout-bar.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/wonderland.html
+++ b/restaurants/wonderland.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/restaurants/zanzibar-lounge.html
+++ b/restaurants/zanzibar-lounge.html
@@ -343,20 +343,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
 <main class="wrap">
   <!-- Overview -->

--- a/search.html
+++ b/search.html
@@ -653,20 +653,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN -->
   <main id="main-content" class="wrap" role="main">

--- a/ships.html
+++ b/ships.html
@@ -1105,20 +1105,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty" rel="noopener external">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main id="content" class="wrap page-grid" role="main">
     <!-- Quick Answer / At a Glance - Early in HTML for SEO/AI, visually in right rail -->

--- a/ships/carnival-cruise-line/carnival-adventure.html
+++ b/ships/carnival-cruise-line/carnival-adventure.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-breeze.html
+++ b/ships/carnival-cruise-line/carnival-breeze.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-celebration.html
+++ b/ships/carnival-cruise-line/carnival-celebration.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-conquest.html
+++ b/ships/carnival-cruise-line/carnival-conquest.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-dream.html
+++ b/ships/carnival-cruise-line/carnival-dream.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-ecstasy.html
+++ b/ships/carnival-cruise-line/carnival-ecstasy.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-elation.html
+++ b/ships/carnival-cruise-line/carnival-elation.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-encounter.html
+++ b/ships/carnival-cruise-line/carnival-encounter.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-fantasy.html
+++ b/ships/carnival-cruise-line/carnival-fantasy.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-fascination.html
+++ b/ships/carnival-cruise-line/carnival-fascination.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-festivale.html
+++ b/ships/carnival-cruise-line/carnival-festivale.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-firenze.html
+++ b/ships/carnival-cruise-line/carnival-firenze.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-freedom.html
+++ b/ships/carnival-cruise-line/carnival-freedom.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-glory.html
+++ b/ships/carnival-cruise-line/carnival-glory.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-horizon.html
+++ b/ships/carnival-cruise-line/carnival-horizon.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-imagination.html
+++ b/ships/carnival-cruise-line/carnival-imagination.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-inspiration.html
+++ b/ships/carnival-cruise-line/carnival-inspiration.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-jubilee.html
+++ b/ships/carnival-cruise-line/carnival-jubilee.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-legend.html
+++ b/ships/carnival-cruise-line/carnival-legend.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-liberty.html
+++ b/ships/carnival-cruise-line/carnival-liberty.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-luminosa.html
+++ b/ships/carnival-cruise-line/carnival-luminosa.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-magic.html
+++ b/ships/carnival-cruise-line/carnival-magic.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-mardi-gras.html
+++ b/ships/carnival-cruise-line/carnival-mardi-gras.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-miracle.html
+++ b/ships/carnival-cruise-line/carnival-miracle.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-panorama.html
+++ b/ships/carnival-cruise-line/carnival-panorama.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-paradise.html
+++ b/ships/carnival-cruise-line/carnival-paradise.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-pride.html
+++ b/ships/carnival-cruise-line/carnival-pride.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-radiance.html
+++ b/ships/carnival-cruise-line/carnival-radiance.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-sensation.html
+++ b/ships/carnival-cruise-line/carnival-sensation.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-spirit.html
+++ b/ships/carnival-cruise-line/carnival-spirit.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-splendor.html
+++ b/ships/carnival-cruise-line/carnival-splendor.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-sunrise.html
+++ b/ships/carnival-cruise-line/carnival-sunrise.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-sunshine.html
+++ b/ships/carnival-cruise-line/carnival-sunshine.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-tropicale.html
+++ b/ships/carnival-cruise-line/carnival-tropicale.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-valor.html
+++ b/ships/carnival-cruise-line/carnival-valor.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-venezia.html
+++ b/ships/carnival-cruise-line/carnival-venezia.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnival-vista.html
+++ b/ships/carnival-cruise-line/carnival-vista.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/carnivale.html
+++ b/ships/carnival-cruise-line/carnivale.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/celebration.html
+++ b/ships/carnival-cruise-line/celebration.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/festivale.html
+++ b/ships/carnival-cruise-line/festivale.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/holiday.html
+++ b/ships/carnival-cruise-line/holiday.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/jubilee.html
+++ b/ships/carnival-cruise-line/jubilee.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/mardi-gras.html
+++ b/ships/carnival-cruise-line/mardi-gras.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/tropicale.html
+++ b/ships/carnival-cruise-line/tropicale.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/unnamed-project-ace-1.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-1.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/unnamed-project-ace-2.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-2.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival-cruise-line/unnamed-project-ace-3.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-3.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-adventure.html
+++ b/ships/carnival/carnival-adventure.html
@@ -511,20 +511,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-breeze.html
+++ b/ships/carnival/carnival-breeze.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-breeze.html
+++ b/ships/carnival/carnival-carnival-breeze.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-celebration.html
+++ b/ships/carnival/carnival-carnival-celebration.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-conquest.html
+++ b/ships/carnival/carnival-carnival-conquest.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-dream.html
+++ b/ships/carnival/carnival-carnival-dream.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-elation.html
+++ b/ships/carnival/carnival-carnival-elation.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-firenze.html
+++ b/ships/carnival/carnival-carnival-firenze.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-freedom.html
+++ b/ships/carnival/carnival-carnival-freedom.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-glory.html
+++ b/ships/carnival/carnival-carnival-glory.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-horizon.html
+++ b/ships/carnival/carnival-carnival-horizon.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-carnival-jubilee.html
+++ b/ships/carnival/carnival-carnival-jubilee.html
@@ -353,20 +353,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-celebration.html
+++ b/ships/carnival/carnival-celebration.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-conquest.html
+++ b/ships/carnival/carnival-conquest.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-dream.html
+++ b/ships/carnival/carnival-dream.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-ecstasy.html
+++ b/ships/carnival/carnival-ecstasy.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-elation.html
+++ b/ships/carnival/carnival-elation.html
@@ -511,20 +511,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-encounter.html
+++ b/ships/carnival/carnival-encounter.html
@@ -511,20 +511,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-fantasy.html
+++ b/ships/carnival/carnival-fantasy.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-fascination.html
+++ b/ships/carnival/carnival-fascination.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-festivale.html
+++ b/ships/carnival/carnival-festivale.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -481,20 +481,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-freedom.html
+++ b/ships/carnival/carnival-freedom.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-glory.html
+++ b/ships/carnival/carnival-glory.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-imagination.html
+++ b/ships/carnival/carnival-imagination.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-inspiration.html
+++ b/ships/carnival/carnival-inspiration.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-jubilee.html
+++ b/ships/carnival/carnival-jubilee.html
@@ -520,34 +520,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-legend.html
+++ b/ships/carnival/carnival-legend.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-liberty.html
+++ b/ships/carnival/carnival-liberty.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-luminosa.html
+++ b/ships/carnival/carnival-luminosa.html
@@ -511,20 +511,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-magic.html
+++ b/ships/carnival/carnival-magic.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-mardi-gras.html
+++ b/ships/carnival/carnival-mardi-gras.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-miracle.html
+++ b/ships/carnival/carnival-miracle.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-paradise.html
+++ b/ships/carnival/carnival-paradise.html
@@ -511,20 +511,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-pride.html
+++ b/ships/carnival/carnival-pride.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-radiance.html
+++ b/ships/carnival/carnival-radiance.html
@@ -511,20 +511,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-sensation.html
+++ b/ships/carnival/carnival-sensation.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-spirit.html
+++ b/ships/carnival/carnival-spirit.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-splendor.html
+++ b/ships/carnival/carnival-splendor.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-sunrise.html
+++ b/ships/carnival/carnival-sunrise.html
@@ -511,20 +511,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -511,20 +511,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-tropicale.html
+++ b/ships/carnival/carnival-tropicale.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-valor.html
+++ b/ships/carnival/carnival-valor.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -511,20 +511,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnival-vista.html
+++ b/ships/carnival/carnival-vista.html
@@ -550,34 +550,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/carnivale.html
+++ b/ships/carnival/carnivale.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/celebration.html
+++ b/ships/carnival/celebration.html
@@ -480,20 +480,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/festivale.html
+++ b/ships/carnival/festivale.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/holiday.html
+++ b/ships/carnival/holiday.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/index.html
+++ b/ships/carnival/index.html
@@ -306,20 +306,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/jubilee.html
+++ b/ships/carnival/jubilee.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/mardi-gras.html
+++ b/ships/carnival/mardi-gras.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/tropicale.html
+++ b/ships/carnival/tropicale.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/unnamed-project-ace-1.html
+++ b/ships/carnival/unnamed-project-ace-1.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/unnamed-project-ace-2.html
+++ b/ships/carnival/unnamed-project-ace-2.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/carnival/unnamed-project-ace-3.html
+++ b/ships/carnival/unnamed-project-ace-3.html
@@ -509,20 +509,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-ascent.html
+++ b/ships/celebrity-cruises/celebrity-ascent.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-beyond.html
+++ b/ships/celebrity-cruises/celebrity-beyond.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-century.html
+++ b/ships/celebrity-cruises/celebrity-century.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-compass.html
+++ b/ships/celebrity-cruises/celebrity-compass.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-constellation.html
+++ b/ships/celebrity-cruises/celebrity-constellation.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-eclipse.html
+++ b/ships/celebrity-cruises/celebrity-eclipse.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-edge.html
+++ b/ships/celebrity-cruises/celebrity-edge.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-equinox.html
+++ b/ships/celebrity-cruises/celebrity-equinox.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-flora.html
+++ b/ships/celebrity-cruises/celebrity-flora.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-galaxy.html
+++ b/ships/celebrity-cruises/celebrity-galaxy.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-infinity.html
+++ b/ships/celebrity-cruises/celebrity-infinity.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-mercury.html
+++ b/ships/celebrity-cruises/celebrity-mercury.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-millennium.html
+++ b/ships/celebrity-cruises/celebrity-millennium.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-reflection.html
+++ b/ships/celebrity-cruises/celebrity-reflection.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-seeker.html
+++ b/ships/celebrity-cruises/celebrity-seeker.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-silhouette.html
+++ b/ships/celebrity-cruises/celebrity-silhouette.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-solstice.html
+++ b/ships/celebrity-cruises/celebrity-solstice.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-summit.html
+++ b/ships/celebrity-cruises/celebrity-summit.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-xpedition.html
+++ b/ships/celebrity-cruises/celebrity-xpedition.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-xperience.html
+++ b/ships/celebrity-cruises/celebrity-xperience.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/celebrity-xploration.html
+++ b/ships/celebrity-cruises/celebrity-xploration.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/horizon.html
+++ b/ships/celebrity-cruises/horizon.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/ss-meridian.html
+++ b/ships/celebrity-cruises/ss-meridian.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/unnamed-edge-class.html
+++ b/ships/celebrity-cruises/unnamed-edge-class.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/unnamed-project-nirvana.html
+++ b/ships/celebrity-cruises/unnamed-project-nirvana.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/unnamed-river-class-x6.html
+++ b/ships/celebrity-cruises/unnamed-river-class-x6.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/celebrity-cruises/zenith.html
+++ b/ships/celebrity-cruises/zenith.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/grandeur-of-the-seas.html
+++ b/ships/grandeur-of-the-seas.html
@@ -755,20 +755,7 @@
     flickersofmajesty.com
   </a>
 </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main class="wrap" id="content" tabindex="-1">
     <!-- ICP-Lite Content Structure -->

--- a/ships/holland-america-line/amsterdam.html
+++ b/ships/holland-america-line/amsterdam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/edam.html
+++ b/ships/holland-america-line/edam.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/eurodam.html
+++ b/ships/holland-america-line/eurodam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/koningsdam.html
+++ b/ships/holland-america-line/koningsdam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/leerdam.html
+++ b/ships/holland-america-line/leerdam.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/maartensdijk.html
+++ b/ships/holland-america-line/maartensdijk.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/maasdam.html
+++ b/ships/holland-america-line/maasdam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/nieuw-amsterdam-ii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-ii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/nieuw-amsterdam-iii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/nieuw-amsterdam-iv.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iv.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/nieuw-amsterdam-v.html
+++ b/ships/holland-america-line/nieuw-amsterdam-v.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/nieuw-amsterdam.html
+++ b/ships/holland-america-line/nieuw-amsterdam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/nieuw-statendam.html
+++ b/ships/holland-america-line/nieuw-statendam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/none-announced.html
+++ b/ships/holland-america-line/none-announced.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/noordam-ii.html
+++ b/ships/holland-america-line/noordam-ii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/noordam-iii.html
+++ b/ships/holland-america-line/noordam-iii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/noordam-iv.html
+++ b/ships/holland-america-line/noordam-iv.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/noordam.html
+++ b/ships/holland-america-line/noordam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/oosterdam.html
+++ b/ships/holland-america-line/oosterdam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/p-caland.html
+++ b/ships/holland-america-line/p-caland.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/potsdam.html
+++ b/ships/holland-america-line/potsdam.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/prinsendam-i.html
+++ b/ships/holland-america-line/prinsendam-i.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/prinsendam-ii.html
+++ b/ships/holland-america-line/prinsendam-ii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/rijndam-ii.html
+++ b/ships/holland-america-line/rijndam-ii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/rijndam.html
+++ b/ships/holland-america-line/rijndam.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/rotterdam-iv.html
+++ b/ships/holland-america-line/rotterdam-iv.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/rotterdam-v.html
+++ b/ships/holland-america-line/rotterdam-v.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/rotterdam-vi.html
+++ b/ships/holland-america-line/rotterdam-vi.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/rotterdam.html
+++ b/ships/holland-america-line/rotterdam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/ryndam.html
+++ b/ships/holland-america-line/ryndam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/statendam-ii.html
+++ b/ships/holland-america-line/statendam-ii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/statendam-iii.html
+++ b/ships/holland-america-line/statendam-iii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/statendam.html
+++ b/ships/holland-america-line/statendam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/veendam-ii.html
+++ b/ships/holland-america-line/veendam-ii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/veendam-iii.html
+++ b/ships/holland-america-line/veendam-iii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/veendam-iv.html
+++ b/ships/holland-america-line/veendam-iv.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/veendam.html
+++ b/ships/holland-america-line/veendam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/volendam-ii.html
+++ b/ships/holland-america-line/volendam-ii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/volendam-iii.html
+++ b/ships/holland-america-line/volendam-iii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/volendam.html
+++ b/ships/holland-america-line/volendam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/w-a-scholten.html
+++ b/ships/holland-america-line/w-a-scholten.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/westerdam-i.html
+++ b/ships/holland-america-line/westerdam-i.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/westerdam-ii.html
+++ b/ships/holland-america-line/westerdam-ii.html
@@ -471,20 +471,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/holland-america-line/zaandam.html
+++ b/ships/holland-america-line/zaandam.html
@@ -510,34 +510,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
-
-    <!-- Hero section -->
-    <div class="hero" role="img" aria-label="Ship wake at sunrise">
-      <div class="latlon-grid" aria-hidden="true"></div>
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-</header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/ships/index.html
+++ b/ships/index.html
@@ -640,20 +640,7 @@
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit"><a class="pill" href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener noreferrer">Photo © Flickers of Majesty</a></div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <main id="content" class="wrap fleet-grid" role="main">
     <!-- LEFT COLUMN -->

--- a/ships/msc/msc-world-america.html
+++ b/ships/msc/msc-world-america.html
@@ -463,20 +463,7 @@
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
   <main class="wrap" id="content">
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/discovery-class-ship-tbn.html
+++ b/ships/rcl/discovery-class-ship-tbn.html
@@ -547,20 +547,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/icon-class-ship-tbn-2027.html
+++ b/ships/rcl/icon-class-ship-tbn-2027.html
@@ -883,20 +883,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/icon-class-ship-tbn-2028.html
+++ b/ships/rcl/icon-class-ship-tbn-2028.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/icon-of-the-seas.html
+++ b/ships/rcl/icon-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/legend-of-the-seas-1995-built.html
+++ b/ships/rcl/legend-of-the-seas-1995-built.html
@@ -857,20 +857,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
+++ b/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
@@ -883,20 +883,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/legend-of-the-seas.html
+++ b/ships/rcl/legend-of-the-seas.html
@@ -857,20 +857,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/majesty-of-the-seas.html
+++ b/ships/rcl/majesty-of-the-seas.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/monarch-of-the-seas.html
+++ b/ships/rcl/monarch-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/nordic-empress.html
+++ b/ships/rcl/nordic-empress.html
@@ -857,20 +857,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/nordic-prince.html
+++ b/ships/rcl/nordic-prince.html
@@ -526,20 +526,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/oasis-class-ship-tbn-2028.html
+++ b/ships/rcl/oasis-class-ship-tbn-2028.html
@@ -593,20 +593,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -851,20 +851,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -610,20 +610,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/song-of-america.html
+++ b/ships/rcl/song-of-america.html
@@ -566,20 +566,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty  Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- STATUS BANNER -->
   <div class="status-banner retired">

--- a/ships/rcl/song-of-norway.html
+++ b/ships/rcl/song-of-norway.html
@@ -859,20 +859,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/sovereign-of-the-seas.html
+++ b/ships/rcl/sovereign-of-the-seas.html
@@ -851,20 +851,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -851,20 +851,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/splendour-of-the-seas.html
+++ b/ships/rcl/splendour-of-the-seas.html
@@ -875,20 +875,7 @@ updated: 2025-11-18
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/star-class-ship-tbn-2028.html
+++ b/ships/rcl/star-class-ship-tbn-2028.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/star-of-the-seas-aug-2025-debut.html
+++ b/ships/rcl/star-of-the-seas-aug-2025-debut.html
@@ -883,20 +883,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/star-of-the-seas.html
+++ b/ships/rcl/star-of-the-seas.html
@@ -883,20 +883,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/sun-viking.html
+++ b/ships/rcl/sun-viking.html
@@ -560,20 +560,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -851,20 +851,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -851,20 +851,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/viking-serenade.html
+++ b/ships/rcl/viking-serenade.html
@@ -549,20 +549,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty  Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- STATUS BANNER -->
   <div class="status-banner retired">

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -884,20 +884,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -851,20 +851,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -851,20 +851,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap" id="main-content" role="main" tabindex="-1">

--- a/ships/rooms.html
+++ b/ships/rooms.html
@@ -438,20 +438,7 @@
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
   <main class="wrap" id="content">
 <section class="card" aria-labelledby="watch-highlights">
   <h2 id="watch-highlights">Watch: Rooms Highlights</h2>

--- a/solo.html
+++ b/solo.html
@@ -940,20 +940,7 @@
       <div class="hero-credit">
         Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener noreferrer">Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- Main -->
   <main class="wrap layout" id="content" role="main" aria-describedby="solo-intro">

--- a/solo/accessible-cruising.html
+++ b/solo/accessible-cruising.html
@@ -336,20 +336,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- ============================ MAIN ============================ -->
   <main id="content" class="wrap page-grid" role="main" aria-label="Main content">

--- a/solo/freedom-of-your-own-wake.html
+++ b/solo/freedom-of-your-own-wake.html
@@ -649,20 +649,7 @@ header, .hero-header, .navbar { position: relative; z-index: 1000; }
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- ============================ MAIN ============================ -->
   <!-- ============================ MAIN ============================ -->

--- a/solo/solo-cruisers-companion.html
+++ b/solo/solo-cruisers-companion.html
@@ -412,20 +412,7 @@
       <div class="hero-credit">
         <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- ============================ MAIN ============================ -->
   <main id="content" class="wrap" role="main" aria-label="Main content">

--- a/solo/visiting-the-united-states-before-your-cruise.html
+++ b/solo/visiting-the-united-states-before-your-cruise.html
@@ -589,20 +589,7 @@ figure figcaption { text-align:inherit; }
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- ============================== MAIN ============================== -->
   <main id="content" class="wrap page-grid" role="main" aria-label="Main content">

--- a/solo/why-i-started-solo-cruising.html
+++ b/solo/why-i-started-solo-cruising.html
@@ -550,20 +550,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- ============================ MAIN ============================ -->
   <main id="content" class="wrap page-grid" role="main" aria-label="Main content">

--- a/stateroom-check.html
+++ b/stateroom-check.html
@@ -974,20 +974,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <div class="hero-credit">
         <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- MAIN CONTENT -->
   <main class="wrap stateroom-check-container" id="main-content" role="main" tabindex="-1">

--- a/terms.html
+++ b/terms.html
@@ -499,20 +499,7 @@
       <div class="hero-credit">
         <a class="pill long" href="https://instagram.com/flickersofmajesty">Photo © Flickers of Majesty</a>
       </div>
-    </div>
-
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <nav class="nav" aria-label="Main site navigation">
     <div class="nav-item">

--- a/tools/port-tracker.html
+++ b/tools/port-tracker.html
@@ -185,20 +185,7 @@ Soli Deo Gloria
       <div class="hero-credit">
         <a class="pill" href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener">Photo © Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- Main Content -->
   <main class="wrap" id="content" tabindex="-1">

--- a/tools/ship-tracker.html
+++ b/tools/ship-tracker.html
@@ -186,20 +186,7 @@ Soli Deo Gloria
       <div class="hero-credit">
         <a class="pill" href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener">Photo © Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- Main Content -->
   <main class="wrap" id="content" tabindex="-1">

--- a/travel.html
+++ b/travel.html
@@ -1236,20 +1236,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
       <div class="hero-credit">
         <a class="pill" href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener">Photo © Flickers of Majesty — Instagram</a>
       </div>
-    </div>
-  
-    <!-- Hero -->
-    <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
-      <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
-      </div>
-      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
-      <div class="hero-credit">
-        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
-      </div>
-    </div>
-  </header>
+    </div></header>
 
   <!-- Main -->
   <main class="wrap with-right-rail" id="content" tabindex="-1">


### PR DESCRIPTION
Duplicate Hero Section Fixes:
- Fixed 395 files that had duplicate hero divs, compass roses, and logos
- Removed duplicate closing </header> tags on 48 ship pages
- Created audit tools to detect and fix duplicate hero elements site-wide
- All pages now have exactly ONE hero section as intended

Article Rail Enhancements:
- Added 2 missing articles to articles/index.json:
  * "In the Wake of Grief: When Loss Needs Water"
  * "Accessible Cruising: Five Universal Principles"
- Redesigned article rail on index.html with:
  * Clear introductory text explaining what the articles are
  * Article excerpts for better context
  * "Read Article →" CTA button on each item
  * Improved layout with larger thumbnails and better spacing

Files modified: 443 HTML pages, 1 JSON file
New tools: audit_and_fix_duplicates.py, fix_ship_duplicates.py