### PR TITLE
FIX: Restore dropdown menu functionality on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1678,14 +1678,16 @@
         status.textContent = `${view.length} recent articles loaded`;
       }
     })();
+  })();
+  </script>
 
-  // Duck card dismissal persistence
+  <!-- Duck card dismissal persistence -->
+  <script>
   (function() {
     const duckCard = document.getElementById('duck-card');
     if (duckCard && localStorage.getItem('duckCardDismissed') === 'true') {
       duckCard.style.display = 'none';
     }
-  })();
   })();
   </script>
 </body>


### PR DESCRIPTION
Critical JavaScript scope fix - dropdown menus were broken due to misplaced closing bracket from previous duplicate removal.

Problem:
- When removing duplicate dropdown JS, left duck card function trapped inside main IIFE scope
- This prevented the main IIFE from closing properly, breaking all JavaScript
- Dropdown click handlers never executed

Fix:
- Close main IIFE immediately after article rail code (line 1681)
- Move duck card dismissal to separate script block
- Proper scope isolation for both functions

Verified:
- Dropdown JavaScript now executes in correct scope
- Click and hover handlers properly attached
- Duck card persistence still functional