### PR TITLE
FIX: Use correct CSS selector for dropdown menu visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,7 +506,7 @@
     transition: transform 0.2s ease;
   }
 
-  .nav-item[data-open="true"] .nav-disclosure .caret {
+  .nav-group[data-open="true"] .nav-disclosure .caret {
     transform: rotate(180deg);
   }
 
@@ -540,7 +540,7 @@
     background: transparent;
   }
 
-  .nav-item[data-open="true"] > .submenu {
+  .nav-group[data-open="true"] > .submenu {
     display: block;
     opacity: 1;
     visibility: visible;
@@ -859,7 +859,7 @@
       transition: transform 0.2s ease;
     }
 
-    .nav-item[data-open="true"] .nav-disclosure .caret {
+    .nav-group[data-open="true"] .nav-disclosure .caret {
       transform: rotate(180deg);
     }
 
@@ -891,7 +891,7 @@
       background: transparent;
     }
 
-    .nav-item[data-open="true"] .submenu,
+    .nav-group[data-open="true"] .submenu,
     .nav-group.open .submenu {
       display: block;
       opacity: 1;
@@ -993,7 +993,7 @@
       transition: transform 0.2s ease;
     }
 
-    .nav-item[data-open="true"] .nav-disclosure .caret {
+    .nav-group[data-open="true"] .nav-disclosure .caret {
       transform: rotate(180deg);
     }
 
@@ -1025,7 +1025,7 @@
       background: transparent;
     }
 
-    .nav-item[data-open="true"] .submenu,
+    .nav-group[data-open="true"] .submenu,
     .nav-group.open .submenu {
       display: block;
       opacity: 1;


### PR DESCRIPTION
Changed CSS selectors from `.nav-item[data-open="true"]` to `.nav-group[data-open="true"]` to match the external stylesheet and working ship pages.

Problem:
- Dropdown menus on index.html were not showing when clicked
- CSS selector `.nav-item[data-open="true"]` wasn't matching properly
- External stylesheet uses `.nav-group[data-open="true"]`
- Ship pages (which work) also use `.nav-group[data-open="true"]`

Solution:
- Updated all 6 occurrences of `.nav-item[data-open="true"]` to use `.nav-group[data-open="true"]` instead
- This matches the selector that the JavaScript sets (data-open on .nav-group)
- Aligns with external stylesheet and working ship page patterns

Changes:
- Submenu visibility: `.nav-group[data-open="true"] > .submenu`
- Caret rotation: `.nav-group[data-open="true"] .nav-disclosure .caret`
- Applied to all media query variants