### PR TITLE
FIX: Increase dropdown menu z-index to appear above header

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,7 +526,7 @@
     visibility: hidden;
     pointer-events: none;
     transition: opacity 0.2s ease, visibility 0.2s ease;
-    z-index: 2100;
+    z-index: 10000;
   }
 
   /* Safe zone bridge */
@@ -878,7 +878,7 @@
       visibility: hidden;
       pointer-events: none;
       transition: opacity 0.2s ease, visibility 0.2s ease;
-      z-index: 2100;
+      z-index: 10000;
     }
 
     .submenu::before {
@@ -1012,7 +1012,7 @@
       visibility: hidden;
       pointer-events: none;
       transition: opacity 0.2s ease, visibility 0.2s ease;
-      z-index: 2100;
+      z-index: 10000;
     }
 
     .submenu::before {


### PR DESCRIPTION
The dropdown menus were hidden behind the header due to z-index stacking.

Problem:
- Header (.hero-header) has z-index: 9000
- Dropdown menus (.submenu) had z-index: 2100
- Since nav is inside header, submenu appeared behind header
- Clicking dropdown did nothing visible (menu was rendering but hidden)

Solution:
- Increased .submenu z-index from 2100 to 10000
- Now higher than header's 9000, so dropdown appears on top
- Updated all 3 occurrences (main + 2 media query variants)

This matches the skip-link's z-index (also 10000) which should appear above everything when focused.