### PR TITLE
FIX: Dropdown menus not appearing on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,10 +541,10 @@
   }
 
   .nav-group[data-open="true"] > .submenu {
-    display: block;
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
+    display: block !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+    pointer-events: auto !important;
   }
 
   .submenu a {
@@ -893,10 +893,10 @@
 
     .nav-group[data-open="true"] .submenu,
     .nav-group.open .submenu {
-      display: block;
-      opacity: 1;
-      visibility: visible;
-      pointer-events: auto;
+      display: block !important;
+      opacity: 1 !important;
+      visibility: visible !important;
+      pointer-events: auto !important;
     }
 
     .submenu a {
@@ -1027,10 +1027,10 @@
 
     .nav-group[data-open="true"] .submenu,
     .nav-group.open .submenu {
-      display: block;
-      opacity: 1;
-      visibility: visible;
-      pointer-events: auto;
+      display: block !important;
+      opacity: 1 !important;
+      visibility: visible !important;
+      pointer-events: auto !important;
     }
 
     .submenu a {


### PR DESCRIPTION
Issue: Clicking dropdown navigation buttons changed caret direction but submenu did not appear.

Root Cause: CSS specificity issue where .submenu display rules
were not overriding the default display: none properly.

Solution: Added !important declarations to dropdown show rules:
- .nav-group[data-open="true"] > .submenu
- .nav-group[data-open="true"] .submenu
- .nav-group.open .submenu

Changes:
- display: block !important
- opacity: 1 !important
- visibility: visible !important
- pointer-events: auto !important

This ensures dropdown menus appear reliably when data-open="true" is set by JavaScript, regardless of CSS cascade order.

Tested: Dropdowns now appear when clicked.