### PR TITLE
CHORE: Bump cache busters to v3.010.302

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
   <!-- ======================================================
        In the Wake — Home
-       Version: 3.010.301  |  Soli Deo Gloria ✝️
+       Version: 3.010.302  |  Soli Deo Gloria ✝️
 
        ✅ Production-Ready Template Applied
        ✅ WCAG 2.1 Level AA Compliant
@@ -32,7 +32,7 @@
   <!-- SEO: Theme & Appearance -->
   <meta name="color-scheme" content="light"/>
   <meta name="theme-color" content="#0e6e8e"/>
-  <meta name="version" content="3.010.301"/>
+  <meta name="version" content="3.010.302"/>
   <meta name="author" content="In the Wake"/>
   <meta name="publisher" content="In the Wake"/>
 
@@ -241,12 +241,12 @@
   <!-- Performance: DNS Prefetch & Preconnect -->
   <link rel="dns-prefetch" href="https://www.flickersofmajesty.com"/>
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
-  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.300" imagesrcset="/assets/index_hero.webp?v=3.010.300" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.302" imagesrcset="/assets/index_hero.webp?v=3.010.302" fetchpriority="high"/>
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.302"/>
   <style>
-  /* ===== Production Index Styles v3.010.300 ===== */
+  /* ===== Production Index Styles v3.010.302 ===== */
   :root {
     --sea: #0a3d62;
     --foam: #e6f4f8;
@@ -598,7 +598,7 @@
     position: relative;
     width: 100%;
     min-height: clamp(200px, 24vw, 340px);
-    background: url('/assets/index_hero.webp?v=3.010.300') 50% 50%/cover no-repeat;
+    background: url('/assets/index_hero.webp?v=3.010.302') 50% 50%/cover no-repeat;
     display: flex;
     align-items: flex-end;
     overflow-x: clip;
@@ -1077,7 +1077,7 @@
 
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
-  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.302" fetchpriority="high"/>
 </head>
 <body class="page">
   <!-- ai-breadcrumbs
@@ -1085,7 +1085,7 @@
        type: Website Homepage
        category: Cruise Planning Hub
        updated: 2025-11-15
-       version: 3.010.300
+       version: 3.010.302
        expertise: Royal Caribbean specialist, 50+ cruises, accessibility advocate, pastor, photographer
        primary-tools: Drink Calculator, Ships Database, Restaurant Guide, Stateroom Check
        target-audience: Cruise planners, Royal Caribbean travelers, solo cruisers, accessibility-focused travelers
@@ -1111,7 +1111,7 @@
     <div class="navbar">
       <div class="brand">
         <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
-        <span class="tiny version-badge" aria-label="Site version 3.010.300">v3.010.300</span>
+        <span class="tiny version-badge" aria-label="Site version 3.010.302">v3.010.302</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
         <div class="nav-item">
@@ -1170,7 +1170,7 @@
 
     <!-- Hero -->
     <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.302" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
         <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" width="560" height="567" alt="In the Wake" decoding="async" fetchpriority="high"/>
       </div>
@@ -1285,7 +1285,7 @@
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.302" type="image/webp"/>
             <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
           </picture>
         </a>
@@ -1488,7 +1488,7 @@
 
       function setImageWithFallback(imgEl, primary, altPaths=[]){
         if(!imgEl) return;
-        const stamp='v=3.010.301';
+        const stamp='v=3.010.302';
         const tried=new Set();
         const queue=[primary,...altPaths].filter(Boolean).map(p => p.includes('?')?p+'&'+stamp:p+'?'+stamp);
         function tryNext(){


### PR DESCRIPTION
Updated all cache buster version numbers from 3.010.300/3.010.301 to 3.010.302 to force browser reload of:
- assets/styles.css (dropdown navigation fix)
- index.html (infinite scroll fix)
- All preloaded assets (hero images, compass, author image)

Changes:
- Header comment version: 3.010.302
- Meta version tag: 3.010.302
- Stylesheet link: ?v=3.010.302
- Inline CSS version comment: v3.010.302
- All asset URLs: ?v=3.010.302
- Version badge: v3.010.302
- AI-breadcrumbs version: 3.010.302
- JS cache stamp: v=3.010.302

This ensures users get the critical fixes without manual cache clearing.