### PR TITLE
FIX: Dropdown inline styles using wrong selector (.open vs [data-open])

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
   <!-- ======================================================
        In the Wake — Home
-       Version: 3.010.303  |  Soli Deo Gloria ✝️
+       Version: 3.010.304  |  Soli Deo Gloria ✝️
 
        ✅ Production-Ready Template Applied
        ✅ WCAG 2.1 Level AA Compliant
@@ -32,7 +32,7 @@
   <!-- SEO: Theme & Appearance -->
   <meta name="color-scheme" content="light"/>
   <meta name="theme-color" content="#0e6e8e"/>
-  <meta name="version" content="3.010.303"/>
+  <meta name="version" content="3.010.304"/>
   <meta name="author" content="In the Wake"/>
   <meta name="publisher" content="In the Wake"/>
 
@@ -241,12 +241,12 @@
   <!-- Performance: DNS Prefetch & Preconnect -->
   <link rel="dns-prefetch" href="https://www.flickersofmajesty.com"/>
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
-  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.303" imagesrcset="/assets/index_hero.webp?v=3.010.303" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.304" imagesrcset="/assets/index_hero.webp?v=3.010.304" fetchpriority="high"/>
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.303"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.304"/>
   <style>
-  /* ===== Production Index Styles v3.010.303 ===== */
+  /* ===== Production Index Styles v3.010.304 ===== */
   :root {
     --sea: #0a3d62;
     --foam: #e6f4f8;
@@ -528,12 +528,12 @@
     border-radius: 12px;
     padding: .6rem;
     box-shadow: 0 8px 24px rgba(8,48,65,.15);
-    display: none;
+    display: none !important;
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
     transition: opacity 0.2s ease, visibility 0.2s ease;
-    z-index: 10000;
+    z-index: 10000 !important;
   }
 
   /* Safe zone bridge */
@@ -598,7 +598,7 @@
     position: relative;
     width: 100%;
     min-height: clamp(200px, 24vw, 340px);
-    background: url('/assets/index_hero.webp?v=3.010.303') 50% 50%/cover no-repeat;
+    background: url('/assets/index_hero.webp?v=3.010.304') 50% 50%/cover no-repeat;
     display: flex;
     align-items: flex-end;
     overflow-x: clip;
@@ -880,12 +880,12 @@
       border-radius: 12px;
       padding: .6rem;
       box-shadow: 0 8px 24px rgba(8,48,65,.15);
-      display: none;
+      display: none !important;
       opacity: 0;
       visibility: hidden;
       pointer-events: none;
       transition: opacity 0.2s ease, visibility 0.2s ease;
-      z-index: 10000;
+      z-index: 10000 !important;
     }
 
     .submenu::before {
@@ -899,7 +899,7 @@
     }
 
     .nav-group[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] > .submenu {
       display: block !important;
       opacity: 1 !important;
       visibility: visible !important;
@@ -1014,12 +1014,12 @@
       border-radius: 12px;
       padding: .6rem;
       box-shadow: 0 8px 24px rgba(8,48,65,.15);
-      display: none;
+      display: none !important;
       opacity: 0;
       visibility: hidden;
       pointer-events: none;
       transition: opacity 0.2s ease, visibility 0.2s ease;
-      z-index: 10000;
+      z-index: 10000 !important;
     }
 
     .submenu::before {
@@ -1033,7 +1033,7 @@
     }
 
     .nav-group[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] > .submenu {
       display: block !important;
       opacity: 1 !important;
       visibility: visible !important;
@@ -1077,7 +1077,7 @@
 
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
-  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.303" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.304" fetchpriority="high"/>
 </head>
 <body class="page">
   <!-- ai-breadcrumbs
@@ -1085,7 +1085,7 @@
        type: Website Homepage
        category: Cruise Planning Hub
        updated: 2025-11-15
-       version: 3.010.303
+       version: 3.010.304
        expertise: Royal Caribbean specialist, 50+ cruises, accessibility advocate, pastor, photographer
        primary-tools: Drink Calculator, Ships Database, Restaurant Guide, Stateroom Check
        target-audience: Cruise planners, Royal Caribbean travelers, solo cruisers, accessibility-focused travelers
@@ -1111,7 +1111,7 @@
     <div class="navbar">
       <div class="brand">
         <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
-        <span class="tiny version-badge" aria-label="Site version 3.010.303">v3.010.303</span>
+        <span class="tiny version-badge" aria-label="Site version 3.010.304">v3.010.304</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
         <div class="nav-item">
@@ -1170,7 +1170,7 @@
 
     <!-- Hero -->
     <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.303" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.304" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
         <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" width="560" height="567" alt="In the Wake" decoding="async" fetchpriority="high"/>
       </div>
@@ -1285,7 +1285,7 @@
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.303" type="image/webp"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.304" type="image/webp"/>
             <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
           </picture>
         </a>
@@ -1488,7 +1488,7 @@
 
       function setImageWithFallback(imgEl, primary, altPaths=[]){
         if(!imgEl) return;
-        const stamp='v=3.010.303';
+        const stamp='v=3.010.304';
         const tried=new Set();
         const queue=[primary,...altPaths].filter(Boolean).map(p => p.includes('?')?p+'&'+stamp:p+'?'+stamp);
         function tryNext(){


### PR DESCRIPTION
CRITICAL FIX: Found root cause of dropdown failure

The inline styles in index.html were using TWO DIFFERENT selectors:
- Line 550: .nav-group[data-open="true"] > .submenu (CORRECT)
- Line 902: .nav-group.open .submenu (WRONG - looking for .open class)
- Line 1036: .nav-group.open .submenu (WRONG - looking for .open class)

JavaScript sets data-open="true" attribute but lines 902 and 1036 were looking for an .open CLASS that never gets added!

FIXES:
1. Changed all .nav-group.open selectors to .nav-group[data-open="true"]
2. Added !important to display: none (lines 531, 883, 1017)
3. Added !important to z-index: 10000 (lines 536, 888, 1022)
4. Bumped cache busters to v3.010.304

This should FINALLY fix the dropdown menus.
Testing: Hard refresh required (Ctrl+Shift+R)