### PR TITLE
FIX: Use correct selector nav-item (not nav-group) for data-open attr…

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -720,7 +720,7 @@ html, body { overflow-x: hidden; }
   display:none !important;
   z-index:10000 !important;
 }
-.nav-group[data-open="true"] .submenu{ display:block !important; opacity:1 !important; visibility:visible !important; pointer-events:auto !important; }
+.nav-item[data-open="true"] .submenu{ display:block !important; opacity:1 !important; visibility:visible !important; pointer-events:auto !important; }
 
 /* Submenu items */
 .submenu a{
@@ -771,7 +771,7 @@ html, body{ overflow-x:hidden }
   border-radius:12px; padding:.35rem; box-shadow:0 8px 24px rgba(8,48,65,.12);
   display:none !important; z-index:10000 !important;
 }
-.nav-group[data-open="true"] .submenu{ display:block !important; opacity:1 !important; visibility:visible !important; pointer-events:auto !important; }
+.nav-item[data-open="true"] .submenu{ display:block !important; opacity:1 !important; visibility:visible !important; pointer-events:auto !important; }
 
 /* Hover fallback (works even if JS fails) */
 @media (hover:hover){
@@ -863,8 +863,8 @@ html, body{ overflow-x:hidden }
 }
 
 /* JS toggles this; this rule MUST be present and later in cascade */
-.nav-group[data-open="true"] > .submenu,
-.nav-group[data-open="true"] .submenu{
+.nav-item[data-open="true"] > .submenu,
+.nav-item[data-open="true"] .submenu{
   display:block !important; opacity:1 !important; visibility:visible !important; pointer-events:auto !important;
 }
 

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
   <!-- ======================================================
        In the Wake — Home
-       Version: 3.010.304  |  Soli Deo Gloria ✝️
+       Version: 3.010.305  |  Soli Deo Gloria ✝️
 
        ✅ Production-Ready Template Applied
        ✅ WCAG 2.1 Level AA Compliant
@@ -32,7 +32,7 @@
   <!-- SEO: Theme & Appearance -->
   <meta name="color-scheme" content="light"/>
   <meta name="theme-color" content="#0e6e8e"/>
-  <meta name="version" content="3.010.304"/>
+  <meta name="version" content="3.010.305"/>
   <meta name="author" content="In the Wake"/>
   <meta name="publisher" content="In the Wake"/>
 
@@ -241,12 +241,12 @@
   <!-- Performance: DNS Prefetch & Preconnect -->
   <link rel="dns-prefetch" href="https://www.flickersofmajesty.com"/>
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
-  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.304" imagesrcset="/assets/index_hero.webp?v=3.010.304" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.305" imagesrcset="/assets/index_hero.webp?v=3.010.305" fetchpriority="high"/>
 
   <!-- Styles -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.304"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.305"/>
   <style>
-  /* ===== Production Index Styles v3.010.304 ===== */
+  /* ===== Production Index Styles v3.010.305 ===== */
   :root {
     --sea: #0a3d62;
     --foam: #e6f4f8;
@@ -513,7 +513,7 @@
     transition: transform 0.2s ease;
   }
 
-  .nav-group[data-open="true"] .nav-disclosure .caret {
+  .nav-item[data-open="true"] .nav-disclosure .caret {
     transform: rotate(180deg);
   }
 
@@ -547,7 +547,7 @@
     background: transparent;
   }
 
-  .nav-group[data-open="true"] > .submenu {
+  .nav-item[data-open="true"] > .submenu {
     display: block !important;
     opacity: 1 !important;
     visibility: visible !important;
@@ -598,7 +598,7 @@
     position: relative;
     width: 100%;
     min-height: clamp(200px, 24vw, 340px);
-    background: url('/assets/index_hero.webp?v=3.010.304') 50% 50%/cover no-repeat;
+    background: url('/assets/index_hero.webp?v=3.010.305') 50% 50%/cover no-repeat;
     display: flex;
     align-items: flex-end;
     overflow-x: clip;
@@ -866,7 +866,7 @@
       transition: transform 0.2s ease;
     }
 
-    .nav-group[data-open="true"] .nav-disclosure .caret {
+    .nav-item[data-open="true"] .nav-disclosure .caret {
       transform: rotate(180deg);
     }
 
@@ -898,8 +898,8 @@
       background: transparent;
     }
 
-    .nav-group[data-open="true"] .submenu,
-    .nav-group[data-open="true"] > .submenu {
+    .nav-item[data-open="true"] .submenu,
+    .nav-item[data-open="true"] > .submenu {
       display: block !important;
       opacity: 1 !important;
       visibility: visible !important;
@@ -1000,7 +1000,7 @@
       transition: transform 0.2s ease;
     }
 
-    .nav-group[data-open="true"] .nav-disclosure .caret {
+    .nav-item[data-open="true"] .nav-disclosure .caret {
       transform: rotate(180deg);
     }
 
@@ -1032,8 +1032,8 @@
       background: transparent;
     }
 
-    .nav-group[data-open="true"] .submenu,
-    .nav-group[data-open="true"] > .submenu {
+    .nav-item[data-open="true"] .submenu,
+    .nav-item[data-open="true"] > .submenu {
       display: block !important;
       opacity: 1 !important;
       visibility: visible !important;
@@ -1077,7 +1077,7 @@
 
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
-  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.304" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.305" fetchpriority="high"/>
 </head>
 <body class="page">
   <!-- ai-breadcrumbs
@@ -1085,7 +1085,7 @@
        type: Website Homepage
        category: Cruise Planning Hub
        updated: 2025-11-15
-       version: 3.010.304
+       version: 3.010.305
        expertise: Royal Caribbean specialist, 50+ cruises, accessibility advocate, pastor, photographer
        primary-tools: Drink Calculator, Ships Database, Restaurant Guide, Stateroom Check
        target-audience: Cruise planners, Royal Caribbean travelers, solo cruisers, accessibility-focused travelers
@@ -1111,7 +1111,7 @@
     <div class="navbar">
       <div class="brand">
         <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
-        <span class="tiny version-badge" aria-label="Site version 3.010.304">v3.010.304</span>
+        <span class="tiny version-badge" aria-label="Site version 3.010.305">v3.010.305</span>
       </div>
       <nav class="nav" aria-label="Main site navigation">
         <div class="nav-item">
@@ -1170,7 +1170,7 @@
 
     <!-- Hero -->
     <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.304" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.305" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
         <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" width="560" height="567" alt="In the Wake" decoding="async" fetchpriority="high"/>
       </div>
@@ -1285,7 +1285,7 @@
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.304" type="image/webp"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.305" type="image/webp"/>
             <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
           </picture>
         </a>
@@ -1488,7 +1488,7 @@
 
       function setImageWithFallback(imgEl, primary, altPaths=[]){
         if(!imgEl) return;
-        const stamp='v=3.010.304';
+        const stamp='v=3.010.305';
         const tried=new Set();
         const queue=[primary,...altPaths].filter(Boolean).map(p => p.includes('?')?p+'&'+stamp:p+'?'+stamp);
         function tryNext(){


### PR DESCRIPTION
…ibute

ROOT CAUSE FOUND: Compared working version from Nov 20 vs broken version

WORKING VERSION (commit 32b08d1d): Used .nav-item[data-open="true"]
BROKEN VERSION (all recent commits): Used .nav-group[data-open="true"]

HTML STRUCTURE:
<div class="nav-item nav-group" data-open="false">
  ^         ^
  |         └─ Also has nav-group class
  └─────────── Primary class for data-open attribute

The element has BOTH classes, but the working selector targets .nav-item because that's the primary class the JavaScript interacts with.

CHANGES:
1. Changed ALL .nav-group[data-open="true"] to .nav-item[data-open="true"]
2. Updated index.html (8 instances)
3. Updated assets/styles.css (5 instances)
4. Bumped cache to v3.010.305

This restores the selector pattern that was working on Nov 20-21. Testing: Hard refresh required (Ctrl+Shift+R)