### PR TITLE
FIX: Site-wide dropdown menu CSS selector mismatch (286 files)

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -806,7 +806,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -940,7 +940,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/accessibility.html
+++ b/accessibility.html
@@ -812,7 +812,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -946,7 +946,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/admin/reports/articles.html
+++ b/admin/reports/articles.html
@@ -320,7 +320,7 @@ Page: /admin/reports/articles.html · v3.008 · Built: 2025-10-17T00:00:00Z
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -454,7 +454,7 @@ Page: /admin/reports/articles.html · v3.008 · Built: 2025-10-17T00:00:00Z
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/admin/reports/sw-health.html
+++ b/admin/reports/sw-health.html
@@ -369,7 +369,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/assets/css/calculator.css
+++ b/assets/css/calculator.css
@@ -377,7 +377,7 @@ small,
 }
 
 .nav-group[data-open="true"] > .submenu,
-.nav-group.open > .submenu,
+.nav-group[data-open="true"] > .submenu,
 .nav-group:hover > .submenu,
 .nav-group:focus-within > .submenu {
   display: block !important;

--- a/assets/ships/grandeur-of-the-seas.html
+++ b/assets/ships/grandeur-of-the-seas.html
@@ -127,7 +127,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -261,7 +261,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -862,15 +862,25 @@ html, body{ overflow-x:hidden }
   transition:opacity .15s ease;
 }
 
-/* JS toggles this; this rule MUST be present and later in cascade */
+/* JS toggles data-open="true"; these rules MUST be present and later in cascade */
+/* Support both .nav-item and .nav-group since elements may have either or both classes */
 .nav-item[data-open="true"] > .submenu,
-.nav-item[data-open="true"] .submenu{
+.nav-item[data-open="true"] .submenu,
+.nav-group[data-open="true"] > .submenu,
+.nav-group[data-open="true"] .submenu{
   display:block !important; opacity:1 !important; visibility:visible !important; pointer-events:auto !important;
+}
+
+/* Caret rotation for both .nav-item and .nav-group */
+.nav-group[data-open="true"] .nav-disclosure .caret{
+  transform: rotate(180deg);
 }
 
 /* Optional assist so hover/focus still works without JS */
 .nav-group:hover > .submenu,
-.nav-group:focus-within > .submenu{
+.nav-group:focus-within > .submenu,
+.nav-item:hover > .submenu,
+.nav-item:focus-within > .submenu{
   display:block !important; opacity:1 !important; visibility:visible !important; pointer-events:auto !important;
 }
 

--- a/authors/ken-baker.html
+++ b/authors/ken-baker.html
@@ -398,7 +398,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -532,7 +532,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/authors/tina-maulsby.html
+++ b/authors/tina-maulsby.html
@@ -389,7 +389,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -523,7 +523,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines.html
+++ b/cruise-lines.html
@@ -479,7 +479,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -613,7 +613,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines/carnival.html
+++ b/cruise-lines/carnival.html
@@ -451,7 +451,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -585,7 +585,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines/celebrity.html
+++ b/cruise-lines/celebrity.html
@@ -451,7 +451,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -585,7 +585,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines/disney.html
+++ b/cruise-lines/disney.html
@@ -451,7 +451,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -585,7 +585,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines/holland-america.html
+++ b/cruise-lines/holland-america.html
@@ -448,7 +448,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -582,7 +582,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines/msc.html
+++ b/cruise-lines/msc.html
@@ -451,7 +451,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -585,7 +585,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines/norwegian.html
+++ b/cruise-lines/norwegian.html
@@ -458,7 +458,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -592,7 +592,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines/princess.html
+++ b/cruise-lines/princess.html
@@ -454,7 +454,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -588,7 +588,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines/viking.html
+++ b/cruise-lines/viking.html
@@ -400,7 +400,7 @@ All work on this project is offered as a gift to God.
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -534,7 +534,7 @@ All work on this project is offered as a gift to God.
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -399,7 +399,7 @@ All work on this project is offered as a gift to God.
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -533,7 +533,7 @@ All work on this project is offered as a gift to God.
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/disability-at-sea.html
+++ b/disability-at-sea.html
@@ -285,7 +285,7 @@ ADDENDUM: Facebook Domain Verification v3.008.021
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -419,7 +419,7 @@ ADDENDUM: Facebook Domain Verification v3.008.021
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -733,7 +733,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -934,7 +934,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -1068,7 +1068,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/offline.html
+++ b/offline.html
@@ -403,7 +403,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/packing-lists.html
+++ b/packing-lists.html
@@ -855,7 +855,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -989,7 +989,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/planning.html
+++ b/planning.html
@@ -919,7 +919,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -1053,7 +1053,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ports.html
+++ b/ports.html
@@ -302,7 +302,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
     .nav-item[data-open="true"] .submenu,
     .nav-group[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -433,7 +433,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -567,7 +567,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/privacy.html
+++ b/privacy.html
@@ -242,7 +242,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants.html
+++ b/restaurants.html
@@ -362,7 +362,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
     .nav-item[data-open="true"] .submenu,
     .nav-group[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -493,7 +493,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -627,7 +627,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -375,7 +375,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -509,7 +509,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -374,7 +374,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -508,7 +508,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -372,7 +372,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -506,7 +506,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -379,7 +379,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -513,7 +513,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -378,7 +378,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -512,7 +512,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/chops.html
+++ b/restaurants/chops.html
@@ -378,7 +378,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -512,7 +512,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -370,7 +370,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -504,7 +504,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -371,7 +371,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -505,7 +505,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/dining-activities.html
+++ b/restaurants/dining-activities.html
@@ -329,7 +329,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -463,7 +463,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -377,7 +377,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -511,7 +511,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -379,7 +379,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -513,7 +513,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/giovannis.html
+++ b/restaurants/giovannis.html
@@ -360,7 +360,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -494,7 +494,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/izumi.html
+++ b/restaurants/izumi.html
@@ -240,7 +240,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -357,7 +357,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -491,7 +491,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -363,7 +363,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -497,7 +497,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -359,7 +359,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -493,7 +493,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -368,7 +368,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -502,7 +502,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/room-service.html
+++ b/restaurants/room-service.html
@@ -377,7 +377,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -511,7 +511,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -369,7 +369,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -503,7 +503,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -351,7 +351,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -485,7 +485,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -383,7 +383,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -517,7 +517,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -366,7 +366,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -500,7 +500,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -364,7 +364,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -498,7 +498,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -350,7 +350,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -484,7 +484,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -358,7 +358,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -492,7 +492,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-adventure.html
+++ b/ships/carnival-cruise-line/carnival-adventure.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-breeze.html
+++ b/ships/carnival-cruise-line/carnival-breeze.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-celebration.html
+++ b/ships/carnival-cruise-line/carnival-celebration.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-conquest.html
+++ b/ships/carnival-cruise-line/carnival-conquest.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-dream.html
+++ b/ships/carnival-cruise-line/carnival-dream.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-ecstasy.html
+++ b/ships/carnival-cruise-line/carnival-ecstasy.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-elation.html
+++ b/ships/carnival-cruise-line/carnival-elation.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-encounter.html
+++ b/ships/carnival-cruise-line/carnival-encounter.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-fantasy.html
+++ b/ships/carnival-cruise-line/carnival-fantasy.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-fascination.html
+++ b/ships/carnival-cruise-line/carnival-fascination.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-festivale.html
+++ b/ships/carnival-cruise-line/carnival-festivale.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-firenze.html
+++ b/ships/carnival-cruise-line/carnival-firenze.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-freedom.html
+++ b/ships/carnival-cruise-line/carnival-freedom.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-glory.html
+++ b/ships/carnival-cruise-line/carnival-glory.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-horizon.html
+++ b/ships/carnival-cruise-line/carnival-horizon.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-imagination.html
+++ b/ships/carnival-cruise-line/carnival-imagination.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-inspiration.html
+++ b/ships/carnival-cruise-line/carnival-inspiration.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-jubilee.html
+++ b/ships/carnival-cruise-line/carnival-jubilee.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-legend.html
+++ b/ships/carnival-cruise-line/carnival-legend.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-liberty.html
+++ b/ships/carnival-cruise-line/carnival-liberty.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-luminosa.html
+++ b/ships/carnival-cruise-line/carnival-luminosa.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-magic.html
+++ b/ships/carnival-cruise-line/carnival-magic.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-mardi-gras.html
+++ b/ships/carnival-cruise-line/carnival-mardi-gras.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-miracle.html
+++ b/ships/carnival-cruise-line/carnival-miracle.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-panorama.html
+++ b/ships/carnival-cruise-line/carnival-panorama.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-paradise.html
+++ b/ships/carnival-cruise-line/carnival-paradise.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-pride.html
+++ b/ships/carnival-cruise-line/carnival-pride.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-radiance.html
+++ b/ships/carnival-cruise-line/carnival-radiance.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-sensation.html
+++ b/ships/carnival-cruise-line/carnival-sensation.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-spirit.html
+++ b/ships/carnival-cruise-line/carnival-spirit.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-splendor.html
+++ b/ships/carnival-cruise-line/carnival-splendor.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-sunrise.html
+++ b/ships/carnival-cruise-line/carnival-sunrise.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-sunshine.html
+++ b/ships/carnival-cruise-line/carnival-sunshine.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-tropicale.html
+++ b/ships/carnival-cruise-line/carnival-tropicale.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-valor.html
+++ b/ships/carnival-cruise-line/carnival-valor.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-venezia.html
+++ b/ships/carnival-cruise-line/carnival-venezia.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnival-vista.html
+++ b/ships/carnival-cruise-line/carnival-vista.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/carnivale.html
+++ b/ships/carnival-cruise-line/carnivale.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/celebration.html
+++ b/ships/carnival-cruise-line/celebration.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/festivale.html
+++ b/ships/carnival-cruise-line/festivale.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/holiday.html
+++ b/ships/carnival-cruise-line/holiday.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/jubilee.html
+++ b/ships/carnival-cruise-line/jubilee.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/mardi-gras.html
+++ b/ships/carnival-cruise-line/mardi-gras.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/tropicale.html
+++ b/ships/carnival-cruise-line/tropicale.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/unnamed-project-ace-1.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-1.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/unnamed-project-ace-2.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-2.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival-cruise-line/unnamed-project-ace-3.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-3.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-adventure.html
+++ b/ships/carnival/carnival-adventure.html
@@ -375,7 +375,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-breeze.html
+++ b/ships/carnival/carnival-breeze.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-breeze.html
+++ b/ships/carnival/carnival-carnival-breeze.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-celebration.html
+++ b/ships/carnival/carnival-carnival-celebration.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-conquest.html
+++ b/ships/carnival/carnival-carnival-conquest.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-dream.html
+++ b/ships/carnival/carnival-carnival-dream.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-elation.html
+++ b/ships/carnival/carnival-carnival-elation.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-firenze.html
+++ b/ships/carnival/carnival-carnival-firenze.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-freedom.html
+++ b/ships/carnival/carnival-carnival-freedom.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-glory.html
+++ b/ships/carnival/carnival-carnival-glory.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-horizon.html
+++ b/ships/carnival/carnival-carnival-horizon.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-carnival-jubilee.html
+++ b/ships/carnival/carnival-carnival-jubilee.html
@@ -217,7 +217,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-celebration.html
+++ b/ships/carnival/carnival-celebration.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-conquest.html
+++ b/ships/carnival/carnival-conquest.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-dream.html
+++ b/ships/carnival/carnival-dream.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-ecstasy.html
+++ b/ships/carnival/carnival-ecstasy.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-elation.html
+++ b/ships/carnival/carnival-elation.html
@@ -375,7 +375,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-encounter.html
+++ b/ships/carnival/carnival-encounter.html
@@ -375,7 +375,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-fantasy.html
+++ b/ships/carnival/carnival-fantasy.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-fascination.html
+++ b/ships/carnival/carnival-fascination.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-festivale.html
+++ b/ships/carnival/carnival-festivale.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -345,7 +345,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-freedom.html
+++ b/ships/carnival/carnival-freedom.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-glory.html
+++ b/ships/carnival/carnival-glory.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-imagination.html
+++ b/ships/carnival/carnival-imagination.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-inspiration.html
+++ b/ships/carnival/carnival-inspiration.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-jubilee.html
+++ b/ships/carnival/carnival-jubilee.html
@@ -383,7 +383,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-legend.html
+++ b/ships/carnival/carnival-legend.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-liberty.html
+++ b/ships/carnival/carnival-liberty.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-luminosa.html
+++ b/ships/carnival/carnival-luminosa.html
@@ -375,7 +375,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-magic.html
+++ b/ships/carnival/carnival-magic.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-mardi-gras.html
+++ b/ships/carnival/carnival-mardi-gras.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-miracle.html
+++ b/ships/carnival/carnival-miracle.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-paradise.html
+++ b/ships/carnival/carnival-paradise.html
@@ -375,7 +375,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-pride.html
+++ b/ships/carnival/carnival-pride.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-radiance.html
+++ b/ships/carnival/carnival-radiance.html
@@ -375,7 +375,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-sensation.html
+++ b/ships/carnival/carnival-sensation.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-spirit.html
+++ b/ships/carnival/carnival-spirit.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-splendor.html
+++ b/ships/carnival/carnival-splendor.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-sunrise.html
+++ b/ships/carnival/carnival-sunrise.html
@@ -375,7 +375,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -375,7 +375,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-tropicale.html
+++ b/ships/carnival/carnival-tropicale.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-valor.html
+++ b/ships/carnival/carnival-valor.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -375,7 +375,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnival-vista.html
+++ b/ships/carnival/carnival-vista.html
@@ -413,7 +413,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/carnivale.html
+++ b/ships/carnival/carnivale.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/celebration.html
+++ b/ships/carnival/celebration.html
@@ -344,7 +344,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/festivale.html
+++ b/ships/carnival/festivale.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/holiday.html
+++ b/ships/carnival/holiday.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/index.html
+++ b/ships/carnival/index.html
@@ -205,7 +205,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/jubilee.html
+++ b/ships/carnival/jubilee.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/mardi-gras.html
+++ b/ships/carnival/mardi-gras.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/tropicale.html
+++ b/ships/carnival/tropicale.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/unnamed-project-ace-1.html
+++ b/ships/carnival/unnamed-project-ace-1.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/unnamed-project-ace-2.html
+++ b/ships/carnival/unnamed-project-ace-2.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/carnival/unnamed-project-ace-3.html
+++ b/ships/carnival/unnamed-project-ace-3.html
@@ -373,7 +373,7 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-ascent.html
+++ b/ships/celebrity-cruises/celebrity-ascent.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-beyond.html
+++ b/ships/celebrity-cruises/celebrity-beyond.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-century.html
+++ b/ships/celebrity-cruises/celebrity-century.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-compass.html
+++ b/ships/celebrity-cruises/celebrity-compass.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-constellation.html
+++ b/ships/celebrity-cruises/celebrity-constellation.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-eclipse.html
+++ b/ships/celebrity-cruises/celebrity-eclipse.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-edge.html
+++ b/ships/celebrity-cruises/celebrity-edge.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-equinox.html
+++ b/ships/celebrity-cruises/celebrity-equinox.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-flora.html
+++ b/ships/celebrity-cruises/celebrity-flora.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-galaxy.html
+++ b/ships/celebrity-cruises/celebrity-galaxy.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-infinity.html
+++ b/ships/celebrity-cruises/celebrity-infinity.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-mercury.html
+++ b/ships/celebrity-cruises/celebrity-mercury.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-millennium.html
+++ b/ships/celebrity-cruises/celebrity-millennium.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-reflection.html
+++ b/ships/celebrity-cruises/celebrity-reflection.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-seeker.html
+++ b/ships/celebrity-cruises/celebrity-seeker.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-silhouette.html
+++ b/ships/celebrity-cruises/celebrity-silhouette.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-solstice.html
+++ b/ships/celebrity-cruises/celebrity-solstice.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-summit.html
+++ b/ships/celebrity-cruises/celebrity-summit.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-xpedition.html
+++ b/ships/celebrity-cruises/celebrity-xpedition.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-xperience.html
+++ b/ships/celebrity-cruises/celebrity-xperience.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/celebrity-xploration.html
+++ b/ships/celebrity-cruises/celebrity-xploration.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/horizon.html
+++ b/ships/celebrity-cruises/horizon.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/ss-meridian.html
+++ b/ships/celebrity-cruises/ss-meridian.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/unnamed-edge-class.html
+++ b/ships/celebrity-cruises/unnamed-edge-class.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/unnamed-project-nirvana.html
+++ b/ships/celebrity-cruises/unnamed-project-nirvana.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/unnamed-river-class-x6.html
+++ b/ships/celebrity-cruises/unnamed-river-class-x6.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/celebrity-cruises/zenith.html
+++ b/ships/celebrity-cruises/zenith.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/grandeur-of-the-seas.html
+++ b/ships/grandeur-of-the-seas.html
@@ -423,7 +423,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -557,7 +557,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/amsterdam.html
+++ b/ships/holland-america-line/amsterdam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/edam.html
+++ b/ships/holland-america-line/edam.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/eurodam.html
+++ b/ships/holland-america-line/eurodam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/koningsdam.html
+++ b/ships/holland-america-line/koningsdam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/leerdam.html
+++ b/ships/holland-america-line/leerdam.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/maartensdijk.html
+++ b/ships/holland-america-line/maartensdijk.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/maasdam.html
+++ b/ships/holland-america-line/maasdam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/nieuw-amsterdam-ii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-ii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/nieuw-amsterdam-iii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/nieuw-amsterdam-iv.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iv.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/nieuw-amsterdam-v.html
+++ b/ships/holland-america-line/nieuw-amsterdam-v.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/nieuw-amsterdam.html
+++ b/ships/holland-america-line/nieuw-amsterdam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/nieuw-statendam.html
+++ b/ships/holland-america-line/nieuw-statendam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/none-announced.html
+++ b/ships/holland-america-line/none-announced.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/noordam-ii.html
+++ b/ships/holland-america-line/noordam-ii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/noordam-iii.html
+++ b/ships/holland-america-line/noordam-iii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/noordam-iv.html
+++ b/ships/holland-america-line/noordam-iv.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/noordam.html
+++ b/ships/holland-america-line/noordam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/oosterdam.html
+++ b/ships/holland-america-line/oosterdam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/p-caland.html
+++ b/ships/holland-america-line/p-caland.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/potsdam.html
+++ b/ships/holland-america-line/potsdam.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/prinsendam-i.html
+++ b/ships/holland-america-line/prinsendam-i.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/prinsendam-ii.html
+++ b/ships/holland-america-line/prinsendam-ii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/rijndam-ii.html
+++ b/ships/holland-america-line/rijndam-ii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/rijndam.html
+++ b/ships/holland-america-line/rijndam.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/rotterdam-iv.html
+++ b/ships/holland-america-line/rotterdam-iv.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/rotterdam-v.html
+++ b/ships/holland-america-line/rotterdam-v.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/rotterdam-vi.html
+++ b/ships/holland-america-line/rotterdam-vi.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/rotterdam.html
+++ b/ships/holland-america-line/rotterdam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/ryndam.html
+++ b/ships/holland-america-line/ryndam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/statendam-ii.html
+++ b/ships/holland-america-line/statendam-ii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/statendam-iii.html
+++ b/ships/holland-america-line/statendam-iii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/statendam.html
+++ b/ships/holland-america-line/statendam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/veendam-ii.html
+++ b/ships/holland-america-line/veendam-ii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/veendam-iii.html
+++ b/ships/holland-america-line/veendam-iii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/veendam-iv.html
+++ b/ships/holland-america-line/veendam-iv.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/veendam.html
+++ b/ships/holland-america-line/veendam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/volendam-ii.html
+++ b/ships/holland-america-line/volendam-ii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/volendam-iii.html
+++ b/ships/holland-america-line/volendam-iii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/volendam.html
+++ b/ships/holland-america-line/volendam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/w-a-scholten.html
+++ b/ships/holland-america-line/w-a-scholten.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/westerdam-i.html
+++ b/ships/holland-america-line/westerdam-i.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/westerdam-ii.html
+++ b/ships/holland-america-line/westerdam-ii.html
@@ -335,7 +335,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/holland-america-line/zaandam.html
+++ b/ships/holland-america-line/zaandam.html
@@ -373,7 +373,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/index.html
+++ b/ships/index.html
@@ -360,7 +360,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -525,7 +525,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/msc/msc-world-america.html
+++ b/ships/msc/msc-world-america.html
@@ -144,7 +144,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -278,7 +278,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/icon-class-ship-tbn-2027.html
+++ b/ships/rcl/icon-class-ship-tbn-2027.html
@@ -617,7 +617,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -751,7 +751,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/icon-class-ship-tbn-2028.html
+++ b/ships/rcl/icon-class-ship-tbn-2028.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/icon-of-the-seas.html
+++ b/ships/rcl/icon-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/legend-of-the-seas-1995-built.html
+++ b/ships/rcl/legend-of-the-seas-1995-built.html
@@ -591,7 +591,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -725,7 +725,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
+++ b/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
@@ -617,7 +617,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -751,7 +751,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/legend-of-the-seas.html
+++ b/ships/rcl/legend-of-the-seas.html
@@ -591,7 +591,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -725,7 +725,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/majesty-of-the-seas.html
+++ b/ships/rcl/majesty-of-the-seas.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/monarch-of-the-seas.html
+++ b/ships/rcl/monarch-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/nordic-empress.html
+++ b/ships/rcl/nordic-empress.html
@@ -591,7 +591,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -725,7 +725,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -551,7 +551,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -685,7 +685,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/song-of-norway.html
+++ b/ships/rcl/song-of-norway.html
@@ -593,7 +593,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -727,7 +727,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/sovereign-of-the-seas.html
+++ b/ships/rcl/sovereign-of-the-seas.html
@@ -551,7 +551,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -685,7 +685,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -551,7 +551,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -685,7 +685,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/splendour-of-the-seas.html
+++ b/ships/rcl/splendour-of-the-seas.html
@@ -609,7 +609,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -743,7 +743,7 @@ updated: 2025-11-18
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/star-class-ship-tbn-2028.html
+++ b/ships/rcl/star-class-ship-tbn-2028.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/star-of-the-seas-aug-2025-debut.html
+++ b/ships/rcl/star-of-the-seas-aug-2025-debut.html
@@ -617,7 +617,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -751,7 +751,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/star-of-the-seas.html
+++ b/ships/rcl/star-of-the-seas.html
@@ -617,7 +617,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -751,7 +751,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -551,7 +551,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -685,7 +685,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -551,7 +551,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -685,7 +685,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -618,7 +618,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -752,7 +752,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -551,7 +551,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -685,7 +685,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -551,7 +551,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -685,7 +685,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/rooms.html
+++ b/ships/rooms.html
@@ -153,7 +153,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -287,7 +287,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/ships/template.html
+++ b/ships/template.html
@@ -227,7 +227,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/solo.html
+++ b/solo.html
@@ -359,7 +359,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -493,7 +493,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/solo/freedom-of-your-own-wake.html
+++ b/solo/freedom-of-your-own-wake.html
@@ -168,7 +168,7 @@
   }
   /* Programmatic open (JS) */
   .nav-group[data-open="true"] > .submenu,
-  .nav-group.open > .submenu{
+  .nav-group[data-open="true"] > .submenu{
     display:block !important;
     opacity:1 !important;
     visibility:visible !important;
@@ -269,7 +269,7 @@
 
 /* Reveal when the group is “open” (dataset or class) */
 .nav-group[data-open="true"] > .submenu,
-.nav-group.open > .submenu{
+.nav-group[data-open="true"] > .submenu{
   display: block !important;
   opacity: 1 !important;
   visibility: visible !important;
@@ -400,7 +400,7 @@ header, .hero-header, .navbar { position: relative; z-index: 1000; }
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -534,7 +534,7 @@ header, .hero-header, .navbar { position: relative; z-index: 1000; }
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/solo/solo-cruisers-companion.html
+++ b/solo/solo-cruisers-companion.html
@@ -254,7 +254,7 @@
   }
 
   .nav-item[data-open="true"] .submenu,
-  .nav-group.open .submenu {
+  .nav-group[data-open="true"] .submenu {
     display: block;
     opacity: 1;
     visibility: visible;

--- a/solo/visiting-the-united-states-before-your-cruise.html
+++ b/solo/visiting-the-united-states-before-your-cruise.html
@@ -300,7 +300,7 @@ figure figcaption { text-align:inherit; }
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -434,7 +434,7 @@ figure figcaption { text-align:inherit; }
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/solo/why-i-started-solo-cruising.html
+++ b/solo/why-i-started-solo-cruising.html
@@ -156,7 +156,7 @@
     display:none !important;opacity:0 !important;visibility:hidden !important;pointer-events:none !important;z-index:2100;
   }
   .nav-group[data-open="true"] > .submenu,
-  .nav-group.open > .submenu{display:block !important;opacity:1 !important;visibility:visible !important;pointer-events:auto !important;}
+  .nav-group[data-open="true"] > .submenu{display:block !important;opacity:1 !important;visibility:visible !important;pointer-events:auto !important;}
   .nav-group:hover > .submenu,
   .nav-group:focus-within > .submenu{display:block !important;opacity:1 !important;visibility:visible !important;pointer-events:auto !important;}
   .submenu a{display:block;width:100%;margin:0;padding:.5rem .65rem;border-radius:.65rem;border:0;background:transparent;color:var(--ink);text-decoration:none}
@@ -301,7 +301,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -435,7 +435,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/stateroom-check.html
+++ b/stateroom-check.html
@@ -668,7 +668,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -802,7 +802,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/terms.html
+++ b/terms.html
@@ -371,7 +371,7 @@
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;

--- a/travel.html
+++ b/travel.html
@@ -947,7 +947,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;
@@ -1081,7 +1081,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
     }
 
     .nav-item[data-open="true"] .submenu,
-    .nav-group.open .submenu {
+    .nav-group[data-open="true"] .submenu {
       display: block;
       opacity: 1;
       visibility: visible;


### PR DESCRIPTION
Root cause: CSS used wrong selector .nav-group.open (class) but JavaScript sets data-open="true" (data attribute). These never matched.

Changes:
- Fixed .nav-group.open → .nav-group[data-open="true"] in all HTML/CSS files
- Updated styles.css with comprehensive selectors for both .nav-item and .nav-group with data-open attribute
- Added hover/focus-within fallbacks for both selector types

This fixes dropdown menus site-wide that were completely non-functional.