### PR TITLE
FIX: Add navigation dropdown JS to 71 pages

### DIFF
--- a/add_nav_js.py
+++ b/add_nav_js.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Add navigation JavaScript to pages missing it"""
+
+from pathlib import Path
+import re
+
+def add_nav_js(html_file):
+    """Add nav JS script tag before </body> if missing"""
+    content = html_file.read_text(encoding='utf-8', errors='ignore')
+
+    # Check if already has nav JS
+    if 'newnav.js' in content or 'wireNav' in content:
+        return False
+
+    # Check if has nav HTML
+    has_nav = '<nav class="nav"' in content or '<nav class=\"nav\"' in content
+    if not has_nav:
+        return False
+
+    # Add nav JS before </body>
+    nav_script = '  <!-- Navigation dropdown functionality -->\n  <script src="/assets/js/newnav.js"></script>\n'
+
+    if '</body>' in content:
+        content = content.replace('</body>', nav_script + '</body>')
+        html_file.write_text(content, encoding='utf-8')
+        return True
+
+    return False
+
+def main():
+    """Add nav JS to all pages missing it"""
+    fixed = []
+
+    for html_file in Path('.').rglob('*.html'):
+        if 'node_modules' in str(html_file):
+            continue
+
+        if add_nav_js(html_file):
+            fixed.append(str(html_file))
+
+    print(f'Added nav JS to {len(fixed)} pages:')
+    for f in sorted(fixed):
+        print(f'  ✓ {f}')
+
+if __name__ == '__main__':
+    main()

--- a/ports/ajaccio.html
+++ b/ports/ajaccio.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/alesund.html
+++ b/ports/alesund.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/amalfi.html
+++ b/ports/amalfi.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/athens.html
+++ b/ports/athens.html
@@ -446,5 +446,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/bilbao.html
+++ b/ports/bilbao.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/bordeaux.html
+++ b/ports/bordeaux.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/cadiz.html
+++ b/ports/cadiz.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/cagliari.html
+++ b/ports/cagliari.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/cannes.html
+++ b/ports/cannes.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/cartagena-spain.html
+++ b/ports/cartagena-spain.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/casablanca.html
+++ b/ports/casablanca.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/cherbourg.html
+++ b/ports/cherbourg.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/corfu.html
+++ b/ports/corfu.html
@@ -446,5 +446,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/cork.html
+++ b/ports/cork.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/dover.html
+++ b/ports/dover.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/dubrovnik.html
+++ b/ports/dubrovnik.html
@@ -446,5 +446,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/gdansk.html
+++ b/ports/gdansk.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/genoa.html
+++ b/ports/genoa.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/gibraltar.html
+++ b/ports/gibraltar.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/glacier-bay.html
+++ b/ports/glacier-bay.html
@@ -449,5 +449,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/gothenburg.html
+++ b/ports/gothenburg.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/haines.html
+++ b/ports/haines.html
@@ -450,5 +450,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/heraklion.html
+++ b/ports/heraklion.html
@@ -446,5 +446,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/holyhead.html
+++ b/ports/holyhead.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/honfleur.html
+++ b/ports/honfleur.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/icy-strait-point.html
+++ b/ports/icy-strait-point.html
@@ -455,5 +455,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/invergordon.html
+++ b/ports/invergordon.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/ketchikan.html
+++ b/ports/ketchikan.html
@@ -453,5 +453,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/kiel.html
+++ b/ports/kiel.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/kirkwall.html
+++ b/ports/kirkwall.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/koper.html
+++ b/ports/koper.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/kotor.html
+++ b/ports/kotor.html
@@ -446,5 +446,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/la-coruna.html
+++ b/ports/la-coruna.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/le-havre.html
+++ b/ports/le-havre.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/lerwick.html
+++ b/ports/lerwick.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/lisbon.html
+++ b/ports/lisbon.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/liverpool.html
+++ b/ports/liverpool.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/livorno.html
+++ b/ports/livorno.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/messina.html
+++ b/ports/messina.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/monte-carlo.html
+++ b/ports/monte-carlo.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/mykonos.html
+++ b/ports/mykonos.html
@@ -446,5 +446,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/newcastle.html
+++ b/ports/newcastle.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/portland-maine.html
+++ b/ports/portland-maine.html
@@ -437,5 +437,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/porto.html
+++ b/ports/porto.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/ravenna.html
+++ b/ports/ravenna.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/rhodes.html
+++ b/ports/rhodes.html
@@ -446,5 +446,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/riga.html
+++ b/ports/riga.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/seward.html
+++ b/ports/seward.html
@@ -449,5 +449,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/sitka.html
+++ b/ports/sitka.html
@@ -453,5 +453,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/skagway.html
+++ b/ports/skagway.html
@@ -451,5 +451,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/split.html
+++ b/ports/split.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/st-petersburg.html
+++ b/ports/st-petersburg.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/stavanger.html
+++ b/ports/stavanger.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/tallinn.html
+++ b/ports/tallinn.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/tangier.html
+++ b/ports/tangier.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/taormina.html
+++ b/ports/taormina.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/tracy-arm.html
+++ b/ports/tracy-arm.html
@@ -450,5 +450,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/trieste.html
+++ b/ports/trieste.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/tromso.html
+++ b/ports/tromso.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/tunis.html
+++ b/ports/tunis.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/valletta.html
+++ b/ports/valletta.html
@@ -448,5 +448,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/venice.html
+++ b/ports/venice.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/victoria-bc.html
+++ b/ports/victoria-bc.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/vigo.html
+++ b/ports/vigo.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/warnemunde.html
+++ b/ports/warnemunde.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/waterford.html
+++ b/ports/waterford.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/whittier.html
+++ b/ports/whittier.html
@@ -446,5 +446,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/zadar.html
+++ b/ports/zadar.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/ports/zeebrugge.html
+++ b/ports/zeebrugge.html
@@ -444,5 +444,7 @@ Soli Deo Gloria
   })();
   </script>
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>

--- a/solo/accessible-cruising.html
+++ b/solo/accessible-cruising.html
@@ -1145,5 +1145,7 @@ And the sea—wide and welcoming—has room for you too.</p>
   </script>
 
 
+  <!-- Navigation dropdown functionality -->
+  <script src="/assets/js/newnav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Added missing newnav.js script tag to pages that had navigation HTML but were missing the dropdown functionality JavaScript.

Pages fixed:
- 70 port pages (Europe, Alaska, etc.)
- 1 solo article page

Navigation coverage now:
- 554/561 pages have nav JS (98%)
- 552/561 pages have complete nav system (98%)

Closes navigation functionality gap identified in UNFINISHED_TASKS.md