### PR TITLE
FIX: Restore Key Facts section above Author/Articles in right rail

### DIFF
--- a/index.html
+++ b/index.html
@@ -937,25 +937,6 @@
 
   <!-- MAIN CONTENT -->
   <main id="main-content" class="wrap page-grid" role="main" aria-label="Main content">
-    <!-- ICP-Lite Content Structure -->
-    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin: 1rem auto 1.5rem;">
-      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> This page provides cruise planning resources for In the Wake. Use the information below to help plan your cruise vacation.
-      </p>
-
-      <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching in the wake, comparing options, and gathering information for trip planning.
-      </p>
-
-      <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
-        <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
-        <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Topic:</strong> In the Wake</li>
-          <li><strong>Purpose:</strong> Cruise planning resource</li>
-        </ul>
-      </div>
-    </section>
-
     <!-- LEFT: welcome + top explore -->
     <section style="grid-column: 1;" aria-label="Welcome and explore">
       <!-- Duck Spotting Card - Special Callout (Dismissible) -->
@@ -1032,8 +1013,26 @@
       </section>
     </section>
 
-    <!-- RIGHT RAIL - starts row 2 (after Key Facts in row 1), spans remaining rows -->
-    <aside class="rail" role="complementary" aria-label="Author & articles" style="grid-column: 2; grid-row: 2 / -1;">
+    <!-- RIGHT COLUMN: Key Facts + Author + Articles -->
+    <aside class="rail" role="complementary" aria-label="Key facts, author & articles" style="grid-column: 2;">
+      <!-- Key Facts -->
+      <section class="page-intro" style="margin: 0 0 1rem 0;">
+        <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+          <strong>Quick Answer:</strong> This page provides cruise planning resources for In the Wake. Use the information below to help plan your cruise vacation.
+        </p>
+
+        <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
+          <strong>Best For:</strong> Cruisers researching in the wake, comparing options, and gathering information for trip planning.
+        </p>
+
+        <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
+          <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
+          <ul style="margin: 0; padding-left: 1.25rem;">
+            <li><strong>Topic:</strong> In the Wake</li>
+            <li><strong>Purpose:</strong> Cruise planning resource</li>
+          </ul>
+        </div>
+      </section>
       <!-- Author card (Vertical Layout) -->
       <section class="card author-card-vertical" aria-labelledby="author-heading">
         <h3 id="author-heading">About the Author</h3>


### PR DESCRIPTION
Restructured the grid layout:
- Key Facts, Author, and Articles now all in a single column 2 container
- They stack naturally in normal document flow
- Removed complex grid-row positioning that was causing issues