### PR TITLE
FIX: Standardize Flickers of Majesty hero credit attribution format

### DIFF
--- a/UNFINISHED_TASKS_AUDIT_2025_11_24.md
+++ b/UNFINISHED_TASKS_AUDIT_2025_11_24.md
@@ -1,0 +1,288 @@
+# UNFINISHED_TASKS.md Audit Report
+
+**Date:** 2025-11-24
+**Auditor:** Claude (FOM Integration Instance)
+**Method:** File system verification, grep analysis, comprehensive checks
+
+---
+
+## Executive Summary
+
+**Overall Status:** UNFINISHED_TASKS.md is **MOSTLY ACCURATE** but contains several outdated claims and missing recent completions (FOM integration).
+
+**Accuracy Rate:** ~85% accurate (most metrics verified, but missing recent work)
+
+---
+
+## ✅ VERIFIED ACCURATE
+
+### Site Metrics
+- ✅ **561 total HTML pages** - Verified
+- ✅ **544 pages with ICP-Lite** (97% coverage) - Verified
+- ✅ **147 port pages** - Verified
+- ✅ **50 RCL ship pages** - Verified
+- ✅ **40 ship logbooks** (38 active + 2 historic) - Verified
+- ✅ **7 solo articles** - Verified
+
+### Completed P0 Tasks
+- ✅ Navigation fixed (281 pages) - Verified in main
+- ✅ WebP images updated - Verified in main
+- ✅ Port Tracker created - EXISTS at tools/port-tracker.html
+- ✅ Ship Tracker created - EXISTS at tools/ship-tracker.html
+- ✅ Ship cards redesigned - Verified (assets/css/item-cards.css)
+- ✅ Search functionality - search.html EXISTS
+- ✅ Sitemap - sitemap.xml EXISTS
+
+### Completed P1 Tasks
+- ✅ "In the Wake of Grief" article - EXISTS (722 lines, solo/in-the-wake-of-grief.html)
+- ✅ Hawaii port batch - 5 ports exist (Honolulu, Kona, Hilo, Maui, Nawiliwili)
+- ✅ All active ships have logbooks - Verified (40 JSON files)
+- ✅ Historic ship logbooks - Nordic Prince and Sun Viking exist
+
+### ICP-Lite Rollout
+- ✅ **544/561 pages (97%)** have ICP-Lite meta tags - Verified
+- ✅ **17 pages missing** identified:
+  - 10 Asia/Pacific ports (auckland, bali, bangkok, brisbane, hong-kong, shanghai, singapore, south-pacific, sydney, tokyo)
+  - 4 solo/articles pages (accessible-cruising, freedom-of-your-own-wake, visiting-the-united-states, why-i-started-solo-cruising)
+  - 1 solo page (in-the-wake-of-grief.html)
+  - 2 tracker tools (port-tracker.html, ship-tracker.html)
+
+---
+
+## ❌ INACCURATE / OUTDATED
+
+### 1. "Standards Catastrophe" Status
+
+**Claimed:** "⏳ PENDING USER UPLOAD - Comprehensive standards rebuild from 220+ fragments"
+
+**Reality:**
+- ❌ `/old-files/` directory does **NOT EXIST**
+- ✅ `/new-standards/` directory **DOES EXIST** with 13 files
+- ✅ `/new-standards/foundation/` has 7 comprehensive documents
+- ✅ `/new-standards/v3.010/` has 4 current innovation docs
+- ✅ `/admin/claude/` has complete documentation:
+  - CLAUDE.md ✓
+  - ITW-LITE_PROTOCOL.md ✓
+  - STANDARDS_INDEX.md ✓
+  - STANDARDS_GUIDE.md ✓
+  - CODEBASE_GUIDE.md ✓
+
+**Conclusion:** Standards rebuild appears **COMPLETE** or was never needed. The `/old-files/` directory doesn't exist.
+
+### 2. Missing Protocol Docs
+
+**Claimed:** "ITW-LITE_PROTOCOL, STANDARDS_INDEX_33.md, CLAUDE.md (all missing)"
+
+**Reality:**
+- ❌ Root-level docs missing: STANDARDS_INDEX_33.md, ITW-LITE_PROTOCOL.md, CLAUDE.md
+- ✅ BUT all exist in `/admin/claude/`:
+  - admin/claude/ITW-LITE_PROTOCOL.md ✓
+  - admin/claude/STANDARDS_INDEX.md ✓ (not "33" suffix)
+  - admin/claude/CLAUDE.md ✓
+
+**Conclusion:** Docs exist but in `/admin/claude/` instead of root. May need symlinking or copying to root.
+
+### 3. Placeholder Pages
+
+**Claimed:** "drinks.html, ports.html hub, restaurants.html (all 'coming soon')"
+
+**Reality:**
+- ❌ drinks.html does **NOT EXIST** (not needed - drink-calculator.html and drink-packages.html exist)
+- ✅ ports.html EXISTS and is a **complete hub page** (not placeholder)
+- ✅ restaurants.html EXISTS and is a **complete hub page** (type: Hub/Index Page)
+
+**Conclusion:** No placeholder pages found. All mentioned pages either exist as complete hubs or aren't needed.
+
+### 4. Missing Articles
+
+**Claimed:** Need articles for:
+- Solo Cruising (expand)
+- Healing Relationships at Sea
+- Cruising for Rest & Recovery
+- Family Cruising Challenges
+
+**Reality:**
+- ✅ Solo cruising article EXISTS: solo/solo-cruisers-companion.html
+- ✅ Additional solo article EXISTS: solo/why-i-started-solo-cruising.html
+- ❌ "Healing Relationships" - Does NOT exist
+- ❌ "Rest & Recovery" - Does NOT exist
+- ❌ "Family Challenges" - Does NOT exist
+
+**Conclusion:** 2 solo articles exist, but 3 themed articles still needed.
+
+---
+
+## 🆕 MISSING FROM UNFINISHED_TASKS.md
+
+### FOM Integration (2025-11-24) - NOT DOCUMENTED
+
+**MAJOR OMISSION:** Entire FOM Claude Code integration is not mentioned in UNFINISHED_TASKS.md!
+
+**Completed:**
+- ✅ Merged 6-layer Claude Code system from Flickers of Majesty
+- ✅ 7 auto-activating skills (1 CITW + 6 FOM adapted)
+- ✅ 5 plugins (SEO, accessibility, performance)
+- ✅ 4 workflow commands (/commit, /create-pr, /update-docs, /add-to-changelog)
+- ✅ 2 hooks (skill-activation, tool-use-tracker)
+- ✅ ITW-Lite v3.010 philosophy codified in skill-rules.json
+- ✅ Complete documentation:
+  - .claude/ONBOARDING.md
+  - .claude/INSTALLATION.md
+  - FOM_MERGE_PLAN.md
+  - FOM_STANDARDS_ALIGNMENT.md
+- ✅ Standards alignment verified (zero conflicts)
+- ✅ Merged to main via PR #213
+
+**Impact:** Major enhancement to development workflow and AI assistance capabilities.
+
+---
+
+## 📊 UPDATED PRIORITY STATUS
+
+### P0 - Critical
+**All P0 tasks COMPLETE** except:
+1. ⚠️ Download Wiki Commons images for ~19 ships (partially done - 270 attribution references found)
+2. ⚠️ Fix remaining placeholder attributions (Adventure, Enchantment, Explorer - Symphony appears done)
+
+### P1 - High Priority
+**Status:** 7/9 complete
+
+**Completed:**
+- ✅ "In the Wake of Grief" article
+- ✅ Hawaii port batch
+- ✅ Search functionality
+- ✅ Active ship logbooks
+- ✅ Historic ship logbooks
+- ✅ Sitemap.xml
+- ✅ Ports.html and restaurants.html hubs
+
+**Still Needed:**
+1. ❌ Write "Healing Relationships at Sea" article (15+ logbook references)
+2. ❌ Write "Cruising for Rest & Recovery" article (25 logbook references)
+3. ❌ Write "Family Cruising Challenges" article (20 logbook references)
+4. ⚠️ Complete venues.json with all dining data
+5. ⚠️ Google Search Console setup
+6. ⚠️ Download remaining Wiki Commons images + attribution workflow
+
+**Note:** "Expand Solo Cruising" already done - solo-cruisers-companion.html exists
+
+### P2 - Medium Priority
+1. ICP-Lite meta tags for 17 remaining pages (Asia/Pacific ports, solo/articles, tools)
+2. Expand "Accessible Cruising" article (optional)
+3. Middle East port batch (4 ports)
+4. Caribbean completion batch (8-10 ports)
+5. Cross-linking improvements
+6. Performance optimization
+
+### P3 - Low / P4 - Future
+- Multi-cruise-line expansion (Carnival, Virgin, Princess, Norwegian, Celebrity)
+- Asia/Australia/Pacific port expansions
+- Advanced analytics
+
+---
+
+## 🎯 RECOMMENDED UPDATES TO UNFINISHED_TASKS.md
+
+### 1. Add FOM Integration Section
+
+```markdown
+## 🤖 FOM CLAUDE CODE INTEGRATION (2025-11-24)
+
+**Status:** ✅ COMPLETE
+**Branch:** Merged to main via PR #213
+
+### Summary
+Integrated 6-layer Claude Code enhancement system from Flickers of Majesty:
+- 7 auto-activating skills (ITW-Lite v3.010 philosophy)
+- 5 plugins (SEO, accessibility, performance)
+- 4 workflow commands
+- 2 auto-activation hooks
+- Complete documentation (.claude/ONBOARDING.md, INSTALLATION.md)
+
+### Documentation
+- FOM_MERGE_PLAN.md - Merge strategy
+- FOM_STANDARDS_ALIGNMENT.md - Standards verification
+- .claude/ONBOARDING.md - Onboarding for new Claude sessions
+- .claude/INSTALLATION.md - Technical installation guide
+
+See commit 67213ac and PR #213 for details.
+```
+
+### 2. Update Standards Catastrophe Section
+
+```markdown
+## 🚨 STANDARDS REBUILD
+
+**Status:** ✅ COMPLETE (or NOT NEEDED)
+
+### Current State
+- ✅ `/new-standards/` directory exists with 13 files
+- ✅ `/new-standards/foundation/` has 7 comprehensive documents
+- ✅ `/new-standards/v3.010/` has 4 current innovation docs
+- ✅ `/admin/claude/` has complete documentation suite
+- ❌ `/old-files/` directory does not exist
+
+### Remaining
+- [ ] Optional: Copy/symlink admin/claude/*.md to root for easier access
+- [ ] Optional: Create root CLAUDE.md, ITW-LITE_PROTOCOL.md, STANDARDS_INDEX.md
+```
+
+### 3. Update P1 Tasks
+
+```markdown
+### P1 - High Priority (3/9 remaining)
+
+**Completed:**
+- ✅ "In the Wake of Grief" article
+- ✅ Hawaii ports (5)
+- ✅ Search functionality
+- ✅ All ship logbooks
+- ✅ Ports/restaurants hubs (NOT placeholders)
+- ✅ Solo cruising articles (2 exist)
+
+**Remaining:**
+1. ❌ "Healing Relationships at Sea" article
+2. ❌ "Cruising for Rest & Recovery" article
+3. ❌ "Family Cruising Challenges" article
+4. ⚠️ Wiki Commons images (~19 ships)
+5. ⚠️ Complete venues.json
+6. ⚠️ Google Search Console setup
+```
+
+### 4. Update ICP-Lite Section
+
+```markdown
+## 🤖 ICP-LITE & ITW-LITE ROLLOUT
+
+**Current Status:** 544/561 pages (97%) ✅
+
+**17 Pages Missing ICP-Lite:**
+- Asia/Pacific ports (10): auckland, bali, bangkok, brisbane, hong-kong, shanghai, singapore, south-pacific, sydney, tokyo
+- solo/articles (4): accessible-cruising, freedom-of-your-own-wake, visiting-the-united-states, why-i-started-solo-cruising
+- Solo page (1): in-the-wake-of-grief.html
+- Tools (2): port-tracker.html, ship-tracker.html
+
+**Protocol Docs:**
+- ✅ admin/claude/ITW-LITE_PROTOCOL.md EXISTS
+- ✅ admin/claude/STANDARDS_INDEX.md EXISTS
+- ✅ admin/claude/CLAUDE.md EXISTS
+- ⚠️ Optional: Copy to root for easier access
+```
+
+---
+
+## 📋 SUMMARY
+
+**Verified Claims:** ~85% accurate
+**Major Omissions:** FOM integration not documented
+**Inaccuracies:** Standards catastrophe status, placeholder pages claims
+**Outdated:** Protocol docs location, solo article counts
+
+**Recommended Action:** Update UNFINISHED_TASKS.md with:
+1. FOM integration section (COMPLETE)
+2. Corrected standards rebuild status
+3. Updated P1 task list
+4. Corrected placeholder pages status
+5. ICP-Lite missing pages list
+
+**Soli Deo Gloria** ✝️

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -875,7 +875,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">
-        <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
+        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
     </div></header>
 

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -875,7 +875,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">
-        <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
+        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
     </div></header>
 

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -866,7 +866,7 @@ updated: 2025-11-18
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">
-        <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
+        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
     </div></header>
 


### PR DESCRIPTION
Updated hero credit format on Adventure, Enchantment, and Explorer to match Symphony's cleaner single-link attribution style:
- Before: Span with separate links to website and Instagram handle
- After: Single link "Photo by Flickers of Majesty — Instagram"

This resolves placeholder attribution inconsistencies and aligns all ship pages with the established standard (Symphony of the Seas format).

Files updated:
- ships/rcl/adventure-of-the-seas.html
- ships/rcl/enchantment-of-the-seas.html
- ships/rcl/explorer-of-the-seas.html

Also added: UNFINISHED_TASKS_AUDIT_2025_11_24.md (comprehensive task audit report)

Soli Deo Gloria ✝️