### PR TITLE
FIX: Complete attribution standardization for all 50 RCL ships

### DIFF
--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -866,7 +866,7 @@ updated: 2025-11-18
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">
-        <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
+        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
     </div></header>
 

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -866,7 +866,7 @@ updated: 2025-11-18
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">
-        <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
+        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
     </div></header>
 

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -866,7 +866,7 @@ updated: 2025-11-18
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">
-        <span class="pill long">Photo by <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a> (<a href="https://www.instagram.com/flickersofmajesty/" target="_blank" rel="noopener">@flickersofmajesty</a>)</span>
+        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
     </div></header>
 

--- a/ships/rcl/song-of-america.html
+++ b/ships/rcl/song-of-america.html
@@ -557,7 +557,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">
-        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty  Instagram</a>
+        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
     </div></header>
 

--- a/ships/rcl/viking-serenade.html
+++ b/ships/rcl/viking-serenade.html
@@ -540,7 +540,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <div class="tagline">A Cruise Traveler's Logbook</div>
       </div>
       <div class="hero-credit">
-        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty  Instagram</a>
+        <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>
       </div>
     </div></header>
 


### PR DESCRIPTION
Verified and standardized hero credit format across all 50 Royal Caribbean ship pages to match Symphony of the Seas standard format.

Fixed 5 ships with attribution inconsistencies:

**Old span format → Single link format (3 ships):**
- ships/rcl/brilliance-of-the-seas.html:869
- ships/rcl/allure-of-the-seas.html:869
- ships/rcl/anthem-of-the-seas.html:869

**Tab character typo → Em dash (2 ships):**
- ships/rcl/song-of-america.html:560
- ships/rcl/viking-serenade.html:543

All 50 ships now use consistent attribution format: <a class="pill long" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo by Flickers of Majesty — Instagram</a>

Verification: Grepped all 50 ship files, confirmed 45 already correct, 5 fixed.

Soli Deo Gloria ✝️