### PR TITLE
Add Soli Deo Gloria invocations and ICP-Lite meta tags site-wide

### DIFF
--- a/ports/auckland.html
+++ b/ports/auckland.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to Auckland and Bay of Islands cruise ports: Sky Tower, Waiheke Island wineries, Hole in the Rock, and Kiwi hospitality." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>Auckland &amp; Bay of Islands Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Auckland and Bay of Islands cruise ports: Sky Tower, Waiheke Island wineries, Hole in the Rock, and Kiwi hospitality." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/ports/bali.html
+++ b/ports/bali.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to Bali cruise port via Benoa: Uluwatu temple, Ubud rice terraces, monkey forest, beach clubs, and Jimbaran sunset seafood." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>Bali / Benoa Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Bali cruise port via Benoa: Uluwatu temple, Ubud rice terraces, monkey forest, beach clubs, and Jimbaran sunset seafood." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/ports/bangkok.html
+++ b/ports/bangkok.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to Bangkok cruise port via Laem Chabang: Grand Palace, Wat Arun, street food, floating markets, and rooftop bars." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>Bangkok / Laem Chabang Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Bangkok cruise port via Laem Chabang: Grand Palace, Wat Arun, street food, floating markets, and rooftop bars." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/ports/brisbane.html
+++ b/ports/brisbane.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to Brisbane cruise port: South Bank beach, Lone Pine Koala Sanctuary, CityCat ferry, and why it's Australia's most relaxed port." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>Brisbane Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Brisbane cruise port: South Bank beach, Lone Pine Koala Sanctuary, CityCat ferry, and why it's Australia's most relaxed port." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/ports/hong-kong.html
+++ b/ports/hong-kong.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to Hong Kong cruise port: Victoria Peak, Big Buddha, Star Ferry, dim sum, and the Symphony of Lights show." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>Hong Kong Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Hong Kong cruise port: Victoria Peak, Big Buddha, Star Ferry, dim sum, and the Symphony of Lights show." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/ports/shanghai.html
+++ b/ports/shanghai.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to Shanghai cruise port: The Bund, Shanghai Tower, Yu Garden, xiaolongbao, and the city where past meets future." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>Shanghai Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Shanghai cruise port: The Bund, Shanghai Tower, Yu Garden, xiaolongbao, and the city where past meets future." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/ports/singapore.html
+++ b/ports/singapore.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to Singapore cruise port: Gardens by the Bay, Marina Bay Sands, hawker centers, and why it's Asia's top-rated port." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>Singapore Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Singapore cruise port: Gardens by the Bay, Marina Bay Sands, hawker centers, and why it's Asia's top-rated port." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/ports/south-pacific.html
+++ b/ports/south-pacific.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to South Pacific cruise ports: Bora Bora, Tahiti, Moorea, Fiji, Vanuatu, and Nouméa – turquoise lagoons and paradise islands." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>South Pacific Islands Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to South Pacific cruise ports: Bora Bora, Tahiti, Moorea, Fiji, Vanuatu, and Nouméa – turquoise lagoons and paradise islands." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/ports/sydney.html
+++ b/ports/sydney.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to Sydney cruise port: Opera House, Harbour Bridge, Bondi Beach, and why it's Australia's highest-rated port." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>Sydney Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Sydney cruise port: Opera House, Harbour Bridge, Bondi Beach, and why it's Australia's highest-rated port." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/ports/tokyo.html
+++ b/ports/tokyo.html
@@ -1,8 +1,20 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- ICP-Lite v1.0 Meta Tags -->
+  <meta name="ai-summary" content="First-person guide to Tokyo and Yokohama cruise ports: Tsukiji Market, TeamLab, Shibuya Crossing, Senso-ji temple, and Japanese efficiency." />
+  <meta name="last-reviewed" content="2025-11-24" />
+  <meta name="content-protocol" content="ICP-Lite v1.0" />
+
   <title>Tokyo / Yokohama Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Tokyo and Yokohama cruise ports: Tsukiji Market, TeamLab, Shibuya Crossing, Senso-ji temple, and Japanese efficiency." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />

--- a/restaurants/150-central-park.html
+++ b/restaurants/150-central-park.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/adagio-dining-room.html
+++ b/restaurants/adagio-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/amber-and-oak.html
+++ b/restaurants/amber-and-oak.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/american-icon-grill.html
+++ b/restaurants/american-icon-grill.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/aquarium-bar.html
+++ b/restaurants/aquarium-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/aquarius-dining-room.html
+++ b/restaurants/aquarius-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/bamboo-room.html
+++ b/restaurants/bamboo-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/bell-and-barley.html
+++ b/restaurants/bell-and-barley.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/ben-and-jerrys.html
+++ b/restaurants/ben-and-jerrys.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/bionic-bar.html
+++ b/restaurants/bionic-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/boardwalk-dog-house.html
+++ b/restaurants/boardwalk-dog-house.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/boleros.html
+++ b/restaurants/boleros.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/brass-and-bock.html
+++ b/restaurants/brass-and-bock.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/bubbles.html
+++ b/restaurants/bubbles.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/bull-and-bear-pub.html
+++ b/restaurants/bull-and-bear-pub.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/cantina-fresca.html
+++ b/restaurants/cantina-fresca.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/cascades-dining-room.html
+++ b/restaurants/cascades-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/casino-bar.html
+++ b/restaurants/casino-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/celebration-table.html
+++ b/restaurants/celebration-table.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/champagne-bar.html
+++ b/restaurants/champagne-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/chic.html
+++ b/restaurants/chic.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/chops.html
+++ b/restaurants/chops.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/cloud-17.html
+++ b/restaurants/cloud-17.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/concierge-lounge.html
+++ b/restaurants/concierge-lounge.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/congo-bar.html
+++ b/restaurants/congo-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/cosmopolitan-club.html
+++ b/restaurants/cosmopolitan-club.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/crown-and-castle-pub.html
+++ b/restaurants/crown-and-castle-pub.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/crown-and-kettle.html
+++ b/restaurants/crown-and-kettle.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/dazzles.html
+++ b/restaurants/dazzles.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/desserted.html
+++ b/restaurants/desserted.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/devinly-decadence.html
+++ b/restaurants/devinly-decadence.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/diamond-club.html
+++ b/restaurants/diamond-club.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/dining-activities.html
+++ b/restaurants/dining-activities.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/duck-and-dog-pub.html
+++ b/restaurants/duck-and-dog-pub.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/dueling-pianos.html
+++ b/restaurants/dueling-pianos.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/edelweiss-dining-room.html
+++ b/restaurants/edelweiss-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/empire-supper-club.html
+++ b/restaurants/empire-supper-club.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/english-pub.html
+++ b/restaurants/english-pub.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/fish-and-ships.html
+++ b/restaurants/fish-and-ships.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/game-reserve.html
+++ b/restaurants/game-reserve.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/giovannis-italian-kitchen.html
+++ b/restaurants/giovannis-italian-kitchen.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/giovannis.html
+++ b/restaurants/giovannis.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/globe-and-atlas.html
+++ b/restaurants/globe-and-atlas.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/great-gatsby-dining-room.html
+++ b/restaurants/great-gatsby-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/hooked-seafood.html
+++ b/restaurants/hooked-seafood.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/hot-pot.html
+++ b/restaurants/hot-pot.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/izumi-in-the-park.html
+++ b/restaurants/izumi-in-the-park.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/izumi.html
+++ b/restaurants/izumi.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/jamies-italian.html
+++ b/restaurants/jamies-italian.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/johnny-rockets.html
+++ b/restaurants/johnny-rockets.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/leaf-and-bean.html
+++ b/restaurants/leaf-and-bean.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/lime-and-coconut.html
+++ b/restaurants/lime-and-coconut.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/lincoln-park-supper-club.html
+++ b/restaurants/lincoln-park-supper-club.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/lobby-bar.html
+++ b/restaurants/lobby-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/lous-jazz-n-blues.html
+++ b/restaurants/lous-jazz-n-blues.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/mason-jar.html
+++ b/restaurants/mason-jar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/minstrel-dining-room.html
+++ b/restaurants/minstrel-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/my-fair-lady-dining-room.html
+++ b/restaurants/my-fair-lady-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/north-star-bar.html
+++ b/restaurants/north-star-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/oasis-bar.html
+++ b/restaurants/oasis-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/olive-or-twist.html
+++ b/restaurants/olive-or-twist.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/on-air.html
+++ b/restaurants/on-air.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/pesky-parrot.html
+++ b/restaurants/pesky-parrot.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/pier-7.html
+++ b/restaurants/pier-7.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/pig-and-whistle-pub.html
+++ b/restaurants/pig-and-whistle-pub.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/playmakers.html
+++ b/restaurants/playmakers.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/plaza-bar.html
+++ b/restaurants/plaza-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/pool-bar.html
+++ b/restaurants/pool-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/portside-bbq.html
+++ b/restaurants/portside-bbq.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/quill-and-compass.html
+++ b/restaurants/quill-and-compass.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/r-bar.html
+++ b/restaurants/r-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/reflections-dining-room.html
+++ b/restaurants/reflections-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/rising-tide-bar.html
+++ b/restaurants/rising-tide-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/ritas-cantina.html
+++ b/restaurants/ritas-cantina.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/room-service.html
+++ b/restaurants/room-service.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/royal-railway.html
+++ b/restaurants/royal-railway.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/rye-and-bean.html
+++ b/restaurants/rye-and-bean.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/sabor-taqueria.html
+++ b/restaurants/sabor-taqueria.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/sabor.html
+++ b/restaurants/sabor.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/sapphire-dining-room.html
+++ b/restaurants/sapphire-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/sapphire-restaurant.html
+++ b/restaurants/sapphire-restaurant.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/schooner-bar.html
+++ b/restaurants/schooner-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/sichuan-red.html
+++ b/restaurants/sichuan-red.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/silk.html
+++ b/restaurants/silk.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/sky-bar.html
+++ b/restaurants/sky-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/solarium-bar.html
+++ b/restaurants/solarium-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <!-- ai-breadcrumbs

--- a/restaurants/solarium-cafe.html
+++ b/restaurants/solarium-cafe.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/sprinkles.html
+++ b/restaurants/sprinkles.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/star-lounge.html
+++ b/restaurants/star-lounge.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/starbucks.html
+++ b/restaurants/starbucks.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/sugar-beach.html
+++ b/restaurants/sugar-beach.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/suite-lounge.html
+++ b/restaurants/suite-lounge.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/swim-and-tonic.html
+++ b/restaurants/swim-and-tonic.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/tavern-bar.html
+++ b/restaurants/tavern-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/the-bamboo-room.html
+++ b/restaurants/the-bamboo-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/the-dining-room.html
+++ b/restaurants/the-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/the-grande.html
+++ b/restaurants/the-grande.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/the-overlook.html
+++ b/restaurants/the-overlook.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/the-pit-stop.html
+++ b/restaurants/the-pit-stop.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/tides-dining-room.html
+++ b/restaurants/tides-dining-room.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/trellis-bar.html
+++ b/restaurants/trellis-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/two70-bar.html
+++ b/restaurants/two70-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/viking-crown-lounge.html
+++ b/restaurants/viking-crown-lounge.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/vintages.html
+++ b/restaurants/vintages.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/restaurants/vortex.html
+++ b/restaurants/vortex.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/wig-and-gavel.html
+++ b/restaurants/wig-and-gavel.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/wipeout-bar.html
+++ b/restaurants/wipeout-bar.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/wonderland.html
+++ b/restaurants/wonderland.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/restaurants/zanzibar-lounge.html
+++ b/restaurants/zanzibar-lounge.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en" class="no-js">
 <head>
 <script>(function(){document.documentElement.classList.remove('no-js')})();</script>

--- a/ships/carnival-cruise-line/carnival-adventure.html
+++ b/ships/carnival-cruise-line/carnival-adventure.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-breeze.html
+++ b/ships/carnival-cruise-line/carnival-breeze.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-celebration.html
+++ b/ships/carnival-cruise-line/carnival-celebration.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-conquest.html
+++ b/ships/carnival-cruise-line/carnival-conquest.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-dream.html
+++ b/ships/carnival-cruise-line/carnival-dream.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-ecstasy.html
+++ b/ships/carnival-cruise-line/carnival-ecstasy.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-elation.html
+++ b/ships/carnival-cruise-line/carnival-elation.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-encounter.html
+++ b/ships/carnival-cruise-line/carnival-encounter.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-fantasy.html
+++ b/ships/carnival-cruise-line/carnival-fantasy.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-fascination.html
+++ b/ships/carnival-cruise-line/carnival-fascination.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-festivale.html
+++ b/ships/carnival-cruise-line/carnival-festivale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-firenze.html
+++ b/ships/carnival-cruise-line/carnival-firenze.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-freedom.html
+++ b/ships/carnival-cruise-line/carnival-freedom.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-glory.html
+++ b/ships/carnival-cruise-line/carnival-glory.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-horizon.html
+++ b/ships/carnival-cruise-line/carnival-horizon.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-imagination.html
+++ b/ships/carnival-cruise-line/carnival-imagination.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-inspiration.html
+++ b/ships/carnival-cruise-line/carnival-inspiration.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-jubilee.html
+++ b/ships/carnival-cruise-line/carnival-jubilee.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-legend.html
+++ b/ships/carnival-cruise-line/carnival-legend.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-liberty.html
+++ b/ships/carnival-cruise-line/carnival-liberty.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-luminosa.html
+++ b/ships/carnival-cruise-line/carnival-luminosa.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-magic.html
+++ b/ships/carnival-cruise-line/carnival-magic.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-mardi-gras.html
+++ b/ships/carnival-cruise-line/carnival-mardi-gras.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-miracle.html
+++ b/ships/carnival-cruise-line/carnival-miracle.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-panorama.html
+++ b/ships/carnival-cruise-line/carnival-panorama.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-paradise.html
+++ b/ships/carnival-cruise-line/carnival-paradise.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-pride.html
+++ b/ships/carnival-cruise-line/carnival-pride.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-radiance.html
+++ b/ships/carnival-cruise-line/carnival-radiance.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-sensation.html
+++ b/ships/carnival-cruise-line/carnival-sensation.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-spirit.html
+++ b/ships/carnival-cruise-line/carnival-spirit.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-splendor.html
+++ b/ships/carnival-cruise-line/carnival-splendor.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-sunrise.html
+++ b/ships/carnival-cruise-line/carnival-sunrise.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-sunshine.html
+++ b/ships/carnival-cruise-line/carnival-sunshine.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-tropicale.html
+++ b/ships/carnival-cruise-line/carnival-tropicale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-valor.html
+++ b/ships/carnival-cruise-line/carnival-valor.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-venezia.html
+++ b/ships/carnival-cruise-line/carnival-venezia.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnival-vista.html
+++ b/ships/carnival-cruise-line/carnival-vista.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/carnivale.html
+++ b/ships/carnival-cruise-line/carnivale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/celebration.html
+++ b/ships/carnival-cruise-line/celebration.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/festivale.html
+++ b/ships/carnival-cruise-line/festivale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/holiday.html
+++ b/ships/carnival-cruise-line/holiday.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/index.html
+++ b/ships/carnival-cruise-line/index.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/ships/carnival-cruise-line/jubilee.html
+++ b/ships/carnival-cruise-line/jubilee.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/mardi-gras.html
+++ b/ships/carnival-cruise-line/mardi-gras.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/tropicale.html
+++ b/ships/carnival-cruise-line/tropicale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/unnamed-project-ace-1.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-1.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/unnamed-project-ace-2.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-2.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival-cruise-line/unnamed-project-ace-3.html
+++ b/ships/carnival-cruise-line/unnamed-project-ace-3.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-adventure.html
+++ b/ships/carnival/carnival-adventure.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-breeze.html
+++ b/ships/carnival/carnival-breeze.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-carnival-breeze.html
+++ b/ships/carnival/carnival-carnival-breeze.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-carnival-celebration.html
+++ b/ships/carnival/carnival-carnival-celebration.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-carnival-conquest.html
+++ b/ships/carnival/carnival-carnival-conquest.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-carnival-dream.html
+++ b/ships/carnival/carnival-carnival-dream.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-carnival-elation.html
+++ b/ships/carnival/carnival-carnival-elation.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-carnival-firenze.html
+++ b/ships/carnival/carnival-carnival-firenze.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-carnival-freedom.html
+++ b/ships/carnival/carnival-carnival-freedom.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-carnival-glory.html
+++ b/ships/carnival/carnival-carnival-glory.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-carnival-horizon.html
+++ b/ships/carnival/carnival-carnival-horizon.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-carnival-jubilee.html
+++ b/ships/carnival/carnival-carnival-jubilee.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-celebration.html
+++ b/ships/carnival/carnival-celebration.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-conquest.html
+++ b/ships/carnival/carnival-conquest.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-dream.html
+++ b/ships/carnival/carnival-dream.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-ecstasy.html
+++ b/ships/carnival/carnival-ecstasy.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-elation.html
+++ b/ships/carnival/carnival-elation.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-encounter.html
+++ b/ships/carnival/carnival-encounter.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-fantasy.html
+++ b/ships/carnival/carnival-fantasy.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-fascination.html
+++ b/ships/carnival/carnival-fascination.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-festivale.html
+++ b/ships/carnival/carnival-festivale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-freedom.html
+++ b/ships/carnival/carnival-freedom.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-glory.html
+++ b/ships/carnival/carnival-glory.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-imagination.html
+++ b/ships/carnival/carnival-imagination.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-inspiration.html
+++ b/ships/carnival/carnival-inspiration.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-jubilee.html
+++ b/ships/carnival/carnival-jubilee.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-legend.html
+++ b/ships/carnival/carnival-legend.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-liberty.html
+++ b/ships/carnival/carnival-liberty.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-luminosa.html
+++ b/ships/carnival/carnival-luminosa.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-magic.html
+++ b/ships/carnival/carnival-magic.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-mardi-gras.html
+++ b/ships/carnival/carnival-mardi-gras.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-miracle.html
+++ b/ships/carnival/carnival-miracle.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-paradise.html
+++ b/ships/carnival/carnival-paradise.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-pride.html
+++ b/ships/carnival/carnival-pride.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-radiance.html
+++ b/ships/carnival/carnival-radiance.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-sensation.html
+++ b/ships/carnival/carnival-sensation.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-spirit.html
+++ b/ships/carnival/carnival-spirit.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-splendor.html
+++ b/ships/carnival/carnival-splendor.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-sunrise.html
+++ b/ships/carnival/carnival-sunrise.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-tropicale.html
+++ b/ships/carnival/carnival-tropicale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/carnival-valor.html
+++ b/ships/carnival/carnival-valor.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnival-vista.html
+++ b/ships/carnival/carnival-vista.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 
 <html lang="en">
 <head>

--- a/ships/carnival/carnivale.html
+++ b/ships/carnival/carnivale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/celebration.html
+++ b/ships/carnival/celebration.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/festivale.html
+++ b/ships/carnival/festivale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/holiday.html
+++ b/ships/carnival/holiday.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/index.html
+++ b/ships/carnival/index.html
@@ -1,4 +1,11 @@
-<!doctype html><html><head>
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+<html><head>
 <!-- ai-breadcrumbs
      entity: Carnival Fleet Pages
      type: Ship Information Page

--- a/ships/carnival/jubilee.html
+++ b/ships/carnival/jubilee.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/mardi-gras.html
+++ b/ships/carnival/mardi-gras.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/tropicale.html
+++ b/ships/carnival/tropicale.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/unnamed-project-ace-1.html
+++ b/ships/carnival/unnamed-project-ace-1.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/unnamed-project-ace-2.html
+++ b/ships/carnival/unnamed-project-ace-2.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/carnival/unnamed-project-ace-3.html
+++ b/ships/carnival/unnamed-project-ace-3.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-ascent.html
+++ b/ships/celebrity-cruises/celebrity-ascent.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-beyond.html
+++ b/ships/celebrity-cruises/celebrity-beyond.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-century.html
+++ b/ships/celebrity-cruises/celebrity-century.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-compass.html
+++ b/ships/celebrity-cruises/celebrity-compass.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-constellation.html
+++ b/ships/celebrity-cruises/celebrity-constellation.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-eclipse.html
+++ b/ships/celebrity-cruises/celebrity-eclipse.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-edge.html
+++ b/ships/celebrity-cruises/celebrity-edge.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-equinox.html
+++ b/ships/celebrity-cruises/celebrity-equinox.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-flora.html
+++ b/ships/celebrity-cruises/celebrity-flora.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-galaxy.html
+++ b/ships/celebrity-cruises/celebrity-galaxy.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-infinity.html
+++ b/ships/celebrity-cruises/celebrity-infinity.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-mercury.html
+++ b/ships/celebrity-cruises/celebrity-mercury.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-millennium.html
+++ b/ships/celebrity-cruises/celebrity-millennium.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-reflection.html
+++ b/ships/celebrity-cruises/celebrity-reflection.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-seeker.html
+++ b/ships/celebrity-cruises/celebrity-seeker.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-silhouette.html
+++ b/ships/celebrity-cruises/celebrity-silhouette.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-solstice.html
+++ b/ships/celebrity-cruises/celebrity-solstice.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-summit.html
+++ b/ships/celebrity-cruises/celebrity-summit.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-xpedition.html
+++ b/ships/celebrity-cruises/celebrity-xpedition.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-xperience.html
+++ b/ships/celebrity-cruises/celebrity-xperience.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/celebrity-xploration.html
+++ b/ships/celebrity-cruises/celebrity-xploration.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/horizon.html
+++ b/ships/celebrity-cruises/horizon.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/index.html
+++ b/ships/celebrity-cruises/index.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/ships/celebrity-cruises/ss-meridian.html
+++ b/ships/celebrity-cruises/ss-meridian.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/unnamed-edge-class.html
+++ b/ships/celebrity-cruises/unnamed-edge-class.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/unnamed-project-nirvana.html
+++ b/ships/celebrity-cruises/unnamed-project-nirvana.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/unnamed-river-class-x6.html
+++ b/ships/celebrity-cruises/unnamed-river-class-x6.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/celebrity-cruises/zenith.html
+++ b/ships/celebrity-cruises/zenith.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/grandeur-of-the-seas.html
+++ b/ships/grandeur-of-the-seas.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/amsterdam.html
+++ b/ships/holland-america-line/amsterdam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/edam.html
+++ b/ships/holland-america-line/edam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/eurodam.html
+++ b/ships/holland-america-line/eurodam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/index.html
+++ b/ships/holland-america-line/index.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/ships/holland-america-line/koningsdam.html
+++ b/ships/holland-america-line/koningsdam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/leerdam.html
+++ b/ships/holland-america-line/leerdam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/maartensdijk.html
+++ b/ships/holland-america-line/maartensdijk.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/maasdam.html
+++ b/ships/holland-america-line/maasdam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/nieuw-amsterdam-ii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-ii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/nieuw-amsterdam-iii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/nieuw-amsterdam-iv.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iv.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/nieuw-amsterdam-v.html
+++ b/ships/holland-america-line/nieuw-amsterdam-v.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/nieuw-amsterdam.html
+++ b/ships/holland-america-line/nieuw-amsterdam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/nieuw-statendam.html
+++ b/ships/holland-america-line/nieuw-statendam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/none-announced.html
+++ b/ships/holland-america-line/none-announced.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/noordam-ii.html
+++ b/ships/holland-america-line/noordam-ii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/noordam-iii.html
+++ b/ships/holland-america-line/noordam-iii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/noordam-iv.html
+++ b/ships/holland-america-line/noordam-iv.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/noordam.html
+++ b/ships/holland-america-line/noordam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/oosterdam.html
+++ b/ships/holland-america-line/oosterdam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/p-caland.html
+++ b/ships/holland-america-line/p-caland.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/potsdam.html
+++ b/ships/holland-america-line/potsdam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/prinsendam-i.html
+++ b/ships/holland-america-line/prinsendam-i.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/prinsendam-ii.html
+++ b/ships/holland-america-line/prinsendam-ii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/rijndam-ii.html
+++ b/ships/holland-america-line/rijndam-ii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/rijndam.html
+++ b/ships/holland-america-line/rijndam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/rotterdam-iv.html
+++ b/ships/holland-america-line/rotterdam-iv.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/rotterdam-v.html
+++ b/ships/holland-america-line/rotterdam-v.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/rotterdam-vi.html
+++ b/ships/holland-america-line/rotterdam-vi.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/rotterdam.html
+++ b/ships/holland-america-line/rotterdam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/ryndam.html
+++ b/ships/holland-america-line/ryndam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/statendam-ii.html
+++ b/ships/holland-america-line/statendam-ii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/statendam-iii.html
+++ b/ships/holland-america-line/statendam-iii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/statendam.html
+++ b/ships/holland-america-line/statendam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/veendam-ii.html
+++ b/ships/holland-america-line/veendam-ii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/veendam-iii.html
+++ b/ships/holland-america-line/veendam-iii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/veendam-iv.html
+++ b/ships/holland-america-line/veendam-iv.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/veendam.html
+++ b/ships/holland-america-line/veendam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/volendam-ii.html
+++ b/ships/holland-america-line/volendam-ii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/volendam-iii.html
+++ b/ships/holland-america-line/volendam-iii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/volendam.html
+++ b/ships/holland-america-line/volendam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/w-a-scholten.html
+++ b/ships/holland-america-line/w-a-scholten.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/westerdam-i.html
+++ b/ships/holland-america-line/westerdam-i.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/westerdam-ii.html
+++ b/ships/holland-america-line/westerdam-ii.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/holland-america-line/zaandam.html
+++ b/ships/holland-america-line/zaandam.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/index.html
+++ b/ships/index.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/msc/msc-world-america.html
+++ b/ships/msc/msc-world-america.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/rooms.html
+++ b/ships/rooms.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs

--- a/ships/template.html
+++ b/ships/template.html
@@ -1,4 +1,11 @@
 <!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs


### PR DESCRIPTION
Standards compliance update:
- Added Soli Deo Gloria block to 186 ship pages
- Added Soli Deo Gloria block to 129 restaurant pages
- Added Soli Deo Gloria + ICP-Lite meta tags to 10 Asia-Pacific port pages (auckland, bali, bangkok, brisbane, hong-kong, shanghai, singapore, south-pacific, sydney, tokyo)

Total: 325 files updated