### PR TITLE
FIX: Resolve merge conflict and template literal escapes

### DIFF
--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -1663,13 +1663,13 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
         if(!primary){
           const slugify = s => (s||'').toLowerCase().replace(/https?:\/\/[^/]+/,'').replace(/[#?].*$/,'').split('/').filter(Boolean).pop()||'';
           const guess = slugify(href) || slugify(title);
-          if(guess) primary = `/assets/articles/\${guess}/cover.jpg`;
+          if(guess) primary = `/assets/articles/${guess}/cover.jpg`;
         }
 
         const alts = [];
         if(primary){
           const base = primary.replace(/\.(jpg|jpeg|png|webp)$/i,'');
-          alts.push(`\${base}.jpeg`, `\${base}.JPG`, `\${base}.webp`, `\${base}.png`);
+          alts.push(`${base}.jpeg`, `${base}.JPG`, `${base}.webp`, `${base}.png`);
         }
         setImageWithFallback(el, primary || '/assets/index_hero.webp', alts);
       });
@@ -1679,17 +1679,12 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
       // Announce to screen readers
       const status = document.getElementById('a11y-status');
       if(status) {
-        status.textContent = `\${view.length} recent articles loaded`;
+        status.textContent = `${view.length} recent articles loaded`;
       }
     })();
   })();
   </script>
-<<<<<<< HEAD
-
-
-=======
-  <!-- Navigation dropdown functionality -->
-    <!-- Navigation dropdown functionality (New Clean Implementation) -->
+  <!-- Navigation dropdown functionality (New Clean Implementation) -->
   <script>
   (function() {
     'use strict';
@@ -1743,6 +1738,5 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
     });
   })();
   </script>
->>>>>>> 4aa11716 (FIX: Add missing navigation script to 477 HTML pages)
 </body>
 </html>


### PR DESCRIPTION
Fixed multiple JavaScript issues preventing page from working.

Changes:
1. Resolved merge conflict (removed <<<<<<< HEAD and >>>>>>> markers)
   - Kept navigation dropdown functionality from incoming merge

2. Fixed 3 escaped template literals (causing text to show on page):
   - Line 1666: /assets/articles/${guess} → /assets/articles/${guess}
   - Line 1672: ${base}.jpeg → ${base}.jpeg (4 occurrences)
   - Line 1682: ${view.length} → ${view.length} (the debug message showing on page)

The escaped template literals were being rendered as literal text instead of evaluated, causing "(dollar)(brace)view.length(brace) recent articles loaded" to appear at top of page.

All JavaScript should now execute properly.