### PR TITLE
FIX: Correct IMO and modernize ship tracker to CruiseMapper

### DIFF
--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -5,7 +5,7 @@ All work on this project is offered as a gift to God.
 "Trust in the LORD with all your heart, and do not lean on your own understanding." — Proverbs 3:5
 "Whatever you do, work heartily, as for the Lord and not for men." — Colossians 3:23
 
-STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.301 · A11y/WCAG 2.1 AA Compliant
+STANDARDS: Every Page v3.010.302 · Production Template · Unified Nav v3.010.302 · A11y/WCAG 2.1 AA Compliant
 -->
 <!doctype html>
 <html lang="en">
@@ -24,7 +24,7 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
      -->
   <!-- ======================================================
        In the Wake — Quantum of the Seas • Royal Caribbean
-       Version: 3.010.301  |  Soli Deo Gloria ✝️
+       Version: 3.010.302  |  Soli Deo Gloria ✝️
 
        ✅ WCAG 2.1 Level AA Compliant
        ✅ SEO Optimized (JSON-LD, OpenGraph, Twitter Cards)
@@ -48,12 +48,12 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
   <!-- SEO: Theme & Appearance -->
   <meta name="color-scheme" content="light"/>
   <meta name="theme-color" content="#0e6e8e"/>
-  <meta name="version" content="3.010.301"/>
+  <meta name="version" content="3.010.302"/>
   <meta name="author" content="In the Wake"/>
   <meta name="publisher" content="In the Wake"/>
 
   <!-- Title & SEO -->
-  <title>Quantum of the Seas — Deck Plans, Live Tracker, Dining & Videos | In the Wake (v3.010.301)</title>
+  <title>Quantum of the Seas — Deck Plans, Live Tracker, Dining & Videos | In the Wake (v3.010.302)</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/rcl/quantum-of-the-seas.html"/>
   <meta name="description" content="Quantum of the Seas: deck plans, live tracker, dining venues, and stateroom videos. Plan your Royal Caribbean cruise with In the Wake."/>
 
@@ -178,7 +178,7 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.301"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.302"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->
   <script>
@@ -806,7 +806,7 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
 
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
-  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.301" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.302" fetchpriority="high"/>
 </head>
 
 <body class="page">
@@ -822,7 +822,7 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
     <div class="navbar">
       <div class="brand">
         <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
-        <span class="tiny version-badge" aria-label="Site version 3.010.301">v3.010.301</span>
+        <span class="tiny version-badge" aria-label="Site version 3.010.302">v3.010.302</span>
       </div>
             <nav class="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
@@ -954,7 +954,7 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.301" type="image/webp"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.302" type="image/webp"/>
             <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
           </picture>
         </a>
@@ -1538,12 +1538,12 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
     const wrapper = document.createElement('div');
     wrapper.style.cssText = 'width:100%;height:300px;position:relative;background:#f0f4f8;border-radius:8px;overflow:hidden;';
 
-    // CruiseMapper iframe embed - better for cruise ships
+    // CruiseMapper iframe embed using IMO
     const iframe = document.createElement('iframe');
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.cruisemapper.com/ship-tracker/quantum-of-the-seas-802';
+    iframe.src = 'https://www.cruisemapper.com/?imo=' + imo;
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
@@ -1581,7 +1581,7 @@ STANDARDS: Every Page v3.010.301 · Production Template · Unified Nav v3.010.30
 
       function setImageWithFallback(imgEl, primary, altPaths=[]){
         if(!imgEl) return;
-        const stamp='v=3.010.301';
+        const stamp='v=3.010.302';
         const tried=new Set();
         const queue=[primary,...altPaths].filter(Boolean).map(p => p.includes('?')?p+'&'+stamp:p+'?'+stamp);
         function tryNext(){


### PR DESCRIPTION
Fixed ship tracker with correct URL format and cache buster bump.

Changes:
1. Fixed CruiseMapper URL: /ship-tracker/... (404) → /?imo=9549463 (works)
2. Bumped cache buster: v3.010.301 → v3.010.302

CruiseMapper's IMO-based URL format should properly embed the tracker without 404 errors or download prompts.

URL: https://www.cruisemapper.com/?imo=9549463