### PR TITLE
PROMOTE: Ship tracker to full-size card

### DIFF
--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -1145,23 +1145,22 @@ STANDARDS: Every Page v3.010.302 · Production Template · Unified Nav v3.010.30
       <div id="videoFallback" class="tiny hidden">Videos will appear once our sources sync for this ship.</div>
     </section>
 
-    <!-- Row: Deck Plans + Live Tracker -->
-    <section class="grid-2">
-      <section class="card" aria-labelledby="deck-plans">
-        <h2 id="deck-plans">Ship Map (Deck Plans)</h2>
-        <p><a class="btn" href="https://www.royalcaribbean.com/cruise-ships/quantum-of-the-seas/deck-plans" target="_blank" rel="noopener">Open Official Deck Plans →</a></p>
-        <figure>
-          <img src="/assets/ship-map.png" alt="Quantum of the Seas simplified deck plan preview" loading="lazy"/>
-        </figure>
-      </section>
+    <!-- Live Ship Tracker -->
+    <section class="card itinerary" aria-labelledby="liveTrackHeading" data-imo="9549463" data-name="QUANTUM-OF-THE-SEAS">
+      <h2 id="liveTrackHeading">Where Is Quantum Right Now?</h2>
+      <p>See the ship's current position, speed, and next port on a live tracker.</p>
 
-      <section class="card itinerary" aria-labelledby="liveTrackHeading" data-imo="9549463" data-name="QUANTUM-OF-THE-SEAS">
-        <h2 id="liveTrackHeading">Where Is Quantum Right Now?</h2>
-        <p>See the ship's current position, speed, and next port on a live tracker.</p>
+      <div id="vf-tracker-container" style="width:100%;height:500px;position:relative;"></div>
+      <p class="tiny">See <a href="/ports.html">ports</a> for more information about individual ports.</p>
+    </section>
 
-        <div id="vf-tracker-container" style="width:100%;height:300px;position:relative;"></div>
-        <p class="tiny">See <a href="/ports.html">ports</a> for more information about individual ports.</p>
-      </section>
+    <!-- Deck Plans -->
+    <section class="card" aria-labelledby="deck-plans">
+      <h2 id="deck-plans">Ship Map (Deck Plans)</h2>
+      <p><a class="btn" href="https://www.royalcaribbean.com/cruise-ships/quantum-of-the-seas/deck-plans" target="_blank" rel="noopener">Open Official Deck Plans →</a></p>
+      <figure>
+        <img src="/assets/ship-map.png" alt="Quantum of the Seas simplified deck plan preview" loading="lazy"/>
+      </figure>
     </section>
 
     <!-- FAQ Section -->
@@ -1536,7 +1535,7 @@ STANDARDS: Every Page v3.010.302 · Production Template · Unified Nav v3.010.30
 
     // Create wrapper div
     const wrapper = document.createElement('div');
-    wrapper.style.cssText = 'width:100%;height:300px;position:relative;background:#f0f4f8;border-radius:8px;overflow:hidden;';
+    wrapper.style.cssText = 'width:100%;height:500px;position:relative;background:#f0f4f8;border-radius:8px;overflow:hidden;';
 
     // CruiseMapper iframe embed using IMO
     const iframe = document.createElement('iframe');


### PR DESCRIPTION
Promoted ship tracker from grid-2 layout to full-width card section.

Changes:
1. Moved tracker out of grid-2 with deck plans
2. Gave tracker its own full-width card section (like video carousel)
3. Increased height: 300px → 500px for better visibility
4. Deck plans now in separate full-width section below tracker

Ship tracker now has same prominence as video carousel.