### PR TITLE
Add Celestyal Olympia image to Song of America

### DIFF
--- a/assets/data/media/rcl/song-of-america.json
+++ b/assets/data/media/rcl/song-of-america.json
@@ -1,0 +1,31 @@
+{
+  "ship_slug": "song-of-america",
+  "first_look_images": [
+    {
+      "slug": "song_of_america_final_form",
+      "display_name": "Song of America in final form as Celestyal Olympia",
+      "source": "wikimedia_commons",
+      "file_page": "https://commons.wikimedia.org/wiki/File:Celestyal_Olympia_at_quay_in_Port_of_Rhodes_23_August_2023.jpg",
+      "hotlink_preview": "/assets/ships/Celestyal_Olympia_at_quay_in_Port_of_Rhodes_23_August_2023.webp",
+      "local_fullres": "/assets/ships/Celestyal_Olympia_at_quay_in_Port_of_Rhodes_23_August_2023.jpg",
+      "license": "CC BY-SA",
+      "license_url": "https://creativecommons.org/licenses/by-sa/4.0/",
+      "author": "Wikimedia Commons",
+      "author_url": "https://commons.wikimedia.org",
+      "license_verified": true,
+      "alt": "Song of America (later Celestyal Olympia) at Rhodes, August 23, 2023"
+    }
+  ],
+  "extra_credits": [],
+  "dining_hero": {
+    "policy": "universal",
+    "primary_src": "/assets/img/Cordelia_Empress_Food_Court.jpg",
+    "fallbacks": [
+      "/assets/ships/rcl/song-of-america/dining-hero.jpg?v=3.006",
+      "/assets/ships/song-of-america-dining.jpg?v=3.006"
+    ],
+    "source_note": "Universal dining hero (Commons; to be replaced by Flickers of Majesty shot when available)",
+    "license_verified": false,
+    "alt": "Song of America dining venue seating with ocean view"
+  }
+}


### PR DESCRIPTION
Song of America's final form as Celestyal Olympia photographed at Rhodes, Greece in August 2023. This shows the ship's appearance after sale from Royal Caribbean.

Source: Wikimedia Commons, CC BY-SA 4.0