### PR TITLE
Create attractive 'Coming Soon' placeholder for Nordic Prince

### DIFF
--- a/assets/data/media/rcl/nordic-prince.json
+++ b/assets/data/media/rcl/nordic-prince.json
@@ -1,0 +1,31 @@
+{
+  "ship_slug": "nordic-prince",
+  "first_look_images": [
+    {
+      "slug": "nordic_prince_coming_soon",
+      "display_name": "Nordic Prince - Coming Soon",
+      "source": "placeholder",
+      "file_page": null,
+      "hotlink_preview": "/assets/ships/nordic-prince-coming-soon.svg",
+      "local_fullres": "/assets/ships/nordic-prince-coming-soon.svg",
+      "license": "Internal placeholder",
+      "license_url": null,
+      "author": "In the Wake",
+      "author_url": null,
+      "license_verified": true,
+      "alt": "Nordic Prince - Image coming soon. Historic Royal Caribbean ship 1971-1995."
+    }
+  ],
+  "extra_credits": [],
+  "dining_hero": {
+    "policy": "universal",
+    "primary_src": "/assets/img/Cordelia_Empress_Food_Court.jpg",
+    "fallbacks": [
+      "/assets/ships/rcl/nordic-prince/dining-hero.jpg?v=3.006",
+      "/assets/ships/nordic-prince-dining.jpg?v=3.006"
+    ],
+    "source_note": "Universal dining hero (Commons; to be replaced by actual ship photography when available)",
+    "license_verified": false,
+    "alt": "Nordic Prince dining venue seating with ocean view"
+  }
+}

--- a/assets/ships/nordic-prince-coming-soon.svg
+++ b/assets/ships/nordic-prince-coming-soon.svg
@@ -1,0 +1,53 @@
+<svg width="1200" height="800" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <!-- Background gradient -->
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a365d;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#2c5282;stop-opacity:1" />
+    </linearGradient>
+
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#60a5fa;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#3b82f6;stop-opacity:1" />
+    </linearGradient>
+
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="800" fill="url(#bgGradient)"/>
+
+  <!-- Decorative wave pattern -->
+  <path d="M0,400 Q300,350 600,400 T1200,400 L1200,800 L0,800 Z" fill="#1e3a5f" opacity="0.3"/>
+  <path d="M0,450 Q300,400 600,450 T1200,450 L1200,800 L0,800 Z" fill="#1e3a5f" opacity="0.2"/>
+
+  <!-- Logo -->
+  <image href="/assets/logo_wake_512.png" x="350" y="200" width="500" height="auto" opacity="0.9"/>
+
+  <!-- Coming Soon text -->
+  <text x="600" y="580" font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="bold"
+        text-anchor="middle" fill="url(#textGradient)" filter="url(#glow)">
+    COMING SOON
+  </text>
+
+  <!-- Ship name -->
+  <text x="600" y="650" font-family="Georgia, serif" font-size="36" font-weight="300"
+        text-anchor="middle" fill="#cbd5e1" opacity="0.9">
+    Nordic Prince
+  </text>
+
+  <!-- Subtitle -->
+  <text x="600" y="690" font-family="Arial, sans-serif" font-size="20" font-style="italic"
+        text-anchor="middle" fill="#94a3b8" opacity="0.8">
+    Historic Royal Caribbean Ship • 1971-1995
+  </text>
+
+  <!-- Decorative line -->
+  <line x1="400" y1="530" x2="800" y2="530" stroke="#3b82f6" stroke-width="2" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
Added custom SVG placeholder featuring:
- Nautical blue gradient background
- Decorative wave patterns
- Site logo centered
- "COMING SOON" text with gradient and glow effect
- Ship name and historic dates (1971-1995)
- Elegant typography and layout

Nordic Prince was RCL's second ship (1971-1995) but has no freely available images. This placeholder maintains visual consistency while indicating future content availability.