### PR TITLE
Wire 2 existing articles into solo.html article loader

### DIFF
--- a/solo.html
+++ b/solo.html
@@ -608,6 +608,8 @@
               <h2>Articles</h2>
               <p>JavaScript is off. Open articles directly:</p>
               <ul>
+                <li><a href="/solo/solo-cruisers-companion.html">The Solo Cruiser's Companion: A Practical Guide</a></li>
+                <li><a href="/solo/in-the-wake-of-grief.html">In the Wake of Grief: When Loss Needs Water</a></li>
                 <li><a href="/solo/solo-cruising-practical-guide.html">The Practical Guide to Cruising Alone</a></li>
                 <li><a href="/solo/why-i-started-solo-cruising.html">Why I Started Solo Cruising</a></li>
                 <li><a href="/solo/freedom-of-your-own-wake.html">The Freedom of Your Own Wake</a></li>
@@ -738,6 +740,18 @@
     ];
 
     var RAW_ARTICLES = [
+      { slug:"solo-cruisers-companion",
+        title:"The Solo Cruiser's Companion: A Practical Guide",
+        hero: ORIGIN + "/assets/index_hero.webp",
+        dek:"A comprehensive guide for traveling alone at sea — ship selection, dining strategies, activities for introverts, and tips for managing anxiety.",
+        date:"2025-11-19",
+        authorId:"ken", tags:["solo","practical","introvert","anxiety","dining","comprehensive"] },
+      { slug:"in-the-wake-of-grief",
+        title:"In the Wake of Grief: When Loss Needs Water",
+        hero: ORIGIN + "/assets/index_hero.webp",
+        dek:"A guide for widows, widowers, and the bereaved navigating first cruises, first holidays, and the journey from 'we' to 'I.'",
+        date:"2025-11-19",
+        authorId:"ken", tags:["solo","grief","healing","widow","loss","reflection"] },
       { slug:"solo-cruising-practical-guide",
         title:"Solo in the Wake: The Practical Guide to Cruising Alone",
         hero: ORIGIN + "/solo/images/flickersofmajesty.jpeg",

--- a/solo/articles/in-the-wake-of-grief.html
+++ b/solo/articles/in-the-wake-of-grief.html
@@ -1,0 +1,722 @@
+<article id="in-the-wake-of-grief" data-slug="in-the-wake-of-grief">
+  <h1>In the Wake of Grief: When Loss Needs Water</h1>
+  <p class="dek">A guide for widows, widowers, and the bereaved navigating first cruises, first holidays, and the journey from "we" to "I."</p>
+  <p class="byline">by Ken Baker</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="who-this-is-for">Who This Article Is For</h2>
+
+<p><strong>This article is for you if:</strong></p>
+<ul>
+<li>You're a widow or widower considering your first cruise after losing your spouse</li>
+<li>You're facing your first holidays without them and the thought of staying home feels unbearable</li>
+<li>You've been a "we" for decades and don't know how to be an "I"</li>
+<li>You're nervous about traveling alone after years of traveling as a couple</li>
+<li>You feel guilty every time you smile or imagine beauty</li>
+<li>You need permission to feel joy without betraying their memory</li>
+<li>You're looking for gentle community that doesn't require you to explain your grief</li>
+<li>You want practical guidance from someone who understands both grief and cruising</li>
+<li>You're wondering if it's "too soon" (and tired of other people's timelines)</li>
+</ul>
+
+<p><strong>This article may not be for you if:</strong></p>
+<ul>
+<li>You're in deep shock—typically the first few months after loss (there is no shame in waiting)</li>
+<li>You're looking for general solo travel advice without the grief component—see our <a href="/solo/why-i-started-solo-cruising.html">Solo Cruising Guide</a></li>
+<li>You need professional grief counseling or couples therapy—this is pastoral travel guidance, not clinical treatment</li>
+<li>You're trying to escape financial or family responsibilities—travel can create space to breathe, but it cannot solve those problems</li>
+<li>You're seeking a "cure" for grief—cruising won't erase your loss, but it may help you carry it differently</li>
+</ul>
+
+<p><em>A note on faith: This article includes Scripture and pastoral reflections because faith has been a comfort to many grieving travelers—including the author. If that's not your tradition, take what helps and leave what doesn't. The practical guidance stands on its own.</em></p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="margarets-story">Opening Story — Margaret's First Christmas at Sea</h2>
+
+<p><em>(Some years back, when <a href="/ships/rcl/grandeur-of-the-seas.html">Grandeur of the Seas</a> still sailed from Baltimore on winter Bahamas itineraries.)</em></p>
+
+<p>Margaret was 68 the Christmas she boarded <a href="/ships/grandeur-of-the-seas.html">Grandeur of the Seas</a> without Tom. They had been married forty-seven years. For nearly five decades Christmas had meant the same things: his off-key carols, the way he carved the ham, the way he always over-tipped the pizza guy on Christmas Eve "because no one should be working tonight."</p>
+
+<p>Then, in February, cancer took him.</p>
+
+<p>The house became too quiet, and the calendar too loud. By December, her adult children were worried: "Mom, you can't be alone for Christmas." "Come to our house." "We'll make it special."</p>
+
+<p>But the thought of sitting in their homes—surrounded by their joy, their noise, their pity—made her chest tighten. She loved them. But she could not bear being the center of a grief she didn't have the strength to explain.</p>
+
+<p>Every stocking, every ornament, every "Remember when Dad…" felt like a wave she no longer knew how to stand in.</p>
+
+<p>One night, long after midnight, she saw a discounted fare for a five-night Christmas sailing from Baltimore. She booked it.</p>
+
+<p>"I'll just survive five days," she whispered.</p>
+
+<h3 id="day-1">Day 1 — The Panic</h3>
+
+<p>From the moment the ship eased away from the pier, she regretted it.</p>
+
+<p>Couples leaned on the railings. Families pointed out the skyline. Margaret lay on her cabin bed staring at the ceiling.</p>
+
+<p>"This was a mistake," she whispered.</p>
+
+<p>Her chest felt hollow. Every hallway echoed. Every Christmas decoration looked like it belonged to another life.</p>
+
+<h3 id="christmas-eve">Christmas Eve — The Fracture</h3>
+
+<p>She forced herself into the small onboard chapel. The pastor read Isaiah 9: "The people who walked in darkness have seen a great light…"</p>
+
+<p>The words fell into her like stones. Quiet tears came. She slipped out early, before the lights rose.</p>
+
+<p>No one followed. No one asked her to explain.</p>
+
+<p>Sometimes the smallest mercies are the most profound.</p>
+
+<h3 id="christmas-dinner">Christmas Dinner — The Invitation</h3>
+
+<p>The maître d' seated her alone, but a couple in their seventies—one table over—noticed her trembling hands and gentle sadness.</p>
+
+<p>"Would you like to join us?" the wife asked softly.</p>
+
+<p>They weren't trying to fix her. They weren't performing pity. They had lost their son ten years prior. They knew the shape of quiet sorrow.</p>
+
+<p>They talked about the menu, the weather, the ship. Nothing heavy. Nothing forced. Just warmth. Just presence.</p>
+
+<p>And presence, offered without pressure, is its own kind of healing.</p>
+
+<h3 id="formal-night">Formal Night — The Breaking</h3>
+
+<p>She tried to watch the dancing in the Centrum—couples gliding, holding each other, moving in patterns she no longer belonged to.</p>
+
+<p>She made it five minutes before retreating to her balcony, where she cried until the wind chilled her tears.</p>
+
+<h3 id="day-4">Day 4 — The Shift</h3>
+
+<p>After dinner, she returned to her cabin. When she opened the door, she stopped.</p>
+
+<p>On her bed sat a towel animal: A penguin.</p>
+
+<p>Tom loved penguins.</p>
+
+<p>It held a tiny "Merry Christmas" sign between its flippers.</p>
+
+<p>It was so ridiculous and earnest that she laughed out loud—an involuntary, startled laugh.</p>
+
+<p>Then guilt slammed into her chest.</p>
+
+<p>"How can I laugh? Tom is gone."</p>
+
+<p>But another thought followed—uninvited, but soft:</p>
+
+<p><em>Tom would've laughed too.</em></p>
+
+<p>She could almost hear him teasing: "They got you with the penguin, didn't they?"</p>
+
+<p>That laugh didn't erase grief. But it cracked open the smallest window of light.</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="our-stories-met">And Here Is Where Our Stories Met</h2>
+
+<p>I didn't know Margaret then. Not until the day we both stood in Curaçao—me with my brother and my grandfather, she with two couples from her dining table.</p>
+
+<p>We had all booked the same accessible-bus island tour. (For more on <a href="/accessibility.html">accessible cruising</a>—including considerations for widows and widowers who've experienced mobility changes after caregiving—see our <a href="/solo/accessible-cruising.html">Accessible Cruising Guide</a>.)</p>
+
+<p>Halfway through the day, the bus broke down—completely—and the hydraulic lift trapped my brother and my grandfather inside until a replacement vehicle could reach us.</p>
+
+<p>What could've been chaos became an unexpected mercy.</p>
+
+<p>The delay became an extended lunch overlooking the ocean—bright turquoise water, warm breeze, Grandeur anchored in the distance. People relaxed. The urgency dissolved. And slowly, people started talking.</p>
+
+<p>Not loudly. Not forced. Just stories emerging the way grief often does—accidentally, gently, in the cracks of a day that didn't go according to plan.</p>
+
+<p>That's when I met Margaret.</p>
+
+<p>Over a table of grilled fish and cold sodas, she told me about Tom. About the penguins. About their Christmas traditions. About feeling like she was betraying him every time she smiled.</p>
+
+<p>And I told her my story too—the losses I'd carried, including the grief of my foster daughters of ten years; they live, but they live out of reach.</p>
+
+<p>She listened in that quiet, steady way only the bereaved can.</p>
+
+<p>We talked for less than an hour. Yet the weight we carried felt lighter simply by sharing it.</p>
+
+<p>When the replacement bus arrived, we hugged like old friends. Then we disappeared back into the strange, moving city that is a cruise ship—two grieving souls momentarily carried by the same tide.</p>
+
+<p>She later wrote:</p>
+
+<blockquote>
+<p>"I didn't 'get over' Tom on that cruise. But somewhere between Baltimore and the islands, I learned I could carry him differently. The ocean held me while I figured that out."</p>
+</blockquote>
+
+<p>If you're reading this, maybe the ocean is calling you, too—gently, patiently—inviting you to breathe where your grief doesn't need to be hidden or justified.</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="permission">You Don't Need Permission, But Take It Anyway</h2>
+
+<p>Bereaved people live in a strange prison of external expectations.</p>
+
+<p>If you stay home, people worry. If you date, people judge. If you travel, someone will inevitably say:</p>
+
+<ul>
+<li>"Wow, that was fast."</li>
+<li>"Finally, you're getting out."</li>
+<li>Or the one nearly every <a href="/solo/solo-cruisers-companion.html">solo cruiser</a> (see also <a href="/solo/why-i-started-solo-cruising.html">Tina's story</a>) hears: "That's sad that you're traveling by yourself."</li>
+</ul>
+
+<p>But they don't know your timeline. They don't live with the empty chair. They don't sleep on your side of the bed. They don't see the toothbrush that hasn't moved.</p>
+
+<p>Grief does not operate on polite schedules. Neither should you.</p>
+
+<h3 id="guilt-trap">The Guilt Trap</h3>
+
+<p>Survivor guilt isn't usually "I should have done more." More often it sounds like:</p>
+
+<ul>
+<li>"How dare I laugh when they can't?"</li>
+<li>"If I feel joy, am I letting go?"</li>
+<li>"If I live, am I betraying them?"</li>
+</ul>
+
+<p>Joy doesn't erase love. Laughter doesn't dishonor memory. Life doesn't invalidate grief.</p>
+
+<p>You don't need permission to breathe. But you may need permission to believe that breathing is allowed.</p>
+
+<h3 id="timelines">Cultural Timelines</h3>
+
+<p>People like grief to be tidy. Grief is not tidy.</p>
+
+<p>Ecclesiastes 3 offers seasons, not deadlines.</p>
+
+<h3 id="ready-for-travel">Signs You Might Be Ready for Travel</h3>
+
+<p>You might be ready if:</p>
+<ul>
+<li>You can imagine beauty without only pain.</li>
+<li>Fear and hope coexist.</li>
+<li>You're booking FOR you—not FROM pressure.</li>
+<li>You can tolerate the idea of joy.</li>
+</ul>
+
+<p>It may be too soon if:</p>
+<ul>
+<li>You're in deep shock.</li>
+<li>Money is tight.</li>
+<li>You want to escape responsibilities.</li>
+<li>You're booking to silence grief—not explore it.</li>
+</ul>
+
+<h3 id="practical-permission">Practical Permission</h3>
+
+<ul>
+<li>Start with a refund-eligible cruise.</li>
+<li>Keep it short.</li>
+<li>Say to yourself: "If all I do is sit on the balcony, that's allowed."</li>
+</ul>
+
+<p>Margaret later said: "I regretted going almost every day… and I'd do it again. Because regret in motion is different than regret in paralysis."</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="ship-size">Choosing the Right Ship and Itinerary for Your Grief</h2>
+
+<p>There is no one-size-fits-all answer for bereaved travelers. Different grief needs call for different ship experiences.</p>
+
+<p>Some widows and widowers need the quiet intimacy of their peers. Others need the joyful chaos of young families. Both are valid. Both are healing.</p>
+
+<h3 id="smaller-ships">Option A: Smaller Ships + Longer Itineraries</h3>
+
+<p><strong>Ship Size:</strong> 1,000-2,500 passengers (Radiance, Brilliance, Jewel, Grandeur class)<br>
+<strong>Itinerary:</strong> 7-14+ nights — Alaska, Europe, repositioning cruises</p>
+
+<p><strong>Best for:</strong> Widows and widowers seeking intimacy, quiet reflection, and people closer to their age.</p>
+
+<p><strong>Why This Works:</strong></p>
+<ul>
+<li>You're more likely to encounter peers — other solo travelers, retirees, people navigating similar seasons of life</li>
+<li>Fewer crowds mean less sensory overwhelm</li>
+<li>Longer voyages create space for meaningful connections to form naturally</li>
+<li>More time to process grief without rushing port to port</li>
+<li>Quiet corners and gentle rhythms</li>
+</ul>
+
+<p><strong>Consider this option if:</strong> You want gentle community, quieter spaces, deeper conversations, and the wisdom of those who understand long marriages.</p>
+
+<h3 id="larger-ships">Option B: Larger Ships + Shorter Itineraries</h3>
+
+<p><strong>Ship Size:</strong> 3,500-6,000+ passengers (Oasis, Quantum, Freedom, <a href="/ships.html#voyager-class">Voyager class</a>)<br>
+<strong>Itinerary:</strong> 3-5 nights — Bahamas, Caribbean, weekend getaways</p>
+
+<p><strong>Best for:</strong> Widows and widowers who need energy, want to be around happy younger people, and long to revisit days when life felt vibrant.</p>
+
+<p><strong>Why This Works:</strong></p>
+<ul>
+<li>Surrounded by families, children, laughter, and joyful energy</li>
+<li>More anonymity — you can cry in the <a href="/restaurants/solarium-bistro.html">Solarium</a> and no one will track your story</li>
+<li>More activities, stimulation, and distraction when sadness feels too heavy</li>
+<li>Short commitment if you're unsure whether you're ready</li>
+<li>Reminds you what joy looks like — without requiring you to perform it</li>
+</ul>
+
+<p><strong>Consider this option if:</strong> You feel suffocated by quiet, need life and laughter around you, want to remember what "normal" felt like before everything changed.</p>
+
+<h3 id="mid-size">Mid-Size Ships: The Middle Ground</h3>
+
+<p><strong>Ship Size:</strong> 2,500-3,500 passengers<br>
+<strong>Itinerary:</strong> 5-7 nights — varied</p>
+
+<p>These offer a balance: enough people to find your tribe, but not so many that you feel lost.</p>
+
+<h3 id="real-question">The Real Question</h3>
+
+<p>What does your grief need right now?</p>
+
+<p>Some widows need the wisdom of their peers who've walked this path.<br>
+Others need the hope of children playing — a reminder that life continues.</p>
+
+<p>Both are valid.<br>
+Both are healing.<br>
+Both honor the person you lost.</p>
+
+<p>You are not betraying Tom by choosing a mega-ship with waterslides.<br>
+You are not weak for choosing a small ship where you can cry in peace.</p>
+
+<p>Choose the ship that creates space for you to breathe — whether that breath is quiet or surrounded by joyful noise.</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="triggers">Triggers Will Hit—Have an Exit Plan</h2>
+
+<p>Triggers are not signs of weakness. They are signs of love. Your brain recognizes echoes of someone who mattered.</p>
+
+<p>Cruises are full of echoes.</p>
+
+<h3 id="triggers-feel-like">What Grief Triggers Feel Like</h3>
+
+<p>A song plays that you haven't heard since the funeral.<br>
+A couple holds hands and suddenly you can't breathe.<br>
+A dessert arrives they would have ordered.<br>
+Someone says, "Is your spouse joining you?"<br>
+A sunset turns your heart inside out.</p>
+
+<p>Triggers come fast. They come sideways. They come like waves.</p>
+
+<h3 id="planning-helps">Why Planning Helps</h3>
+
+<p>Because grief hijacks your body. An exit plan returns autonomy.</p>
+
+<h3 id="exit-strategies">Physical Exit Strategies</h3>
+
+<p>On Day 1, map your safe zones:</p>
+<ul>
+<li>Chapel</li>
+<li><a href="/restaurants/solarium-bistro.html">Solarium</a></li>
+<li>Library corner</li>
+<li>A quiet deck chair</li>
+<li>Your balcony</li>
+<li>A predictable path back to your cabin</li>
+</ul>
+
+<p>Sit on aisles during shows. Tell the dining team you might step out quickly.</p>
+
+<h3 id="emotional-tools">Emotional Exit Tools</h3>
+
+<ul>
+<li>5-4-3-2-1 grounding</li>
+<li>A trusted friend on standby</li>
+<li>Journaling without judgment</li>
+<li>Crying anywhere you need</li>
+<li>Scripture or prayer if that's your anchor</li>
+</ul>
+
+<h3 id="social-scripts">Social Survival Scripts</h3>
+
+<p>You owe no one your story.</p>
+<ul>
+<li>"Traveling solo this time."</li>
+<li>"They passed away."</li>
+<li>"I'd rather not talk about it."</li>
+<li>Shift the subject without guilt.</li>
+</ul>
+
+<h3 id="what-helped-margaret">What Helped Margaret</h3>
+
+<p>She identified high-risk moments on her daily schedule. She read Tom's favorite book on the balcony. She touched his ring in the cabin safe each morning. She cried in Curaçao because the water was beautiful and he would have loved it.</p>
+
+<p>Triggers aren't failure. Triggers are love that still has weight.</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="anonymous-community">Anonymous Community Is Real Community</h2>
+
+<p>On land, people ask, "How are you?" And you freeze—because the honest answer is too heavy for the moment.</p>
+
+<p>On a ship, strangers don't know your history. And strangely, that makes them safer.</p>
+
+<h3 id="why-anonymous">Why Anonymous Community Heals</h3>
+
+<p>You can choose how much to share. You can choose whether to speak at all. You can be known lightly—not defined by your loss.</p>
+
+<p>Small, gentle connections form:</p>
+<ul>
+<li>A couple at dinner who simply makes space at the table</li>
+<li>A man who waves every morning from across the deck</li>
+<li>Crew who remember your coffee</li>
+<li>A stranger who senses your struggle</li>
+</ul>
+
+<h3 id="tissue-woman">The Tissue Woman</h3>
+
+<p>Margaret told me about a moment in the Solarium:</p>
+
+<p>She sat with sunglasses on, staring at the water, silently falling apart. A woman—never introduced, never named—walked by, paused, reached into her bag, and handed Margaret a small packet of tissues.</p>
+
+<p>They didn't speak. It was not dramatic. It was simply human.</p>
+
+<p>Sometimes the smallest kindnesses preach the clearest gospel.</p>
+
+<h3 id="light-touch">Light-Touch Connections</h3>
+
+<p>These tiny interactions are often the most healing:</p>
+<ul>
+<li>A wave across the deck</li>
+<li>A shared smile at breakfast</li>
+<li>Someone giving you space without questions</li>
+</ul>
+
+<p>Bereaved people are exhausted by explaining. On a ship, you're not required to.</p>
+
+<h3 id="dining-choices">Dining Choices with Compassion</h3>
+
+<p><strong>Solo table:</strong> Quiet, controlled, safe. But sometimes lonely.</p>
+
+<p><strong>Shared table:</strong> Conversation, connection, a lift. But sometimes emotionally costly.</p>
+
+<p>Both are valid. Choose based on the day, not an identity.</p>
+
+<p>Margaret told me about the retired pastor who waved from Deck 8 every morning—a small, silent liturgy of presence. It didn't fix grief, but it steadied her.</p>
+
+<p>Community doesn't need to be deep to matter. Sometimes the quiet stranger is exactly the church you need.</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="grief-and-joy">Grief and Joy Can Coexist</h2>
+
+<p>Culture wants grief to be linear. God allows grief to be human.</p>
+
+<p>You can be shattered and still capable of laughter.<br>
+You can ache and still feel beauty.<br>
+You can love someone who is gone and still taste joy without betraying them.</p>
+
+<h3 id="dual-process">The Dual-Process Model (In Plain Words)</h3>
+
+<p>Healthy grief moves between:</p>
+<ul>
+<li><strong>Loss mode:</strong> remembering, crying, aching</li>
+<li><strong>Life mode:</strong> eating, resting, trying new things, functioning</li>
+</ul>
+
+<p>You will oscillate—sometimes hourly. That is normal.</p>
+
+<h3 id="what-this-looks-like">What This Looks Like at Sea</h3>
+
+<p>You might:</p>
+<ul>
+<li>Cry at formal dinner, then enjoy dessert</li>
+<li>Skip a port, then find peace in a book</li>
+<li>Watch couples dance and feel both pain and gratitude</li>
+<li>Sit alone at breakfast and feel both lonely and free</li>
+</ul>
+
+<p>Joy is not disloyalty. Sorrow is not failure. Both can inhabit the same heart.</p>
+
+<p>Margaret laughed at a penguin towel animal and cried five minutes later. Both moments were true.</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="final-cruises">Final Cruises: When the Journey Is About Legacy, Not Loss</h2>
+
+<p>Not all grief travel happens after someone is gone. Sometimes the hardest cruise is the one you take together—knowing it will be the last.</p>
+
+<p>Anticipatory grief is its own weight. You're mourning someone who is still here, trying to make memories while watching them fade, holding joy and devastation in the same breath.</p>
+
+<p>If you're planning a final cruise with a terminally ill spouse, parent, or grandparent—or if you're the one who is dying and want to give your family one last gift—this section is for you.</p>
+
+<h3 id="permission-final-journey">Permission for the Final Journey</h3>
+
+<p><strong>You are allowed to do this.</strong></p>
+
+<p>Some people will say it's too risky. Too expensive. Too hard. But creating sacred memories in the time you have left is not reckless—it's holy.</p>
+
+<p>A cruise can offer:</p>
+<ul>
+<li>Medical staff on board (though not hospice-level care)</li>
+<li><a href="/accessibility.html">Accessibility</a> accommodations (wheelchairs, oxygen, special diets)</li>
+<li>A contained environment where family can be together without the distractions of home</li>
+<li>Beauty that serves as backdrop for blessing</li>
+<li>A liminal space—neither here nor there—where hard conversations become possible</li>
+</ul>
+
+<h3 id="making-it-work">Practical Considerations</h3>
+
+<p><strong>Medical clearance:</strong> Get a doctor's letter. Be honest with the cruise line about conditions—they need to know if this is realistic. Some conditions disqualify cruising; others don't. Ask.</p>
+
+<p><strong>Travel insurance:</strong> Standard policies won't cover pre-existing terminal conditions. Look for "cancel for any reason" (CFAR) coverage. Read the fine print. Accept that some risk is unavoidable.</p>
+
+<p><strong>Ship choice:</strong> Smaller ships mean shorter walks to dining and activities. Mid-size ships (Radiance, Brilliance class) often have better medical facilities than you'd expect. Stay close to elevators. Book accessible cabins even if you don't "need" them yet—you might by day 3.</p>
+
+<p><strong>Pacing:</strong> Skip the packed shore excursions. Sit on the balcony. Let the ship do the moving. The goal is presence, not productivity.</p>
+
+<h3 id="what-these-cruises-become">What These Cruises Become</h3>
+
+<p>Families who take final cruises often report:</p>
+<ul>
+<li>Conversations that wouldn't have happened at home</li>
+<li>Laughter they didn't expect</li>
+<li>Photos that become treasures</li>
+<li>A sense that they gave their loved one something beautiful at the end</li>
+<li>Peace that they tried—even if the trip was hard</li>
+</ul>
+
+<p>One grandfather watched his grandchildren climb the rock wall on Radiance while he sat in a wheelchair on the pool deck. He couldn't climb. But he could watch them climb. And that was enough.</p>
+
+<p>One grandmother gave her granddaughters matching bracelets at dinner on the last formal night—a blessing she'd written out by hand, a legacy passed down before she was gone.</p>
+
+<p>These moments don't erase the grief that's coming. But they become anchors when the grief arrives.</p>
+
+<h3 id="after-theyre-gone">After They're Gone</h3>
+
+<p>If you've already lost someone after a final cruise, the ship may hold complicated memories. You might want to return to the same ship—or never sail again. Both are valid.</p>
+
+<p>But know this: you gave them a gift. You chose presence over paralysis. You made beauty in the shadow of death.</p>
+
+<p>That is not denial. That is love.</p>
+
+<p><strong>Read more stories:</strong></p>
+<ul>
+<li><a href="/ships/rcl/radiance-of-the-seas.html">Grandpa's Last Alaska</a> (<a href="/ships/rcl/radiance-of-the-seas.html">Radiance of the Seas</a>) — a family's final journey before saying goodbye</li>
+<li><a href="/ships/rcl/jewel-of-the-seas.html">The Grandmother's Last Gift</a> (<a href="/ships/rcl/jewel-of-the-seas.html">Jewel of the Seas</a>) — legacy and blessing at sea</li>
+</ul>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="healthy-vs-avoidance">Healthy Grief Travel vs. Avoidance</h2>
+
+<p>Travel is powerful. It can create room to feel—or room to flee.</p>
+
+<h3 id="healthy-grief-travel">Healthy Grief Travel</h3>
+
+<p>Looks like:</p>
+<ul>
+<li>Seeking space to breathe</li>
+<li>Allowing beauty to touch trauma</li>
+<li>Being open to God's presence</li>
+<li>Facing emotions instead of drowning them</li>
+<li>Returning with insight</li>
+</ul>
+
+<p>Ask:</p>
+<ul>
+<li>Am I running from pain or making space for it?</li>
+<li>Do I have a support system?</li>
+<li>Am I okay being alone with my thoughts for a moment?</li>
+</ul>
+
+<h3 id="avoidance">Avoidance</h3>
+
+<p>Watch for:</p>
+<ul>
+<li>Booking too soon</li>
+<li>Endless travel</li>
+<li>Emotional numbness</li>
+<li>Reckless spending</li>
+<li>Drinking to silence grief</li>
+<li>No support at home</li>
+</ul>
+
+<p>Avoidance delays grief. It does not dilute it.</p>
+
+<h3 id="integration">Integration Afterward</h3>
+
+<p>Healthy re-entry:</p>
+<ul>
+<li>Journal</li>
+<li>Talk to someone safe</li>
+<li>Continue counseling</li>
+<li>Bring home a new practice that helped you breathe</li>
+</ul>
+
+<p>Margaret returned home still grieving. But she had proof she could exist in beauty without Tom beside her.</p>
+
+<p>That is not healing. That is progress.</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="practical-tools">Practical Tools for the Journey</h2>
+
+<p><strong>Pack comfort:</strong> Photo, ring, familiar scent, soft clothing, tea, Bible or devotional book, journal.</p>
+
+<p><strong>Find support:</strong> Chapel, Solarium, library, quiet decks.</p>
+
+<p><strong>Bring connection:</strong> Therapist, pastor, trusted friend.</p>
+
+<p><strong>Afterward:</strong> Write. Rest. Reconnect. Reflect.</p>
+
+<p>For more practical solo travel tips, see our <a href="/solo/why-i-started-solo-cruising.html">Solo Cruising Guide</a>.</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="faq">Common Questions About Cruising After Loss</h2>
+
+<h3 id="faq-1">1. When is it too soon to cruise after losing my spouse?</h3>
+
+<p>There is no universal timeline. Grief operates on seasons, not schedules.</p>
+
+<p><strong>It may be too soon if:</strong></p>
+<ul>
+<li>You're in deep shock (typically the first 3-6 months for most people)</li>
+<li>You can't imagine beauty without only pain</li>
+<li>You're booking to escape responsibilities or silence grief entirely</li>
+<li>Money is extremely tight and the trip would cause financial stress</li>
+</ul>
+
+<p><strong>You might be ready if:</strong></p>
+<ul>
+<li>You can tolerate the idea of joy coexisting with grief</li>
+<li>Fear and hope can live together in your chest</li>
+<li>You're booking FOR yourself—not FROM external pressure</li>
+<li>You can imagine sitting on a balcony and simply breathing</li>
+<li>You're okay with the possibility that you might cry most days—and go anyway</li>
+</ul>
+
+<p><strong>Remember:</strong> Margaret booked her Christmas cruise 10 months after Tom died. Some widows wait two years. Others go at six months. Your timeline is between you and God—not you and other people's expectations.</p>
+
+<p>If you're unsure, book a refundable fare on a short sailing. Give yourself permission to cancel if it doesn't feel right.</p>
+
+<h3 id="faq-2">2. How do I handle dining alone as a widow or widower?</h3>
+
+<p>You have options. Choose based on the day, not an identity.</p>
+
+<p><strong>Solo Table:</strong></p>
+<ul>
+<li>Quiet, controlled, safe</li>
+<li>You set the pace</li>
+<li>No pressure to engage</li>
+<li>But: Sometimes lonely, especially on formal nights</li>
+</ul>
+
+<p><strong>Shared Table (with other guests):</strong></p>
+<ul>
+<li>Conversation, connection, a temporary lift</li>
+<li>You might meet other solo travelers or kind couples</li>
+<li>Light-touch community</li>
+<li>But: Emotionally costly some days, requires energy</li>
+</ul>
+
+<p><strong>Tips:</strong></p>
+<ul>
+<li>You can switch between solo and shared during the cruise—ask the maître d'</li>
+<li>Sit near the aisle at shared tables so you can step away if needed</li>
+<li>If someone asks about your spouse, you owe no one your story</li>
+<li>Some nights you'll want company. Other nights you'll need silence. Both are allowed.</li>
+</ul>
+
+<h3 id="faq-3">3. What if I have an emotional breakdown on the ship?</h3>
+
+<p>You will probably cry. That is not a breakdown—that is grief being honest.</p>
+
+<p><strong>Have an exit plan.</strong> On Day 1, map your safe zones: chapel, Solarium, library corner, quiet deck, balcony, cabin.</p>
+
+<p><strong>If you feel a wave coming:</strong></p>
+<ul>
+<li>Sit on aisles during shows so you can leave quickly</li>
+<li>Wear sunglasses (even indoors if needed—no one will judge)</li>
+<li>Walk to a safe zone</li>
+<li>Breathe: 5-4-3-2-1 grounding (5 things you see, 4 you hear, 3 you touch, 2 you smell, 1 you taste)</li>
+</ul>
+
+<p><strong>Know this:</strong> Crew see grieving passengers regularly—they are trained to offer quiet help. You are not "ruining" anyone's vacation by crying. Triggers aren't failure. Triggers are love that still has weight.</p>
+
+<h3 id="faq-4">4. Is it okay to feel joy while I'm still grieving?</h3>
+
+<p>Yes. Absolutely yes.</p>
+
+<p>Joy doesn't erase love.<br>
+Laughter doesn't dishonor memory.<br>
+Life doesn't invalidate grief.</p>
+
+<p><strong>The lie grief whispers:</strong> "If I smile, I'm letting them go." "If I enjoy this, I'm betraying them."</p>
+
+<p><strong>The truth:</strong> You can be shattered and still capable of laughter. You can ache for them and still taste beauty. You can carry their memory into joy—and honor them by living.</p>
+
+<p><strong>What Scripture says:</strong> Ecclesiastes 3 gives us seasons—not deadlines. A time to weep AND a time to laugh. A time to mourn AND a time to dance. Both. Not one or the other. Both.</p>
+
+<p>You are not betraying them by living. You are honoring them by carrying their memory into beauty.</p>
+
+<h3 id="faq-5">5. Should I tell other passengers I'm widowed?</h3>
+
+<p>You owe no one your story. Share only what feels safe.</p>
+
+<p><strong>If someone asks, "Is your spouse joining you?"</strong></p>
+
+<p>You can say:</p>
+<ul>
+<li>"Traveling solo this time." (Deflects without explaining)</li>
+<li>"They passed away." (Honest and clear—often stops follow-up questions)</li>
+<li>"I'd rather not talk about it." (Boundaries are allowed)</li>
+</ul>
+
+<p>Then shift the subject: "Have you been to this port before?" or "What show are you seeing tonight?"</p>
+
+<p><strong>If you want to share:</strong> Some widows find relief in naming their loss to safe people. Anonymous community is powerful: strangers don't know your history, so you can choose how much to reveal.</p>
+
+<p>You don't have to wear your grief as your identity. On land, people know your story. At sea, you can just be another passenger enjoying the sunset.</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="read-more-stories">Read More Widow and Widower Stories</h2>
+
+<p>You are not alone. Read stories from other widows and widowers who found peace at sea:</p>
+
+<ul>
+<li><a href="/ships/rcl/radiance-of-the-seas.html">The Widow Who Learned to Laugh Again</a> (<a href="/ships/rcl/radiance-of-the-seas.html">Radiance of the Seas</a>)</li>
+<li><a href="/ships/rcl/independence-of-the-seas.html">The FlowRider Widow</a> (<a href="/ships/rcl/independence-of-the-seas.html">Independence of the Seas</a>)</li>
+<li><a href="/ships/rcl/brilliance-of-the-seas.html">First Voyage After Loss</a> (<a href="/ships/rcl/brilliance-of-the-seas.html">Brilliance of the Seas</a>)</li>
+<li><a href="/ships/rcl/jewel-of-the-seas.html">The Widower's First Christmas Without Her</a> (<a href="/ships/rcl/jewel-of-the-seas.html">Jewel of the Seas</a>)</li>
+<li><a href="/ships/rcl/radiance-of-the-seas.html">Grandpa's Last Alaska</a> (Radiance of the Seas) — for families making final journeys</li>
+</ul>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="final-word">Final Pastoral Word</h2>
+
+<p>You don't heal from loss by cruising.</p>
+
+<p>The ocean won't give you your loved one back. The ship won't erase grief.</p>
+
+<p>But water has always been where God meets hurting people—and where He has met me when I was hurting.</p>
+
+<p>Jonah cried from the deep. The disciples met Jesus in the storm. Peter met the risen Christ beside a charcoal fire, waves in His ears.</p>
+
+<p>And for me, the sea has been where I began to make peace with the loss of my foster daughters of ten years; they live, but they live out of reach.</p>
+
+<p>Maybe you'll step onto a ship and mostly cry. I did. That's okay.</p>
+
+<p>It's also okay if you don't cry at all. We all grieve differently—quiet or loud, tearful or dry-eyed, all at once or in slow motion.</p>
+
+<p>You are not betraying their memory by living. You are honoring them by carrying their memory into beauty.</p>
+
+<p>The ocean is waiting. And the God who made the waters—and who holds your tears in His hands—will meet you there.</p>
+
+<p>— Ken Baker, In the Wake</p>
+
+<hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+<h2 id="continue-journey">Continue Your Journey</h2>
+
+<ul>
+<li>Explore <a href="/solo/">other solo travel articles</a> for practical guidance</li>
+<li>Read <a href="/ships/">ship logbooks</a> to find your next cruise</li>
+<li>Learn about <a href="/solo/accessible-cruising.html">accessible cruising options</a> if mobility is a concern</li>
+</ul>
+
+</article>

--- a/solo/articles/solo-cruisers-companion.html
+++ b/solo/articles/solo-cruisers-companion.html
@@ -1,0 +1,269 @@
+<article id="solo-cruisers-companion" data-slug="solo-cruisers-companion" class="solo-article" itemscope itemtype="https://schema.org/Article">
+  <header>
+    <h1 itemprop="headline">The Solo Cruiser's Companion</h1>
+    <p class="dek" itemprop="description">A Practical Guide for Traveling Alone at Sea</p>
+    <p class="byline">by Ken Baker</p>
+  </header>
+
+  <p>Tina Maulsby's story of <a href="/solo/why-i-started-solo-cruising.html" class="xref">discovering solo cruising</a> resonates with thousands of travelers who've felt that same pull — the desire to go, even when no one else can join. Her piece captures the <em>why</em> beautifully. This companion piece focuses on the <em>how</em>: the practical decisions, strategies, and tools that turn a nervous first-timer into a confident solo cruiser.</p>
+
+  <p>This isn't about convincing you to cruise alone. If you're reading this, you've probably already decided — or you're close. This is about making that first trip successful enough that you'll want to do it again.</p>
+
+  <h2 id="who-this-guide-is-for">Who This Guide Is For</h2>
+
+  <p>This guide is written for:</p>
+
+  <ul>
+    <li><strong>First-time solo cruisers</strong> who want to know what to expect</li>
+    <li><strong>Introverts</strong> who need solitude but also want to avoid awkwardness</li>
+    <li><strong>Anxious travelers</strong> who need strategies, not just reassurance</li>
+    <li><strong>Returning cruisers</strong> whose travel partner is no longer available</li>
+    <li><strong>Anyone considering it</strong> who wants honest, practical information</li>
+  </ul>
+
+  <p>If you're grieving the loss of a travel companion — whether through death, divorce, or simply life changes — you may also find comfort in <a href="/solo/in-the-wake-of-grief.html" class="xref">In the Wake of Grief</a>, which addresses the particular challenges of cruising after loss.</p>
+
+  <h2 id="three-myths">Three Myths That Keep People Home</h2>
+
+  <h3>Myth 1: "I'll be the only one alone"</h3>
+  <p>You won't be. Solo cruisers are everywhere — they're just not always visible because they're not sitting in pairs looking nervous. The solo traveler reading on their balcony, the one at the sushi bar, the person who slips into the back row of the comedy show — they're all around you. On any given Royal Caribbean sailing, solo travelers make up 5-15% of passengers.</p>
+
+  <h3>Myth 2: "It's too expensive"</h3>
+  <p>The single supplement is real, and it stings. Most cruise lines charge 150-200% of the per-person double occupancy rate for solo travelers. But consider what you're actually paying for: complete control of your space, your schedule, your experience. Some find it worth every penny. Others hunt for waived supplements during sales, or try Norwegian's Studio cabins designed specifically for solo travelers.</p>
+
+  <h3>Myth 3: "I'll be lonely"</h3>
+  <p>Loneliness and solitude are different things. You'll likely experience solitude — quiet mornings on your balcony, peaceful meals with a book. That's often the point. Loneliness only happens if you want connection but can't find it. On a cruise ship, connection is always available: the solo meetup, trivia teams that need one more, the bartender who remembers your drink. The question isn't whether you'll find people — it's whether you'll want to.</p>
+
+  <h2 id="choosing-your-ship">Choosing Your Ship: The Solo Matrix</h2>
+
+  <p>Not all ships suit all personalities. Here's how to think about ship selection as a solo traveler:</p>
+
+  <table class="ship-matrix">
+    <thead>
+      <tr>
+        <th>Ship Class</th>
+        <th>Size Feel</th>
+        <th>Best For</th>
+        <th>Consider If...</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="/ships.html#oasis-class" class="xref">Oasis Class</a></td>
+        <td>City</td>
+        <td>Anonymity seekers</td>
+        <td>You want to disappear into crowds when needed</td>
+      </tr>
+      <tr>
+        <td><a href="/ships.html#freedom-class" class="xref">Freedom Class</a></td>
+        <td>Large town</td>
+        <td>Activity lovers</td>
+        <td>You want lots to do but still manageable navigation</td>
+      </tr>
+      <tr>
+        <td><a href="/ships.html#radiance-class" class="xref">Radiance Class</a></td>
+        <td>Village</td>
+        <td>Introverts</td>
+        <td>You prefer quiet spaces and less stimulation</td>
+      </tr>
+      <tr>
+        <td><a href="/ships.html#vision-class" class="xref">Vision Class</a></td>
+        <td>Small village</td>
+        <td>Classic cruisers</td>
+        <td>You want genuine crew connections</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout">
+    <div class="callout-title">Introvert's Pick</div>
+    <p>The <a href="/ships.html#radiance-class" class="xref">Radiance class</a> ships — <a href="/ships/rcl/radiance-of-the-seas.html" class="xref">Radiance</a>, <a href="/ships/rcl/brilliance-of-the-seas.html" class="xref">Brilliance</a>, <a href="/ships/rcl/serenade-of-the-seas.html" class="xref">Serenade</a>, and <a href="/ships/rcl/jewel-of-the-seas.html" class="xref">Jewel of the Seas</a> — are particularly well-suited for solo introverts. At around 90,000 GT with 2,500 passengers, they're large enough to offer variety but small enough to feel manageable. The glass-walled lounges and expansive decks provide plenty of quiet corners.</p>
+  </div>
+
+  <h2 id="the-dining-question">The Dining Question</h2>
+
+  <p>Dining causes the most anxiety for first-time solo cruisers. Here's how to handle it:</p>
+
+  <h3>Traditional Dining</h3>
+  <p>You'll be seated with others — could be wonderful, could be awkward. If you enjoy meeting people, this is efficient: same tablemates every night means you skip small talk by night three. If you dread it, you have options.</p>
+
+  <h3>My Time Dining</h3>
+  <p>Request a table for one, or two if you want space to spread out. The hostess won't judge you — they see solo diners constantly. Some nights you'll want company; ask to join a larger table.</p>
+
+  <h3>Specialty Restaurants</h3>
+  <p>Many have bar seating perfect for solos. At <a href="/restaurants/izumi.html" class="xref">Izumi</a>, the sushi bar is often better than a table anyway — you can watch the chef work and chat if you feel like it. <a href="/restaurants/chops.html" class="xref">Chops Grille</a> sometimes has bar-style seating as well.</p>
+
+  <h3>Windjammer Buffet</h3>
+  <p>Your pressure-free option. Grab food, find a table by the window, eat while reading or people-watching. No one thinks twice about someone eating alone at a buffet. The <a href="/restaurants/windjammer.html" class="xref">Windjammer</a> is also perfect for those nights when you just want to eat quickly and get back to whatever you were doing.</p>
+
+  <div class="callout">
+    <div class="callout-title">Pro Tip</div>
+    <p>Lunch in specialty restaurants is often less expensive and less formal than dinner. Solo dining at midday feels completely natural — it's just lunch.</p>
+  </div>
+
+  <h2 id="activities">Activities: Alone Together</h2>
+
+  <p>The best solo activities share a quality: they're social but not requiring. You're with others, but participation is optional.</p>
+
+  <h3>Naturally Solo-Friendly</h3>
+  <ul>
+    <li><strong>Trivia</strong> — Teams often need one more person. Just ask to join.</li>
+    <li><strong>Fitness classes</strong> — Everyone's focused on themselves anyway.</li>
+    <li><strong>Lectures and shows</strong> — Theater seating is inherently individual.</li>
+    <li><strong>The <a href="/restaurants/solarium-bistro.html">Solarium</a></strong> — Adults-only, quiet by design. Bring a book.</li>
+    <li><strong>Art auctions</strong> — Browse, sip champagne, leave whenever you want.</li>
+  </ul>
+
+  <h3>Where to Find Your People</h3>
+  <ul>
+    <li><strong>Solo meetup</strong> — Usually on Day 1, check the Cruise Compass. Attendance varies but it's a good way to find faces you'll recognize later.</li>
+    <li><strong>Bar seating at dinner</strong> — The people who choose the bar are often solo travelers or couples who like conversation.</li>
+    <li><strong>Outdoor movies</strong> — Grab a lounger, share the popcorn station. Easy come, easy go.</li>
+  </ul>
+
+  <h2 id="introvert-survival">The Introvert's Survival Kit</h2>
+
+  <p>If you're introverted, solo cruising can be either perfect or exhausting, depending on how you manage your energy. Here's what works:</p>
+
+  <h3>Your Room Is Your Refuge</h3>
+  <p>Splurge on a balcony if you can afford it. That outdoor space becomes your decompression chamber — morning coffee, afternoon reading, evening sailaway. It's where you recharge.</p>
+
+  <h3>Find Your Quiet Corners</h3>
+  <p>Every ship has them. The library (often empty), the top deck forward (windy but peaceful), the <a href="/restaurants/solarium-bistro.html">Solarium</a> in the morning. Walk the ship on Day 1 and identify three spots where you can retreat. On <a href="/ships.html#radiance-class" class="xref">Radiance class</a> ships, try the Viking Crown Lounge during off-hours.</p>
+
+  <h3>Book the Early Excursions</h3>
+  <p>The early departure tours have fewer people. You'll often get a smaller group, and you'll be back on the ship before the crowds return. Bonus: the ship is quiet in the afternoon while everyone else is still in port.</p>
+
+  <h3>Use Room Service</h3>
+  <p>It's included for breakfast on most Royal Caribbean ships. Sometimes you just don't want to see people before 10 AM, and that's fine.</p>
+
+  <h2 id="anxiety-at-sea">Anxiety at Sea: What Actually Helps</h2>
+
+  <p>If you deal with anxiety, here are strategies that actually work on a cruise:</p>
+
+  <h3>Pre-Book Everything</h3>
+  <p>Uncertainty feeds anxiety. Book your specialty dining, your shows, your excursions before you board. The Cruise Planner app lets you schedule almost everything. Walking into dinner knowing exactly where you'll sit removes a surprising amount of stress.</p>
+
+  <h3>Learn the Ship Layout</h3>
+  <p>Disorientation increases anxiety. On embarkation day, walk every public deck. Note the stairwells (faster than elevators), the nearest restrooms, the quiet corners. On big ships like <a href="/ships.html#oasis-class" class="xref">Oasis class</a>, this might take an hour. It's worth it.</p>
+
+  <h3>Establish Routines</h3>
+  <p>Your anxiety will quiet once you have patterns. Morning coffee in the same spot. The same route to dinner. The same server who knows your order. Cruise ships are excellent for routine because everything is available every day.</p>
+
+  <h3>Know Your Outs</h3>
+  <p>In any social situation, know how you'll leave. Trivia: your phone buzzes, you have to go. Dinner conversation: you're meeting someone for the show. Just having an exit plan makes it easier to stay.</p>
+
+  <h3>The Guest Services Safety Net</h3>
+  <p>If you're struggling, Guest Services can help in ways you might not expect. They can move your dining time, change your table assignment, even find you a quieter cabin if the noise is a problem. You're not bothering them — it's literally their job.</p>
+
+  <h2 id="practical-stuff">The Practical Stuff</h2>
+
+  <h3>Stateroom Selection</h3>
+  <p>As a solo traveler, your room matters more because you'll spend more time there. Consider:</p>
+  <ul>
+    <li><strong>Balcony vs. Inside</strong> — Balconies provide private outdoor space. Inside cabins are cheaper but can feel claustrophobic on a 7-day cruise.</li>
+    <li><strong>Location</strong> — Mid-ship, mid-deck for less motion. Avoid cabins near elevators, nightclubs, or above the theater.</li>
+    <li><strong>Use our <a href="/stateroom-check.html" class="xref">Stateroom Check</a> tool</strong> to verify your cabin location.</li>
+  </ul>
+
+  <h3>Packing for Solo</h3>
+  <p>When no one can watch your stuff, you pack differently:</p>
+  <ul>
+    <li><strong>Anti-theft bag</strong> for port days (slash-proof, lockable zippers)</li>
+    <li><strong>Portable safe</strong> for beach excursions (locks to chair)</li>
+    <li><strong>Door stop alarm</strong> if it makes you sleep better</li>
+    <li>See our <a href="/packing-lists.html" class="xref">Packing Lists</a> for complete recommendations</li>
+  </ul>
+
+  <h3>The Single Supplement</h3>
+  <p>Ways to reduce the sting:</p>
+  <ul>
+    <li>Book during "single supplement waived" promotions</li>
+    <li>Try Norwegian's Studio cabins (built for solo travelers)</li>
+    <li>Consider repositioning cruises (lower base fares)</li>
+    <li>Look at guarantees (cheapest category, cabin assigned at sailing)</li>
+  </ul>
+
+  <h3>Safety Considerations</h3>
+  <p>Cruise ships are extremely safe, but solo travelers should still:</p>
+  <ul>
+    <li>Keep your Sea Pass secure — it's your ID, room key, and payment card</li>
+    <li>Tell someone your plans if doing independent port exploration</li>
+    <li>Trust your instincts in port the same as you would at home</li>
+    <li>Don't overindulge — you're responsible for getting yourself back to the ship</li>
+  </ul>
+
+  <h2 id="stories">Stories from the Logbooks</h2>
+
+  <p>Our cruise logbooks are full of solo travel moments. Here are a few that capture the reality:</p>
+
+  <blockquote>
+    <p>"Day 3 and I finally stopped looking for my husband at every turn. Sat in the Solarium with a book and realized this was the first time in 40 years I'd chosen a vacation spot entirely for myself. Terrifying. Also liberating."</p>
+    <footer>— <a href="/ships/rcl/grandeur-of-the-seas.html" class="xref">Grandeur of the Seas</a>, Bahamas</footer>
+  </blockquote>
+
+  <blockquote>
+    <p>"Joined a trivia team on Day 1. Lost badly. Same team for five more days. Won once. Made four friends I still email. Solo cruising is just cruising with friends you haven't met yet."</p>
+    <footer>— <a href="/ships/rcl/freedom-of-the-seas.html" class="xref">Freedom of the Seas</a>, Caribbean</footer>
+  </blockquote>
+
+  <blockquote>
+    <p>"Introvert here. Worried constantly about dinners. Ended up eating at the sushi bar every night. Chef knew my order by Day 2. Best dining experience I've had on any cruise."</p>
+    <footer>— <a href="/ships/rcl/anthem-of-the-seas.html" class="xref">Anthem of the Seas</a>, Bermuda</footer>
+  </blockquote>
+
+  <p>If you've cruised solo and want to share your experience, consider contributing to our logbooks.</p>
+
+  <h2 id="faq">Frequently Asked Questions</h2>
+
+  <div class="faq-item">
+    <p class="faq-q">Do I have to pay a single supplement?</p>
+    <p class="faq-a">Usually yes — most cruise lines charge 150-200% of the per-person double occupancy rate. Norwegian's Studio cabins are the main exception, designed for solo travelers without the supplement. Some lines occasionally waive it during sales.</p>
+  </div>
+
+  <div class="faq-item">
+    <p class="faq-q">Will I be seated alone at dinner?</p>
+    <p class="faq-a">Only if you want to be. Traditional dining typically seats you with others, which can be wonderful or awkward. My Time Dining lets you request table size. Specialty restaurants often have bar seating perfect for solos. The <a href="/restaurants/windjammer.html" class="xref">Windjammer</a> buffet offers complete control.</p>
+  </div>
+
+  <div class="faq-item">
+    <p class="faq-q">Is solo cruising safe?</p>
+    <p class="faq-a">Cruise ships are among the safest travel environments. Security cameras are everywhere, crew members are trained to assist, and your room has a safe for valuables. The main concerns are the same as any travel: keep your Sea Pass secure, don't overindulge, and trust your instincts in port.</p>
+  </div>
+
+  <div class="faq-item">
+    <p class="faq-q">What if I get lonely?</p>
+    <p class="faq-a">Loneliness is different from solitude. If you need connection, join the solo meetup, attend trivia, or sit at the bar during dinner. If you need solitude, enjoy it guilt-free — that's what you came for. The Solarium is perfect for quiet reflection.</p>
+  </div>
+
+  <div class="faq-item">
+    <p class="faq-q">Which ship class is best for solo cruising?</p>
+    <p class="faq-a">It depends on your personality. <a href="/ships.html#radiance-class" class="xref">Radiance class</a> ships are intimate and quiet — perfect for introverts. <a href="/ships.html#oasis-class" class="xref">Oasis class</a> ships offer anonymity in crowds and endless options. <a href="/ships.html#freedom-class" class="xref">Freedom class</a> ships balance activity with manageable size. <a href="/ships.html#vision-class" class="xref">Vision class</a> ships provide classic cruising with genuine crew connections.</p>
+  </div>
+
+  <h2 id="permission-slip">The Permission Slip</h2>
+
+  <p>Tina wrote about <a href="/solo/why-i-started-solo-cruising.html" class="xref">giving yourself permission to go</a>. I want to extend that:</p>
+
+  <p><strong>You have permission to:</strong></p>
+  <ul>
+    <li>Eat dinner alone with a book and not feel weird about it</li>
+    <li>Skip the solo meetup if you don't feel like meeting people</li>
+    <li>Spend the whole sea day in your cabin if that's what you need</li>
+    <li>Order room service every night if restaurants feel overwhelming</li>
+    <li>Leave any conversation, any activity, any time</li>
+    <li>Be exactly as social or unsocial as you want to be</li>
+  </ul>
+
+  <p>Solo cruising works because you make the rules. Every other vacation involves compromise — with partners, with kids, with friends. This one doesn't have to. That's the whole point.</p>
+
+  <p>So pack your bags. Book the cabin. Walk up that gangway alone. You'll be following in the wake of thousands of solo cruisers who did it scared and came home changed.</p>
+
+  <p>See you on board.</p>
+
+  <footer class="byline" style="margin-top:2rem;padding-top:1rem;border-top:1px solid var(--foam)">
+    <p><strong>Ken Baker</strong><br/>
+    <em>In the Wake</em></p>
+    <p class="tiny">See also: <a href="/solo/why-i-started-solo-cruising.html">Tina's story</a> · <a href="/solo/in-the-wake-of-grief.html">Cruising after loss</a> · <a href="/accessibility.html">Accessible cruising</a></p>
+  </footer>
+</article>


### PR DESCRIPTION
Added solo-cruisers-companion and in-the-wake-of-grief to the solo.html RAW_ARTICLES array and noscript fallback. Created article fragments in /solo/articles/ for the dynamic loader.

These articles already existed but weren't accessible through the solo page's article loader system.