### PR TITLE
Add missing page-grid CSS to ships.html

### DIFF
--- a/ships.html
+++ b/ships.html
@@ -729,6 +729,31 @@
     .visually-hidden-focusable{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
     .visually-hidden-focusable:focus{position:fixed;left:12px;top:12px;width:auto;height:auto;padding:.45rem .7rem;background:#fff;border:2px solid var(--sea,#0e6e8e);border-radius:10px;z-index:9999}
 
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     /* Header / Hero */
     .hero-header {
       position: relative;


### PR DESCRIPTION
The main element had class="page-grid" but the CSS rules for the 2-column layout were missing, causing content to stack vertically instead of displaying in the proper right rail pattern.