### PR TITLE
Add missing page-grid CSS to 141 pages site-wide

### DIFF
--- a/admin/fix_page_grid_css.py
+++ b/admin/fix_page_grid_css.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Fix missing .page-grid CSS across all pages that use the class.
+
+This script finds HTML files that have class="page-grid" but are missing
+the CSS definition, and adds the required grid layout styles.
+"""
+
+import os
+import re
+from pathlib import Path
+
+# ANSI colors
+GREEN = '\033[92m'
+YELLOW = '\033[93m'
+CYAN = '\033[96m'
+RED = '\033[91m'
+BOLD = '\033[1m'
+RESET = '\033[0m'
+
+# CSS to inject
+PAGE_GRID_CSS = '''
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+'''
+
+def has_page_grid_class(content):
+    """Check if file uses page-grid class."""
+    return bool(re.search(r'class="[^"]*page-grid[^"]*"', content))
+
+def has_page_grid_css(content):
+    """Check if file has .page-grid CSS definition."""
+    return bool(re.search(r'\.page-grid\s*\{', content))
+
+def add_page_grid_css(content):
+    """Add page-grid CSS to the first <style> block."""
+    # Find the first <style> tag and insert after it
+    match = re.search(r'(<style[^>]*>)', content)
+    if match:
+        insert_pos = match.end()
+        return content[:insert_pos] + PAGE_GRID_CSS + content[insert_pos:]
+    return None
+
+def process_file(filepath):
+    """Process a single HTML file."""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        if not has_page_grid_class(content):
+            return 'skip', 'No page-grid class'
+
+        if has_page_grid_css(content):
+            return 'ok', 'Already has CSS'
+
+        new_content = add_page_grid_css(content)
+        if new_content is None:
+            return 'error', 'No <style> tag found'
+
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+
+        return 'fixed', 'Added page-grid CSS'
+    except Exception as e:
+        return 'error', str(e)
+
+def main():
+    root = Path('/home/user/InTheWake')
+
+    # Files to check
+    patterns = [
+        '*.html',
+        'ports/*.html',
+        'authors/*.html',
+        'restaurants/*.html',
+        'cruise-lines/*.html',
+        'tools/*.html',
+        'solo/*.html',
+    ]
+
+    files_to_check = []
+    for pattern in patterns:
+        files_to_check.extend(root.glob(pattern))
+
+    # Deduplicate and sort
+    files_to_check = sorted(set(files_to_check))
+
+    print(f"\n{BOLD}{'═' * 60}{RESET}")
+    print(f"{BOLD}🔧 Page Grid CSS Fixer{RESET}")
+    print(f"{BOLD}{'═' * 60}{RESET}\n")
+
+    stats = {'fixed': 0, 'ok': 0, 'skip': 0, 'error': 0}
+    fixed_files = []
+
+    for filepath in files_to_check:
+        status, message = process_file(filepath)
+        stats[status] += 1
+
+        rel_path = filepath.relative_to(root)
+
+        if status == 'fixed':
+            print(f"  {GREEN}✓{RESET} {rel_path} — {message}")
+            fixed_files.append(str(rel_path))
+        elif status == 'error':
+            print(f"  {RED}✗{RESET} {rel_path} — {message}")
+        # Skip 'ok' and 'skip' to reduce noise
+
+    print(f"\n{BOLD}{'─' * 60}{RESET}")
+    print(f"\n{BOLD}Summary:{RESET}")
+    print(f"  {GREEN}Fixed:{RESET}   {stats['fixed']} pages")
+    print(f"  {CYAN}Already OK:{RESET} {stats['ok']} pages")
+    print(f"  {YELLOW}Skipped:{RESET} {stats['skip']} pages (no page-grid class)")
+    if stats['error'] > 0:
+        print(f"  {RED}Errors:{RESET}  {stats['error']} pages")
+
+    print(f"\n{BOLD}{'═' * 60}{RESET}\n")
+
+    return fixed_files
+
+if __name__ == '__main__':
+    main()

--- a/authors/ken-baker.html
+++ b/authors/ken-baker.html
@@ -98,6 +98,31 @@
 
   <!-- Local styles for the author page -->
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .author-hero{display:flex; gap:1rem; align-items:center; padding:1rem}
     .author-hero .avatar{
       width:88px; height:88px; border-radius:999px; overflow:hidden; flex:none; background:#e9f3f7

--- a/ports.html
+++ b/ports.html
@@ -160,6 +160,31 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- Dropdown Navigation Styles -->
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   /* Header / Hero */
   .hero-header {
     position: relative;

--- a/ports/ajaccio.html
+++ b/ports/ajaccio.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/alesund.html
+++ b/ports/alesund.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/amalfi.html
+++ b/ports/amalfi.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/amsterdam.html
+++ b/ports/amsterdam.html
@@ -40,6 +40,31 @@ Soli Deo Gloria
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight {

--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/athens.html
+++ b/ports/athens.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/bar-harbor.html
+++ b/ports/bar-harbor.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/barcelona.html
+++ b/ports/barcelona.html
@@ -60,6 +60,31 @@ All work on this project is offered as a gift to God.
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/belfast.html
+++ b/ports/belfast.html
@@ -15,6 +15,31 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/belize.html
+++ b/ports/belize.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/bermuda.html
+++ b/ports/bermuda.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/bilbao.html
+++ b/ports/bilbao.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/bonaire.html
+++ b/ports/bonaire.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/bordeaux.html
+++ b/ports/bordeaux.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/boston.html
+++ b/ports/boston.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/cadiz.html
+++ b/ports/cadiz.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/cagliari.html
+++ b/ports/cagliari.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/cannes.html
+++ b/ports/cannes.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/cartagena-spain.html
+++ b/ports/cartagena-spain.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/cartagena.html
+++ b/ports/cartagena.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/casablanca.html
+++ b/ports/casablanca.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/charlottetown.html
+++ b/ports/charlottetown.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/cherbourg.html
+++ b/ports/cherbourg.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/civitavecchia.html
+++ b/ports/civitavecchia.html
@@ -60,6 +60,31 @@ All work on this project is offered as a gift to God.
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -120,6 +120,31 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/copenhagen.html
+++ b/ports/copenhagen.html
@@ -40,6 +40,31 @@ Soli Deo Gloria
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight {

--- a/ports/corfu.html
+++ b/ports/corfu.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/cork.html
+++ b/ports/cork.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/costa-maya.html
+++ b/ports/costa-maya.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/cozumel.html
+++ b/ports/cozumel.html
@@ -111,6 +111,31 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/curacao.html
+++ b/ports/curacao.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/dominica.html
+++ b/ports/dominica.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/dover.html
+++ b/ports/dover.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/dublin.html
+++ b/ports/dublin.html
@@ -15,6 +15,31 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/dubrovnik.html
+++ b/ports/dubrovnik.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/gdansk.html
+++ b/ports/gdansk.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/genoa.html
+++ b/ports/genoa.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/gibraltar.html
+++ b/ports/gibraltar.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/glacier-bay.html
+++ b/ports/glacier-bay.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/gothenburg.html
+++ b/ports/gothenburg.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/grand-cayman.html
+++ b/ports/grand-cayman.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/grand-turk.html
+++ b/ports/grand-turk.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/grenada.html
+++ b/ports/grenada.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/guadeloupe.html
+++ b/ports/guadeloupe.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/haines.html
+++ b/ports/haines.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/halifax.html
+++ b/ports/halifax.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/helsinki.html
+++ b/ports/helsinki.html
@@ -15,6 +15,31 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/heraklion.html
+++ b/ports/heraklion.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/hilo.html
+++ b/ports/hilo.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/holyhead.html
+++ b/ports/holyhead.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/honfleur.html
+++ b/ports/honfleur.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/honolulu.html
+++ b/ports/honolulu.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/ibiza.html
+++ b/ports/ibiza.html
@@ -40,6 +40,31 @@ Soli Deo Gloria
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight {

--- a/ports/icy-strait-point.html
+++ b/ports/icy-strait-point.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/invergordon.html
+++ b/ports/invergordon.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/jamaica.html
+++ b/ports/jamaica.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/juneau.html
+++ b/ports/juneau.html
@@ -111,6 +111,31 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/ketchikan.html
+++ b/ports/ketchikan.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/key-west.html
+++ b/ports/key-west.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/kiel.html
+++ b/ports/kiel.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/kirkwall.html
+++ b/ports/kirkwall.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/kona.html
+++ b/ports/kona.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/koper.html
+++ b/ports/koper.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/kotor.html
+++ b/ports/kotor.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/kusadasi.html
+++ b/ports/kusadasi.html
@@ -111,6 +111,31 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/la-coruna.html
+++ b/ports/la-coruna.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/labadee.html
+++ b/ports/labadee.html
@@ -111,6 +111,31 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/le-havre.html
+++ b/ports/le-havre.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/lerwick.html
+++ b/ports/lerwick.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/lisbon.html
+++ b/ports/lisbon.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/liverpool.html
+++ b/ports/liverpool.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/livorno.html
+++ b/ports/livorno.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/malaga.html
+++ b/ports/malaga.html
@@ -40,6 +40,31 @@ Soli Deo Gloria
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight {

--- a/ports/marseille.html
+++ b/ports/marseille.html
@@ -60,6 +60,31 @@ All work on this project is offered as a gift to God.
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/martinique.html
+++ b/ports/martinique.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/maui.html
+++ b/ports/maui.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/messina.html
+++ b/ports/messina.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/monte-carlo.html
+++ b/ports/monte-carlo.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/mykonos.html
+++ b/ports/mykonos.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/naples.html
+++ b/ports/naples.html
@@ -60,6 +60,31 @@ All work on this project is offered as a gift to God.
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/nawiliwili.html
+++ b/ports/nawiliwili.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/newcastle.html
+++ b/ports/newcastle.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/newport.html
+++ b/ports/newport.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/norwegian-fjords.html
+++ b/ports/norwegian-fjords.html
@@ -15,6 +15,31 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/oslo.html
+++ b/ports/oslo.html
@@ -15,6 +15,31 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/palma.html
+++ b/ports/palma.html
@@ -46,6 +46,31 @@ Soli Deo Gloria
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight {

--- a/ports/panama-canal.html
+++ b/ports/panama-canal.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/portland-maine.html
+++ b/ports/portland-maine.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/portland.html
+++ b/ports/portland.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/porto.html
+++ b/ports/porto.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/progreso.html
+++ b/ports/progreso.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/quebec-city.html
+++ b/ports/quebec-city.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/ravenna.html
+++ b/ports/ravenna.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/reykjavik.html
+++ b/ports/reykjavik.html
@@ -15,6 +15,31 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/rhodes.html
+++ b/ports/rhodes.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/riga.html
+++ b/ports/riga.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/roatan.html
+++ b/ports/roatan.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/saguenay.html
+++ b/ports/saguenay.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/saint-john.html
+++ b/ports/saint-john.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/samana.html
+++ b/ports/samana.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/san-juan.html
+++ b/ports/san-juan.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/santorini.html
+++ b/ports/santorini.html
@@ -111,6 +111,31 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/scotland.html
+++ b/ports/scotland.html
@@ -15,6 +15,31 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/seward.html
+++ b/ports/seward.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/sitka.html
+++ b/ports/sitka.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/skagway.html
+++ b/ports/skagway.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/southampton.html
+++ b/ports/southampton.html
@@ -40,6 +40,31 @@ Soli Deo Gloria
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight {

--- a/ports/split.html
+++ b/ports/split.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/st-kitts.html
+++ b/ports/st-kitts.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/st-maarten.html
+++ b/ports/st-maarten.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/st-petersburg.html
+++ b/ports/st-petersburg.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/st-thomas.html
+++ b/ports/st-thomas.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/stavanger.html
+++ b/ports/stavanger.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/stockholm.html
+++ b/ports/stockholm.html
@@ -16,6 +16,31 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/sydney-ns.html
+++ b/ports/sydney-ns.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/tallinn.html
+++ b/ports/tallinn.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/tangier.html
+++ b/ports/tangier.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/taormina.html
+++ b/ports/taormina.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/tortola.html
+++ b/ports/tortola.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/tracy-arm.html
+++ b/ports/tracy-arm.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/trieste.html
+++ b/ports/trieste.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/tromso.html
+++ b/ports/tromso.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/tunis.html
+++ b/ports/tunis.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/valencia.html
+++ b/ports/valencia.html
@@ -46,6 +46,31 @@ Soli Deo Gloria
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight {

--- a/ports/valletta.html
+++ b/ports/valletta.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/venice.html
+++ b/ports/venice.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/victoria-bc.html
+++ b/ports/victoria-bc.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/vigo.html
+++ b/ports/vigo.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/villefranche.html
+++ b/ports/villefranche.html
@@ -60,6 +60,31 @@ All work on this project is offered as a gift to God.
   </script>
 
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry {
       font-size: 1.05rem;
       line-height: 1.8;

--- a/ports/virgin-gorda.html
+++ b/ports/virgin-gorda.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/warnemunde.html
+++ b/ports/warnemunde.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/waterford.html
+++ b/ports/waterford.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/whittier.html
+++ b/ports/whittier.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/zadar.html
+++ b/ports/zadar.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/ports/zeebrugge.html
+++ b/ports/zeebrugge.html
@@ -26,6 +26,31 @@ Soli Deo Gloria
   }
   </script>
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     .logbook-entry { font-size: 1.05rem; line-height: 1.8; color: #134; }
     .logbook-entry p { margin-bottom: 1.25rem; }
     .poignant-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e6f4f8 100%); border-left: 4px solid var(--accent, #0e6e8e); padding: 1.25rem 1.5rem; margin: 1.5rem 0; border-radius: 0 12px 12px 0; font-style: italic; }

--- a/privacy.html
+++ b/privacy.html
@@ -110,6 +110,31 @@
   "description": "Our privacy policy explains how In the Wake collects, uses, and protects your data. GDPR and CCPA compliant. Your privacy matters."
 }
   </script><style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
     /* Navigation */
     .nav {
       flex: 1 1 auto;

--- a/restaurants.html
+++ b/restaurants.html
@@ -221,6 +221,31 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- Dropdown Navigation Styles -->
   <style>
+    /* Page Grid Layout (2-column with right rail) */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 360px;
+      }
+    }
+
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   /* Header / Hero */
   .hero-header {
     position: relative;


### PR DESCRIPTION
Many pages had class="page-grid" on the main element but lacked the CSS definition, causing content to stack vertically instead of displaying in the proper 2-column right rail layout.

Fixed pages:
- ports.html, privacy.html, restaurants.html
- authors/ken-baker.html
- 137 port guide pages in ports/

Also added admin/fix_page_grid_css.py for future use.