### PR TITLE
Fix ship page grid layout - remove incorrect span 999

### DIFF
--- a/admin/fix_ship_grid_spans.py
+++ b/admin/fix_ship_grid_spans.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Fix ship pages that have incorrect grid-row: 1 / span 999 positioning.
+
+The normalization script incorrectly added grid positioning to inner sections
+that should be inside the main content wrapper without explicit positioning.
+"""
+
+import os
+import re
+from pathlib import Path
+
+# ANSI colors
+GREEN = '\033[92m'
+YELLOW = '\033[93m'
+CYAN = '\033[96m'
+RED = '\033[91m'
+BOLD = '\033[1m'
+RESET = '\033[0m'
+
+def fix_ship_page(filepath):
+    """Fix a single ship page."""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        original = content
+        changes = []
+
+        # Fix 1: Remove "grid-column: 1; grid-row: 1 / span 999;" from inner sections
+        # These sections should be inside the main content div without explicit positioning
+        pattern1 = r'<section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">'
+        replacement1 = '<section class="grid-2">'
+        if pattern1 in content:
+            content = content.replace(pattern1, replacement1)
+            changes.append("Removed grid-row span from grid-2 section")
+
+        # Fix 2: Remove standalone "grid-column: 1; grid-row: 1 / span 999;" style from sections
+        pattern2 = r'<section style="grid-column: 1; grid-row: 1 / span 999;" class="cards stack">'
+        replacement2 = '<section class="cards stack">'
+        if pattern2 in content:
+            content = content.replace(pattern2, replacement2)
+            changes.append("Removed grid-row span from cards stack section")
+
+        # Fix 3: Fix mismatched </section> that should be </div> after main content intro
+        # Look for pattern: intro paragraph followed by </section> then grid-2
+        pattern3 = r'(</p>\s*)\n\s*</section>\s*\n(\s*)(<!-- Row 1:|<section class="grid-2">)'
+        def fix_closing_tag(m):
+            changes.append("Fixed </section> -> closing for main content intro")
+            return m.group(1) + '\n' + m.group(2) + m.group(3)
+        content = re.sub(pattern3, fix_closing_tag, content)
+
+        if content != original:
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.write(content)
+            return 'fixed', changes
+        else:
+            return 'ok', []
+
+    except Exception as e:
+        return 'error', [str(e)]
+
+def main():
+    ships_dir = Path('/home/user/InTheWake/ships/rcl')
+
+    print(f"\n{BOLD}{'═' * 60}{RESET}")
+    print(f"{BOLD}🔧 Ship Grid Span Fixer{RESET}")
+    print(f"{BOLD}{'═' * 60}{RESET}\n")
+
+    stats = {'fixed': 0, 'ok': 0, 'error': 0}
+
+    for filepath in sorted(ships_dir.glob('*.html')):
+        status, changes = fix_ship_page(filepath)
+        stats[status] += 1
+
+        if status == 'fixed':
+            print(f"  {GREEN}✓{RESET} {filepath.name}")
+            for change in changes:
+                print(f"      {CYAN}→{RESET} {change}")
+        elif status == 'error':
+            print(f"  {RED}✗{RESET} {filepath.name}: {changes[0]}")
+
+    print(f"\n{BOLD}{'─' * 60}{RESET}")
+    print(f"\n{BOLD}Summary:{RESET}")
+    print(f"  {GREEN}Fixed:{RESET}   {stats['fixed']} pages")
+    print(f"  {CYAN}Already OK:{RESET} {stats['ok']} pages")
+    if stats['error'] > 0:
+        print(f"  {RED}Errors:{RESET}  {stats['error']} pages")
+    print(f"\n{BOLD}{'═' * 60}{RESET}\n")
+
+if __name__ == '__main__':
+    main()

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -566,10 +566,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal for active families, couples seeking variety, and travelers who want iconic cruise features like ice skating shows and rock climbing without the overwhelming scale of newer mega-ships — that "sweet spot" between intimate smaller vessels and the newest giants, with worldwide destinations from Alaska to Australia.
         If you're seeking the latest innovations or prefer smaller, more intimate ships, you may want to explore Quantum-class or Vision-class vessels instead.
       </p>
-    </section>
-
     <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -619,10 +619,8 @@ updated: 2025-11-18
         It's ideal if you want one of the world's largest cruise ships with up to 6,780 guests, extensive dining and entertainment options, and the space to explore something new each day.
         If you're seeking a more intimate ship or prefer newer Icon-class innovations, you may want to explore Quantum-class or <a href="/ships/rcl/icon-of-the-seas.html">Icon of the Seas</a> instead.
       </p>
-    </section>
-
     <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -557,10 +557,8 @@ updated: 2025-11-18
         It's ideal if you want Quantum-class innovations with about 4,180 guests at double occupancy — more intimate than <a href="/ships.html#oasis-class">Oasis class</a> yet packed with high-tech experiences.
         If you're looking for the classic neighborhood layout or the largest ships afloat, you may want to explore Oasis or Icon class instead.
       </p>
-    </section>
-
     <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -557,10 +557,8 @@ updated: 2025-11-18
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
         If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
     <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -565,10 +565,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         Enchantment of the Seas welcomes cruisers seeking a mid-sized ship with an intimate atmosphere and beautiful ocean views. Her <a href="/ships.html#vision-class">Vision Class</a> design features floor-to-ceiling glass walls throughout public spaces, bringing the sea and sky into your cruise experience in a way larger ships simply can't match.
         Perfect for first-time cruisers and families who want the Royal Caribbean experience without feeling overwhelmed, Enchantment offers enough activities and dining to keep everyone happy while maintaining an easier-to-navigate layout. If you're drawn to shorter cruise getaways or worldwide adventures with a more relaxed, less-crowded vibe, Enchantment could be your ideal match.
       </p>
-    </section>
-
     <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -557,10 +557,8 @@ updated: 2025-11-18
         It's ideal if you want about 3,286 guests at double occupancy — offering a balance of activities and space without the massive scale of Oasis or Icon class ships.
         If you're seeking the newest features or prefer a larger ship, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
     <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want a larger ship experience (about 3,634 guests at double occupancy) — bigger than Voyager or <a href="/ships.html#radiance-class">Radiance class</a> but more intimate than Oasis or Icon class.
         If you're seeking seven neighborhoods, the absolute newest innovations, or cutting-edge technology, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -633,10 +633,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         Grandeur of the Seas tends to suit travelers who appreciate a more intimate ship experience with fewer crowds, stunning ocean views through floor-to-ceiling windows, and diverse itineraries. The <a href="/ships.html#vision-class">Vision Class</a> design brings the sea closer through panoramic glass walls in public spaces, creating an airy, light-filled atmosphere perfect for those who love to watch the waves.
         With her mid-size profile, Grandeur offers the right balance: enough venues and activities to stay engaged, yet small enough to never feel overwhelming. If you value easier navigation, shorter lines, and a relaxed pace over non-stop entertainment and massive water parks, Grandeur might be your sweet spot.
       </p>
-    </section>
-
     <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want one of the world's largest cruise ships with up to 6,780 guests and extensive dining and entertainment options.
         If you're seeking a more intimate ship or prefer Icon-class innovations, you may want to explore Quantum-class or <a href="/ships/rcl/icon-of-the-seas.html">Icon of the Seas</a> instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/icon-of-the-seas.html
+++ b/ships/rcl/icon-of-the-seas.html
@@ -619,10 +619,8 @@ updated: 2025-11-18
         It's ideal if you want cutting-edge features and revolutionary design with up to 7,600 guests on the world's most innovative cruise ship.
         If you prefer a more intimate ship or classic Royal Caribbean designs, you may want to explore Voyager, Freedom, Quantum, or <a href="/ships.html#oasis-class">Oasis class</a> instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want Royal Caribbean's energy and entertainment on a ship with about 4,515 guests — larger than <a href="/ships.html#voyager-class">Voyager class</a> but more intimate than Oasis or Icon class.
         If you're seeking seven neighborhoods or the newest innovations like the Ultimate Abyss, you may want to explore Oasis or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
         If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
     <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/legend-of-the-seas-1995-built.html
+++ b/ships/rcl/legend-of-the-seas-1995-built.html
@@ -531,10 +531,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p style="color: #0c5460; font-size: 1.05rem; line-height: 1.6; margin: 0;">
         Legend of the Seas (built 1995) is a <a href="/ships.html#vision-class">Vision Class</a> ship offering mid-sized intimacy with panoramic glass-wrapped views, perfect for travelers who want Royal Caribbean quality without mega-ship crowds. With Viking Crown Lounge and signature <a href="/ships.html#vision-class">Vision Class</a> design, she accommodates about 1,804 guests at double occupancy.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/legend-of-the-seas.html
+++ b/ships/rcl/legend-of-the-seas.html
@@ -607,10 +607,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class, offering an intimate atmosphere with about 1,804 guests at double occupancy.
         If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want a Freedom-class experience with around 4,960 guests — larger than <a href="/ships.html#voyager-class">Voyager class</a> but more intimate than Oasis or Icon class.
         If you're seeking seven neighborhoods or the absolute newest innovations, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/majesty-of-the-seas.html
+++ b/ships/rcl/majesty-of-the-seas.html
@@ -632,10 +632,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
         Majesty of the Seas (1992-2020) represented Royal Caribbean's Sovereign Class era, offering classic cruise experiences with 2,744 guests at double occupancy. As the third and final Sovereign Class ship, she helped establish Royal Caribbean's reputation for Caribbean short cruises. After leaving the Royal Caribbean fleet, Majesty was sold to Pullmantur and later scrapped in 2020.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want a mid-sized ship with about 3,344 guests at double occupancy — offering a balance of activities and space without the massive scale of Oasis or Icon class ships.
         If you're seeking the newest features or prefer a larger ship, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/monarch-of-the-seas.html
+++ b/ships/rcl/monarch-of-the-seas.html
@@ -623,10 +623,8 @@ updated: 2025-11-18
       <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
         Monarch of the Seas (1991-2013) was the second Sovereign Class ship, offering classic cruise experiences with 2,744 guests at double occupancy. She helped establish Royal Caribbean's reputation for Caribbean cruising during the 1990s and early 2000s. After leaving the Royal Caribbean fleet, Monarch was sold to Pullmantur and later scrapped in 2020.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want Royal Caribbean's signature entertainment and activities without the massive scale of mega-ships like Oasis or Icon class.
         If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/nordic-empress.html
+++ b/ships/rcl/nordic-empress.html
@@ -605,10 +605,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
         Nordic Empress (1990-2008) pioneered Royal Caribbean's short-cruise market from Miami, offering 3- and 4-night Caribbean getaways. She was known for her intimate size and classic cruise experience with about 1,840 guests at double occupancy. After leaving the Royal Caribbean fleet in 2008, she was sold to Pullmantur and continued sailing until 2020.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want maximum dining, entertainment, and activity options in one sailing, with space for 5,400+ guests without feeling crowded.
         If you're looking for a more intimate, quiet ship experience or prefer classic ocean-view focused design, you may want to explore Radiance or <a href="/ships.html#voyager-class">Voyager class</a> instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want Quantum Ultra-class technology and activities with about 4,198 guests at double occupancy — more intimate than <a href="/ships.html#oasis-class">Oasis class</a> but packed with unique experiences.
         If you're looking for the classic neighborhood layout or the largest ships afloat, you may want to explore Oasis or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want Quantum-class innovations with about 4,180 guests at double occupancy — more intimate than <a href="/ships.html#oasis-class">Oasis class</a> yet packed with high-tech experiences.
         If you're looking for the classic neighborhood layout or the largest ships afloat, you may want to explore Oasis or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -523,8 +523,6 @@ updated: 2025-11-18
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
         If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
     <!-- Row 1: First Look + Dining -->
     <section class="grid-2">
       <!-- First Look + Stats -->

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -634,10 +634,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
         If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -625,10 +625,8 @@ updated: 2025-11-18
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
         If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/song-of-america.html
+++ b/ships/rcl/song-of-america.html
@@ -551,10 +551,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
         Song of America (1982-1999) was one of the largest cruise ships in the world when built at over 37,700 gross tons. She helped establish Royal Caribbean as a major cruise line during the industry's growth period in the 1980s and 1990s. After leaving the Royal Caribbean fleet in 1999, the ship was sold and renamed multiple times before being scrapped in 2025, ending a 43-year career at sea.
       </p>
-    </section>
-
   <!-- Row 1: Ship Overview + Stats -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- Ship Overview -->
       <section class="card" aria-labelledby="ship-overview">
         <h2 id="ship-overview">Historical Overview</h2>

--- a/ships/rcl/song-of-norway.html
+++ b/ships/rcl/song-of-norway.html
@@ -607,10 +607,8 @@ updated: 2025-11-18
       <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
         Song of Norway (1970) was Royal Caribbean's first ship, the 18,416 GT vessel that started it all. As the founding ship, she pioneered Caribbean cruising and helped establish the industry's modern era. After leaving the Royal Caribbean fleet, Song of Norway was sold to Sun Cruises and eventually scrapped, but her legacy as the ship that launched Royal Caribbean International remains forever significant.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/sovereign-of-the-seas.html
+++ b/ships/rcl/sovereign-of-the-seas.html
@@ -598,10 +598,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
         Sovereign of the Seas (1988-2008) was the lead ship of the Sovereign Class and the world's largest cruise ship when launched. She helped establish Royal Caribbean as a major cruise line and pioneered many features that became industry standards. After leaving the Royal Caribbean fleet, Sovereign was sold to Pullmantur and later scrapped in 2020.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -600,10 +600,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal if you want Quantum-class innovation with Asian-market itineraries and features like robot bartenders and virtual balconies.
         If you're looking for the absolute largest ships or classic neighborhood layouts, you may want to explore Oasis or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/splendour-of-the-seas.html
+++ b/ships/rcl/splendour-of-the-seas.html
@@ -626,10 +626,8 @@ updated: 2025-11-18
         The ship was sold to TUI/Marella Cruises in 2017 and continues sailing as Marella Discovery, preserving the distinctive glass-wrapped architecture.
         If you're looking for currently sailing Royal Caribbean ships, explore Vision-class sisters like Grandeur, Rhapsody, Vision, and Enchantment, or modern Radiance, Quantum, and Icon class vessels.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/star-of-the-seas.html
+++ b/ships/rcl/star-of-the-seas.html
@@ -627,10 +627,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal if you want one of the world's largest ships (248,663 GT, up to 7,600 guests) with cutting-edge technology, multi-generational family activities, and amenities you can't find anywhere else at sea.
         If you're seeking a more intimate mid-sized ship or prefer classic cruise layouts, you may want to explore <a href="/ships.html#radiance-class">Radiance Class</a> or <a href="/ships.html#voyager-class">Voyager Class</a> instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -600,10 +600,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal if you want one of the world's largest cruise ships with space for ~5,518 guests, extensive dining and entertainment options, and the 7-neighborhood layout.
         If you're seeking a more intimate ship or prefer the newest Icon-class innovations, you may want to explore Quantum-class or <a href="/ships/rcl/icon-of-the-seas.html">Icon of the Seas</a> instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -600,10 +600,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal if you want one of the world's largest and newest cruise ships (launched 2024) with space for up to 5,668 guests at double occupancy, extensive dining and entertainment options, and cutting-edge amenities.
         If you're seeking a more intimate ship or prefer mid-sized vessels, you may want to explore Radiance-class or Voyager-class ships instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/viking-serenade.html
+++ b/ships/rcl/viking-serenade.html
@@ -534,10 +534,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
         Viking Serenade (1990-2002) was originally built in 1982 as Scandinavian Star and converted for Royal Caribbean cruise service in 1991. She offered mid-sized cruising experiences on Alaska and Caribbean itineraries with about 1,870 guests at double occupancy. After leaving the Royal Caribbean fleet in 2002, the vessel continued sailing under different operators as Island Escape.
       </p>
-    </section>
-
   <!-- Row 1: Ship Overview + Stats -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- Ship Overview -->
       <section class="card" aria-labelledby="ship-overview">
         <h2 id="ship-overview">Historical Overview</h2>

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -634,10 +634,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal if you want Royal Caribbean's signature service and entertainment with an intimate atmosphere.
         If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -600,10 +600,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal if you want Royal Caribbean's signature service and entertainment without the massive scale of mega-ships like Oasis or Icon class.
         If you're looking for the absolute newest venues, cutting-edge technology, or neighborhood layouts, you may want to explore Quantum, Oasis, or Icon class instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -600,10 +600,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         It's ideal if you want one of the world's largest cruise ships with extensive dining and entertainment options, and the space to explore something new each day.
         If you're seeking a more intimate ship or prefer smaller-scale experiences, you may want to explore Radiance, Voyager, or <a href="/ships.html#vision-class">Vision class</a> instead.
       </p>
-    </section>
-
   <!-- Row 1: First Look + Dining -->
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="grid-2">
+    <section class="grid-2">
       <!-- First Look + Stats -->
       <section class="card" aria-labelledby="first-look">
         <h2 id="first-look">A First Look</h2>


### PR DESCRIPTION
The earlier normalization script incorrectly added grid-column: 1; grid-row: 1 / span 999; to inner sections that should be inside the main content wrapper without explicit grid positioning.

Fixed 38 ship pages by:
- Removing grid-row span from grid-2 sections
- Fixing mismatched closing tags