### PR TITLE
Add service worker registration to 489 pages

### DIFF
--- a/.claude/skills/standards/resources/examples/perfect-html-page.html
+++ b/.claude/skills/standards/resources/examples/perfect-html-page.html
@@ -98,6 +98,13 @@
       color: #0e6e8e;
     }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <!-- Skip Link (Required for accessibility) -->

--- a/about-us.html
+++ b/about-us.html
@@ -192,6 +192,13 @@
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
 
   <!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
     /* ===== WCAG 2.1 AA Compliant + SEO Optimized Styles ===== */

--- a/accessibility.html
+++ b/accessibility.html
@@ -202,6 +202,13 @@
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
 
   <!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
     /* ===== WCAG 2.1 AA Compliant + SEO Optimized Styles ===== */

--- a/admin/fix_sw_registration.py
+++ b/admin/fix_sw_registration.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Add Service Worker registration to all HTML pages missing it.
+Soli Deo Gloria
+"""
+
+import os
+import re
+from pathlib import Path
+
+# Directories to skip
+SKIP_DIRS = {'admin', 'new-standards', 'node_modules', '.git'}
+
+# The SW registration snippet to add
+SW_SNIPPET = '''
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+'''
+
+def should_process(filepath):
+    """Check if file should be processed."""
+    parts = Path(filepath).parts
+    return not any(skip in parts for skip in SKIP_DIRS)
+
+def has_sw_registration(content):
+    """Check if file already has service worker registration."""
+    return 'serviceWorker' in content and 'register' in content
+
+def add_sw_registration(content):
+    """Add SW registration snippet to HTML content."""
+
+    # Try to insert before the first <link rel="stylesheet" or before </head>
+
+    # Pattern 1: Before first stylesheet link
+    stylesheet_match = re.search(r'(\n\s*<link\s+rel=["\']stylesheet["\'])', content, re.IGNORECASE)
+    if stylesheet_match:
+        insert_pos = stylesheet_match.start()
+        return content[:insert_pos] + SW_SNIPPET + content[insert_pos:]
+
+    # Pattern 2: Before </head>
+    head_close = re.search(r'(\n\s*</head>)', content, re.IGNORECASE)
+    if head_close:
+        insert_pos = head_close.start()
+        return content[:insert_pos] + SW_SNIPPET + content[insert_pos:]
+
+    # Pattern 3: After <head> opening (last resort)
+    head_open = re.search(r'(<head[^>]*>)', content, re.IGNORECASE)
+    if head_open:
+        insert_pos = head_open.end()
+        return content[:insert_pos] + SW_SNIPPET + content[insert_pos:]
+
+    return None  # Couldn't find insertion point
+
+def main():
+    root = Path('/home/user/InTheWake')
+
+    fixed_files = []
+    skipped_files = []
+    error_files = []
+    already_has = []
+
+    # Find all HTML files
+    for html_file in root.rglob('*.html'):
+        if not should_process(html_file):
+            skipped_files.append(str(html_file))
+            continue
+
+        try:
+            content = html_file.read_text(encoding='utf-8')
+
+            if has_sw_registration(content):
+                already_has.append(str(html_file))
+                continue
+
+            new_content = add_sw_registration(content)
+
+            if new_content is None:
+                error_files.append((str(html_file), "No insertion point found"))
+                continue
+
+            html_file.write_text(new_content, encoding='utf-8')
+            fixed_files.append(str(html_file))
+
+        except Exception as e:
+            error_files.append((str(html_file), str(e)))
+
+    # Report
+    print(f"\n=== Service Worker Registration Fix ===\n")
+    print(f"Already had SW registration: {len(already_has)}")
+    print(f"Fixed (added SW registration): {len(fixed_files)}")
+    print(f"Skipped (admin/standards): {len(skipped_files)}")
+    print(f"Errors: {len(error_files)}")
+
+    if fixed_files:
+        print(f"\n--- Fixed Files ({len(fixed_files)}) ---")
+        # Group by directory
+        by_dir = {}
+        for f in fixed_files:
+            rel = os.path.relpath(f, root)
+            dir_name = os.path.dirname(rel) or '(root)'
+            if dir_name not in by_dir:
+                by_dir[dir_name] = []
+            by_dir[dir_name].append(os.path.basename(rel))
+
+        for dir_name, files in sorted(by_dir.items()):
+            print(f"\n{dir_name}/: {len(files)} files")
+            if len(files) <= 5:
+                for f in files:
+                    print(f"  - {f}")
+
+    if error_files:
+        print(f"\n--- Errors ---")
+        for f, err in error_files:
+            print(f"  {f}: {err}")
+
+    return len(fixed_files)
+
+if __name__ == '__main__':
+    main()

--- a/articles.html
+++ b/articles.html
@@ -152,6 +152,13 @@
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
 
   <!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* ===== Production Articles Hub Styles v3.010.300 ===== */

--- a/authors/ken-baker.html
+++ b/authors/ken-baker.html
@@ -31,6 +31,13 @@
   <link rel="canonical" href="https://cruisinginthewake.com/authors/ken-baker.html"/>
 
   <!-- Styles (same-origin so cache-buster can touch it) -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- Cache-buster (same-origin CSS/JS only) -->

--- a/authors/tina-maulsby.html
+++ b/authors/tina-maulsby.html
@@ -41,6 +41,13 @@
   <link rel="canonical" href="https://cruisinginthewake.com/authors/tina-maulsby.html"/>
 
   <!-- Styles (same-origin so cache-buster can touch it) -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- Cache-buster (same-origin CSS/JS only) -->

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -277,6 +277,13 @@
   "description": "Compare Soda, Refreshment, Deluxe, and Coffee Card vs \u00e0-la-carte with live break-even chart. Free Royal Caribbean drink calculator with Crown & Anchor support."
 }
   </script><!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <link rel="stylesheet" href="/assets/css/calculator.css?v=3.010.300"/>
   

--- a/drink-packages.html
+++ b/drink-packages.html
@@ -375,6 +375,13 @@
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/index.html
+++ b/index.html
@@ -243,6 +243,13 @@
   <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.400" imagesrcset="/assets/index_hero.webp?v=3.010.400" fetchpriority="high"/>
 
   <!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <style>
   /* ===== Production Index Styles v3.010.400 ===== */

--- a/offline.html
+++ b/offline.html
@@ -44,6 +44,13 @@ STANDARDS: Every Page v3.010.300 · Offline Fallback · A11y/WCAG 2.1 AA Complia
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <style>

--- a/packing-lists.html
+++ b/packing-lists.html
@@ -201,6 +201,13 @@
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
 
   <!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
     /* ===== WCAG 2.1 AA Compliant + SEO Optimized Styles ===== */

--- a/planning.html
+++ b/planning.html
@@ -206,6 +206,13 @@
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
 
   <!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
     /* ===== WCAG 2.1 AA Compliant + SEO Optimized Styles ===== */

--- a/ports.html
+++ b/ports.html
@@ -156,6 +156,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- Dropdown Navigation Styles -->

--- a/ports/ajaccio.html
+++ b/ports/ajaccio.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Ajaccio, Corsica — Napoleon's birthplace, maquis-covered mountains, Capo di Feno wild beaches, and Corsican charisma."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/ajaccio.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/alesund.html
+++ b/ports/alesund.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Ålesund, Norway — Art Nouveau fairy tale rebuilt after 1904 fire, pastel buildings, turrets, Mount Aksla viewpoint."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/alesund.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/amalfi.html
+++ b/ports/amalfi.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Amalfi Coast via Salerno — Positano, Amalfi, Ravello's Terrace of Infinity, and Europe's most beautiful coastline."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/amalfi.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/amsterdam.html
+++ b/ports/amsterdam.html
@@ -25,6 +25,13 @@ Soli Deo Gloria
 
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <script type="application/ld+json">

--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Aruba — Eagle Beach fofoti trees, Baby Beach snorkeling, and sunset catamaran adventures on One Happy Island."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/aruba.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/athens.html
+++ b/ports/athens.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Athens, Greece — Acropolis, Parthenon, Ancient Agora, Plaka neighborhood, and the birthplace of Western civilization."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/athens.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/auckland.html
+++ b/ports/auckland.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>Auckland &amp; Bay of Islands Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Auckland and Bay of Islands cruise ports: Sky Tower, Waiheke Island wineries, Hole in the Rock, and Kiwi hospitality." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/bali.html
+++ b/ports/bali.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>Bali / Benoa Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Bali cruise port via Benoa: Uluwatu temple, Ubud rice terraces, monkey forest, beach clubs, and Jimbaran sunset seafood." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/bangkok.html
+++ b/ports/bangkok.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>Bangkok / Laem Chabang Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Bangkok cruise port via Laem Chabang: Grand Palace, Wat Arun, street food, floating markets, and rooftop bars." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/bar-harbor.html
+++ b/ports/bar-harbor.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Bar Harbor, Maine — Acadia National Park, Cadillac Mountain sunrise, Thunder Hole, Jordan Pond popovers, and fresh lobster."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/bar-harbor.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/barcelona.html
+++ b/ports/barcelona.html
@@ -33,6 +33,13 @@ All work on this project is offered as a gift to God.
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/belfast.html
+++ b/ports/belfast.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Belfast — Titanic Belfast museum, black taxi mural tours, and day trips to the Giant's Causeway."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/belfast.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
     /* Page Grid Layout (2-column with right rail) */

--- a/ports/belize.html
+++ b/ports/belize.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Belize City — cave tubing through bat caves, Great Blue Hole flights, Altun Ha ruins, and Marie Sharp's hot sauce."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/belize.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Bergen, Norway — colorful Bryggen wharf houses, Mount Fløyen funicular, fish market, and gateway to the fjords."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/bergen.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/bermuda.html
+++ b/ports/bermuda.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Bermuda — Horseshoe Bay pink sand beach, Royal Naval Dockyard, Hamilton town, rum swizzles, and British-Caribbean charm."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/bermuda.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/bilbao.html
+++ b/ports/bilbao.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Bilbao, Spain — Frank Gehry's titanium Guggenheim masterpiece, Puppy flower-dog, pintxos heaven, Basque cool."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/bilbao.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/bonaire.html
+++ b/ports/bonaire.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Bonaire — Klein Bonaire snorkeling, flamingo sanctuary, 1000 Steps beach, and salt pyramids on the diver's island."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/bonaire.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/bordeaux.html
+++ b/ports/bordeaux.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Bordeaux, France — wine capital of world with Cité du Vin museum, Miroir d'Eau reflecting pool, Saint-Émilion."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/bordeaux.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/boston.html
+++ b/ports/boston.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Boston — Freedom Trail history, Fenway Park, North End Italian food, Mike's Pastry cannoli, and Revolutionary War sites."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/boston.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/brisbane.html
+++ b/ports/brisbane.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>Brisbane Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Brisbane cruise port: South Bank beach, Lone Pine Koala Sanctuary, CityCat ferry, and why it's Australia's most relaxed port." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/cadiz.html
+++ b/ports/cadiz.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Cadiz, Spain — oldest city in Western Europe, golden cathedral dome, La Caleta beach, and best pescaito frito."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/cadiz.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/cagliari.html
+++ b/ports/cagliari.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Cagliari, Sardinia — Castello district, Gulf of Angels, flamingos in lagoons, and Poetto beach paradise."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/cagliari.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/cannes.html
+++ b/ports/cannes.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Cannes, France — La Croisette, Palais des Festivals, Île Sainte-Marguerite, and French Riviera beaches."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/cannes.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/cartagena-spain.html
+++ b/ports/cartagena-spain.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Cartagena, Spain — perfectly preserved Roman theater, Art Nouveau buildings, and Spain's most surprising cruise port."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/cartagena-spain.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/cartagena.html
+++ b/ports/cartagena.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Cartagena, Colombia — UNESCO walled city, Getsemaní street art, colonial architecture, ceviche, and Caribbean sunset."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/cartagena.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/casablanca.html
+++ b/ports/casablanca.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Casablanca, Morocco — massive Hassan II Mosque, art-deco architecture, Rick's Café, and authentic Moroccan city energy."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/casablanca.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/charlottetown.html
+++ b/ports/charlottetown.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Charlottetown, PEI — birthplace of Canada, Anne of Green Gables, red sand beaches, Cows ice cream, and Island charm."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/charlottetown.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/cherbourg.html
+++ b/ports/cherbourg.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Cherbourg, France — largest artificial harbor, Cité de la Mer submarine museum, D-Day beaches, Normandy charm."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/cherbourg.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/civitavecchia.html
+++ b/ports/civitavecchia.html
@@ -33,6 +33,13 @@ All work on this project is offered as a gift to God.
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -67,6 +67,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/copenhagen.html
+++ b/ports/copenhagen.html
@@ -25,6 +25,13 @@ Soli Deo Gloria
 
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <script type="application/ld+json">

--- a/ports/corfu.html
+++ b/ports/corfu.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Corfu, Greece — Venetian Old Town, British and French influences, Paleokastritsa beaches, and emerald Ionian beauty."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/corfu.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/cork.html
+++ b/ports/cork.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Cork/Cobh, Ireland — heartbreaking Titanic Experience, St. Colman's Cathedral, steepest streets, English Market."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/cork.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/costa-maya.html
+++ b/ports/costa-maya.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Costa Maya — Mahahual beach town, Maya Chan snorkeling on the Mesoamerican Reef, and authentic Chacchoben Mayan ruins."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/costa-maya.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/cozumel.html
+++ b/ports/cozumel.html
@@ -58,6 +58,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/curacao.html
+++ b/ports/curacao.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Curaçao — Handelskade rainbow buildings, Porto Marie beach snorkeling, and the famous swimming pigs."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/curacao.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/dominica.html
+++ b/ports/dominica.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Dominica — Trafalgar Falls, Ti Tou Gorge canyon swim, Champagne Reef volcanic snorkeling on the Nature Island."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/dominica.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/dover.html
+++ b/ports/dover.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Dover, England — white cliffs, massive medieval castle, WWII tunnels, gateway to London or Canterbury."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/dover.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/dublin.html
+++ b/ports/dublin.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Dublin and Cobh — Book of Kells, Guinness Storehouse, Temple Bar, and the warmest welcome in cruising."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/dublin.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
     /* Page Grid Layout (2-column with right rail) */

--- a/ports/dubrovnik.html
+++ b/ports/dubrovnik.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Dubrovnik, Croatia — medieval city walls, red roofs, marble streets, and breathtaking Adriatic beauty."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/dubrovnik.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/gdansk.html
+++ b/ports/gdansk.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Gdansk, Poland — amber capital, Solidarity birthplace, perfectly rebuilt Hanseatic façades along Motława River."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/gdansk.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/genoa.html
+++ b/ports/genoa.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Genoa, Italy — Rolli Palaces, medieval caruggi alleys, Europe's biggest medieval center, and the best focaccia."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/genoa.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/gibraltar.html
+++ b/ports/gibraltar.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Gibraltar — 1,400 ft Rock with Barbary macaques, WWII tunnels, St. Michael's Cave, and views to Africa."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/gibraltar.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/glacier-bay.html
+++ b/ports/glacier-bay.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Glacier Bay National Park — 16 tidewater glaciers, scenic cruising day, park rangers narrate, Margerie Glacier calving."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/glacier-bay.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/gothenburg.html
+++ b/ports/gothenburg.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Gothenburg, Sweden — trams, Feskekôrka seafood, car-free archipelago islands, friendliest Swedish city."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/gothenburg.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/grand-cayman.html
+++ b/ports/grand-cayman.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Grand Cayman — Stingray City sandbar, Seven Mile Beach, Starfish Point, and duty-free shopping in George Town."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/grand-cayman.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/grand-turk.html
+++ b/ports/grand-turk.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Grand Turk, Turks & Caicos — Governor's Beach, spectacular wall diving, conch salad, and the postcard Caribbean fantasy."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/grand-turk.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/grenada.html
+++ b/ports/grenada.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Grenada — Grand Anse Beach, Concord Falls hiking, nutmeg ice cream, and chocolate tours on the Spice Isle."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/grenada.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/guadeloupe.html
+++ b/ports/guadeloupe.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Guadeloupe — Sainte-Anne beach, Pointe des Châteaux, French boulangeries, ti' punch, and authentic French-Caribbean charm."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/guadeloupe.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/haines.html
+++ b/ports/haines.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Haines, Alaska — Chilkat Bald Eagle Preserve, river float with 50+ eagles, brown bears, authentic salmon bake, and small-town Alaska charm."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/haines.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/halifax.html
+++ b/ports/halifax.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Halifax, Nova Scotia — Citadel Hill, Maritime Museum Titanic exhibit, waterfront boardwalk, and Halifax donair."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/halifax.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/helsinki.html
+++ b/ports/helsinki.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Helsinki — Suomenlinna fortress, Löyly sauna, rock church, and Finnish design culture."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/helsinki.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
     /* Page Grid Layout (2-column with right rail) */

--- a/ports/heraklion.html
+++ b/ports/heraklion.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Heraklion, Crete — gateway to Knossos Palace, Europe's oldest palace, birthplace of the Minotaur myth, and 4,000-year-old frescoes."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/heraklion.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/hilo.html
+++ b/ports/hilo.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Hilo, Big Island — Volcanoes National Park, Rainbow Falls, Kilauea Iki crater hike, greenest side of Hawaii."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/hilo.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/holyhead.html
+++ b/ports/holyhead.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Holyhead, Wales — gateway to Snowdonia mountains, Caernarfon Castle, longest village name, Anglesey."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/holyhead.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/honfleur.html
+++ b/ports/honfleur.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Honfleur, France — prettiest harbor in Normandy with colorful Vieux Bassin, birthplace of Impressionism."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/honfleur.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/hong-kong.html
+++ b/ports/hong-kong.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>Hong Kong Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Hong Kong cruise port: Victoria Peak, Big Buddha, Star Ferry, dim sum, and the Symphony of Lights show." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/honolulu.html
+++ b/ports/honolulu.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Honolulu, Oahu — Pearl Harbor memorial, Waikiki Beach, Diamond Head hike, and doing it all in a single port day."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/honolulu.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/ibiza.html
+++ b/ports/ibiza.html
@@ -25,6 +25,13 @@ Soli Deo Gloria
 
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <script type="application/ld+json">

--- a/ports/icy-strait-point.html
+++ b/ports/icy-strait-point.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Icy Strait Point — 100% Tlingit-owned, world-class whale watching, world's longest zip line, authentic Hoonah Alaska."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/icy-strait-point.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/invergordon.html
+++ b/ports/invergordon.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Invergordon, Scotland — gateway to Loch Ness, Urquhart Castle, dramatic Highlands, Nessie sightings."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/invergordon.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/jamaica.html
+++ b/ports/jamaica.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Jamaica — Dunn's River Falls climbing, Blue Hole jumping, Scotchies jerk chicken, and reggae vibes in Falmouth and Ocho Rios."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/jamaica.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/juneau.html
+++ b/ports/juneau.html
@@ -58,6 +58,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/ketchikan.html
+++ b/ports/ketchikan.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Ketchikan, Alaska — world-class totem poles, Creek Street boardwalks, Misty Fjords flightseeing, and salmon capital charm."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/ketchikan.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/key-west.html
+++ b/ports/key-west.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Key West — Hemingway House polydactyl cats, Duval Street bar crawl, Mallory Square sunset, and the best key lime pie on Earth."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/key-west.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/kiel.html
+++ b/ports/kiel.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Kiel, Germany — sailing capital with Olympic harbor, massive Kiel Canal locks, Laboe Naval Memorial and U-boat museum."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/kiel.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/kirkwall.html
+++ b/ports/kirkwall.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Kirkwall, Orkney, Scotland — 5,000-year-old Skara Brae, Ring of Brodgar stones, Viking cathedral, Highland Park whisky."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/kirkwall.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/kona.html
+++ b/ports/kona.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Kailua-Kona, Big Island — Kona coffee farms, historic village, world-famous night manta ray snorkel experience."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/kona.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/koper.html
+++ b/ports/koper.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Koper, Slovenia — Venetian palaces, Tito Square, Parenzana bike trail through Istrian countryside, fresh truffles."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/koper.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/kotor.html
+++ b/ports/kotor.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Kotor, Montenegro — medieval town in Europe's southernmost fjord, dramatic fortress climb, and spectacular mountain scenery."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/kotor.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/kusadasi.html
+++ b/ports/kusadasi.html
@@ -58,6 +58,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/la-coruna.html
+++ b/ports/la-coruna.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to La Coruña, Spain — City of Glass with 1,900-year-old Tower of Hercules lighthouse, glazed galerías, Riazor beach."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/la-coruna.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/labadee.html
+++ b/ports/labadee.html
@@ -58,6 +58,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/le-havre.html
+++ b/ports/le-havre.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Le Havre/Paris, France — realistic gateway to Paris for Eiffel Tower, Louvre, Montmartre in single day."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/le-havre.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/lerwick.html
+++ b/ports/lerwick.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Lerwick, Shetland, Scotland — Britain's northernmost town with ponies, Jarlshof archaeology, Sumburgh Head puffins."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/lerwick.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/lisbon.html
+++ b/ports/lisbon.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Lisbon, Portugal — seven hills, colorful tiles, Tram 28, Belém monastery, pastel de nata, and fado soul."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/lisbon.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/liverpool.html
+++ b/ports/liverpool.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Liverpool, England — The Beatles pilgrimage, Albert Dock museums, Magical Mystery Tour, friendliest Scousers."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/liverpool.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/livorno.html
+++ b/ports/livorno.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Florence and Pisa via Livorno — the Duomo, Michelangelo's David, Uffizi, Leaning Tower, and cradle of the Renaissance."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/livorno.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/malaga.html
+++ b/ports/malaga.html
@@ -25,6 +25,13 @@ Soli Deo Gloria
 
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <script type="application/ld+json">

--- a/ports/marseille.html
+++ b/ports/marseille.html
@@ -33,6 +33,13 @@ All work on this project is offered as a gift to God.
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/martinique.html
+++ b/ports/martinique.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Martinique — Les Salines beach, St-Pierre volcano ruins, rhum agricole tasting, and French-Caribbean fusion cuisine."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/martinique.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/maui.html
+++ b/ports/maui.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Maui via Kahului port — Iao Valley, Upcountry lavender farms, Road to Hana, post-Lahaina fire update and alternatives."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/maui.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/messina.html
+++ b/ports/messina.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Messina, Sicily — gateway to Taormina's Greek theater with Mount Etna backdrop and Isola Bella beach."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/messina.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/monte-carlo.html
+++ b/ports/monte-carlo.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Monte Carlo, Monaco — Casino de Monte-Carlo, Grand Prix circuit, superyachts, and pure Mediterranean glamour."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/monte-carlo.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/mykonos.html
+++ b/ports/mykonos.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Mykonos, Greece — white cubist houses, electric-blue domes, windmills, Little Venice, and pristine beaches."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/mykonos.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/naples.html
+++ b/ports/naples.html
@@ -33,6 +33,13 @@ All work on this project is offered as a gift to God.
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Nassau — Atlantis Aquaventure, Cabbage Beach, Queen's Staircase, and the best cracked conch in the Bahamas."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/nassau.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/nawiliwili.html
+++ b/ports/nawiliwili.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Nawiliwili, Kauai — Waimea Canyon, Na Pali coast catamaran, most dramatically beautiful Hawaiian island."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/nawiliwili.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/newcastle.html
+++ b/ports/newcastle.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Newcastle upon Tyne, England — seven bridges, Angel of the North, Geordie warmth, best nightlife in Britain."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/newcastle.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/newport.html
+++ b/ports/newport.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Newport, Rhode Island — Gilded Age mansions, Cliff Walk, The Breakers, America's sailing capital, and 1890s elegance."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/newport.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/norwegian-fjords.html
+++ b/ports/norwegian-fjords.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Norwegian Fjords — Geiranger's waterfalls, Flåm Railway, Briksdal Glacier, and the most spectacular scenery in cruising."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/norwegian-fjords.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
     /* Page Grid Layout (2-column with right rail) */

--- a/ports/oslo.html
+++ b/ports/oslo.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Oslo — Viking Ship Museum, Munch's Scream, Opera House roof walk, and sailing up the Oslofjord."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/oslo.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
     /* Page Grid Layout (2-column with right rail) */

--- a/ports/palma.html
+++ b/ports/palma.html
@@ -30,6 +30,13 @@ Soli Deo Gloria
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/panama-canal.html
+++ b/ports/panama-canal.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Panama Canal transit — Gatun Locks, Gaillard Cut, Bridge of the Americas, and the most fascinating cruise day you'll ever have."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/panama-canal.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/portland-maine.html
+++ b/ports/portland-maine.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Portland, Maine — Portland Head Light, Old Port cobblestones, lobster rolls, craft breweries, Maritime Museum."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/portland-maine.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/portland.html
+++ b/ports/portland.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Portland, Dorset, England — Jurassic Coast, Chesil Beach's 18-mile pebble ridge, Portland Bill lighthouse, fossils."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/portland.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/porto.html
+++ b/ports/porto.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Porto (Leixões), Portugal — terracotta roofs cascading to Douro, port wine lodges, São Bento station azulejos."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/porto.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/progreso.html
+++ b/ports/progreso.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Progreso — your gateway to Chichen Itzá, one of the New Seven Wonders of the World, with Mayan ruins and authentic Yucatan culture."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/progreso.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/quebec-city.html
+++ b/ports/quebec-city.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Quebec City — fortified walls, Château Frontenac, Petit-Champlain, poutine, and the most European-feeling city in North America."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/quebec-city.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/ravenna.html
+++ b/ports/ravenna.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Ravenna, Italy — world capital of Byzantine mosaics, eight UNESCO sites, San Vitale, and Galla Placidia."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/ravenna.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/reykjavik.html
+++ b/ports/reykjavik.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Reykjavik — Golden Circle geysers, Blue Lagoon, Hallgrímskirkja, and Iceland's otherworldly landscapes."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/reykjavik.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
     /* Page Grid Layout (2-column with right rail) */

--- a/ports/rhodes.html
+++ b/ports/rhodes.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Rhodes, Greece — best-preserved medieval city in Europe, Street of the Knights, ancient walls, and Lindos Acropolis."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/rhodes.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/riga.html
+++ b/ports/riga.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Riga, Latvia — Art Nouveau capital of the world with Hanseatic old town and biggest market halls in Europe."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/riga.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/roatan.html
+++ b/ports/roatan.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Roatán — West Bay Beach shore snorkeling, Gumbalimba Park monkeys, and the best-value beach day in the Caribbean."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/roatan.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/saguenay.html
+++ b/ports/saguenay.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Saguenay, Quebec — dramatic fjord scenery, beluga whale watching, Sainte-Anne church, and jaw-dropping cliffs."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/saguenay.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/saint-john.html
+++ b/ports/saint-john.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Saint John, New Brunswick — Bay of Fundy highest tides, Reversing Falls, City Market, and Maritime coastal beauty."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/saint-john.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/samana.html
+++ b/ports/samana.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Samaná, Dominican Republic — best humpback whale watching in the Caribbean, Cayo Levantado, El Limón waterfall, and whale song."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/samana.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/san-juan.html
+++ b/ports/san-juan.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to San Juan — El Morro fortress, Old San Juan blue cobblestones, mofongo, and the birthplace of the piña colada."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/san-juan.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/santorini.html
+++ b/ports/santorini.html
@@ -58,6 +58,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/scotland.html
+++ b/ports/scotland.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Scotland — Edinburgh Castle, Royal Mile, Glasgow museums, and Highland day trips from South Queensferry and Greenock."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/scotland.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
     /* Page Grid Layout (2-column with right rail) */

--- a/ports/seward.html
+++ b/ports/seward.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Seward, Alaska — Kenai Fjords National Park, orcas, humpbacks, Exit Glacier, Alaska SeaLife Center, and wildlife paradise."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/seward.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/shanghai.html
+++ b/ports/shanghai.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>Shanghai Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Shanghai cruise port: The Bund, Shanghai Tower, Yu Garden, xiaolongbao, and the city where past meets future." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/singapore.html
+++ b/ports/singapore.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>Singapore Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Singapore cruise port: Gardens by the Bay, Marina Bay Sands, hawker centers, and why it's Asia's top-rated port." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/sitka.html
+++ b/ports/sitka.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Sitka, Alaska — Russian onion domes, Tlingit culture, sea otters, Fortress of the Bear, and Mount Edgecumbe volcano."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/sitka.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/skagway.html
+++ b/ports/skagway.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Skagway, Alaska — White Pass & Yukon Route Railway, Klondike Gold Rush history, wooden boardwalks, and frozen-in-time 1898 charm."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/skagway.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/south-pacific.html
+++ b/ports/south-pacific.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>South Pacific Islands Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to South Pacific cruise ports: Bora Bora, Tahiti, Moorea, Fiji, Vanuatu, and Nouméa – turquoise lagoons and paradise islands." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/southampton.html
+++ b/ports/southampton.html
@@ -25,6 +25,13 @@ Soli Deo Gloria
 
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <script type="application/ld+json">

--- a/ports/split.html
+++ b/ports/split.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Split, Croatia — Diocletian's Palace turned living city, Romans and Venetians sharing marble streets, Riva promenade."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/split.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/st-kitts.html
+++ b/ports/st-kitts.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to St. Kitts — Cockleshell Beach, Brimstone Hill Fortress, scenic railway with rum punch, and Killer Bee cocktails."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/st-kitts.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/st-maarten.html
+++ b/ports/st-maarten.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to St. Maarten — Maho Beach plane spotting, Orient Beach French side, and experiencing two countries in one day."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/st-maarten.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/st-petersburg.html
+++ b/ports/st-petersburg.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to St. Petersburg, Russia — imperial excess with golden spires, Hermitage museum, Church on Spilled Blood mosaics, canal cruises."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/st-petersburg.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/st-thomas.html
+++ b/ports/st-thomas.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to St. Thomas — Magens Bay Beach, Paradise Point tram, Bushwackers, and duty-free shopping in the USVI."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/st-thomas.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/stavanger.html
+++ b/ports/stavanger.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Stavanger, Norway — white wooden houses, street art, Lysefjord cruise with Pulpit Rock views, adventure capital charm."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/stavanger.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/stockholm.html
+++ b/ports/stockholm.html
@@ -14,6 +14,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Stockholm — Vasa Museum, Gamla Stan old town, ABBA Museum, and the stunning 14-island archipelago sail-in."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/stockholm.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
     /* Page Grid Layout (2-column with right rail) */

--- a/ports/sydney-ns.html
+++ b/ports/sydney-ns.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Sydney, Nova Scotia — world's largest fiddle, Cape Breton culture, Cabot Trail, and Alexander Graham Bell museum."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/sydney-ns.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/sydney.html
+++ b/ports/sydney.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>Sydney Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Sydney cruise port: Opera House, Harbour Bridge, Bondi Beach, and why it's Australia's highest-rated port." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/tallinn.html
+++ b/ports/tallinn.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Tallinn, Estonia — perfectly preserved Hanseatic fairy tale with orange roofs, church spires, medieval walls."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/tallinn.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/tangier.html
+++ b/ports/tangier.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Tangier, Morocco — medina maze, Café Hafa overlooking Spain, Cap Spartel, and mint tea culture."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/tangier.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/taormina.html
+++ b/ports/taormina.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Taormina, Sicily — ancient Greek theater, medieval streets, Mount Etna looming above the Ionian Sea, and Isola Bella."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/taormina.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/tokyo.html
+++ b/ports/tokyo.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <title>Tokyo / Yokohama Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person guide to Tokyo and Yokohama cruise ports: Tsukiji Market, TeamLab, Shibuya Crossing, Senso-ji temple, and Japanese efficiency." />
   <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/css/common.css" />
   <link rel="stylesheet" href="/assets/css/articles.css" />
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/ports/tortola.html
+++ b/ports/tortola.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Tortola — The Baths boulder caves on Virgin Gorda, Smuggler's Cove beach, and legendary painkiller cocktails in the BVI."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/tortola.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/tracy-arm.html
+++ b/ports/tracy-arm.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Tracy Arm Fjord, Alaska — 30-mile narrow fjord, twin Sawyer Glaciers, 4,000-foot granite walls, icebergs with harbor seals, and stunning Alaska scenery."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/tracy-arm.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/trieste.html
+++ b/ports/trieste.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Trieste, Italy — elegant Habsburg cafés, largest sea-facing piazza in Italy, Miramare Castle, and literary soul."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/trieste.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/tromso.html
+++ b/ports/tromso.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Tromsø, Norway — Arctic capital with midnight sun or northern lights, reindeer sledding, stunning Arctic Cathedral."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/tromso.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/tunis.html
+++ b/ports/tunis.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Tunis, Tunisia — gateway to Carthage ruins, Sidi Bou Said blue-and-white perfection, and Tunis medina. Three UNESCO sites."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/tunis.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/valencia.html
+++ b/ports/valencia.html
@@ -30,6 +30,13 @@ Soli Deo Gloria
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/valletta.html
+++ b/ports/valletta.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Valletta, Malta — golden limestone fortress built by knights, Caravaggio paintings, WWII history, and Blue Lagoon."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/valletta.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/venice.html
+++ b/ports/venice.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Venice, Italy — St. Mark's Basilica, gondolas, canals, bridges, and timeless Venetian beauty."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/venice.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/victoria-bc.html
+++ b/ports/victoria-bc.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Victoria, British Columbia — Butchart Gardens, high tea at the Empress, Parliament buildings, elegant Alaska cruise bookend."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/victoria-bc.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/vigo.html
+++ b/ports/vigo.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Vigo, Spain — gateway to Cíes Islands Atlantic paradise with world's best beaches, Rodas Beach, Galician charm."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/vigo.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/villefranche.html
+++ b/ports/villefranche.html
@@ -33,6 +33,13 @@ All work on this project is offered as a gift to God.
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- JSON-LD: BreadcrumbList -->

--- a/ports/virgin-gorda.html
+++ b/ports/virgin-gorda.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Virgin Gorda, BVI — The Baths spectacular granite boulder grottos, Devil's Bay beach, and Caribbean snorkeling paradise."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/virgin-gorda.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/warnemunde.html
+++ b/ports/warnemunde.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Warnemünde, Germany — perfect beach town and gateway to Berlin with Brandenburg Gate, Museum Island, Checkpoint Charlie."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/warnemunde.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/waterford.html
+++ b/ports/waterford.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Waterford, Ireland — Viking triangles, finest crystal in world, oldest Irish city, medieval museum."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/waterford.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/whittier.html
+++ b/ports/whittier.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Whittier, Alaska — town under one roof, 26 Glaciers tour in Prince William Sound, best glacier day in Alaska."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/whittier.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/zadar.html
+++ b/ports/zadar.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Zadar, Croatia — Roman ruins, Sea Organ playing wave music, Greeting to the Sun light show, coolest small Adriatic city."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/zadar.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/ports/zeebrugge.html
+++ b/ports/zeebrugge.html
@@ -13,6 +13,13 @@ Soli Deo Gloria
   <meta name="description" content="First-person logbook guide to Zeebrugge/Bruges, Belgium — gateway to perfectly preserved medieval Bruges with canals, swans, chocolate shops."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/zeebrugge.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <script type="application/ld+json">
   {

--- a/privacy.html
+++ b/privacy.html
@@ -81,6 +81,13 @@
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 <script type="application/ld+json">
 {

--- a/restaurants.html
+++ b/restaurants.html
@@ -216,6 +216,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <link rel="stylesheet" href="/assets/css/item-cards.css?v=1.0.0"/>
 

--- a/restaurants/150-central-park.html
+++ b/restaurants/150-central-park.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/adagio-dining-room.html
+++ b/restaurants/adagio-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/amber-and-oak.html
+++ b/restaurants/amber-and-oak.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/american-icon-grill.html
+++ b/restaurants/american-icon-grill.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -53,6 +53,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="aquadome market, icon class, star of the seas, icon of the seas, food hall, complimentary, stalls, thai, bbq, mediterranean, crepes, tacos">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/aquadome-market.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/aquarium-bar.html
+++ b/restaurants/aquarium-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/aquarius-dining-room.html
+++ b/restaurants/aquarius-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/bamboo-room.html
+++ b/restaurants/bamboo-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -51,6 +51,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="basecamp, thrill island, icon class, star of the seas, icon of the seas, smash burger, waffle chicken nuggets, cheese curds, quick service">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/basecamp.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/bell-and-barley.html
+++ b/restaurants/bell-and-barley.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/ben-and-jerrys.html
+++ b/restaurants/ben-and-jerrys.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/bionic-bar.html
+++ b/restaurants/bionic-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/boardwalk-dog-house.html
+++ b/restaurants/boardwalk-dog-house.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/boleros.html
+++ b/restaurants/boleros.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/brass-and-bock.html
+++ b/restaurants/brass-and-bock.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/bubbles.html
+++ b/restaurants/bubbles.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/bull-and-bear-pub.html
+++ b/restaurants/bull-and-bear-pub.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -49,6 +49,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="cafe promenade, coffee, snacks, 24/7, royal promenade, sandwiches, croissants, cookies, royal roast, lattes">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/cafe-promenade.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -53,6 +53,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="cafe two70, café @ two70, two70, quantum class, complimentary, salads, sandwiches, soups, pastries, breakfast, lunch, promenade views, royal caribbean">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/cafe-two70.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/cantina-fresca.html
+++ b/restaurants/cantina-fresca.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/cascades-dining-room.html
+++ b/restaurants/cascades-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/casino-bar.html
+++ b/restaurants/casino-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/celebration-table.html
+++ b/restaurants/celebration-table.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/champagne-bar.html
+++ b/restaurants/champagne-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -46,6 +46,13 @@ All work on this project is offered as a gift to God.
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/chefs-table.html">
   <meta name="referrer" content="no-referrer">
   <meta name="theme-color" content="#0a3d62">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/chic.html
+++ b/restaurants/chic.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/chops.html
+++ b/restaurants/chops.html
@@ -44,6 +44,13 @@ All work on this project is offered as a gift to God.
   <meta name="ai-summary" content="Chops Grille is Royal Caribbean's fleet-wide premium steakhouse offering hand-cut USDA Prime steaks, fresh seafood, and classic sides with attentive service and intimate ambiance. Lunch $21–25, dinner $39–65 plus gratuity.">
   <meta name="last-reviewed" content="2025-11-18">
   <meta name="content-protocol" content="ICP-Lite v1.0">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/cloud-17.html
+++ b/restaurants/cloud-17.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -49,6 +49,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="coastal kitchen, royal suite class, sky class, star class, junior suite, pinnacle, med-cal, suite dining">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/coastal-kitchen.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/concierge-lounge.html
+++ b/restaurants/concierge-lounge.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/congo-bar.html
+++ b/restaurants/congo-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/cosmopolitan-club.html
+++ b/restaurants/cosmopolitan-club.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/crown-and-castle-pub.html
+++ b/restaurants/crown-and-castle-pub.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/crown-and-kettle.html
+++ b/restaurants/crown-and-kettle.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/dazzles.html
+++ b/restaurants/dazzles.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/desserted.html
+++ b/restaurants/desserted.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/devinly-decadence.html
+++ b/restaurants/devinly-decadence.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/diamond-club.html
+++ b/restaurants/diamond-club.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -50,6 +50,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="crown lounge, diamond lounge, crown & anchor, loyalty, diamond plus, pinnacle, concierge, happy hour">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/crown-lounge.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/dining-activities.html
+++ b/restaurants/dining-activities.html
@@ -46,6 +46,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:url" content="https://www.cruisinginthewake.com/restaurants/dining-activities.html">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/dining-activities.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.235">
   <style>
     :root{--rope:#D9B382}

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -51,6 +51,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="dog house, boardwalk, hot dogs, sausages, bratwurst, thuringer, coney dog, toppings bar, oasis class, harmony of the seas, wonder of the seas, utopia of the seas">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/dog-house.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/duck-and-dog-pub.html
+++ b/restaurants/duck-and-dog-pub.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/dueling-pianos.html
+++ b/restaurants/dueling-pianos.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/edelweiss-dining-room.html
+++ b/restaurants/edelweiss-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -53,6 +53,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="el loco fresh, complimentary, tacos, burritos, quesadillas, nachos, street corn, salsa bar, pool deck, oasis class, icon class, wonder of the seas, utopia of the seas">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/el-loco-fresh.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/empire-supper-club.html
+++ b/restaurants/empire-supper-club.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/english-pub.html
+++ b/restaurants/english-pub.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/fish-and-ships.html
+++ b/restaurants/fish-and-ships.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/game-reserve.html
+++ b/restaurants/game-reserve.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/giovannis-italian-kitchen.html
+++ b/restaurants/giovannis-italian-kitchen.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/giovannis.html
+++ b/restaurants/giovannis.html
@@ -41,6 +41,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:image" content="https://www.cruisinginthewake.com/assets/og/giovannis.jpg">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/giovannis.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=3.002">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/globe-and-atlas.html
+++ b/restaurants/globe-and-atlas.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/great-gatsby-dining-room.html
+++ b/restaurants/great-gatsby-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/hooked-seafood.html
+++ b/restaurants/hooked-seafood.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/hot-pot.html
+++ b/restaurants/hot-pot.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/izumi-in-the-park.html
+++ b/restaurants/izumi-in-the-park.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/izumi.html
+++ b/restaurants/izumi.html
@@ -35,6 +35,13 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.0">
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/izumi.html">
   <title>Izumi Sushi & Hibachi | Royal Caribbean 2025 Menus & Reviews | Cruising in the Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css">
 <script type="application/ld+json">
 {

--- a/restaurants/jamies-italian.html
+++ b/restaurants/jamies-italian.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/johnny-rockets.html
+++ b/restaurants/johnny-rockets.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -43,6 +43,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="cafe latte tudes, latte tudes, coffee, espresso, starbucks, pastries, radiance class, vision class">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/cafe-latte-tudes.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/leaf-and-bean.html
+++ b/restaurants/leaf-and-bean.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/lime-and-coconut.html
+++ b/restaurants/lime-and-coconut.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/lincoln-park-supper-club.html
+++ b/restaurants/lincoln-park-supper-club.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/lobby-bar.html
+++ b/restaurants/lobby-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/lous-jazz-n-blues.html
+++ b/restaurants/lous-jazz-n-blues.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/mason-jar.html
+++ b/restaurants/mason-jar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -41,6 +41,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS (header/hero/nav lives here) -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/minstrel-dining-room.html
+++ b/restaurants/minstrel-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/my-fair-lady-dining-room.html
+++ b/restaurants/my-fair-lady-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/north-star-bar.html
+++ b/restaurants/north-star-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/oasis-bar.html
+++ b/restaurants/oasis-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/olive-or-twist.html
+++ b/restaurants/olive-or-twist.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/on-air.html
+++ b/restaurants/on-air.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -45,6 +45,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="pearl cafe, icon class, star of the seas, icon of the seas, 24/7, complimentary, sandwiches, salads, pastries, coffee, views">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/pearl-cafe.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/pesky-parrot.html
+++ b/restaurants/pesky-parrot.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/pier-7.html
+++ b/restaurants/pier-7.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/pig-and-whistle-pub.html
+++ b/restaurants/pig-and-whistle-pub.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/playmakers.html
+++ b/restaurants/playmakers.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/plaza-bar.html
+++ b/restaurants/plaza-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/pool-bar.html
+++ b/restaurants/pool-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/portside-bbq.html
+++ b/restaurants/portside-bbq.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/quill-and-compass.html
+++ b/restaurants/quill-and-compass.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/r-bar.html
+++ b/restaurants/r-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/reflections-dining-room.html
+++ b/restaurants/reflections-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/rising-tide-bar.html
+++ b/restaurants/rising-tide-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/ritas-cantina.html
+++ b/restaurants/ritas-cantina.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/room-service.html
+++ b/restaurants/room-service.html
@@ -44,6 +44,13 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/royal-railway.html
+++ b/restaurants/royal-railway.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/rye-and-bean.html
+++ b/restaurants/rye-and-bean.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/sabor-taqueria.html
+++ b/restaurants/sabor-taqueria.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/sabor.html
+++ b/restaurants/sabor.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -38,6 +38,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-18">
   <meta name="content-protocol" content="ICP-Lite v1.0">
   <meta name="theme-color" content="#0a3d62">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/sapphire-dining-room.html
+++ b/restaurants/sapphire-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/sapphire-restaurant.html
+++ b/restaurants/sapphire-restaurant.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/schooner-bar.html
+++ b/restaurants/schooner-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/sichuan-red.html
+++ b/restaurants/sichuan-red.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/silk.html
+++ b/restaurants/silk.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/sky-bar.html
+++ b/restaurants/sky-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/solarium-bar.html
+++ b/restaurants/solarium-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -41,6 +41,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="solarium bistro, adults only, mediterranean, spa cuisine, healthy dining, royal caribbean, oasis class, symphony, wonder">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/solarium-bistro.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/solarium-cafe.html
+++ b/restaurants/solarium-cafe.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -50,6 +50,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="sorrentos, sorrento's, pizza, complimentary, royal promenade, late night, pepperoni, cheese, margherita, bbq chicken, veggie, garlic knots">
 
   <!-- Site CSS (unified) -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/sprinkles.html
+++ b/restaurants/sprinkles.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/star-lounge.html
+++ b/restaurants/star-lounge.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/starbucks.html
+++ b/restaurants/starbucks.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/sugar-beach.html
+++ b/restaurants/sugar-beach.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/suite-lounge.html
+++ b/restaurants/suite-lounge.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -43,6 +43,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="surfside eatery, icon class, star of the seas, icon of the seas, family dining, buffet, sundaes, nuggets, tacos, surfside neighborhood">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/surfside-eatery.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/swim-and-tonic.html
+++ b/restaurants/swim-and-tonic.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/tavern-bar.html
+++ b/restaurants/tavern-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/the-bamboo-room.html
+++ b/restaurants/the-bamboo-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/the-dining-room.html
+++ b/restaurants/the-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/the-grande.html
+++ b/restaurants/the-grande.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -43,6 +43,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="the grove, suite neighborhood, sea class, star class, icon class, mediterranean, mezze, al fresco, suite dining">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/the-grove.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/the-overlook.html
+++ b/restaurants/the-overlook.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/the-pit-stop.html
+++ b/restaurants/the-pit-stop.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/tides-dining-room.html
+++ b/restaurants/tides-dining-room.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/trellis-bar.html
+++ b/restaurants/trellis-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/two70-bar.html
+++ b/restaurants/two70-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/viking-crown-lounge.html
+++ b/restaurants/viking-crown-lounge.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/vintages.html
+++ b/restaurants/vintages.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -43,6 +43,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="vitality cafe, vitality at sea, wellness, smoothies, protein shakes, spa, royal caribbean, oasis class, wonder of the seas">
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/restaurants/vitality-cafe.html">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/vortex.html
+++ b/restaurants/vortex.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/wig-and-gavel.html
+++ b/restaurants/wig-and-gavel.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -38,6 +38,13 @@ All work on this project is offered as a gift to God.
   <meta name="venue-tags" content="windjammer, marketplace, buffet, complimentary, breakfast, lunch, dinner, vegan, vegetarian, indian, gluten-free, kids, themes">
 
   <!-- Site CSS (use your unified sheet) -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/restaurants/wipeout-bar.html
+++ b/restaurants/wipeout-bar.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/wonderland.html
+++ b/restaurants/wonderland.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/restaurants/zanzibar-lounge.html
+++ b/restaurants/zanzibar-lounge.html
@@ -40,6 +40,13 @@ All work on this project is offered as a gift to God.
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Site CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.257">
 
   <!-- Analytics -->

--- a/search.html
+++ b/search.html
@@ -452,6 +452,13 @@
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-adventure.html
+++ b/ships/carnival/carnival-adventure.html
@@ -254,6 +254,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-breeze.html
+++ b/ships/carnival/carnival-breeze.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-carnival-breeze.html
+++ b/ships/carnival/carnival-carnival-breeze.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Breeze — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-breeze.html">
 <meta name="description" content="Carnival Breeze — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-carnival-celebration.html
+++ b/ships/carnival/carnival-carnival-celebration.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Celebration — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-celebration.html">
 <meta name="description" content="Carnival Celebration — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-carnival-conquest.html
+++ b/ships/carnival/carnival-carnival-conquest.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Conquest — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-conquest.html">
 <meta name="description" content="Carnival Conquest — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-carnival-dream.html
+++ b/ships/carnival/carnival-carnival-dream.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Dream — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-dream.html">
 <meta name="description" content="Carnival Dream — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-carnival-elation.html
+++ b/ships/carnival/carnival-carnival-elation.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Elation — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-elation.html">
 <meta name="description" content="Carnival Elation — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-carnival-firenze.html
+++ b/ships/carnival/carnival-carnival-firenze.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Firenze — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-firenze.html">
 <meta name="description" content="Carnival Firenze — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-carnival-freedom.html
+++ b/ships/carnival/carnival-carnival-freedom.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Freedom — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-freedom.html">
 <meta name="description" content="Carnival Freedom — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-carnival-glory.html
+++ b/ships/carnival/carnival-carnival-glory.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Glory — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-glory.html">
 <meta name="description" content="Carnival Glory — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-carnival-horizon.html
+++ b/ships/carnival/carnival-carnival-horizon.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Horizon — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-horizon.html">
 <meta name="description" content="Carnival Horizon — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-carnival-jubilee.html
+++ b/ships/carnival/carnival-carnival-jubilee.html
@@ -22,6 +22,13 @@ All work on this project is offered as a gift to God.
 <meta charset="utf-8">
 <title>Carnival Jubilee — Carnival Cruise Line — Royal Caribbean | v2.224</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234">
 <link rel="canonical" href="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-jubilee.html">
 <meta name="description" content="Carnival Jubilee — Carnival Cruise Line (Coming Soon) — placeholder page compliant with In The Wake Standards v2.224.">

--- a/ships/carnival/carnival-celebration.html
+++ b/ships/carnival/carnival-celebration.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-conquest.html
+++ b/ships/carnival/carnival-conquest.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-dream.html
+++ b/ships/carnival/carnival-dream.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-ecstasy.html
+++ b/ships/carnival/carnival-ecstasy.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/carnival-elation.html
+++ b/ships/carnival/carnival-elation.html
@@ -254,6 +254,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-encounter.html
+++ b/ships/carnival/carnival-encounter.html
@@ -254,6 +254,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-fantasy.html
+++ b/ships/carnival/carnival-fantasy.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/carnival-fascination.html
+++ b/ships/carnival/carnival-fascination.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/carnival-festivale.html
+++ b/ships/carnival/carnival-festivale.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -28,6 +28,13 @@ All work on this project is offered as a gift to God.
 <link href="https://inthewake.example/ships/carnival/carnival-firenze.html" rel="canonical"/>
 <meta content="Details, deck plans, photos, and videos for Carnival Firenze — Active (Present) ship with Carnival Cruise Line." name="description"/>
 <link href="https://www.carnival.com" rel="preconnect"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/carnival/carnival-freedom.html
+++ b/ships/carnival/carnival-freedom.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-glory.html
+++ b/ships/carnival/carnival-glory.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-imagination.html
+++ b/ships/carnival/carnival-imagination.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/carnival-inspiration.html
+++ b/ships/carnival/carnival-inspiration.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/carnival-jubilee.html
+++ b/ships/carnival/carnival-jubilee.html
@@ -28,6 +28,13 @@ All work on this project is offered as a gift to God.
 <link href="https://inthewake.example/ships/carnival/carnival-jubilee.html" rel="canonical"/>
 <meta content="Details, deck plans, photos, and videos for Carnival Jubilee — Active (Present) ship with Carnival Cruise Line." name="description"/>
 <link href="https://www.carnival.com" rel="preconnect"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/carnival/carnival-legend.html
+++ b/ships/carnival/carnival-legend.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-liberty.html
+++ b/ships/carnival/carnival-liberty.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-luminosa.html
+++ b/ships/carnival/carnival-luminosa.html
@@ -254,6 +254,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-magic.html
+++ b/ships/carnival/carnival-magic.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-mardi-gras.html
+++ b/ships/carnival/carnival-mardi-gras.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-miracle.html
+++ b/ships/carnival/carnival-miracle.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-paradise.html
+++ b/ships/carnival/carnival-paradise.html
@@ -254,6 +254,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-pride.html
+++ b/ships/carnival/carnival-pride.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-radiance.html
+++ b/ships/carnival/carnival-radiance.html
@@ -254,6 +254,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-sensation.html
+++ b/ships/carnival/carnival-sensation.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/carnival-spirit.html
+++ b/ships/carnival/carnival-spirit.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-splendor.html
+++ b/ships/carnival/carnival-splendor.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-sunrise.html
+++ b/ships/carnival/carnival-sunrise.html
@@ -254,6 +254,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -254,6 +254,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-tropicale.html
+++ b/ships/carnival/carnival-tropicale.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/carnival-valor.html
+++ b/ships/carnival/carnival-valor.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -254,6 +254,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnival-vista.html
+++ b/ships/carnival/carnival-vista.html
@@ -291,6 +291,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/ships/carnival/carnivale.html
+++ b/ships/carnival/carnivale.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/celebration.html
+++ b/ships/carnival/celebration.html
@@ -28,6 +28,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <link rel="preconnect" href="https://www.carnival.com">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/carnival/festivale.html
+++ b/ships/carnival/festivale.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/holiday.html
+++ b/ships/carnival/holiday.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/index.html
+++ b/ships/carnival/index.html
@@ -167,6 +167,13 @@ All work on this project is offered as a gift to God.
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head><body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <!-- ARIA Live Regions -->

--- a/ships/carnival/jubilee.html
+++ b/ships/carnival/jubilee.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/mardi-gras.html
+++ b/ships/carnival/mardi-gras.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/tropicale.html
+++ b/ships/carnival/tropicale.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/unnamed-project-ace-1.html
+++ b/ships/carnival/unnamed-project-ace-1.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/unnamed-project-ace-2.html
+++ b/ships/carnival/unnamed-project-ace-2.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/unnamed-project-ace-3.html
+++ b/ships/carnival/unnamed-project-ace-3.html
@@ -109,6 +109,13 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
 
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Apex • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-ascent.html
+++ b/ships/celebrity-cruises/celebrity-ascent.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Ascent • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-beyond.html
+++ b/ships/celebrity-cruises/celebrity-beyond.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Beyond • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-century.html
+++ b/ships/celebrity-cruises/celebrity-century.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Century • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-compass.html
+++ b/ships/celebrity-cruises/celebrity-compass.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Compass • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-constellation.html
+++ b/ships/celebrity-cruises/celebrity-constellation.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Constellation • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-eclipse.html
+++ b/ships/celebrity-cruises/celebrity-eclipse.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Eclipse • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-edge.html
+++ b/ships/celebrity-cruises/celebrity-edge.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Edge • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-equinox.html
+++ b/ships/celebrity-cruises/celebrity-equinox.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Equinox • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-flora.html
+++ b/ships/celebrity-cruises/celebrity-flora.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Flora • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-galaxy.html
+++ b/ships/celebrity-cruises/celebrity-galaxy.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Galaxy • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-infinity.html
+++ b/ships/celebrity-cruises/celebrity-infinity.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Infinity • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-mercury.html
+++ b/ships/celebrity-cruises/celebrity-mercury.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Mercury • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-millennium.html
+++ b/ships/celebrity-cruises/celebrity-millennium.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Millennium • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-reflection.html
+++ b/ships/celebrity-cruises/celebrity-reflection.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Reflection • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-seeker.html
+++ b/ships/celebrity-cruises/celebrity-seeker.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Seeker • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-silhouette.html
+++ b/ships/celebrity-cruises/celebrity-silhouette.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Silhouette • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-solstice.html
+++ b/ships/celebrity-cruises/celebrity-solstice.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Solstice • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-summit.html
+++ b/ships/celebrity-cruises/celebrity-summit.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Summit • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Xcel • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-xpedition.html
+++ b/ships/celebrity-cruises/celebrity-xpedition.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Xpedition • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-xperience.html
+++ b/ships/celebrity-cruises/celebrity-xperience.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Xperience • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/celebrity-xploration.html
+++ b/ships/celebrity-cruises/celebrity-xploration.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Celebrity Xploration • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/horizon.html
+++ b/ships/celebrity-cruises/horizon.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Horizon • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/index.html
+++ b/ships/celebrity-cruises/index.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/celebrity-cruises/index.html">
   
   <!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
   
   <style>

--- a/ships/celebrity-cruises/ss-meridian.html
+++ b/ships/celebrity-cruises/ss-meridian.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>SS Meridian • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/unnamed-edge-class.html
+++ b/ships/celebrity-cruises/unnamed-edge-class.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Unnamed (Edge-class) • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/unnamed-project-nirvana.html
+++ b/ships/celebrity-cruises/unnamed-project-nirvana.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Unnamed (Project Nirvana) • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/unnamed-river-class-x6.html
+++ b/ships/celebrity-cruises/unnamed-river-class-x6.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Unnamed (River-class x6) • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/celebrity-cruises/zenith.html
+++ b/ships/celebrity-cruises/zenith.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Zenith • Celebrity Cruises • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/amsterdam.html
+++ b/ships/holland-america-line/amsterdam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Amsterdam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/edam.html
+++ b/ships/holland-america-line/edam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Edam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/eurodam.html
+++ b/ships/holland-america-line/eurodam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Eurodam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/index.html
+++ b/ships/holland-america-line/index.html
@@ -18,6 +18,13 @@ All work on this project is offered as a gift to God.
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/holland-america-line/index.html">
   
   <!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
   
   <style>

--- a/ships/holland-america-line/koningsdam.html
+++ b/ships/holland-america-line/koningsdam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Koningsdam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/leerdam.html
+++ b/ships/holland-america-line/leerdam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Leerdam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/maartensdijk.html
+++ b/ships/holland-america-line/maartensdijk.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Maartensdijk • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/maasdam.html
+++ b/ships/holland-america-line/maasdam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Maasdam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/nieuw-amsterdam-ii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-ii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Nieuw Amsterdam (II) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/nieuw-amsterdam-iii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Nieuw Amsterdam (III) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/nieuw-amsterdam-iv.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iv.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Nieuw Amsterdam (IV) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/nieuw-amsterdam-v.html
+++ b/ships/holland-america-line/nieuw-amsterdam-v.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Nieuw Amsterdam (V) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/nieuw-amsterdam.html
+++ b/ships/holland-america-line/nieuw-amsterdam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Nieuw Amsterdam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/nieuw-statendam.html
+++ b/ships/holland-america-line/nieuw-statendam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Nieuw Statendam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/none-announced.html
+++ b/ships/holland-america-line/none-announced.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>None announced • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/noordam-ii.html
+++ b/ships/holland-america-line/noordam-ii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Noordam (II) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/noordam-iii.html
+++ b/ships/holland-america-line/noordam-iii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Noordam (III) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/noordam-iv.html
+++ b/ships/holland-america-line/noordam-iv.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Noordam (IV) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/noordam.html
+++ b/ships/holland-america-line/noordam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Noordam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/oosterdam.html
+++ b/ships/holland-america-line/oosterdam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Oosterdam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/p-caland.html
+++ b/ships/holland-america-line/p-caland.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>P. Caland • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/potsdam.html
+++ b/ships/holland-america-line/potsdam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Potsdam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/prinsendam-i.html
+++ b/ships/holland-america-line/prinsendam-i.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Prinsendam (I) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/prinsendam-ii.html
+++ b/ships/holland-america-line/prinsendam-ii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Prinsendam (II) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/rijndam-ii.html
+++ b/ships/holland-america-line/rijndam-ii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Rijndam (II) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/rijndam.html
+++ b/ships/holland-america-line/rijndam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Rijndam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/rotterdam-iv.html
+++ b/ships/holland-america-line/rotterdam-iv.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Rotterdam (IV) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/rotterdam-v.html
+++ b/ships/holland-america-line/rotterdam-v.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Rotterdam (V) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/rotterdam-vi.html
+++ b/ships/holland-america-line/rotterdam-vi.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Rotterdam (VI) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/rotterdam.html
+++ b/ships/holland-america-line/rotterdam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Rotterdam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/ryndam.html
+++ b/ships/holland-america-line/ryndam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Ryndam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/statendam-ii.html
+++ b/ships/holland-america-line/statendam-ii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Statendam (II) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/statendam-iii.html
+++ b/ships/holland-america-line/statendam-iii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Statendam (III) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/statendam.html
+++ b/ships/holland-america-line/statendam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Statendam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/veendam-ii.html
+++ b/ships/holland-america-line/veendam-ii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Veendam (II) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/veendam-iii.html
+++ b/ships/holland-america-line/veendam-iii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Veendam (III) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/veendam-iv.html
+++ b/ships/holland-america-line/veendam-iv.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Veendam (IV) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/veendam.html
+++ b/ships/holland-america-line/veendam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Veendam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/volendam-ii.html
+++ b/ships/holland-america-line/volendam-ii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Volendam (II) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/volendam-iii.html
+++ b/ships/holland-america-line/volendam-iii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Volendam (III) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/volendam.html
+++ b/ships/holland-america-line/volendam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Volendam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/w-a-scholten.html
+++ b/ships/holland-america-line/w-a-scholten.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>W.A. Scholten • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/westerdam-i.html
+++ b/ships/holland-america-line/westerdam-i.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Westerdam (I) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/westerdam-ii.html
+++ b/ships/holland-america-line/westerdam-ii.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Westerdam (II) • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/holland-america-line/zaandam.html
+++ b/ships/holland-america-line/zaandam.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
 <title>Zaandam • Holland America Line • In The Wake</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
   <style>
   /* Header / Hero */

--- a/ships/index.html
+++ b/ships/index.html
@@ -65,6 +65,13 @@ All work on this project is offered as a gift to God.
   <meta name="page:version" content="3.008.032"/>
 
   <!-- CSS (site-wide) -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.008.032"/>
 
   <!-- Page styles -->

--- a/ships/msc/msc-world-america.html
+++ b/ships/msc/msc-world-america.html
@@ -25,6 +25,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
   <title>Msc World America — In the Wake (v2.201)</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://jsschrstrcks1.github.io/InTheWake/assets/styles.css?v=2.201"/>
   
   <link rel="stylesheet" href="https://jsschrstrcks1.github.io/InTheWake/assets/vendor/swiper-bundle.min.css?v=2.201"/>

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -255,6 +255,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/discovery-class-ship-tbn.html
+++ b/ships/rcl/discovery-class-ship-tbn.html
@@ -222,6 +222,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -255,6 +255,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -255,6 +255,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/icon-class-ship-tbn-2027.html
+++ b/ships/rcl/icon-class-ship-tbn-2027.html
@@ -254,6 +254,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/icon-class-ship-tbn-2028.html
+++ b/ships/rcl/icon-class-ship-tbn-2028.html
@@ -254,6 +254,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/icon-of-the-seas.html
+++ b/ships/rcl/icon-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/legend-of-the-seas-1995-built.html
+++ b/ships/rcl/legend-of-the-seas-1995-built.html
@@ -228,6 +228,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
+++ b/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
@@ -254,6 +254,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/legend-of-the-seas.html
+++ b/ships/rcl/legend-of-the-seas.html
@@ -228,6 +228,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/majesty-of-the-seas.html
+++ b/ships/rcl/majesty-of-the-seas.html
@@ -255,6 +255,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/monarch-of-the-seas.html
+++ b/ships/rcl/monarch-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/nordic-empress.html
+++ b/ships/rcl/nordic-empress.html
@@ -228,6 +228,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/nordic-prince.html
+++ b/ships/rcl/nordic-prince.html
@@ -196,6 +196,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/oasis-class-ship-tbn-2028.html
+++ b/ships/rcl/oasis-class-ship-tbn-2028.html
@@ -223,6 +223,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -178,6 +178,13 @@ STANDARDS: Every Page v3.010.302 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.302"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
@@ -254,6 +254,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
@@ -254,6 +254,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -255,6 +255,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/song-of-america.html
+++ b/ships/rcl/song-of-america.html
@@ -197,6 +197,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/song-of-norway.html
+++ b/ships/rcl/song-of-norway.html
@@ -230,6 +230,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/sovereign-of-the-seas.html
+++ b/ships/rcl/sovereign-of-the-seas.html
@@ -178,6 +178,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -178,6 +178,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/splendour-of-the-seas.html
+++ b/ships/rcl/splendour-of-the-seas.html
@@ -246,6 +246,13 @@ updated: 2025-11-18
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/star-class-ship-tbn-2028.html
+++ b/ships/rcl/star-class-ship-tbn-2028.html
@@ -254,6 +254,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/star-of-the-seas-aug-2025-debut.html
+++ b/ships/rcl/star-of-the-seas-aug-2025-debut.html
@@ -254,6 +254,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/star-of-the-seas.html
+++ b/ships/rcl/star-of-the-seas.html
@@ -254,6 +254,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/sun-viking.html
+++ b/ships/rcl/sun-viking.html
@@ -196,6 +196,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -178,6 +178,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -178,6 +178,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/viking-serenade.html
+++ b/ships/rcl/viking-serenade.html
@@ -197,6 +197,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -255,6 +255,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -178,6 +178,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -178,6 +178,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- ===== Standards helpers (absolute URL + origin normalizer) ===== -->

--- a/ships/rooms.html
+++ b/ships/rooms.html
@@ -34,6 +34,13 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
   <title>Rooms — In the Wake (v2.201)</title>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://jsschrstrcks1.github.io/InTheWake/assets/styles.css?v=2.201"/>
   
   <link rel="stylesheet" href="https://jsschrstrcks1.github.io/InTheWake/assets/vendor/swiper-bundle.min.css?v=2.201"/>

--- a/ships/template.html
+++ b/ships/template.html
@@ -68,6 +68,13 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- Global CSS -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.245"/>
 
   <!-- Swiper CSS -->

--- a/solo.html
+++ b/solo.html
@@ -227,6 +227,13 @@
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
 
   <!-- Site bundle -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- SOLO hero + inline-hero card treatment (scoped) -->

--- a/solo/accessible-cruising.html
+++ b/solo/accessible-cruising.html
@@ -230,6 +230,13 @@ All work on this project is offered as a gift to God.
     .toc-sticky{position:static;margin-bottom:1rem}
   }
   </style>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/solo/articles/solo-cruisers-companion.html
+++ b/solo/articles/solo-cruisers-companion.html
@@ -1,5 +1,12 @@
 <article id="solo-cruisers-companion" data-slug="solo-cruisers-companion" class="solo-article" itemscope itemtype="https://schema.org/Article">
   <header>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
     <h1 itemprop="headline">The Solo Cruiser's Companion</h1>
     <p class="dek" itemprop="description">A Practical Guide for Traveling Alone at Sea</p>
     <p class="byline">by Ken Baker</p>

--- a/solo/articles/visiting-the-united-states-before-your-cruise.html
+++ b/solo/articles/visiting-the-united-states-before-your-cruise.html
@@ -27,6 +27,13 @@
   <link rel="preload" as="image" href="/solo/images/flickersofmajesty.jpeg" fetchpriority="high"/>
 
   <!-- CSS (shared) -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css?v=3.009.024"/>
 
   <!-- Page-local helpers -->

--- a/solo/in-the-wake-of-grief-meta.html
+++ b/solo/in-the-wake-of-grief-meta.html
@@ -1,6 +1,13 @@
 <!--
   META TAGS: In the Wake of Grief
-  Add to page <head> when template is built
+  Add to page <head>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+ when template is built
   Location: /solo/in-the-wake-of-<a href="/solo/in-the-wake-of-grief.html">grief</a>.html
 -->
 

--- a/solo/solo-cruisers-companion.html
+++ b/solo/solo-cruisers-companion.html
@@ -228,6 +228,13 @@
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/solo/solo-cruising-practical-guide.html
+++ b/solo/solo-cruising-practical-guide.html
@@ -95,6 +95,13 @@
     ]
   }
   </script>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 </head>

--- a/terms.html
+++ b/terms.html
@@ -36,6 +36,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:site_name" content="In the Wake">
 
   <!-- Styles -->
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="./assets/css/styles.css">
 
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>

--- a/tools/port-tracker.html
+++ b/tools/port-tracker.html
@@ -16,6 +16,13 @@ Soli Deo Gloria
   <meta name="description" content="Track your cruise port visits across all cruise lines, earn achievement badges, and build your personal port collection!"/>
   <link rel="canonical" href="https://cruisinginthewake.com/tools/port-tracker.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
     .tracker-container { max-width: 1400px; margin: 2rem auto; padding: 0 1rem; }

--- a/tools/ship-tracker.html
+++ b/tools/ship-tracker.html
@@ -16,6 +16,13 @@ Soli Deo Gloria
   <meta name="description" content="Track which cruise ships you've sailed on across all lines, earn fleet achievement badges, and build your sailing history!"/>
   <link rel="canonical" href="https://cruisinginthewake.com/tools/ship-tracker.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
   <link rel="stylesheet" href="/assets/styles.css"/>
 
   <!-- Google Analytics -->


### PR DESCRIPTION
Previously only ~19 pages registered the service worker, meaning users who first visited the home page or other popular pages wouldn't get offline support until navigating elsewhere.

Now all HTML pages register the SW, ensuring offline capability regardless of entry point.