### PR TITLE
Fix ships.html grid layout issues - ships display and infinite scroll

### DIFF
--- a/ships.html
+++ b/ships.html
@@ -1052,7 +1052,7 @@
       </div>
     </section>
 
-    <section style="grid-column: 1; grid-row: 1 / span 999;" class="card prose" aria-labelledby="ships-intro">
+    <section style="grid-column: 1;" class="card prose" aria-labelledby="ships-intro">
       <h1 id="ships-intro">Royal Caribbean Ships — Organized by Class</h1>
 
       <p>Explore the Royal Caribbean fleet organized by ship class—from the newest Icon-class megaships to the classic Vision-class vessels. Each ship card shows you available images (cycling randomly each visit) and links directly to detailed ship pages.</p>
@@ -1409,7 +1409,7 @@
     </section>
 
     <!-- RIGHT RAIL -->
-    <aside class="rail" aria-label="Right rail" style="grid-column: 2; grid-row: 2;">
+    <aside class="rail" aria-label="Right rail" style="grid-column: 2;">
       <!-- Author card (vertical pattern matching index.html) -->
       <section class="card author-card-vertical" aria-labelledby="author-heading">
         <h3 id="author-heading">About the Author</h3>


### PR DESCRIPTION
CRITICAL FIXES:

1. Ships Not Displaying in Main Content:
   - Removed grid-row: 1 / span 999 from intro section (line 1055)
   - This 999-row span was creating massive vertical space
   - Fleet list section was auto-placing way down the page
   - Now intro and fleet sections stack naturally in grid-column 1

2. Infinite Scroll Bug After Author Card:
   - Removed grid-row: 2 from right rail aside (line 1412)
   - Right rail was starting at row 2, after the 999-row span
   - Created massive whitespace/infinite scroll effect
   - Now right rail auto-places naturally in grid-column 2

Root Cause:
- grid-row: 1 / span 999 forced intro to occupy rows 1-999
- Fleet list had no row spec → placed after row 999
- Right rail started at row 2 → below row 999 = huge gap

Solution:
- Let grid auto-place all sections naturally
- Left column (grid-column: 1) sections stack top to bottom
- Right column (grid-column: 2) sections stack top to bottom
- Grid handles the layout without explicit row spans

Files Modified:
- ships.html (2 grid-row specifications removed)