### PR TITLE
Merge duplicate 'Royal Caribbean Fleet' sections on ships.html

### DIFF
--- a/ships.html
+++ b/ships.html
@@ -1052,18 +1052,15 @@
       </div>
     </section>
 
-    <section style="grid-column: 1;" class="card prose" aria-labelledby="ships-intro">
-      <h1 id="ships-intro">Royal Caribbean Ships — Organized by Class</h1>
+    <!-- Royal Caribbean Fleet - Main Content Section -->
+    <section class="card prose" aria-labelledby="ships-intro" style="grid-column: 1;">
+      <h1 id="ships-intro">Royal Caribbean Fleet — Organized by Class</h1>
 
       <p>Explore the Royal Caribbean fleet organized by ship class—from the newest Icon-class megaships to the classic Vision-class vessels. Each ship card shows you available images (cycling randomly each visit) and links directly to detailed ship pages.</p>
 
       <div class="ships-share-section">
         <button id="shareShipsPage" class="share-btn" type="button" aria-label="Share this page">Share Page</button>
       </div>
-    </section>
-
-    <section class="card" aria-labelledby="fleet-list" style="grid-column: 1;">
-      <h2 id="fleet-list">Royal Caribbean Fleet — Organized by Class</h2>
 
       <!-- Ship Search -->
       <div class="ship-search-container">


### PR DESCRIPTION
Consolidation:
- Merged two duplicate sections into one comprehensive section
- Section 1: H1 + intro paragraph + share button
- Section 2: H2 + ship search + ships container + noscript fallback
- New: Single section with H1, all content flows together

Changes:
- Removed duplicate H2 "Royal Caribbean Fleet — Organized by Class"
- Kept H1 "Royal Caribbean Fleet — Organized by Class"
- Combined intro paragraph, share button, search, and ship listings
- Maintained all functionality: search, dynamic loading, fallback table
- Positioned in grid-column: 1 for main content area

Result:
- Single unified fleet section starting immediately after header
- No duplication of headings or structure
- Better content flow and user experience
- All features preserved in merged section

Files Modified:
- ships.html (merged lines 1055-1312 into single section)