### PR TITLE
Fix ships.html right rail structure - Remove gap and duplicate aside

### DIFF
--- a/ships.html
+++ b/ships.html
@@ -1023,36 +1023,77 @@
     </div></header>
 
   <main id="content" class="wrap page-grid" role="main">
-    <!-- Quick Answer / At a Glance - Early in HTML for SEO/AI, visually in right rail -->
-    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin: 0 0 1.5rem;">
-      <h2 style="font-size: 1.1rem; margin: 0 0 0.5rem;">At a Glance</h2>
+    <!-- RIGHT COLUMN: At a Glance + Author + Articles -->
+    <aside class="rail" role="complementary" aria-label="At a glance, author & articles" style="grid-column: 2;">
+      <!-- At a Glance / Quick Answer -->
+      <section class="page-intro" style="margin: 0 0 1.5rem;">
+        <h2 style="font-size: 1.1rem; margin: 0 0 0.5rem;">At a Glance</h2>
 
-      <!-- ICP-Lite: Answer Line -->
-      <p class="answer-line">
-        <span class="answer-q">What this page covers</span>
-        <span class="answer-a">All 28 Royal Caribbean ships organized by class, with deck plans, live trackers, and comparisons to help you choose the right vessel for your cruise.</span>
-      </p>
+        <!-- ICP-Lite: Answer Line -->
+        <p class="answer-line">
+          <span class="answer-q">What this page covers</span>
+          <span class="answer-a">All 28 Royal Caribbean ships organized by class, with deck plans, live trackers, and comparisons to help you choose the right vessel for your cruise.</span>
+        </p>
 
-      <!-- ICP-Lite: Fit Guidance -->
-      <section class="fit-guidance">
-        <h3 class="sr-only">Who This Page Is For</h3>
-        <p style="font-size: 0.9rem;">This page welcomes cruisers researching ship options, comparing classes, or planning their first (or fiftieth) sailing. Whether you're drawn to Icon-class innovation or Vision-class intimacy, you'll find the fleet organized to help you choose the vessel that matches your travel rhythm.</p>
+        <!-- ICP-Lite: Fit Guidance -->
+        <section class="fit-guidance">
+          <h3 class="sr-only">Who This Page Is For</h3>
+          <p style="font-size: 0.9rem;">This page welcomes cruisers researching ship options, comparing classes, or planning their first (or fiftieth) sailing. Whether you're drawn to Icon-class innovation or Vision-class intimacy, you'll find the fleet organized to help you choose the vessel that matches your travel rhythm.</p>
+        </section>
+
+        <!-- ICP-Lite: Key Facts -->
+        <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
+          <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
+          <ul style="margin: 0; padding-left: 1.25rem; font-size: 0.9rem;">
+            <li>Fleet size: 28 ships across 7 ship classes</li>
+            <li>Newest ships: <a href="/ships/rcl/icon-of-the-seas.html">Icon of the Seas</a> (2024), Star of the Seas (2025)</li>
+            <li>Largest ships: Icon class at 250,800 GT with 7,600 guest capacity</li>
+            <li>Ship classes: Icon, Oasis, Quantum Ultra, Quantum, Freedom, Voyager, Radiance, Vision</li>
+            <li>Interactive features: Official deck plans, live ship trackers, class comparisons</li>
+          </ul>
+        </div>
       </section>
 
-      <!-- ICP-Lite: Key Facts -->
-      <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
-        <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
-        <ul style="margin: 0; padding-left: 1.25rem; font-size: 0.9rem;">
-          <li>Fleet size: 28 ships across 7 ship classes</li>
-          <li>Newest ships: <a href="/ships/rcl/icon-of-the-seas.html">Icon of the Seas</a> (2024), Star of the Seas (2025)</li>
-          <li>Largest ships: Icon class at 250,800 GT with 7,600 guest capacity</li>
-          <li>Ship classes: Icon, Oasis, Quantum Ultra, Quantum, Freedom, Voyager, Radiance, Vision</li>
-          <li>Interactive features: Official deck plans, live ship trackers, class comparisons</li>
-        </ul>
-      </div>
-    </section>
+      <!-- Author card (vertical pattern matching index.html) -->
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
 
-    <!-- Royal Caribbean Fleet - Main Content Section -->
+      <!-- Ship tracker rail (feature-specific, display:none by default) -->
+      <section id="ship-tracker-rail" class="card" aria-labelledby="tracker-title" style="display:none;position:sticky;top:1rem">
+        <h3 id="tracker-title">Live Ship Location</h3>
+        <p class="tiny muted" id="tracker-ship-name">Hover over a ship to see its live position</p>
+        <div id="tracker-container" style="width:100%;height:280px;background:#f0f4f8;border-radius:8px;overflow:hidden;position:relative">
+          <p class="tiny" style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);text-align:center;color:#789">
+            Hover over a ship card<br>to see its live tracker
+          </p>
+        </div>
+        <p class="tiny muted">Updates automatically on hover</p>
+      </section>
+
+      <!-- Recent Stories rail (matches index.html pattern) -->
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+
+    <!-- LEFT COLUMN: Royal Caribbean Fleet - Main Content Section -->
     <section class="card prose" aria-labelledby="ships-intro" style="grid-column: 1;">
       <h1 id="ships-intro">Royal Caribbean Fleet — Organized by Class</h1>
 
@@ -1404,48 +1445,6 @@
         your cabin with luggage in tow, a quick glance at the layout saves wandering.
       </p>
     </section>
-
-    <!-- RIGHT RAIL -->
-    <aside class="rail" aria-label="Right rail" style="grid-column: 2;">
-      <!-- Author card (vertical pattern matching index.html) -->
-      <section class="card author-card-vertical" aria-labelledby="author-heading">
-        <h3 id="author-heading">About the Author</h3>
-        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
-          <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
-          </picture>
-        </a>
-        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
-        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
-        <p class="tiny">
-          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
-        </p>
-      </section>
-
-      <!-- Ship tracker rail (feature-specific, display:none by default) -->
-      <section id="ship-tracker-rail" class="card" aria-labelledby="tracker-title" style="display:none;position:sticky;top:1rem">
-        <h3 id="tracker-title">Live Ship Location</h3>
-        <p class="tiny muted" id="tracker-ship-name">Hover over a ship to see its live position</p>
-        <div id="tracker-container" style="width:100%;height:280px;background:#f0f4f8;border-radius:8px;overflow:hidden;position:relative">
-          <p class="tiny" style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);text-align:center;color:#789">
-            Hover over a ship card<br>to see its live tracker
-          </p>
-        </div>
-        <p class="tiny muted">Updates automatically on hover</p>
-      </section>
-
-      <!-- Recent Articles rail (matches index.html pattern) -->
-      <section class="card" aria-labelledby="recent-rail-title">
-        <h3 id="recent-rail-title">Recent Stories</h3>
-        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
-        </p>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
-        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
-      </section>
-
-    </aside>
   </main>
 
     <footer class="wrap" role="contentinfo">


### PR DESCRIPTION
Critical Restructuring:
- Moved ICP-Lite section INSIDE the aside (was standalone)
- Matches index.html pattern: aside contains all right rail content
- Author card now immediately follows ICP-Lite (no gap)
- Removed duplicate aside section that was auto-placing far down page

Structure Before:
- ICP-Lite section: standalone in grid-column: 2, grid-row: 1
- Main content: grid-column: 1 (very long)
- Duplicate aside: grid-column: 2, auto-placed after main content
- Result: Huge gap between ICP-Lite and author card

Structure After:
- Single aside in grid-column: 2 containing:
  1. ICP-Lite (At a Glance, Key Facts)
  2. Author card (immediately follows)
  3. Ship tracker
  4. Recent Stories
- Main content in grid-column: 1
- Result: All right rail elements stack naturally, no gaps

Files Modified:
- ships.html (restructured right rail, removed duplicate aside)