### PR TITLE
Fix ships.html page-grid container - Add missing main element

### DIFF
--- a/ships.html
+++ b/ships.html
@@ -1022,6 +1022,7 @@
       </div>
     </div></header>
 
+  <main id="content" class="wrap page-grid" role="main">
     <!-- LEFT COLUMN: Royal Caribbean Fleet - Main Content Section -->
     <section class="card prose" aria-labelledby="ships-intro" style="grid-column: 1; grid-row: 1;">
       <h1 id="ships-intro">Royal Caribbean Fleet — Organized by Class</h1>
@@ -1375,7 +1376,7 @@
     </section>
 
     </section>
-  <main id="content" class="wrap page-grid" role="main">
+
     <!-- RIGHT COLUMN: At a Glance + Author + Articles -->
     <aside class="rail" role="complementary" aria-label="At a glance, author & articles" style="grid-column: 2; grid-row: 1;">
       <!-- At a Glance / Quick Answer -->


### PR DESCRIPTION
Critical Fix:
- Added <main> element after header (was accidentally removed during section swap)
- Removed duplicate <main> tag that was with aside section
- page-grid class now properly wraps both columns

Issue:
- When swapping fleet/aside sections, <main> tag was moved with aside
- Fleet section and aside were OUTSIDE the page-grid container
- Result: No 2-column grid layout, cards full width, right rail below content

Solution:
- <main class="wrap page-grid"> now properly placed after header
- Both fleet section (grid-column: 1) and aside (grid-column: 2) inside main
- Grid system can now create 2-column layout

Structure Now:
<header>...</header>
<main class="wrap page-grid">  ← ADDED HERE
  <section grid-column: 1>Fleet content</section>
  <aside grid-column: 2>Right rail</aside>
</main>

Result:
- 2-column grid layout works correctly
- Cards no longer full width
- Right rail beside main content, not below
- Logo placement correct (matches planning.html pattern)

Files Modified:
- ships.html (added main element, removed duplicate)