### PR TITLE
Add cross-links to port pages (partial - Caribbean)

### DIFF
--- a/ports.html
+++ b/ports.html
@@ -594,27 +594,27 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
         <h3>Bahamas</h3>
         <ul style="columns:2;column-gap:2rem;">
-          <li><strong>Nassau</strong> — Atlantis day passes, downtown shopping, Junkanoo Beach</li>
+          <li><strong><a href="/ports/nassau.html">Nassau</a></strong> — Atlantis day passes, downtown shopping, Junkanoo Beach</li>
           <li><strong>Freeport/Lucaya</strong> — Port Lucaya Marketplace, Garden of the Groves</li>
           <li><strong>Bimini</strong> — Close to Miami, excellent fishing, Resorts World</li>
         </ul>
 
         <h3>Eastern Caribbean</h3>
         <ul style="columns:2;column-gap:2rem;">
-          <li><strong>St. Thomas, USVI</strong> — Charlotte Amalie duty-free shopping, Magens Bay</li>
+          <li><strong><a href="/ports/st-thomas.html">St. Thomas, USVI</a></strong> — Charlotte Amalie duty-free shopping, Magens Bay</li>
           <li><strong>St. John, USVI</strong> — Trunk Bay, Virgin Islands National Park</li>
           <li><strong>St. Croix, USVI</strong> — Christiansted, Buck Island snorkeling</li>
-          <li><strong>St. Maarten/St. Martin</strong> — Philipsburg (Dutch), Marigot (French), Maho Beach</li>
-          <li><strong>San Juan, Puerto Rico</strong> — Old San Juan forts, no passport needed, home port</li>
-          <li><strong>Tortola, BVI</strong> — The Baths at Virgin Gorda, Cane Garden Bay</li>
-          <li><strong>Virgin Gorda, BVI</strong> — The Baths granite boulders</li>
-          <li><strong>St. Kitts</strong> — Brimstone Hill Fortress, scenic railway</li>
+          <li><strong><a href="/ports/st-maarten.html">St. Maarten/St. Martin</a></strong> — Philipsburg (Dutch), Marigot (French), Maho Beach</li>
+          <li><strong><a href="/ports/san-juan.html">San Juan, Puerto Rico</a></strong> — Old San Juan forts, no passport needed, home port</li>
+          <li><strong><a href="/ports/tortola.html">Tortola, BVI</a></strong> — The Baths at Virgin Gorda, Cane Garden Bay</li>
+          <li><strong><a href="/ports/virgin-gorda.html">Virgin Gorda, BVI</a></strong> — The Baths granite boulders</li>
+          <li><strong><a href="/ports/st-kitts.html">St. Kitts</a></strong> — Brimstone Hill Fortress, scenic railway</li>
           <li><strong>Antigua</strong> — Nelson's Dockyard, 365 beaches, Shirley Heights</li>
           <li><strong>St. Lucia</strong> — The Pitons, drive-in volcano, mud baths</li>
           <li><strong>Barbados</strong> — Harrison's Cave, Mount Gay rum, Bridgetown</li>
-          <li><strong>Martinique</strong> — French culture, Mount Pelée, rum distilleries</li>
-          <li><strong>Guadeloupe</strong> — Butterfly-shaped island, La Soufrière volcano</li>
-          <li><strong>Dominica</strong> — Nature isle, waterfalls, Boiling Lake hike</li>
+          <li><strong><a href="/ports/martinique.html">Martinique</a></strong> — French culture, Mount Pelée, rum distilleries</li>
+          <li><strong><a href="/ports/guadeloupe.html">Guadeloupe</a></strong> — Butterfly-shaped island, La Soufrière volcano</li>
+          <li><strong><a href="/ports/dominica.html">Dominica</a></strong> — Nature isle, waterfalls, Boiling Lake hike</li>
         </ul>
 
         <h3>Western Caribbean</h3>


### PR DESCRIPTION
Added links from ports.html to individual port pages for major Caribbean destinations including Nassau, St. Thomas, St. Maarten, San Juan, Tortola, Virgin Gorda, St. Kitts, Martinique, Guadeloupe, and Dominica.

Additional port linking in progress for Western Caribbean, Alaska, Europe, and other regions.

Partial completion of port cross-linking task