### PR TITLE
Add author-card-vertical pattern to 275 pages site-wide

### DIFF
--- a/cruise-lines/carnival.html
+++ b/cruise-lines/carnival.html
@@ -218,6 +218,45 @@
     /* Tiny badges */
     .badge{ font-size:.75rem; background:#eef7fb; border:1px solid var(--rope); border-radius:999px; padding:.1rem .5rem }
   
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -302,7 +341,8 @@
     </div>
   </header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="line-name">
       <h1 id="line-name">Carnival Cruise Line</h1>
@@ -412,6 +452,34 @@
       <h3 id="credits-h">Image Credits</h3>
       <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace placeholders with final credited media.</p>
     </section>
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
 
     <footer class="wrap" role="contentinfo">
@@ -539,6 +607,32 @@
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <!-- Recent Articles Rail -->
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a => 
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
   })();
   </script>
 </body>

--- a/cruise-lines/celebrity.html
+++ b/cruise-lines/celebrity.html
@@ -217,6 +217,45 @@
     @media (min-width:760px){ .grid.two{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
 
     .badge{ font-size:.75rem; background:#eef7fb; border:1px solid var(--rope); border-radius:999px; padding:.1rem .5rem }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -301,7 +340,8 @@
     </div>
   </header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="line-name">
       <h1 id="line-name">Celebrity Cruises</h1>
@@ -419,6 +459,34 @@
       <h3 id="credits-h">Image Credits</h3>
       <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace placeholders with final credited media.</p>
     </section>
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
 
     <footer class="wrap" role="contentinfo">
@@ -543,6 +611,32 @@
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <!-- Recent Articles Rail -->
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a => 
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
   })();
   </script>
 </body>

--- a/cruise-lines/disney.html
+++ b/cruise-lines/disney.html
@@ -217,6 +217,45 @@
     @media (min-width:760px){ .grid.two{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
 
     .badge{ font-size:.75rem; background:#eef7fb; border:1px solid var(--rope); border-radius:999px; padding:.1rem .5rem }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -301,7 +340,8 @@
     </div>
   </header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="line-name">
       <h1 id="line-name">Disney Cruise Line</h1>
@@ -413,6 +453,34 @@
       <h3 id="credits-h">Image Credits</h3>
       <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace placeholders with final credited media.</p>
     </section>
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
 
     <footer class="wrap" role="contentinfo">
@@ -536,6 +604,32 @@
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <!-- Recent Articles Rail -->
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a => 
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
   })();
   </script>
 </body>

--- a/cruise-lines/holland-america.html
+++ b/cruise-lines/holland-america.html
@@ -273,6 +273,45 @@
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -359,7 +398,8 @@
       </div>
     </div></header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header card" aria-labelledby="line-name">
       <h1 id="line-name">Holland America Line</h1>
@@ -481,6 +521,34 @@
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
 
     <footer class="wrap" role="contentinfo">

--- a/cruise-lines/msc.html
+++ b/cruise-lines/msc.html
@@ -217,6 +217,45 @@
     @media (min-width:760px){ .grid.two{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
 
     .badge{ font-size:.75rem; background:#eef7fb; border:1px solid var(--rope); border-radius:999px; padding:.1rem .5rem }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -301,7 +340,8 @@
     </div>
   </header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="line-name">
       <h1 id="line-name">MSC Cruises</h1>
@@ -420,6 +460,34 @@
       <h3 id="credits-h">Image Credits</h3>
       <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace placeholders with final credited media.</p>
     </section>
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
 
     <footer class="wrap" role="contentinfo">
@@ -544,6 +612,32 @@
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <!-- Recent Articles Rail -->
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a => 
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
   })();
   </script>
 </body>

--- a/cruise-lines/norwegian.html
+++ b/cruise-lines/norwegian.html
@@ -223,6 +223,45 @@
     opacity: .8;
     color: var(--text-muted);
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -306,7 +345,8 @@
     </div>
   </header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header card" aria-labelledby="line-name">
       <h1 id="line-name">Norwegian Cruise Line</h1>
@@ -423,6 +463,34 @@
       <h3>Image Credits</h3>
       <p class="tiny">Hero and supplemental images: Wikimedia Commons (place final, specific attributions upon publication).</p>
     </section>
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
 
     <footer class="wrap" role="contentinfo">
@@ -544,6 +612,32 @@
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <!-- Recent Articles Rail -->
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a => 
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
   })();
   </script>
 </body>

--- a/cruise-lines/princess.html
+++ b/cruise-lines/princess.html
@@ -219,6 +219,45 @@
     opacity: .8;
     color: var(--text-muted);
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -302,7 +341,8 @@
     </div>
   </header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header card" aria-labelledby="line-name">
       <h1 id="line-name">Princess Cruises</h1>
@@ -406,6 +446,34 @@
       <h3>Image Credits</h3>
       <p class="tiny">Hero and supplemental images: Wikimedia Commons (place final, specific attributions upon publication).</p>
     </section>
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
 
     <footer class="wrap" role="contentinfo">
@@ -519,6 +587,32 @@
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <!-- Recent Articles Rail -->
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a => 
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
   })();
   </script>
 </body>

--- a/cruise-lines/royal-caribbean.html
+++ b/cruise-lines/royal-caribbean.html
@@ -131,6 +131,45 @@ All work on this project is offered as a gift to God.
     /* Navigation */
     .nav { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; gap: .5rem; white-space: nowrap; overflow: visible; padding-inline: .75rem; }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <script>if('serviceWorker' in navigator){addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));}</script>
@@ -200,7 +239,8 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 2; grid-row: 1; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -482,7 +522,35 @@ All work on this project is offered as a gift to God.
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
     <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
@@ -548,6 +616,32 @@ All work on this project is offered as a gift to God.
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <!-- Recent Articles Rail -->
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a => 
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
   })();
   </script>
 </body>

--- a/cruise-lines/viking.html
+++ b/cruise-lines/viking.html
@@ -179,6 +179,45 @@ All work on this project is offered as a gift to God.
       overflow: visible;
       padding-inline: .75rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -268,7 +307,8 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="line-name">
       <h1 id="line-name">Viking</h1>
@@ -407,6 +447,34 @@ All work on this project is offered as a gift to God.
     </p>
     <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. ✝️</p>
   </footer>
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
 
   <!-- Standards: single search hook, no custom search logic -->
@@ -497,6 +565,32 @@ All work on this project is offered as a gift to God.
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <!-- Recent Articles Rail -->
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a => 
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
   })();
   </script>
 </body>

--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -186,6 +186,45 @@ All work on this project is offered as a gift to God.
       -webkit-overflow-scrolling: touch;
     }
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -275,7 +314,8 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite v1.0: Answer-First Content -->
     <section class="icp-header" aria-labelledby="line-name">
       <h1 id="line-name">Virgin Voyages</h1>
@@ -416,6 +456,34 @@ All work on this project is offered as a gift to God.
     </p>
     <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. ✝️</p>
   </footer>
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
 
   <!-- Standards: single search hook, absolute URLs, no custom search logic -->
@@ -504,6 +572,32 @@ All work on this project is offered as a gift to God.
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <!-- Recent Articles Rail -->
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a => 
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
   })();
   </script>
 </body>

--- a/restaurants/150-central-park.html
+++ b/restaurants/150-central-park.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/adagio-dining-room.html
+++ b/restaurants/adagio-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/amber-and-oak.html
+++ b/restaurants/amber-and-oak.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/american-icon-grill.html
+++ b/restaurants/american-icon-grill.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -213,6 +213,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -337,7 +376,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
 
   <!-- ICP-Lite v1.0: Answer-First Content -->
   <section class="icp-header" aria-labelledby="page-title">
@@ -652,17 +692,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/aquarium-bar.html
+++ b/restaurants/aquarium-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/aquarius-dining-room.html
+++ b/restaurants/aquarius-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/bamboo-room.html
+++ b/restaurants/bamboo-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -212,6 +212,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -355,7 +394,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -583,17 +623,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/bell-and-barley.html
+++ b/restaurants/bell-and-barley.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/ben-and-jerrys.html
+++ b/restaurants/ben-and-jerrys.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -361,17 +401,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/bionic-bar.html
+++ b/restaurants/bionic-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -362,17 +402,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/boardwalk-dog-house.html
+++ b/restaurants/boardwalk-dog-house.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/boleros.html
+++ b/restaurants/boleros.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -364,17 +404,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/brass-and-bock.html
+++ b/restaurants/brass-and-bock.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/bubbles.html
+++ b/restaurants/bubbles.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/bull-and-bear-pub.html
+++ b/restaurants/bull-and-bear-pub.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -210,6 +210,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -300,7 +339,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
 
   <!-- Overview -->
   <section class="card" id="overview">
@@ -583,17 +623,35 @@ All work on this project is offered as a gift to God.
       </ul>
     </div>
   </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -217,6 +217,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -341,7 +380,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
 
   <!-- ICP-Lite v1.0: Answer-First Content -->
   <section class="icp-header" aria-labelledby="page-title">
@@ -579,17 +619,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/cantina-fresca.html
+++ b/restaurants/cantina-fresca.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/cascades-dining-room.html
+++ b/restaurants/cascades-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/casino-bar.html
+++ b/restaurants/casino-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/celebration-table.html
+++ b/restaurants/celebration-table.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/champagne-bar.html
+++ b/restaurants/champagne-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -360,17 +400,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -216,6 +216,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -306,7 +345,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap" id="main">
+<main class="wrap page-grid" id="main">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <h1 class="page-title">Chef's Table</h1>
@@ -465,17 +505,35 @@ All work on this project is offered as a gift to God.
       <li>All Rights Reserved</li>
     </ul>
   </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-    
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/chic.html
+++ b/restaurants/chic.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/chops.html
+++ b/restaurants/chops.html
@@ -216,6 +216,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -366,7 +405,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <h1 class="page-title">Chops Grille</h1>
@@ -549,17 +589,35 @@ All work on this project is offered as a gift to God.
       <li>All Rights Reserved</li>
     </ul>
   </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-    
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/cloud-17.html
+++ b/restaurants/cloud-17.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -208,6 +208,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -298,7 +337,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
 
   <!-- Overview -->
   <section class="card" id="overview">
@@ -524,17 +564,35 @@ All work on this project is offered as a gift to God.
       <p class="tiny legend">Policies can change without notice—confirm current access and menus in the Royal App or with the maître d'.</p>
     </div>
   </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/concierge-lounge.html
+++ b/restaurants/concierge-lounge.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/congo-bar.html
+++ b/restaurants/congo-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/cosmopolitan-club.html
+++ b/restaurants/cosmopolitan-club.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/crown-and-castle-pub.html
+++ b/restaurants/crown-and-castle-pub.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/crown-and-kettle.html
+++ b/restaurants/crown-and-kettle.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/dazzles.html
+++ b/restaurants/dazzles.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/desserted.html
+++ b/restaurants/desserted.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/devinly-decadence.html
+++ b/restaurants/devinly-decadence.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/diamond-club.html
+++ b/restaurants/diamond-club.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -365,17 +405,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -209,6 +209,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -352,7 +391,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -553,17 +593,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/dining-activities.html
+++ b/restaurants/dining-activities.html
@@ -167,6 +167,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -473,17 +512,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -215,6 +215,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -358,7 +397,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -609,17 +649,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/duck-and-dog-pub.html
+++ b/restaurants/duck-and-dog-pub.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/dueling-pianos.html
+++ b/restaurants/dueling-pianos.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/edelweiss-dining-room.html
+++ b/restaurants/edelweiss-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -217,6 +217,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -341,7 +380,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
 
   <!-- ICP-Lite v1.0: Answer-First Content -->
   <section class="icp-header" aria-labelledby="page-title">
@@ -575,17 +615,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/empire-supper-club.html
+++ b/restaurants/empire-supper-club.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/english-pub.html
+++ b/restaurants/english-pub.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/fish-and-ships.html
+++ b/restaurants/fish-and-ships.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/game-reserve.html
+++ b/restaurants/game-reserve.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/giovannis-italian-kitchen.html
+++ b/restaurants/giovannis-italian-kitchen.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/italian-cuisine.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/giovannis.html
+++ b/restaurants/giovannis.html
@@ -198,6 +198,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -515,17 +554,35 @@ All work on this project is offered as a gift to God.
 
     </div>
   </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/globe-and-atlas.html
+++ b/restaurants/globe-and-atlas.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/great-gatsby-dining-room.html
+++ b/restaurants/great-gatsby-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/hooked-seafood.html
+++ b/restaurants/hooked-seafood.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -361,17 +401,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/hot-pot.html
+++ b/restaurants/hot-pot.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/asian-cuisine.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/izumi-in-the-park.html
+++ b/restaurants/izumi-in-the-park.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/asian-cuisine.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/izumi.html
+++ b/restaurants/izumi.html
@@ -177,6 +177,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- LCP Optimization: Preload critical hero images -->

--- a/restaurants/jamies-italian.html
+++ b/restaurants/jamies-italian.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="/assets/images/restaurants/italian-cuisine.svg" alt="" aria-hidden="true">
@@ -362,17 +402,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/johnny-rockets.html
+++ b/restaurants/johnny-rockets.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -362,17 +402,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -195,6 +195,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -338,7 +377,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -631,17 +671,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/leaf-and-bean.html
+++ b/restaurants/leaf-and-bean.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/lime-and-coconut.html
+++ b/restaurants/lime-and-coconut.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -361,17 +401,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/lincoln-park-supper-club.html
+++ b/restaurants/lincoln-park-supper-club.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/lobby-bar.html
+++ b/restaurants/lobby-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/lous-jazz-n-blues.html
+++ b/restaurants/lous-jazz-n-blues.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/mason-jar.html
+++ b/restaurants/mason-jar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -201,6 +201,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -336,7 +375,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -650,17 +690,35 @@ All work on this project is offered as a gift to God.
       </ul>
     </div>
   </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-    
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/minstrel-dining-room.html
+++ b/restaurants/minstrel-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/my-fair-lady-dining-room.html
+++ b/restaurants/my-fair-lady-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/north-star-bar.html
+++ b/restaurants/north-star-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/oasis-bar.html
+++ b/restaurants/oasis-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/olive-or-twist.html
+++ b/restaurants/olive-or-twist.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/on-air.html
+++ b/restaurants/on-air.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -197,6 +197,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <style>
   /* Keep header pills to a single line on wide viewports; allow scroll on small */
@@ -207,7 +246,46 @@ All work on this project is offered as a gift to God.
     .hero-header .navbar .pills{ flex-wrap: nowrap; overflow:auto; scrollbar-width:none }
     .hero-header .navbar .pills::-webkit-scrollbar{ display:none }
   }
-</style>
+
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -350,7 +428,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -621,17 +700,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -206,6 +206,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -330,7 +369,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
 
   <!-- ICP-Lite v1.0: Answer-First Content -->
   <section class="icp-header" aria-labelledby="page-title">
@@ -566,17 +606,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/pesky-parrot.html
+++ b/restaurants/pesky-parrot.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -360,17 +400,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/pier-7.html
+++ b/restaurants/pier-7.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/pig-and-whistle-pub.html
+++ b/restaurants/pig-and-whistle-pub.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/playmakers.html
+++ b/restaurants/playmakers.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -362,17 +402,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/plaza-bar.html
+++ b/restaurants/plaza-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/pool-bar.html
+++ b/restaurants/pool-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -365,17 +405,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/portside-bbq.html
+++ b/restaurants/portside-bbq.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/quill-and-compass.html
+++ b/restaurants/quill-and-compass.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/r-bar.html
+++ b/restaurants/r-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -361,17 +401,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/reflections-dining-room.html
+++ b/restaurants/reflections-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/rising-tide-bar.html
+++ b/restaurants/rising-tide-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/ritas-cantina.html
+++ b/restaurants/ritas-cantina.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/room-service.html
+++ b/restaurants/room-service.html
@@ -215,6 +215,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -568,17 +607,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/royal-railway.html
+++ b/restaurants/royal-railway.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/rye-and-bean.html
+++ b/restaurants/rye-and-bean.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/sabor-taqueria.html
+++ b/restaurants/sabor-taqueria.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/sabor.html
+++ b/restaurants/sabor.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -360,17 +400,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -207,6 +207,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -317,7 +356,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap" id="main">
+<main class="wrap page-grid" id="main">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <h1 class="page-title">Samba Grill</h1>
@@ -502,17 +542,35 @@ All work on this project is offered as a gift to God.
       <li>All Rights Reserved</li>
     </ul>
   </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-    
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/sapphire-dining-room.html
+++ b/restaurants/sapphire-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/sapphire-restaurant.html
+++ b/restaurants/sapphire-restaurant.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/schooner-bar.html
+++ b/restaurants/schooner-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -366,17 +406,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/sichuan-red.html
+++ b/restaurants/sichuan-red.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/asian-cuisine.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/silk.html
+++ b/restaurants/silk.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/asian-cuisine.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/sky-bar.html
+++ b/restaurants/sky-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -362,17 +402,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/solarium-bar.html
+++ b/restaurants/solarium-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -365,17 +405,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -189,6 +189,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -279,7 +318,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
 
 <section class="card" id="overview">
   <img src="/assets/watermark.webp" alt="" aria-hidden="true">
@@ -489,17 +529,35 @@ All work on this project is offered as a gift to God.
     </ul>
   </div>
 </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/solarium-cafe.html
+++ b/restaurants/solarium-cafe.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -221,6 +221,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -364,7 +403,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -627,17 +667,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/sprinkles.html
+++ b/restaurants/sprinkles.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/star-lounge.html
+++ b/restaurants/star-lounge.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/starbucks.html
+++ b/restaurants/starbucks.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -360,17 +400,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/sugar-beach.html
+++ b/restaurants/sugar-beach.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -360,17 +400,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/suite-lounge.html
+++ b/restaurants/suite-lounge.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -362,17 +402,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -204,6 +204,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -347,7 +386,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -604,17 +644,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/swim-and-tonic.html
+++ b/restaurants/swim-and-tonic.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/tavern-bar.html
+++ b/restaurants/tavern-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/the-bamboo-room.html
+++ b/restaurants/the-bamboo-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/the-dining-room.html
+++ b/restaurants/the-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/the-grande.html
+++ b/restaurants/the-grande.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -202,6 +202,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -345,7 +384,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -546,17 +586,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/the-overlook.html
+++ b/restaurants/the-overlook.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/the-pit-stop.html
+++ b/restaurants/the-pit-stop.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/tides-dining-room.html
+++ b/restaurants/tides-dining-room.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/trellis-bar.html
+++ b/restaurants/trellis-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -360,17 +400,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/two70-bar.html
+++ b/restaurants/two70-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -356,17 +396,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/viking-crown-lounge.html
+++ b/restaurants/viking-crown-lounge.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -360,17 +400,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/vintages.html
+++ b/restaurants/vintages.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -364,17 +404,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -188,6 +188,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -331,7 +370,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
@@ -519,17 +559,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/vortex.html
+++ b/restaurants/vortex.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -360,17 +400,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/wig-and-gavel.html
+++ b/restaurants/wig-and-gavel.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -196,6 +196,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -346,7 +385,8 @@ All work on this project is offered as a gift to God.
     </div>
   </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
 
   <!-- Overview -->
   <section class="card" id="overview">
@@ -691,17 +731,35 @@ All work on this project is offered as a gift to God.
       </ul>
     </div>
   </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/wipeout-bar.html
+++ b/restaurants/wipeout-bar.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/wonderland.html
+++ b/restaurants/wonderland.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
@@ -361,17 +401,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/restaurants/zanzibar-lounge.html
+++ b/restaurants/zanzibar-lounge.html
@@ -100,6 +100,45 @@ All work on this project is offered as a gift to God.
 
     }
 
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -223,7 +262,8 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header>
 
-<main class="wrap">
+<main class="wrap page-grid">
+  <div>
   <!-- Overview -->
   <section class="card" id="overview">
     <img src="https://www.cruisinginthewake.com/assets/images/restaurants/bar-lounge.svg" alt="" aria-hidden="true">
@@ -359,17 +399,35 @@ All work on this project is offered as a gift to God.
         <p style="margin: 0.5rem 0; padding-left: 1rem;">Availability varies by ship and class. Check the ships section on this page or the Royal Caribbean website for current fleet availability.</p>
       </details>
     </section>
-      <!-- Recent Articles rail -->
-      <section style="grid-column: 1;" class="card" aria-labelledby="recent-rail-title">
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
         <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
         </p>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
-
-</main>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/carnival-adventure.html
+++ b/ships/carnival/carnival-adventure.html
@@ -108,9 +108,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -119,6 +197,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -129,6 +246,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-adventure.html"/>
@@ -137,6 +293,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -215,6 +410,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-breeze.html
+++ b/ships/carnival/carnival-breeze.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-breeze.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-breeze.html
+++ b/ships/carnival/carnival-carnival-breeze.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-breeze.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-celebration.html
+++ b/ships/carnival/carnival-carnival-celebration.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-celebration.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-conquest.html
+++ b/ships/carnival/carnival-carnival-conquest.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-conquest.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-dream.html
+++ b/ships/carnival/carnival-carnival-dream.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-dream.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-elation.html
+++ b/ships/carnival/carnival-carnival-elation.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-elation.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-firenze.html
+++ b/ships/carnival/carnival-carnival-firenze.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-firenze.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-freedom.html
+++ b/ships/carnival/carnival-carnival-freedom.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-freedom.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-glory.html
+++ b/ships/carnival/carnival-carnival-glory.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-glory.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-horizon.html
+++ b/ships/carnival/carnival-carnival-horizon.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-horizon.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-carnival-jubilee.html
+++ b/ships/carnival/carnival-carnival-jubilee.html
@@ -40,7 +40,46 @@ All work on this project is offered as a gift to God.
 <meta property="og:image" content="https://www.cruisinginthewake.com/assets/images/og-default.jpg">
 <meta property="og:url" content="https://www.cruisinginthewake.com/ships/rcl/carnival/carnival-carnival-jubilee.html">
 <meta name="twitter:card" content="summary_large_image">
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -49,6 +88,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -59,12 +137,90 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -180,6 +336,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -351,7 +546,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-celebration.html
+++ b/ships/carnival/carnival-celebration.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-celebration.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-conquest.html
+++ b/ships/carnival/carnival-conquest.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-conquest.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-dream.html
+++ b/ships/carnival/carnival-dream.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-dream.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-ecstasy.html
+++ b/ships/carnival/carnival-ecstasy.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/carnival-elation.html
+++ b/ships/carnival/carnival-elation.html
@@ -108,9 +108,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -119,6 +197,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -129,6 +246,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-elation.html"/>
@@ -137,6 +293,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -215,6 +410,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-encounter.html
+++ b/ships/carnival/carnival-encounter.html
@@ -108,9 +108,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -119,6 +197,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -129,6 +246,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-encounter.html"/>
@@ -137,6 +293,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -215,6 +410,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-fantasy.html
+++ b/ships/carnival/carnival-fantasy.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/carnival-fascination.html
+++ b/ships/carnival/carnival-fascination.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/carnival-festivale.html
+++ b/ships/carnival/carnival-festivale.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -116,6 +116,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.220a" name="inthewake:standard"/><script type="application/ld+json">
 {
@@ -193,6 +232,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -391,7 +469,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-freedom.html
+++ b/ships/carnival/carnival-freedom.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-freedom.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-glory.html
+++ b/ships/carnival/carnival-glory.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-glory.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-horizon.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-imagination.html
+++ b/ships/carnival/carnival-imagination.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/carnival-inspiration.html
+++ b/ships/carnival/carnival-inspiration.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/carnival-jubilee.html
+++ b/ships/carnival/carnival-jubilee.html
@@ -153,6 +153,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.220a" name="inthewake:standard"/><script type="application/ld+json">
 {
@@ -230,6 +269,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -429,7 +507,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-legend.html
+++ b/ships/carnival/carnival-legend.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-legend.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-liberty.html
+++ b/ships/carnival/carnival-liberty.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-liberty.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-luminosa.html
+++ b/ships/carnival/carnival-luminosa.html
@@ -108,9 +108,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -119,6 +197,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -129,6 +246,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-luminosa.html"/>
@@ -137,6 +293,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -215,6 +410,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-magic.html
+++ b/ships/carnival/carnival-magic.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-magic.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-mardi-gras.html
+++ b/ships/carnival/carnival-mardi-gras.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-mardi-gras.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-miracle.html
+++ b/ships/carnival/carnival-miracle.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-miracle.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-panorama.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-paradise.html
+++ b/ships/carnival/carnival-paradise.html
@@ -108,9 +108,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -119,6 +197,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -129,6 +246,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-paradise.html"/>
@@ -137,6 +293,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -215,6 +410,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-pride.html
+++ b/ships/carnival/carnival-pride.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-pride.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-radiance.html
+++ b/ships/carnival/carnival-radiance.html
@@ -108,9 +108,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -119,6 +197,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -129,6 +246,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-radiance.html"/>
@@ -137,6 +293,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -215,6 +410,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-sensation.html
+++ b/ships/carnival/carnival-sensation.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/carnival-spirit.html
+++ b/ships/carnival/carnival-spirit.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-spirit.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-splendor.html
+++ b/ships/carnival/carnival-splendor.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-splendor.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-sunrise.html
+++ b/ships/carnival/carnival-sunrise.html
@@ -108,9 +108,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -119,6 +197,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -129,6 +246,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-sunrise.html"/>
@@ -137,6 +293,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -215,6 +410,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -108,9 +108,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -119,6 +197,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -129,6 +246,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-sunshine.html"/>
@@ -137,6 +293,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -215,6 +410,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-tropicale.html
+++ b/ships/carnival/carnival-tropicale.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/carnival-valor.html
+++ b/ships/carnival/carnival-valor.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-valor.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -108,9 +108,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -119,6 +197,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -129,6 +246,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-venezia.html"/>
@@ -137,6 +293,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -215,6 +410,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnival-vista.html
+++ b/ships/carnival/carnival-vista.html
@@ -145,9 +145,87 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <meta content="inthewake_standardsv2.221a" name="inthewake:standard"/>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -156,6 +234,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -166,6 +283,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/carnival-vista.html"/>
@@ -174,6 +330,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -252,6 +447,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -458,7 +692,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
     <p class="tiny" style="margin-top: 0.5rem;">

--- a/ships/carnival/carnivale.html
+++ b/ships/carnival/carnivale.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/celebration.html
+++ b/ships/carnival/celebration.html
@@ -116,6 +116,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -193,6 +232,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -393,7 +471,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/festivale.html
+++ b/ships/carnival/festivale.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/holiday.html
+++ b/ships/carnival/holiday.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/index.html
+++ b/ships/carnival/index.html
@@ -20,7 +20,46 @@ All work on this project is offered as a gift to God.
   <meta name="ai-summary" content="Carnival – In The Wake">
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0"><title>Carnival – In The Wake</title>  <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -29,6 +68,45 @@ All work on this project is offered as a gift to God.
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -39,6 +117,45 @@ All work on this project is offered as a gift to God.
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <link rel="canonical" href="https://www.cruisinginthewake.com/ships/carnival/index.html"/>
@@ -47,6 +164,45 @@ All work on this project is offered as a gift to God.
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -162,6 +318,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- LCP Optimization: Preload critical hero images -->

--- a/ships/carnival/jubilee.html
+++ b/ships/carnival/jubilee.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/mardi-gras.html
+++ b/ships/carnival/mardi-gras.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/tropicale.html
+++ b/ships/carnival/tropicale.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/unnamed-project-ace-1.html
+++ b/ships/carnival/unnamed-project-ace-1.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/unnamed-project-ace-2.html
+++ b/ships/carnival/unnamed-project-ace-2.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/carnival/unnamed-project-ace-3.html
+++ b/ships/carnival/unnamed-project-ace-3.html
@@ -108,6 +108,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
   <!-- Service Worker Registration -->
   <script>
@@ -117,7 +156,46 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
   </script>
 
   <link rel="stylesheet" href="https://www.cruisinginthewake.com/assets/styles.css?v=2.234"/>
-<style id="brand-title-hide">.brand-title{display:none!important}</style>
+<style id="brand-title-hide">.brand-title{display:none!important}
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+  </style>
 
   <style id="hero-credit-css">
     .hero{ position:relative }
@@ -126,6 +204,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       padding:.3rem .55rem; border-radius:.5rem; font-size:.85rem;
       box-shadow:0 2px 6px rgba(0,0,0,.12);
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="card-watermark">
@@ -136,12 +253,90 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       background:url('https://www.cruisinginthewake.com/assets/watermark.png') center/contain no-repeat;
       opacity:.06; pointer-events:none;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <style id="hero-vibrancy">
     .hero{ background:url('https://www.cruisinginthewake.com/assets/index_hero.webp') center/cover no-repeat!important;
            filter:saturate(1.35) contrast(1.12) brightness(1.05) }
     .hero::before,.hero::after{ content:none!important }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
 <script type="application/ld+json">
@@ -220,6 +415,45 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -420,7 +654,35 @@ figcaption{font-size:.85rem;color:#555;margin-top:4px}
       </details>
     </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-ascent.html
+++ b/ships/celebrity-cruises/celebrity-ascent.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-beyond.html
+++ b/ships/celebrity-cruises/celebrity-beyond.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-century.html
+++ b/ships/celebrity-cruises/celebrity-century.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-compass.html
+++ b/ships/celebrity-cruises/celebrity-compass.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-constellation.html
+++ b/ships/celebrity-cruises/celebrity-constellation.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-eclipse.html
+++ b/ships/celebrity-cruises/celebrity-eclipse.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-edge.html
+++ b/ships/celebrity-cruises/celebrity-edge.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-equinox.html
+++ b/ships/celebrity-cruises/celebrity-equinox.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-flora.html
+++ b/ships/celebrity-cruises/celebrity-flora.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-galaxy.html
+++ b/ships/celebrity-cruises/celebrity-galaxy.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-infinity.html
+++ b/ships/celebrity-cruises/celebrity-infinity.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-mercury.html
+++ b/ships/celebrity-cruises/celebrity-mercury.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-millennium.html
+++ b/ships/celebrity-cruises/celebrity-millennium.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-reflection.html
+++ b/ships/celebrity-cruises/celebrity-reflection.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-seeker.html
+++ b/ships/celebrity-cruises/celebrity-seeker.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-silhouette.html
+++ b/ships/celebrity-cruises/celebrity-silhouette.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-solstice.html
+++ b/ships/celebrity-cruises/celebrity-solstice.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-summit.html
+++ b/ships/celebrity-cruises/celebrity-summit.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-xpedition.html
+++ b/ships/celebrity-cruises/celebrity-xpedition.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-xperience.html
+++ b/ships/celebrity-cruises/celebrity-xperience.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/celebrity-xploration.html
+++ b/ships/celebrity-cruises/celebrity-xploration.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/horizon.html
+++ b/ships/celebrity-cruises/horizon.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/index.html
+++ b/ships/celebrity-cruises/index.html
@@ -75,6 +75,45 @@ All work on this project is offered as a gift to God.
       font-size: 0.9rem;
       margin-top: -0.5rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- LCP Optimization: Preload critical hero images -->
@@ -146,7 +185,8 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" style="padding: 2rem 1rem;">
+  <main class="wrap page-grid" style="padding: 2rem 1rem;">
+  <div>
     <a href="/ships.html" class="back-link">← Back to All Ships</a>
     
     <h1>Celebrity Cruises Fleet</h1>
@@ -197,6 +237,34 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
   
     <footer class="wrap" role="contentinfo">

--- a/ships/celebrity-cruises/ss-meridian.html
+++ b/ships/celebrity-cruises/ss-meridian.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/unnamed-edge-class.html
+++ b/ships/celebrity-cruises/unnamed-edge-class.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/unnamed-project-nirvana.html
+++ b/ships/celebrity-cruises/unnamed-project-nirvana.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/unnamed-river-class-x6.html
+++ b/ships/celebrity-cruises/unnamed-river-class-x6.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/celebrity-cruises/zenith.html
+++ b/ships/celebrity-cruises/zenith.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/grandeur-of-the-seas.html
+++ b/ships/grandeur-of-the-seas.html
@@ -254,6 +254,26 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail { display: flex; flex-direction: column; gap: 1rem; }
+    .author-card-vertical { text-align: center; }
+    .author-card-vertical .author-avatar { width: 96px; height: 96px; border-radius: 12px; object-fit: cover; margin: 0 auto 1rem; }
+    .author-card-vertical h4 { margin: 0.5rem 0 0.25rem; }
+    .author-card-vertical p { margin: 0.25rem 0; }
+    .rail-list { display: grid; gap: 1rem; }
+
   </style>
 <script type="application/ld+json">
 {
@@ -405,7 +425,8 @@ All work on this project is offered as a gift to God.
 </div>
     </div></header>
 
-  <main class="wrap" id="content" tabindex="-1">
+  <main class="wrap page-grid" id="content" tabindex="-1">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <h1>Grandeur Of The Seas</h1>
@@ -736,7 +757,21 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html"><img class="author-avatar" src="/authors/img/ken1_96.webp" width="96" height="96" alt="Ken Baker" loading="lazy"/></a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+      </section>
+    </aside>
+  </main>
 
     <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
@@ -1100,6 +1135,18 @@ All work on this project is offered as a gift to God.
   })();
   </script>
 
+
+  <script>
+  (async function(){
+    const rail = document.getElementById('recent-rail');
+    if(!rail) return;
+    try {
+      const res = await fetch('/assets/data/articles/index.json');
+      const articles = await res.json();
+      rail.innerHTML = articles.slice(0, 4).map(a => '<div style="margin-bottom:.75rem;"><a href="' + a.url + '">' + a.title + '</a></div>').join('');
+    } catch(e) {}
+  })();
+  </script>
 </body>
 </html>
 // /sw.js — In the Wake image cache (v0.8-stable)

--- a/ships/holland-america-line/amsterdam.html
+++ b/ships/holland-america-line/amsterdam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/edam.html
+++ b/ships/holland-america-line/edam.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/eurodam.html
+++ b/ships/holland-america-line/eurodam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/index.html
+++ b/ships/holland-america-line/index.html
@@ -75,6 +75,45 @@ All work on this project is offered as a gift to God.
       font-size: 0.9rem;
       margin-top: -0.5rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- LCP Optimization: Preload critical hero images -->
@@ -146,7 +185,8 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" style="padding: 2rem 1rem;">
+  <main class="wrap page-grid" style="padding: 2rem 1rem;">
+  <div>
     <a href="/ships.html" class="back-link">← Back to All Ships</a>
     
     <h1>Holland America Line Fleet</h1>
@@ -212,6 +252,34 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     
+  </div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
   </main>
   
     <footer class="wrap" role="contentinfo">

--- a/ships/holland-america-line/koningsdam.html
+++ b/ships/holland-america-line/koningsdam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/leerdam.html
+++ b/ships/holland-america-line/leerdam.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/maartensdijk.html
+++ b/ships/holland-america-line/maartensdijk.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/maasdam.html
+++ b/ships/holland-america-line/maasdam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/nieuw-amsterdam-ii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-ii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/nieuw-amsterdam-iii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/nieuw-amsterdam-iv.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iv.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/nieuw-amsterdam-v.html
+++ b/ships/holland-america-line/nieuw-amsterdam-v.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/nieuw-amsterdam.html
+++ b/ships/holland-america-line/nieuw-amsterdam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/nieuw-statendam.html
+++ b/ships/holland-america-line/nieuw-statendam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/none-announced.html
+++ b/ships/holland-america-line/none-announced.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/noordam-ii.html
+++ b/ships/holland-america-line/noordam-ii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/noordam-iii.html
+++ b/ships/holland-america-line/noordam-iii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/noordam-iv.html
+++ b/ships/holland-america-line/noordam-iv.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/noordam.html
+++ b/ships/holland-america-line/noordam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/oosterdam.html
+++ b/ships/holland-america-line/oosterdam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/p-caland.html
+++ b/ships/holland-america-line/p-caland.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/potsdam.html
+++ b/ships/holland-america-line/potsdam.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/prinsendam-i.html
+++ b/ships/holland-america-line/prinsendam-i.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/prinsendam-ii.html
+++ b/ships/holland-america-line/prinsendam-ii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/rijndam-ii.html
+++ b/ships/holland-america-line/rijndam-ii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/rijndam.html
+++ b/ships/holland-america-line/rijndam.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/rotterdam-iv.html
+++ b/ships/holland-america-line/rotterdam-iv.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/rotterdam-v.html
+++ b/ships/holland-america-line/rotterdam-v.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/rotterdam-vi.html
+++ b/ships/holland-america-line/rotterdam-vi.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/rotterdam.html
+++ b/ships/holland-america-line/rotterdam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/ryndam.html
+++ b/ships/holland-america-line/ryndam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/statendam-ii.html
+++ b/ships/holland-america-line/statendam-ii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/statendam-iii.html
+++ b/ships/holland-america-line/statendam-iii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/statendam.html
+++ b/ships/holland-america-line/statendam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/veendam-ii.html
+++ b/ships/holland-america-line/veendam-ii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/veendam-iii.html
+++ b/ships/holland-america-line/veendam-iii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/veendam-iv.html
+++ b/ships/holland-america-line/veendam-iv.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/veendam.html
+++ b/ships/holland-america-line/veendam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/volendam-ii.html
+++ b/ships/holland-america-line/volendam-ii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/volendam-iii.html
+++ b/ships/holland-america-line/volendam-iii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/volendam.html
+++ b/ships/holland-america-line/volendam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/w-a-scholten.html
+++ b/ships/holland-america-line/w-a-scholten.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/westerdam-i.html
+++ b/ships/holland-america-line/westerdam-i.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/westerdam-ii.html
+++ b/ships/holland-america-line/westerdam-ii.html
@@ -107,6 +107,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -184,6 +223,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -375,7 +453,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/holland-america-line/zaandam.html
+++ b/ships/holland-america-line/zaandam.html
@@ -144,6 +144,45 @@ All work on this project is offered as a gift to God.
     }
 
   }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -221,6 +260,45 @@ All work on this project is offered as a gift to God.
       opacity: .8;
       margin-left: .35rem;
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -413,7 +491,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
 
   <script>
   (function(){

--- a/ships/msc/msc-world-america.html
+++ b/ships/msc/msc-world-america.html
@@ -99,6 +99,45 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .author-card-vertical {
+      text-align: center;
+    }
+    .author-card-vertical .author-avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 12px;
+      object-fit: cover;
+      margin: 0 auto 1rem;
+    }
+    .author-card-vertical h4 {
+      margin: 0.5rem 0 0.25rem;
+    }
+    .author-card-vertical p {
+      margin: 0.25rem 0;
+    }
+    .rail-list {
+      display: grid;
+      gap: 1rem;
+    }
+
   </style>
 <script type="application/ld+json">
 {
@@ -231,7 +270,8 @@ All work on this project is offered as a gift to God.
       </div>
       <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
     </div></header>
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro" style="grid-column: 1 / -1; max-width: 1100px; margin: 1rem auto 1.5rem;">
       <h1>Msc World America</h1>
@@ -344,7 +384,35 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
 
-</main>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+    </aside>
+  </main>
   <footer class="wrap">
     © 2025 In the Wake — A Cruise Traveler’s Logbook
   </footer>

--- a/ships/rooms.html
+++ b/ships/rooms.html
@@ -108,6 +108,26 @@ All work on this project is offered as a gift to God.
     @media (max-width: 768px) {
 
     }
+  
+    /* Page Grid Layout */
+    .page-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 980px) {
+      .page-grid {
+        grid-template-columns: 1fr 320px;
+      }
+    }
+    .rail { display: flex; flex-direction: column; gap: 1rem; }
+    .author-card-vertical { text-align: center; }
+    .author-card-vertical .author-avatar { width: 96px; height: 96px; border-radius: 12px; object-fit: cover; margin: 0 auto 1rem; }
+    .author-card-vertical h4 { margin: 0.5rem 0 0.25rem; }
+    .author-card-vertical p { margin: 0.25rem 0; }
+    .rail-list { display: grid; gap: 1rem; }
+
   </style>
 <script type="application/ld+json">
 {
@@ -206,7 +226,8 @@ All work on this project is offered as a gift to God.
       </div>
       <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
     </div></header>
-  <main class="wrap" id="content">
+  <main class="wrap page-grid" id="content">
+  <div>
 <section class="card" aria-labelledby="watch-highlights">
   <h2 id="watch-highlights">Watch: Rooms Highlights</h2>
   <p class="muted">Video highlights coming soon.</p>
@@ -272,6 +293,20 @@ All work on this project is offered as a gift to God.
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     
+  </div>
+
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html"><img class="author-avatar" src="/authors/img/ken1_96.webp" width="96" height="96" alt="Ken Baker" loading="lazy"/></a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+      </section>
+    </aside>
   </main>
   <footer class="wrap">
     © 2025 In the Wake — A Cruise Traveler’s Logbook
@@ -466,6 +501,18 @@ All work on this project is offered as a gift to God.
       dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInsideDropdown = true; });
       if (!isInsideDropdown) closeAllDropdowns();
     });
+  })();
+  </script>
+
+  <script>
+  (async function(){
+    const rail = document.getElementById('recent-rail');
+    if(!rail) return;
+    try {
+      const res = await fetch('/assets/data/articles/index.json');
+      const articles = await res.json();
+      rail.innerHTML = articles.slice(0, 4).map(a => '<div style="margin-bottom:.75rem;"><a href="' + a.url + '">' + a.title + '</a></div>').join('');
+    } catch(e) {}
   })();
   </script>
 </body>


### PR DESCRIPTION
Standardized author/article pattern across all content pages:

- 129 restaurant pages: Added page-grid layout, author card, Recent Stories
- 10 cruise line sub-pages: Added author card and Recent Stories rail
- 58 Carnival ship pages: Added page-grid, author card, Recent Stories
- 30 Celebrity ship pages: Added page-grid, author card, Recent Stories
- 45 Holland America ship pages: Added page-grid, author card, Recent Stories
- 1 MSC ship page: Added page-grid, author card, Recent Stories
- 2 ships root pages (grandeur-of-the-seas, rooms): Fixed missing pattern

Each page now includes:
- 2-column page-grid layout (content + 320px rail on desktop)
- Author card with Ken Baker profile
- Recent Stories section with dynamic article loading

Excluded (intentional):
- Solo articles: Use JS-populated author cards (Tina pattern)
- Author profile pages: Different purpose
- Utility pages: privacy, terms, search, offline, articles