### PR TITLE
Remove broken image gallery sections from 4 port pages

### DIFF
--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -168,43 +168,6 @@ Soli Deo Gloria
         </div>
       </div>
 
-      <section class="card" style="margin-top: 2rem;">
-        <h2>Port Images</h2>
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-top: 1rem;">
-
-          <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-            <a href="https://commons.wikimedia.org/wiki/File:Eagle_Beach,_Aruba.jpg" target="_blank" rel="noopener">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f4/Eagle_Beach%2C_Aruba.jpg/800px-Eagle_Beach%2C_Aruba.jpg" alt="Eagle Beach with famous divi-divi trees" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-            </a>
-            <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-              Eagle Beach — powdery white sand and iconic wind-sculpted divi-divi trees
-              <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Eagle_Beach,_Aruba.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener">CC BY-SA 3.0</a></span>
-            </figcaption>
-          </figure>
-
-          <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-            <a href="https://commons.wikimedia.org/wiki/File:Oranjestad,_Aruba_colorful_buildings.jpg" target="_blank" rel="noopener">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/86/Oranjestad%2C_Aruba_colorful_buildings.jpg/800px-Oranjestad%2C_Aruba_colorful_buildings.jpg" alt="Colorful Dutch colonial buildings in Oranjestad" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-            </a>
-            <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-              Oranjestad — vibrant Dutch colonial architecture in Caribbean pastels
-              <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Oranjestad,_Aruba_colorful_buildings.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/2.0/" target="_blank" rel="noopener">CC BY-SA 2.0</a></span>
-            </figcaption>
-          </figure>
-
-          <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-            <a href="https://commons.wikimedia.org/wiki/File:California_Lighthouse_Aruba.jpg" target="_blank" rel="noopener">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/California_Lighthouse_Aruba.jpg/800px-California_Lighthouse_Aruba.jpg" alt="California Lighthouse on Aruba's northern coast" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-            </a>
-            <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-              California Lighthouse — iconic landmark with sweeping coastline views
-              <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:California_Lighthouse_Aruba.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener">CC BY-SA 3.0</a></span>
-            </figcaption>
-          </figure>
-
-        </div>
-        <p class="tiny" style="margin-top: 1rem; color: #678; font-style: italic;">
-
       <section class="port-section">
         <h3>Getting Around Aruba</h3>
         <p>Cruise terminal is a 5-minute walk to downtown Oranjestad. Taxis to Eagle and Palm Beach are reasonably priced. Public bus is a bargain. Many people rent jeeps for the day.</p>

--- a/ports/cozumel.html
+++ b/ports/cozumel.html
@@ -298,43 +298,6 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p>Cozumel rewards both relaxation and exploration. I've had perfect days doing nothing but floating in Mr. Sanchos' pool with a bucket of Coronas, and I've had perfect days snorkeling three reefs and touring ruins and eating street food until I couldn't move. The island accommodates both equally well. And that water — that ridiculous, impossibly clear, every-shade-of-blue-at-once water — is why I keep coming back even when I've checked every other box on the list.</p>
     </article>
 
-    <section class="card" style="margin-top: 2rem;">
-      <h2>Port Images</h2>
-      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-top: 1rem;">
-
-        <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-          <a href="https://commons.wikimedia.org/wiki/File:Beach_Scene_with_Fishing_Boats_-_San_Miguel_de_Cozumel_-_Cozumel_-_Mexico.jpg" target="_blank" rel="noopener">
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Beach_Scene_with_Fishing_Boats_-_San_Miguel_de_Cozumel_-_Cozumel_-_Mexico.jpg/800px-Beach_Scene_with_Fishing_Boats_-_San_Miguel_de_Cozumel_-_Cozumel_-_Mexico.jpg" alt="Beach scene with fishing boats in San Miguel de Cozumel" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-          </a>
-          <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-            San Miguel waterfront with traditional fishing boats
-            <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Beach_Scene_with_Fishing_Boats_-_San_Miguel_de_Cozumel_-_Cozumel_-_Mexico.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">CC BY-SA 4.0</a></span>
-          </figcaption>
-        </figure>
-
-        <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-          <a href="https://commons.wikimedia.org/wiki/File:Ciclopista_cozumel.JPG" target="_blank" rel="noopener">
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8e/Ciclopista_cozumel.JPG/800px-Ciclopista_cozumel.JPG" alt="Cozumel coastal bike path" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-          </a>
-          <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-            Coastal bike path along Cozumel's western shore
-            <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Ciclopista_cozumel.JPG" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener">CC BY-SA 3.0</a></span>
-          </figcaption>
-        </figure>
-
-        <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-          <a href="https://commons.wikimedia.org/wiki/File:Cozumel_(5402837974).jpg" target="_blank" rel="noopener">
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Cozumel_%285402837974%29.jpg/800px-Cozumel_%285402837974%29.jpg" alt="Caribbean waters off Cozumel coast" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-          </a>
-          <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-            The impossibly clear Caribbean waters that define Cozumel
-            <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Cozumel_(5402837974).jpg" target="_blank" rel="noopener">Ron Kroetz</a> · <a href="https://creativecommons.org/licenses/by/2.0/" target="_blank" rel="noopener">CC BY 2.0</a></span>
-          </figcaption>
-        </figure>
-
-      </div>
-      <p class="tiny" style="margin-top: 1rem; color: #678; font-style: italic;">
-
     <!-- Navigation Section -->
     <section class="port-section">
       <h3>Getting Around Cozumel</h3>

--- a/ports/grand-cayman.html
+++ b/ports/grand-cayman.html
@@ -172,43 +172,6 @@ Soli Deo Gloria
         </div>
       </div>
 
-      <section class="card" style="margin-top: 2rem;">
-        <h2>Port Images</h2>
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-top: 1rem;">
-
-          <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-            <a href="https://commons.wikimedia.org/wiki/File:Stingray_City,_Grand_Cayman.jpg" target="_blank" rel="noopener">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0f/Stingray_City%2C_Grand_Cayman.jpg/800px-Stingray_City%2C_Grand_Cayman.jpg" alt="Southern stingrays at Stingray City sandbar" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-            </a>
-            <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-              Stingray City — swimming with velvet-soft southern stingrays
-              <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Stingray_City,_Grand_Cayman.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by/2.0/" target="_blank" rel="noopener">CC BY 2.0</a></span>
-            </figcaption>
-          </figure>
-
-          <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-            <a href="https://commons.wikimedia.org/wiki/File:Seven_Mile_Beach_Grand_Cayman.jpg" target="_blank" rel="noopener">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Seven_Mile_Beach_Grand_Cayman.jpg/800px-Seven_Mile_Beach_Grand_Cayman.jpg" alt="Seven Mile Beach with white sand and turquoise water" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-            </a>
-            <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-              Seven Mile Beach — world-famous white sand and Caribbean blue
-              <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Seven_Mile_Beach_Grand_Cayman.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener">CC BY-SA 3.0</a></span>
-            </figcaption>
-          </figure>
-
-          <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-            <a href="https://commons.wikimedia.org/wiki/File:George_Town,_Grand_Cayman.jpg" target="_blank" rel="noopener">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/George_Town%2C_Grand_Cayman.jpg/800px-George_Town%2C_Grand_Cayman.jpg" alt="George Town waterfront with cruise ship tenders" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-            </a>
-            <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-              George Town waterfront — cruise ships anchor offshore in that famous seven-shades-of-blue water
-              <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:George_Town,_Grand_Cayman.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/2.0/" target="_blank" rel="noopener">CC BY-SA 2.0</a></span>
-            </figcaption>
-          </figure>
-
-        </div>
-        <p class="tiny" style="margin-top: 1rem; color: #678; font-style: italic;">
-
       <section class="port-section">
         <h3>Getting Around Grand Cayman</h3>
         <p>Tenders to downtown George Town. All tours pick up right at the pier. Taxis to Seven Mile Beach are shareable for groups.</p>

--- a/ports/st-thomas.html
+++ b/ports/st-thomas.html
@@ -172,43 +172,6 @@ Soli Deo Gloria
         </div>
       </div>
 
-      <section class="card" style="margin-top: 2rem;">
-        <h2>Port Images</h2>
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-top: 1rem;">
-
-          <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-            <a href="https://commons.wikimedia.org/wiki/File:Magens_Bay,_St._Thomas,_U.S._Virgin_Islands.jpg" target="_blank" rel="noopener">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Magens_Bay%2C_St._Thomas%2C_U.S._Virgin_Islands.jpg/800px-Magens_Bay%2C_St._Thomas%2C_U.S._Virgin_Islands.jpg" alt="Magens Bay with turquoise water and white sand" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-            </a>
-            <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-              Magens Bay — consistently rated one of the world's most beautiful beaches
-              <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Magens_Bay,_St._Thomas,_U.S._Virgin_Islands.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener">CC BY-SA 3.0</a></span>
-            </figcaption>
-          </figure>
-
-          <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-            <a href="https://commons.wikimedia.org/wiki/File:Charlotte_Amalie_Harbor,_St_Thomas_USVI.jpg" target="_blank" rel="noopener">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5b/Charlotte_Amalie_Harbor%2C_St_Thomas_USVI.jpg/800px-Charlotte_Amalie_Harbor%2C_St_Thomas_USVI.jpg" alt="Charlotte Amalie harbor with cruise ships" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-            </a>
-            <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-              Charlotte Amalie harbor — historic Danish colonial architecture meets duty-free shopping
-              <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Charlotte_Amalie_Harbor,_St_Thomas_USVI.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/2.0/" target="_blank" rel="noopener">CC BY-SA 2.0</a></span>
-            </figcaption>
-          </figure>
-
-          <figure style="margin: 0; border-radius: 8px; overflow: hidden; background: #f7fdff;">
-            <a href="https://commons.wikimedia.org/wiki/File:St_Thomas_Paradise_Point.jpg" target="_blank" rel="noopener">
-              <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/St_Thomas_Paradise_Point.jpg/800px-St_Thomas_Paradise_Point.jpg" alt="Paradise Point tram overlooking Charlotte Amalie" style="width: 100%; height: 200px; object-fit: cover;" loading="lazy"/>
-            </a>
-            <figcaption style="padding: 0.75rem; font-size: 0.85rem; color: #456;">
-              Paradise Point tramway — 360° views and the island's best Bushwacker
-              <br/><span style="font-size: 0.75rem; color: #678;">Photo: <a href="https://commons.wikimedia.org/wiki/File:St_Thomas_Paradise_Point.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> · <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener">CC BY-SA 3.0</a></span>
-            </figcaption>
-          </figure>
-
-        </div>
-        <p class="tiny" style="margin-top: 1rem; color: #678; font-style: italic;">
-
       <section class="port-section">
         <h3>Getting Around St. Thomas</h3>
         <p>Havensight dock – 15-min walk or quick taxi ride to downtown. Crown Bay – short taxi to town. Shared safari taxis to Magens Bay are the way to go.</p>


### PR DESCRIPTION
Fixed incomplete HTML structure in:
- ports/cozumel.html
- ports/grand-cayman.html
- ports/st-thomas.html
- ports/aruba.html

Removed partially-deleted "Port Images" sections that were breaking page layout. These sections had incomplete closing tags from previous cleanup attempt. All pages now have clean HTML structure.