### PR TITLE
Fix deluxe overcap calculation and add site-wide collapsible pattern

### DIFF
--- a/assets/js/calculator-ui.js
+++ b/assets/js/calculator-ui.js
@@ -1070,10 +1070,36 @@ function renderCostSummary(results) {
       </div>
     `;
 
-    row.setAttribute('role', 'article');
+    // Make cost comparison cards clickable for package selection
+    row.setAttribute('role', 'button');
+    row.setAttribute('tabindex', '0');
+    row.setAttribute('data-package', option.key);
+    row.style.cursor = 'pointer';
     row.setAttribute('aria-label',
-      `${option.title}: ${formatMoney(option.cost)} total${option.key === cheapest.key ? '. Best value option' : ''}`
+      `${option.title}: ${formatMoney(option.cost)} total${option.key === cheapest.key ? '. Best value option' : ''}. Click to calculate with this option.`
     );
+
+    // Click handler to select this package
+    row.addEventListener('click', () => {
+      if (window.PackageSelection && option.key !== 'alc') {
+        window.PackageSelection.selectPackage(option.key);
+      } else if (option.key === 'alc' && window.PackageSelection) {
+        // Reset to recommendation for à la carte
+        window.PackageSelection.resetToRecommendation();
+      }
+    });
+
+    // Keyboard accessibility
+    row.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        if (window.PackageSelection && option.key !== 'alc') {
+          window.PackageSelection.selectPackage(option.key);
+        } else if (option.key === 'alc' && window.PackageSelection) {
+          window.PackageSelection.resetToRecommendation();
+        }
+      }
+    });
 
     table.appendChild(row);
   });

--- a/assets/js/collapsible.js
+++ b/assets/js/collapsible.js
@@ -1,0 +1,148 @@
+/**
+ * In the Wake — Collapsible Sections Utility
+ * Version: 1.0.0
+ *
+ * Provides site-wide collapsible section functionality.
+ * Works with elements using .collapsible-section, .collapsible-header, and .collapsible-content classes.
+ *
+ * Usage:
+ *   <div class="collapsible-section" id="my-section">
+ *     <div class="collapsible-header" tabindex="0" role="button" aria-expanded="true">
+ *       <h3>Section Title</h3>
+ *       <span class="collapsible-toggle" aria-hidden="true">▼</span>
+ *     </div>
+ *     <div class="collapsible-content">
+ *       <!-- Content here -->
+ *     </div>
+ *   </div>
+ *
+ * JavaScript: window.toggleCollapsible('my-section') or click/keyboard on header
+ */
+
+(function(window) {
+  'use strict';
+
+  /**
+   * Toggle a collapsible section by ID
+   * @param {string} sectionId - The ID of the collapsible-section element
+   */
+  function toggleCollapsible(sectionId) {
+    const section = document.getElementById(sectionId);
+    if (!section) {
+      console.warn('[Collapsible] Section not found:', sectionId);
+      return;
+    }
+
+    const isCollapsed = section.classList.toggle('collapsed');
+
+    // Update ARIA state
+    const header = section.querySelector('.collapsible-header');
+    if (header) {
+      header.setAttribute('aria-expanded', !isCollapsed);
+    }
+
+    // Announce to screen readers
+    const title = section.querySelector('.collapsible-header h3, .collapsible-header h4');
+    const titleText = title ? title.textContent.trim() : 'Section';
+    announceToScreenReader(`${titleText} ${isCollapsed ? 'collapsed' : 'expanded'}`);
+  }
+
+  /**
+   * Initialize all collapsible sections on the page
+   * Attaches click and keyboard handlers
+   */
+  function initCollapsibles() {
+    const sections = document.querySelectorAll('.collapsible-section');
+
+    sections.forEach(section => {
+      const header = section.querySelector('.collapsible-header');
+      if (!header) return;
+
+      // Set up accessibility attributes
+      header.setAttribute('tabindex', '0');
+      header.setAttribute('role', 'button');
+      header.setAttribute('aria-expanded', !section.classList.contains('collapsed'));
+
+      // Click handler
+      header.addEventListener('click', (e) => {
+        // Don't toggle if clicking on interactive elements inside header
+        if (e.target.closest('button, a, input')) return;
+        toggleCollapsible(section.id);
+      });
+
+      // Keyboard handler
+      header.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggleCollapsible(section.id);
+        }
+      });
+    });
+  }
+
+  /**
+   * Announce message to screen readers via live region
+   * @param {string} message - The message to announce
+   */
+  function announceToScreenReader(message) {
+    // Try to find existing live region
+    let liveRegion = document.getElementById('a11y-status') ||
+                     document.getElementById('aria-live-region');
+
+    // Create one if it doesn't exist
+    if (!liveRegion) {
+      liveRegion = document.createElement('div');
+      liveRegion.id = 'a11y-status';
+      liveRegion.setAttribute('role', 'status');
+      liveRegion.setAttribute('aria-live', 'polite');
+      liveRegion.setAttribute('aria-atomic', 'true');
+      liveRegion.className = 'sr-only visually-hidden';
+      liveRegion.style.cssText = 'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;';
+      document.body.appendChild(liveRegion);
+    }
+
+    liveRegion.textContent = message;
+
+    // Clear after a moment to allow re-announcement
+    setTimeout(() => {
+      liveRegion.textContent = '';
+    }, 100);
+  }
+
+  /**
+   * Expand a collapsible section
+   * @param {string} sectionId - The ID of the section to expand
+   */
+  function expandSection(sectionId) {
+    const section = document.getElementById(sectionId);
+    if (section && section.classList.contains('collapsed')) {
+      toggleCollapsible(sectionId);
+    }
+  }
+
+  /**
+   * Collapse a collapsible section
+   * @param {string} sectionId - The ID of the section to collapse
+   */
+  function collapseSection(sectionId) {
+    const section = document.getElementById(sectionId);
+    if (section && !section.classList.contains('collapsed')) {
+      toggleCollapsible(sectionId);
+    }
+  }
+
+  // Export to window
+  window.toggleCollapsible = toggleCollapsible;
+  window.initCollapsibles = initCollapsibles;
+  window.expandSection = expandSection;
+  window.collapseSection = collapseSection;
+
+  // Auto-initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCollapsibles);
+  } else {
+    // DOM already loaded
+    initCollapsibles();
+  }
+
+})(window);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -831,3 +831,76 @@ html, body { overflow-x: hidden; }
 }
 
 /* ======================================================================== */
+
+/* ===== Collapsible Sections (Site-wide Component v3.011.000) ===== */
+/* Reusable collapsible panels for sidebars, sections, and accordions */
+
+.collapsible-section {
+  margin-bottom: 1rem;
+}
+
+.collapsible-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  padding: 0.75rem;
+  background: #f7fdff;
+  border-radius: 8px;
+  border: 1px solid #e0f0f5;
+  user-select: none;
+  transition: background 0.2s;
+}
+
+.collapsible-header:hover {
+  background: #e6f4f8;
+}
+
+.collapsible-header:focus {
+  outline: 3px solid var(--accent, #0e6e8e);
+  outline-offset: 2px;
+}
+
+.collapsible-header h3,
+.collapsible-header h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--sea, #0a3d62);
+}
+
+.collapsible-toggle {
+  font-size: 1.2rem;
+  transition: transform 0.3s;
+  color: #666;
+}
+
+.collapsible-section.collapsed .collapsible-toggle {
+  transform: rotate(-90deg);
+}
+
+.collapsible-content {
+  max-height: 2000px;
+  overflow: hidden;
+  transition: max-height 0.3s ease-out, padding 0.3s;
+  padding: 0.75rem 0;
+}
+
+.collapsible-section.collapsed .collapsible-content {
+  max-height: 0;
+  padding: 0;
+}
+
+/* Accessibility: indicate interactivity */
+.collapsible-header[role="button"] {
+  cursor: pointer;
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .collapsible-toggle,
+  .collapsible-content {
+    transition: none;
+  }
+}
+
+/* ===== END Collapsible Sections ===== */

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -462,6 +462,47 @@
       border: 2px solid #cbd5e1;
     }
 
+    /* Clickable cost comparison cards */
+    .cost-option-row:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+      border-color: #0e6e8e;
+    }
+
+    .cost-option-row:active {
+      transform: translateY(0);
+    }
+
+    .cost-option-row:focus {
+      outline: 3px solid #0e6e8e;
+      outline-offset: 2px;
+    }
+
+    .cost-option-row.best-value:hover {
+      box-shadow: 0 6px 16px rgba(16, 185, 129, 0.4);
+    }
+
+    /* Add tap hint */
+    .cost-option-row::after {
+      content: 'Tap to select';
+      display: block;
+      position: absolute;
+      right: 16px;
+      bottom: 4px;
+      font-size: 0.7rem;
+      color: #94a3b8;
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+
+    .cost-option-row {
+      position: relative;
+    }
+
+    .cost-option-row:hover::after {
+      opacity: 1;
+    }
+
     .cost-option-left {
       display: flex;
       align-items: center;


### PR DESCRIPTION
- CRITICAL FIX: Deluxe package overcap was treating $14 as daily cap, not per-drink
  - Old: overcap = total_daily_alc_spend - $14 (nonsensical)
  - New: overcap = sum of (price - $14) for drinks over $14
  - With 4444 cocktails at $13: was $57,758, now $0 (correctly covered)

- Make cost comparison cards in right rail clickable for package selection
  - Click any option to force calculation with that package
  - Added hover states and "Tap to select" hint

- Add site-wide collapsible sections pattern
  - New CSS in styles.css for .collapsible-section components
  - New assets/js/collapsible.js with toggleCollapsible utility
  - Includes accessibility: ARIA states, keyboard support, screen reader announcements

- Bump calculator-math.js to v1.009.000