### PR TITLE
Fix port page grid alignment - move At a Glance inside aside

### DIFF
--- a/ports/cozumel.html
+++ b/ports/cozumel.html
@@ -263,15 +263,6 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Cozumel</li></ol></nav>
 
-    <section class="page-intro" style="grid-column: 2; margin-bottom: 1rem; align-self: start;">
-      <details open style="background: #f7fdff; border: 1px solid #e0f0f5; border-radius: 8px; padding: 0;">
-        <summary style="cursor: pointer; padding: 0.75rem; font-weight: 600; border-left: 3px solid var(--rope, #d9b382); border-radius: 8px 8px 0 0; background: #f7fdff;">At a Glance</summary>
-        <div style="padding: 0.5rem 0.75rem 0.75rem;">
-          <p style="margin: 0;"><strong>Quick Answer:</strong> Cozumel is the most-visited cruise port in Mexico — world-class snorkeling on the Mesoamerican Reef (second largest on earth), all-inclusive beach clubs, authentic Mayan culture, and that impossibly clear Caribbean water.</p>
-        </div>
-      </details>
-    </section>
-
     <div style="grid-column: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay -->
@@ -428,6 +419,14 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   </div>
 
   <aside class="rail" style="grid-column: 2; align-self: start;">
+    <!-- At a Glance (collapsible) -->
+    <details open class="card" style="background: #f7fdff; border: 1px solid #e0f0f5; border-radius: 8px;">
+      <summary style="cursor: pointer; padding: 0.75rem; font-weight: 600; border-left: 3px solid var(--rope, #d9b382); border-radius: 8px 8px 0 0; background: #f7fdff;">At a Glance</summary>
+      <div style="padding: 0.5rem 0.75rem 0.75rem;">
+        <p style="margin: 0;"><strong>Quick Answer:</strong> Cozumel is the most-visited cruise port in Mexico — world-class snorkeling on the Mesoamerican Reef (second largest on earth), all-inclusive beach clubs, authentic Mayan culture, and that impossibly clear Caribbean water.</p>
+      </div>
+    </details>
+
     <!-- Author Card (collapsible) -->
     <details open class="card" style="background: #fff; border: 1px solid #e0f0f5; border-radius: 8px;">
       <summary style="cursor: pointer; padding: 0.75rem; font-weight: 600; border-left: 3px solid var(--rope, #d9b382); border-radius: 8px 8px 0 0; background: #f7fdff;">About the Author</summary>

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -256,15 +256,6 @@ Soli Deo Gloria
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Nassau</li></ol></nav>
 
-    <section class="page-intro" style="grid-column: 2; margin-bottom: 1rem; align-self: start;">
-      <details open style="background: #f7fdff; border: 1px solid #e0f0f5; border-radius: 8px; padding: 0;">
-        <summary style="cursor: pointer; padding: 0.75rem; font-weight: 600; border-left: 3px solid var(--rope, #d9b382); border-radius: 8px 8px 0 0; background: #f7fdff;">At a Glance</summary>
-        <div style="padding: 0.5rem 0.75rem 0.75rem;">
-          <p style="margin: 0;"><strong>Quick Answer:</strong> Nassau is a love-hate-that-you-secretly-love port with Atlantis Aquaventure, gorgeous Cabbage Beach, duty-free rum cake, the famous Straw Market, and the best cracked conch in the Caribbean.</p>
-        </div>
-      </details>
-    </section>
-
     <div style="grid-column: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay -->
@@ -416,6 +407,14 @@ Soli Deo Gloria
     </article>
   </div>
   <aside class="rail" style="grid-column: 2; align-self: start;">
+    <!-- At a Glance (collapsible) -->
+    <details open class="card" style="background: #f7fdff; border: 1px solid #e0f0f5; border-radius: 8px;">
+      <summary style="cursor: pointer; padding: 0.75rem; font-weight: 600; border-left: 3px solid var(--rope, #d9b382); border-radius: 8px 8px 0 0; background: #f7fdff;">At a Glance</summary>
+      <div style="padding: 0.5rem 0.75rem 0.75rem;">
+        <p style="margin: 0;"><strong>Quick Answer:</strong> Nassau is a love-hate-that-you-secretly-love port with Atlantis Aquaventure, gorgeous Cabbage Beach, duty-free rum cake, the famous Straw Market, and the best cracked conch in the Caribbean.</p>
+      </div>
+    </details>
+
     <!-- Author Card (collapsible) -->
     <details open class="card" style="background: #fff; border: 1px solid #e0f0f5; border-radius: 8px;">
       <summary style="cursor: pointer; padding: 0.75rem; font-weight: 600; border-left: 3px solid var(--rope, #d9b382); border-radius: 8px 8px 0 0; background: #f7fdff;">About the Author</summary>


### PR DESCRIPTION
Both columns now start at the same row after breadcrumb:
- Column 1: Main content with hero image and logbook
- Column 2: Aside containing At a Glance + Author + Recent Stories

This fixes the issue where Author Card was dropping down when At a Glance was a separate element.