### PR TITLE
Add gradient-based port-hero sections to 43 port pages

### DIFF
--- a/ports/amsterdam.html
+++ b/ports/amsterdam.html
@@ -191,6 +191,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ff6b00 0%, #ff8c00 35%, #0077b6 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Amsterdam</div>
+      </div>
+
       <h1>Amsterdam: My Canal City That Feels Like a Fairy Tale</h1>
 
       <div class="logbook-entry">

--- a/ports/athens.html
+++ b/ports/athens.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #c8a951 0%, #d4af37 35%, #87ceeb 70%, #0077b6 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Athens</div>
+      </div>
+
       <h1>Athens: My Journey Through Ancient Greece</h1>
       <div class="logbook-entry">
         <p>We docked in Piraeus at dawn and the Acropolis was already lit up like a crown above the city haze. The metro ride into Athens took exactly 19 minutes and dropped us at the foot of the Acropolis hill just as the gates opened. We beat most of the crowds and walked the Panathenaic Way alone for twenty glorious minutes, marble warm under our hands, cicadas screaming, the Parthenon suddenly right there, scarred but standing proud. I actually got goosebumps when the first rays of sun hit the columns and turned them honey-gold.</p>

--- a/ports/barcelona.html
+++ b/ports/barcelona.html
@@ -225,6 +225,11 @@ All work on this project is offered as a gift to God.
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #c60b1e 0%, #ffc400 35%, #0077b6 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Barcelona</div>
+      </div>
+
       <h1>Barcelona: Where Gaudí Meets the Mediterranean</h1>
 
       <div class="logbook-entry">

--- a/ports/belize.html
+++ b/ports/belize.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d6a4f 0%, #40916c 30%, #0077b6 65%, #023e8a 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Belize</div>
+      </div>
+
       <h1>Belize City: My Jungle & Reef Adventure Day</h1>
       <div class="logbook-entry">
         <p>Tendering through the turquoise flats to Belize City with manatees popping up beside the boat is magical – this is the port where you forget the city and go full adventure. My perfect day: off the first tender and straight on an airplane to the Great Blue Hole (Lamanai Air or Tropic Air – absolutely life-changing) or cave tubing and zip-lining combo with Cavetubing.bz (lunch included and totally worth it).</p>

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #e63946 0%, #f4a261 30%, #e9c46a 60%, #2a9d8f 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Bergen</div>
+      </div>
+
       <h1>Bergen: My Gateway to the Fjords</h1>
       <div class="logbook-entry">
         <p>We sailed into the harbor at dawn with Bryggen's crooked wooden façades glowing like gingerbread against the mist. The funicular up Mount Fløyen was waiting – ten minutes later we stood above the cloud layer watching the city sparkle below while goats grazed on the roof of the station restaurant. Back down we wandered the UNESCO-listed Bryggen alleys – timber beams creaking, the smell of tar and salt, tiny galleries tucked between 300-year-old warehouses.</p>

--- a/ports/bermuda.html
+++ b/ports/bermuda.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffb6c1 0%, #ff91a4 30%, #87ceeb 70%, #4aa8c7 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Bermuda</div>
+      </div>
+
       <h1>Bermuda: My Pink Sand Paradise</h1>
       <div class="logbook-entry">
         <p>The ship docks inside a fortress — actual 19th-century stone walls and cannons everywhere. The Dockyard has great museums and shops, but we hopped the ferry to Hamilton first for pastel buildings and Front Street vibes, then public bus #7 straight to Horseshoe Bay.</p>

--- a/ports/bonaire.html
+++ b/ports/bonaire.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffd700 0%, #ffb347 30%, #1e90ff 60%, #0077be 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Bonaire</div>
+      </div>
+
       <h1>Bonaire: My Snorkeler's Paradise</h1>
       <div class="logbook-entry">
         <p>Sailing into Kralendijk with flamingos flying past the ship is unreal – Bonaire is the snorkeler's paradise. My perfect day: off the ship and straight to Klein Bonaire by water taxi (affordable round-trip) – the deserted island with No Name Beach and snorkeling that rivals the Great Barrier Reef right off the sand.</p>

--- a/ports/civitavecchia.html
+++ b/ports/civitavecchia.html
@@ -225,6 +225,11 @@ All work on this project is offered as a gift to God.
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #8b4513 0%, #cd853f 35%, #daa520 70%, #f4a460 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2rem, 8vw, 4rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Civitavecchia</div>
+      </div>
+
       <h1>Civitavecchia: Gateway to the Eternal City</h1>
 
       <div class="logbook-entry">

--- a/ports/copenhagen.html
+++ b/ports/copenhagen.html
@@ -194,6 +194,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #c60c30 0%, #e63946 35%, #ffffff 70%, #f0f8ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2rem, 8vw, 4rem); font-weight: 700; color: #c60c30; text-shadow: 2px 2px 8px rgba(255,255,255,0.8), 0 0 40px rgba(255,255,255,0.5); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Copenhagen</div>
+      </div>
+
       <h1>Copenhagen: My Scandinavian Dream Come True</h1>
 
       <div class="logbook-entry">

--- a/ports/curacao.html
+++ b/ports/curacao.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ff6b35 0%, #f7931e 25%, #00b4d8 60%, #0077b6 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Curaçao</div>
+      </div>
+
       <h1>Curaçao: My Colorful Dutch Caribbean Love</h1>
       <div class="logbook-entry">
         <p>The sail-in through the narrow channel into Willemstad with Handelskade's rainbow buildings reflecting in the water is hands-down the prettiest port entrance in the Caribbean. My perfect day: off the ship and across the swinging Queen Emma pontoon bridge (it actually floats and swings open – so cool) into Punda for photos, then a free ferry to Otrobanda for the Kura Hulanda slavery museum (powerful and beautifully done).</p>

--- a/ports/dominica.html
+++ b/ports/dominica.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d5a27 0%, #3a7d32 30%, #52b788 70%, #40916c 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Dominica</div>
+      </div>
+
       <h1>Dominica: My Nature Island Adventure</h1>
       <div class="logbook-entry">
         <p>Sailing into Roseau with mountains dropping straight into the sea feels like entering Jurassic Park. Dominica is the nature island and I go full adventure: Trafalgar Falls first (short taxi), then the Ti Tou Gorge swim through the narrow canyon to the waterfall (cold but incredible).</p>

--- a/ports/dublin.html
+++ b/ports/dublin.html
@@ -150,6 +150,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #169b62 0%, #2e8b57 35%, #ffffff 65%, #ff883e 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Dublin</div>
+      </div>
+
       <h1>Dublin & Cobh: My Emerald Isle Love That Feels Like Home</h1>
       <div class="logbook-entry">
         <p>Every single time our Royal Caribbean ship sails into Dublin Port or down in Cobh for Cork, I feel an instant warmth — Ireland is the port where cruisers consistently report the friendliest people on the planet (4.9–5.0 average 2023–2025).</p>

--- a/ports/dubrovnik.html
+++ b/ports/dubrovnik.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #8b4513 0%, #cd5c5c 35%, #4169e1 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Dubrovnik</div>
+      </div>
+
       <h1>Dubrovnik: My Adriatic Jewel</h1>
       <div class="logbook-entry">
         <p>We walked off the ship and took the first cable car up Mount Srđ for sunrise — the view of the walled city floating in pink mist is one of the most beautiful things I've ever seen. Then down and straight onto the walls at opening (again, early is everything). We had entire sections to ourselves for the first hour — just us, gulls, and 1,000 years of history.</p>

--- a/ports/glacier-bay.html
+++ b/ports/glacier-bay.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0077b6 0%, #48cae4 30%, #90e0ef 60%, #caf0f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Glacier Bay</div>
+      </div>
+
       <h1>Glacier Bay: My Best Day at Sea</h1>
       <div class="logbook-entry">
         <p>This isn't a port — it's the best day of the entire cruise. We entered the bay at 6 a.m. with mist hanging in the valleys and orcas swimming alongside the ship. National Park Service rangers and a Tlingit cultural interpreter boarded at the mouth and narrated all day over the PA and on the bow.</p>

--- a/ports/grand-turk.html
+++ b/ports/grand-turk.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #00ced1 0%, #40e0d0 30%, #48d1cc 60%, #20b2aa 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2rem, 8vw, 4rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Grand Turk</div>
+      </div>
+
       <h1>Grand Turk: My Perfect Beach Day</h1>
       <div class="logbook-entry">
         <p>We stepped off the ship and immediately kicked off our flip-flops — the cruise center opens straight onto a flawless crescent beach. Margaritaville is right there if you want it, but we turned left and walked 10 minutes to Governor's Beach instead. Zero crowds, powder sand, and water in seven impossible shades of blue.</p>

--- a/ports/grenada.html
+++ b/ports/grenada.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ce1126 0%, #fcd116 35%, #007a3d 70%, #005a2b 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Grenada</div>
+      </div>
+
       <h1>Grenada: My Spice Island Paradise</h1>
       <div class="logbook-entry">
         <p>The sail-in through the Carenage horseshoe harbor with colorful houses stacked up the hills is one of the prettiest in the Caribbean. My perfect day: off the ship and straight to Grand Anse Beach (quick 15-min taxi) – two miles of perfect white sand and calm water.</p>

--- a/ports/guadeloupe.html
+++ b/ports/guadeloupe.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #002395 0%, #0055a4 30%, #00b4d8 60%, #48cae4 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Guadeloupe</div>
+      </div>
+
       <h1>Guadeloupe: My French Caribbean Paradise</h1>
       <div class="logbook-entry">
         <p>We sailed into Pointe-à-Pitre at sunrise and the first thing that hit me was the smell — fresh baguettes and diesel mixed with frangipani. The cruise terminal is modern but the second we stepped outside we were in proper France: gendarmes in kepis, women on scooters with actual baguettes in their baskets, and every second shop a patisserie. I almost cried when I bit into a still-warm pain au chocolat before 8 a.m.</p>

--- a/ports/helsinki.html
+++ b/ports/helsinki.html
@@ -150,6 +150,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #003580 0%, #4a90d9 35%, #ffffff 70%, #f0f8ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #003580; text-shadow: 2px 2px 8px rgba(255,255,255,0.8), 0 0 40px rgba(255,255,255,0.5); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Helsinki</div>
+      </div>
+
       <h1>Helsinki: My Nordic Design & Sauna Heaven</h1>
       <div class="logbook-entry">
         <p>Helsinki is the underrated gem that keeps climbing the rankings — 4.8 average lately because it's clean, friendly, and packed with design. My perfect day: 10-minute tram to Senate Square and Helsinki Cathedral, then the ferry to Suomenlinna sea fortress (UNESCO, gorgeous island walks). Market Square for salmon soup in a bread bowl, then the Löyly public sauna right on the Baltic (sauna — cold plunge — beer on the terrace is life-changing).</p>

--- a/ports/icy-strait-point.html
+++ b/ports/icy-strait-point.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1b4332 0%, #2d6a4f 30%, #40916c 60%, #74c69d 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2rem, 8vw, 4rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Icy Strait Point</div>
+      </div>
+
       <h1>Icy Strait Point: My Wild Alaska</h1>
       <div class="logbook-entry">
         <p>The ship docks literally in wilderness. The pier is a restored 1930s salmon cannery, and the air smells of salt, spruce, and alder smoke from beach fires. Everything here is owned by the Huna Tlingit — profits go directly to the community.</p>

--- a/ports/juneau.html
+++ b/ports/juneau.html
@@ -271,6 +271,11 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
     <!-- Port Header -->
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 30%, #a8e6cf 60%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Juneau</div>
+      </div>
+
       <h1>Juneau, Alaska</h1>
       <p style="font-size: 0.95rem; color: #456; margin-bottom: 0;">
         <strong>Region:</strong> Alaska &nbsp;|&nbsp; <strong>Season:</strong> May – September &nbsp;|&nbsp; <strong>Tender:</strong> No (direct dock)

--- a/ports/ketchikan.html
+++ b/ports/ketchikan.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d6a4f 0%, #40916c 30%, #74c69d 60%, #b7e4c7 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Ketchikan</div>
+      </div>
+
       <h1>Ketchikan: My Salmon & Totem Capital</h1>
       <div class="logbook-entry">
         <p>We sailed in through thick morning mist and suddenly houses on stilts appeared like something from a fairy tale. The smell hit first — low tide, smoked salmon, and wet cedar. Ketchikan gets 162 inches of rain a year and wears it proudly; everything is green, mossy, dripping.</p>

--- a/ports/key-west.html
+++ b/ports/key-west.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ff7f50 0%, #ff6347 30%, #ffa07a 60%, #ff4500 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Key West</div>
+      </div>
+
       <h1>Key West: My Quirky Conch Republic</h1>
       <div class="logbook-entry">
         <p>We walked off the ship straight into conch-town chaos — pastel houses, drag queens on bikes, and the smell of Cuban coffee everywhere. Rented bikes (best decision) and pedaled to the Hemingway House first. The polydactyl cats are as advertised (currently 59 of them), lounging on Papa's bed like they pay rent. The writing studio upstairs still has his typewriter — you can feel the ghosts of rum and genius.</p>

--- a/ports/kotor.html
+++ b/ports/kotor.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d5a27 0%, #3a7d32 35%, #4169e1 70%, #0077b6 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Kotor</div>
+      </div>
+
       <h1>Kotor: My Dramatic Fjord Climb</h1>
       <div class="logbook-entry">
         <p>The sail-in at dawn is one of the most beautiful approaches on Earth — the ship twists through narrow straits with mountains rising 5,000 ft on both sides. We docked right at the Old Town gate and climbed the fortress walls at 8 a.m. sharp. The 1,350 steps are steep but the view from San Giovanni at 280 m above sea level made me cry — the red roofs, the bay, the cruise ship looking like a toy below.</p>

--- a/ports/lisbon.html
+++ b/ports/lisbon.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffc300 0%, #ffb700 35%, #0077b6 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Lisbon</div>
+      </div>
+
       <h1>Lisbon: My Seven Hills of Soul</h1>
       <div class="logbook-entry">
         <p>We sailed under the 25 de Abril Bridge at sunrise and the city appeared like a terracotta dream stacked above the Tagus River. Tram 28E was waiting at the terminal gates – we jumped on the first wooden car of the day and rattled through impossibly narrow Alfama streets while old ladies hung laundry between buildings. Belém was next – the Jerónimos Monastery glowing honey-gold, the smell of cinnamon and custard drifting from Pastéis de Belém where we devoured six pastel de nata standing at the counter like locals.</p>

--- a/ports/marseille.html
+++ b/ports/marseille.html
@@ -225,6 +225,11 @@ All work on this project is offered as a gift to God.
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0055a4 0%, #7b68ee 35%, #e6e6fa 70%, #f0f8ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Marseille</div>
+      </div>
+
       <h1>Marseille: France's Oldest, Most Authentic City</h1>
 
       <div class="logbook-entry">

--- a/ports/martinique.html
+++ b/ports/martinique.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0055a4 0%, #00b4d8 40%, #48cae4 70%, #90e0ef 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Martinique</div>
+      </div>
+
       <h1>Martinique: My French Caribbean Paradise</h1>
       <div class="logbook-entry">
         <p>Sailing into Fort-de-France with Le Carbet mountains behind feels like France dropped a city in the Caribbean. My perfect day: off the ship and straight to Les Salines beach (40-min taxi south) – the most beautiful beach I've ever seen with coconut palms and calm water.</p>

--- a/ports/monte-carlo.html
+++ b/ports/monte-carlo.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffd700 0%, #c5a900 35%, #ce1126 70%, #8b0000 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2rem, 8vw, 4rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Monte Carlo</div>
+      </div>
+
       <h1>Monte Carlo: My Day in James Bond's Playground</h1>
       <div class="logbook-entry">
         <p>We tendered in right under the palace and the first thing I heard was the scream of a V12 Ferrari doing a fly-by on the tunnel straight. The harbor was wall-to-wall floating palaces – one yacht even had a helicopter and a submarine. We walked the Grand Prix circuit (public streets!) and stood on the exact spot where drivers brake from 200 mph into the hairpin – insane.</p>

--- a/ports/mykonos.html
+++ b/ports/mykonos.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffffff 0%, #e6f3ff 35%, #3b82f6 70%, #1e40af 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #1e40af; text-shadow: 2px 2px 8px rgba(255,255,255,0.8), 0 0 40px rgba(255,255,255,0.5); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Mykonos</div>
+      </div>
+
       <h1>Mykonos: My Cycladic Dream</h1>
       <div class="logbook-entry">
         <p>We tendered into the old port and the wind hit us first — that famous meltemi whipping prayer flags and women's dresses like sails. Little Venice was already buzzing with photographers, but we turned left instead of right and found empty alleys where grandmas swept their doorsteps and cats slept in flowerpots. Breakfast was Greek yogurt with thyme honey so thick it stood up on the spoon, eaten on a balcony overlooking the sea.</p>

--- a/ports/naples.html
+++ b/ports/naples.html
@@ -225,6 +225,11 @@ All work on this project is offered as a gift to God.
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #b22222 0%, #cd853f 35%, #4169e1 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Naples</div>
+      </div>
+
       <h1>Naples: Pizza, Pompeii, and Controlled Chaos</h1>
 
       <div class="logbook-entry">

--- a/ports/oslo.html
+++ b/ports/oslo.html
@@ -150,6 +150,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ba0c2f 0%, #ef3340 35%, #ffffff 65%, #00205b 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Oslo</div>
+      </div>
+
       <h1>Oslo: My Favorite Scandinavian Capital by Far</h1>
       <div class="logbook-entry">
         <p>Every single time our Royal Caribbean ship sails up the stunning Oslofjord past tiny islands, red wooden cabins, and the occasional sauna on a rock, I feel like I'm entering the most beautiful capital city approach on earth. Oslo has become a regular on Northern Europe and Norway-intensive itineraries, and cruisers consistently rank it in the top 3 Scandinavian ports (4.8–5.0 average 2023–2025).</p>

--- a/ports/progreso.html
+++ b/ports/progreso.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #bc6c25 0%, #dda15e 35%, #fefae0 65%, #606c38 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Progreso</div>
+      </div>
+
       <h1>Progreso: My Gateway to Chichen Itzá</h1>
       <div class="logbook-entry">
         <p>The longest pier in the world (8 km!) means you wake up staring at an endless stretch of beige beach and emerald shallows. Progreso town itself is charmingly sleepy — men playing dominoes, street dogs napping in shade, smell of marquesitas (crispy sweet crepes) everywhere — but we came for Chichen Itzá and it did not disappoint.</p>

--- a/ports/reykjavik.html
+++ b/ports/reykjavik.html
@@ -150,6 +150,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #4a5568 0%, #718096 30%, #90cdf4 60%, #e2e8f0 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2rem, 8vw, 4rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Reykjavik</div>
+      </div>
+
       <h1>Reykjavik: My Otherworldly Fire-and-Ice Adventure</h1>
       <div class="logbook-entry">
         <p>Docking in Reykjavik and seeing the colorful tin roofs and Hallgrímskirkja church rising like a basalt column is pure magic — Iceland ports have exploded in popularity and average 4.9–5.0.</p>

--- a/ports/samana.html
+++ b/ports/samana.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 35%, #a8dadc 65%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Samaná</div>
+      </div>
+
       <h1>Samaná: My Whale Watching Wonder</h1>
       <div class="logbook-entry">
         <p>We were in Samaná in peak whale season (February) and I still get emotional thinking about it. The ship anchors and tenders us to the dock; we walked straight onto a waiting catamaran with maybe 40 other people — perfect size. Within 30 minutes we were in the bay and the captain cut the engine because we were surrounded.</p>

--- a/ports/santorini.html
+++ b/ports/santorini.html
@@ -271,6 +271,11 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
     <!-- Port Header -->
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1e40af 0%, #3b82f6 35%, #ffffff 70%, #f0f9ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #1e40af; text-shadow: 2px 2px 8px rgba(255,255,255,0.8), 0 0 40px rgba(255,255,255,0.5); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Santorini</div>
+      </div>
+
       <h1>Santorini, Greece</h1>
       <p style="font-size: 0.95rem; color: #456; margin-bottom: 0;">
         <strong>Region:</strong> Greek Islands &nbsp;|&nbsp; <strong>Season:</strong> April – October &nbsp;|&nbsp; <strong>Tender:</strong> Yes (caldera anchorage)

--- a/ports/seward.html
+++ b/ports/seward.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #023e8a 0%, #0077b6 30%, #00b4d8 60%, #90e0ef 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Seward</div>
+      </div>
+
       <h1>Seward: My Best Wildlife Day</h1>
       <div class="logbook-entry">
         <p>We docked in Resurrection Bay with snow-capped mountains all around and bald eagles circling the mast. The air smelled of salt, glacier silt, and coffee from the harbor cafés. Seward is small, walkable, and proud.</p>

--- a/ports/sitka.html
+++ b/ports/sitka.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 30%, #90e0ef 60%, #caf0f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Sitka</div>
+      </div>
+
       <h1>Sitka: My Most Beautiful Alaska Town</h1>
       <div class="logbook-entry">
         <p>We tendered in and the very first thing I saw was a raft of 40+ sea otters floating on their backs right in front of the ship, cracking clams on their chests like furry little businessmen eating lunch. Sitka is heartbreakingly pretty — snow-capped volcanoes across the sound, Russian church spires, bald eagles perched on literally every lamppost.</p>

--- a/ports/skagway.html
+++ b/ports/skagway.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #8b5a2b 0%, #daa520 35%, #f4d03f 65%, #87ceeb 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Skagway</div>
+      </div>
+
       <h1>Skagway: My Klondike Gold Rush Adventure</h1>
       <div class="logbook-entry">
         <p>We woke up docked at the very end of a narrow fjord with sheer granite walls rising thousands of feet on both sides. The morning air was crisp and smelled of pine, saltwater, and fresh coffee from the docks. Skagway itself is literally a movie set — wooden boardwalks, vintage signs, rangers in flat hats and suspenders telling stories like they just stepped out of 1898. Four cruise ships were in port, but the moment we started walking down Broadway, the town's electric energy drew us in.</p>

--- a/ports/split.html
+++ b/ports/split.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #f5f5dc 0%, #d4af37 35%, #4169e1 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Split</div>
+      </div>
+
       <h1>Split: My Living Roman Palace</h1>
       <div class="logbook-entry">
         <p>We walked off the ship and straight into the Peristyle while a klapa group sang under the sphinx. Had the square almost to ourselves at 8 a.m. Climbed the bell tower (terrifying open stairs) for 360° views over red roofs and the Adriatic.</p>

--- a/ports/st-kitts.html
+++ b/ports/st-kitts.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d6a4f 0%, #40916c 30%, #ffd166 70%, #f4a261 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">St. Kitts</div>
+      </div>
+
       <h1>St. Kitts: My Fortress & Beach Paradise</h1>
       <div class="logbook-entry">
         <p>Sailing into Basseterre with Brimstone Hill Fortress looming on the hill feels like entering a pirate movie. My perfect day: shared taxi straight to Cockleshell Beach (great value) – two miles of golden sand, Carambola Beach Club, and the best grilled mahi tacos with Killer Bee rum punch at Reggae Beach Bar.</p>

--- a/ports/stockholm.html
+++ b/ports/stockholm.html
@@ -151,6 +151,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #006aa7 0%, #0077b6 35%, #fecc00 70%, #ffd500 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Stockholm</div>
+      </div>
+
       <h1>Stockholm: My 14-Island Archipelago Masterpiece</h1>
       <div class="logbook-entry">
         <p>Sailing through Stockholm's archipelago at sunrise with thousands of pine-covered islands is one of cruising's greatest thrills — and Stockholm lives up to every bit of the hype (4.8–5.0 stars). My perfect day: off the ship and straight into Gamla Stan's medieval alleys while they're still quiet — cobblestones, rune stones, the narrowest alley (Mårten Trotzigs Gränd), and fika (coffee + cinnamon bun) at Chokladkoppen.</p>

--- a/ports/tortola.html
+++ b/ports/tortola.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0077b6 0%, #00b4d8 35%, #48cae4 65%, #90e0ef 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Tortola</div>
+      </div>
+
       <h1>Tortola: My British Virgin Islands Gateway</h1>
       <div class="logbook-entry">
         <p>Sailing into Road Town with Sage Mountain behind and yachts everywhere feels exclusive. My perfect day: off the ship and straight to The Baths on Virgin Gorda by ferry plus open safari taxi combo (entrance included) – swimming through boulder caves and grottoes is pure Indiana Jones.</p>

--- a/ports/victoria-bc.html
+++ b/ports/victoria-bc.html
@@ -160,6 +160,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #9d4edd 0%, #c77dff 30%, #e0aaff 60%, #f8bbd9 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Victoria</div>
+      </div>
+
       <h1>Victoria: My Elegant Alaska Finish</h1>
       <div class="logbook-entry">
         <p>We arrived at 6 p.m. and Victoria was pure magic in evening light. Shuttle to Butchart Gardens — the sunken garden, rose garden, Japanese garden all lit with fairy lights, the air thick with flowers and woodsmoke. Then high tea at the Fairmont Empress — scones with clotted cream, tiny sandwiches, 15 teas to choose. Felt like royalty.</p>

--- a/ports/virgin-gorda.html
+++ b/ports/virgin-gorda.html
@@ -161,6 +161,11 @@ Soli Deo Gloria
 
     <div style="grid-column: 1;">
     <article class="card">
+      <!-- Port Hero with gradient background -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #6b705c 0%, #a5a58d 30%, #48cae4 65%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Virgin Gorda</div>
+      </div>
+
       <h1>Virgin Gorda: My Baths Adventure</h1>
       <div class="logbook-entry">
         <p>The tender ride from the ship to Spanish Town already had us grinning — water so clear we could see starfish on the bottom. We shared a safari taxi with six other excited cruisers up to The Baths and arrived just after opening (another pro move). The trail down is short but the second you step into the boulder field your jaw drops — house-sized granite spheres scattered like a giant's marbles, forming cathedral-like grottos with shafts of sunlight piercing turquoise pools.</p>


### PR DESCRIPTION
Add decorative port-hero sections with gradient backgrounds to:
- Caribbean: Bermuda, Key West, Grand Turk, Bonaire, Curacao, Dominica, Grenada, Guadeloupe, Martinique, Samana, St. Kitts, Tortola, Virgin Gorda, Belize, Progreso
- Alaska: Juneau, Ketchikan, Skagway, Sitka, Glacier Bay, Icy Strait Point, Seward, Victoria BC
- Mediterranean: Barcelona, Athens, Santorini, Civitavecchia, Naples, Dubrovnik, Mykonos, Kotor, Lisbon, Split, Marseille, Monte Carlo
- Northern Europe: Amsterdam, Copenhagen, Dublin, Reykjavik, Oslo, Bergen, Stockholm, Helsinki

Each port-hero uses a custom gradient reflecting the destination's character (flag colors, local landscapes, or cultural themes) with responsive typography and text shadows for readability.