### PR TITLE
FEAT: Add whimsical distance units to 16 port pages

### DIFF
--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -370,7 +370,7 @@ All work on this project is offered as a gift to God.
 
         <section class="port-section">
           <h3>Getting Around Aruba</h3>
-          <p>The cruise terminal is a 5-minute walk from downtown Oranjestad. From there:</p>
+          <p>The cruise terminal is a 5-minute walk <span class="distance-fun">about 7 minivans in a row</span> from downtown Oranjestad. From there:</p>
           <ul>
             <li><strong>Eagle Beach:</strong> About $12–15 by taxi, or take the inexpensive public bus (Arubus Line 10).</li>
             <li><strong>Palm Beach:</strong> Quick $10–12 taxi ride. Buses also run this route frequently.</li>

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -178,7 +178,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Bergen</h3>
-        <p>Ship docks 5-minute walk from the fish market and Bryggen. Everything is walkable or quick funicular ride.</p>
+        <p>Ship docks 5-minute walk <span class="distance-fun">about 7 minivans in a row</span> from the fish market and Bryggen. Everything is walkable or quick funicular ride.</p>
       </section>
 
       <section class="port-section">

--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -317,10 +317,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <h3>Getting Around CocoCay</h3>
       <p>One of the easiest ports you'll ever navigate. Your ship docks directly at the private pier — walk off the gangway and you're on the island within minutes. Everything is connected by wide, flat paved paths and free trams that run constantly throughout the day.</p>
       <ul>
-        <li><strong>From pier to Thrill Waterpark:</strong> 5–10 minute walk</li>
-        <li><strong>From pier to Oasis Lagoon:</strong> 7–8 minute walk</li>
-        <li><strong>From pier to Chill Island beaches:</strong> 10–12 minute walk</li>
-        <li><strong>From pier to Hideaway Beach (farthest point):</strong> 15 minutes on foot or 5 by tram</li>
+        <li><strong>From pier to Thrill Waterpark:</strong> 5–10 minute walk <span class="distance-fun">about 10 minivans in a row</span></li>
+        <li><strong>From pier to Oasis Lagoon:</strong> 7–8 minute walk <span class="distance-fun">roughly 10 minivans lined up</span></li>
+        <li><strong>From pier to Chill Island beaches:</strong> 10–12 minute walk <span class="distance-fun">about 7 school buses end-to-end</span></li>
+        <li><strong>From pier to Hideaway Beach (farthest point):</strong> 15 minutes on foot <span class="distance-fun">approximately 10 school buses in a row</span> or 5 by tram</li>
       </ul>
       <p>Signage is excellent throughout, and the free Royal Caribbean app map makes orientation effortless. Tram stops are clearly marked and air-conditioned.</p>
     </section>

--- a/ports/copenhagen.html
+++ b/ports/copenhagen.html
@@ -217,12 +217,12 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Copenhagen</h3>
-        <p>Two main terminals: Oceankaj (northern, most common for large ships) has a free shuttle every 10–15 minutes to the city center (20–25 min ride), or Langelinie (closer) is a gorgeous 25-minute waterfront walk or €10 taxi to Nyhavn.</p>
+        <p>Two main terminals: Oceankaj (northern, most common for large ships) has a free shuttle every 10–15 minutes to the city center (20–25 min ride), or Langelinie (closer) is a gorgeous 25-minute waterfront walk <span class="distance-fun">about 17 school buses end-to-end</span> or €10 taxi to Nyhavn.</p>
         <ul>
           <li><strong>Nyhavn:</strong> Free shuttle + 5 min walk, or waterfront walk from Langelinie</li>
           <li><strong>Tivoli Gardens:</strong> Near Rådhuspladsen, easy from city center</li>
           <li><strong>Little Mermaid:</strong> Walkable from Langelinie or canal tour</li>
-          <li><strong>Christiania:</strong> 20-minute walk from Nyhavn</li>
+          <li><strong>Christiania:</strong> 20-minute walk from Nyhavn <span class="distance-fun">roughly 13 school buses lined up</span></li>
         </ul>
         <p><strong>Tip:</strong> Once in town everything is flat and insanely bike-friendly. GoBoats are €50/hour for up to 8 people — bring picnic supplies.</p>
       </section>

--- a/ports/curacao.html
+++ b/ports/curacao.html
@@ -372,12 +372,12 @@ All work on this project is offered as a gift to God.
 
         <section class="port-section">
           <h3>Getting Around Curaçao</h3>
-          <p>The cruise terminal at Mega Pier or Mathey Wharf is a 10–15 minute walk to the Rif Fort and Queen Emma Bridge. From there:</p>
+          <p>The cruise terminal at Mega Pier or Mathey Wharf is a 10–15 minute walk <span class="distance-fun">about 8 school buses end-to-end</span> to the Rif Fort and Queen Emma Bridge. From there:</p>
           <ul>
-            <li><strong>Punda/Handelskade:</strong> 10–15 min walk across Queen Emma Bridge — completely walkable from the port.</li>
+            <li><strong>Punda/Handelskade:</strong> 10–15 min walk across Queen Emma Bridge <span class="distance-fun">roughly 8 school buses lined up</span> — completely walkable from the port.</li>
             <li><strong>Otrobanda:</strong> Free ferry across St. Anna Bay, or walk across the bridge.</li>
             <li><strong>Hato Caves:</strong> 15–20 minute taxi ride north of Willemstad. Guided tours run regularly.</li>
-            <li><strong>Curaçao Museum:</strong> Located in Otrobanda, about a 10-minute walk from the port or a short taxi.</li>
+            <li><strong>Curaçao Museum:</strong> Located in Otrobanda, about a 10-minute walk from the port <span class="distance-fun">about 7 school buses in a row</span> or a short taxi.</li>
             <li><strong>Porto Marie Beach:</strong> About 30-minute taxi ride. Entry fee includes chair and shade.</li>
             <li><strong>Mambo Beach:</strong> Short affordable taxi ride, or around $8–10.</li>
             <li><strong>Landhuis Chobolobo:</strong> 15-minute taxi from port for Blue Curaçao tour.</li>

--- a/ports/juneau.html
+++ b/ports/juneau.html
@@ -312,9 +312,9 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <h3>Getting Around Juneau</h3>
       <p>Juneau is one of the easiest Alaskan ports to navigate. Most Royal Caribbean ships dock right downtown at the AJ Dock, Franklin Dock, or nearby berths — you walk off the gangway into the heart of the city in under 5 minutes.</p>
       <ul>
-        <li><strong>Downtown (shops, restaurants, tram, museums):</strong> 5–15 minute walk on flat sidewalks</li>
+        <li><strong>Downtown (shops, restaurants, tram, museums):</strong> 5–15 minute walk on flat sidewalks <span class="distance-fun">about 7 school buses end-to-end</span></li>
         <li><strong>Mendenhall Glacier Visitor Center:</strong> 13 miles, 20–30 minute shuttle ($35–45 RT) or taxi ($30–40 one way)</li>
-        <li><strong>Whale watching boats:</strong> 5-minute walk from pier to harbor departure points</li>
+        <li><strong>Whale watching boats:</strong> 5-minute walk from pier to harbor departure points <span class="distance-fun">roughly 7 minivans in a row</span></li>
         <li><strong>Helicopter tours:</strong> Short transfer provided by operator</li>
       </ul>
       <p>The city's free public bus system can get you close to Mendenhall if you're budget-minded. The visitor center right at the pier has free maps and friendly locals ready to point you in the right direction.</p>

--- a/ports/kusadasi.html
+++ b/ports/kusadasi.html
@@ -303,12 +303,12 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- Navigation Section -->
     <section class="port-section">
       <h3>Getting Around Kusadasi</h3>
-      <p>Royal Caribbean docks within a 5-minute walk of Kusadasi town center — you can see the bazaar gates from the ship. Ephesus requires transportation:</p>
+      <p>Royal Caribbean docks within a 5-minute walk <span class="distance-fun">about 7 minivans in a row</span> of Kusadasi town center — you can see the bazaar gates from the ship. Ephesus requires transportation:</p>
       <ul>
         <li><strong>Ephesus (17 km):</strong> Taxi €50–70 round-trip for 1–4 people, or dolmuş minibus €3–4 per person</li>
         <li><strong>House of Virgin Mary:</strong> Usually combined with Ephesus tours, additional €10–15 if separate</li>
         <li><strong>Selçuk/Ephesus Museum:</strong> 3 km past Ephesus, easy taxi add-on</li>
-        <li><strong>Town bazaar:</strong> Walk out port gate, 5-minute stroll</li>
+        <li><strong>Town bazaar:</strong> Walk out port gate, 5-minute stroll <span class="distance-fun">roughly 7 minivans lined up</span></li>
       </ul>
       <p>Most cruisers book ship excursions or private guides (highly recommended for context). Independent dolmuş works but requires some navigation.</p>
     </section>

--- a/ports/labadee.html
+++ b/ports/labadee.html
@@ -315,11 +315,11 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <h3>Getting Around Labadee</h3>
       <p>Labadee is extremely easy to navigate. Ships dock at Royal Caribbean's private pier, and you walk straight into the gated resort. Free trams shuttle between the main areas throughout the day.</p>
       <ul>
-        <li><strong>From pier to Barefoot Beach:</strong> 5-minute walk</li>
-        <li><strong>From pier to Columbus Cove:</strong> 8–10 minute walk or tram</li>
-        <li><strong>From pier to Nellie's Beach:</strong> 10–12 minute walk or tram</li>
-        <li><strong>From pier to Dragon's Breath zip line:</strong> 15 minute walk (uphill) or tram to base, then short hike</li>
-        <li><strong>From pier to Artisan's Market:</strong> 2-minute walk</li>
+        <li><strong>From pier to Barefoot Beach:</strong> 5-minute walk <span class="distance-fun">about 7 minivans in a row</span></li>
+        <li><strong>From pier to Columbus Cove:</strong> 8–10 minute walk <span class="distance-fun">roughly 6 school buses lined up</span> or tram</li>
+        <li><strong>From pier to Nellie's Beach:</strong> 10–12 minute walk <span class="distance-fun">about 7 school buses end-to-end</span> or tram</li>
+        <li><strong>From pier to Dragon's Breath zip line:</strong> 15 minute walk <span class="distance-fun">approximately 10 school buses in a row</span> (uphill) or tram to base, then short hike</li>
+        <li><strong>From pier to Artisan's Market:</strong> 2-minute walk <span class="distance-fun">about 3 minivans lined up</span></li>
       </ul>
       <p>Everything is on flat or gently graded paths. Signage is clear, and staff are everywhere to help direct you.</p>
     </section>

--- a/ports/malaga.html
+++ b/ports/malaga.html
@@ -212,8 +212,8 @@ Soli Deo Gloria
         <h3>Getting Around Málaga</h3>
         <p>One of the easiest ports in Europe — ships dock literally 10–12 minutes' walk from Plaza de la Marina and the cathedral. Everything in the historic center is flat and pedestrianized.</p>
         <ul>
-          <li><strong>Picasso Museum/Cathedral:</strong> 10–12 minute walk from ship</li>
-          <li><strong>Alcazaba/Gibralfaro:</strong> 15–20 minute walk, or bus #35 to Gibralfaro</li>
+          <li><strong>Picasso Museum/Cathedral:</strong> 10–12 minute walk from ship <span class="distance-fun">about 7 school buses end-to-end</span></li>
+          <li><strong>Alcazaba/Gibralfaro:</strong> 15–20 minute walk <span class="distance-fun">roughly 12 school buses lined up</span>, or bus #35 to Gibralfaro</li>
           <li><strong>Pedregalejo Beach:</strong> Bus or €10 taxi, 15 minutes</li>
           <li><strong>Ronda:</strong> 1.5 hours by train, stunning day trip</li>
         </ul>

--- a/ports/naples.html
+++ b/ports/naples.html
@@ -258,7 +258,7 @@ All work on this project is offered as a gift to God.
         <h3>Getting Around from Naples</h3>
         <p>Ships dock at Stazione Marittima, within walking distance of the historic center. From there:</p>
         <ul>
-          <li><strong>Naples Historic Center:</strong> 10–15 minute walk to Piazza del Plebiscito and Spaccanapoli</li>
+          <li><strong>Naples Historic Center:</strong> 10–15 minute walk to Piazza del Plebiscito and Spaccanapoli <span class="distance-fun">about 8 school buses end-to-end</span></li>
           <li><strong>Pompeii (24 km):</strong> Circumvesuviana train from Napoli Centrale (€3.90, 35 min) or taxi/private tour €120–150</li>
           <li><strong>Sorrento (50 km):</strong> Circumvesuviana train (€4.20, ~70 min) or ship excursion</li>
           <li><strong>Amalfi Coast:</strong> Best done by ship excursion or private driver (€250–350). Not practical by public transport in a port day.</li>

--- a/ports/oslo.html
+++ b/ports/oslo.html
@@ -172,11 +172,11 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Oslo</h3>
-        <p>Ships dock at either Filipstad or Sørenga — both are a flat 15–25 minute walk or €10 tram ride to the Opera House and city center. Public ferries to Bygdøy leave every 20 minutes right from the pier area (Aker Brygge).</p>
+        <p>Ships dock at either Filipstad or Sørenga — both are a flat 15–25 minute walk <span class="distance-fun">about 13 school buses end-to-end</span> or €10 tram ride to the Opera House and city center. Public ferries to Bygdøy leave every 20 minutes right from the pier area (Aker Brygge).</p>
         <ul>
-          <li><strong>Opera House:</strong> 15–20 minute walk from most terminals</li>
+          <li><strong>Opera House:</strong> 15–20 minute walk from most terminals <span class="distance-fun">roughly 12 school buses lined up</span></li>
           <li><strong>Bygdøy Museums:</strong> Ferry from Aker Brygge (10 min)</li>
-          <li><strong>Vigeland Park:</strong> Tram or 30 min walk</li>
+          <li><strong>Vigeland Park:</strong> Tram or 30 min walk <span class="distance-fun">about 20 school buses in a row</span></li>
         </ul>
       </section>
 

--- a/ports/palma.html
+++ b/ports/palma.html
@@ -218,9 +218,9 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Palma</h3>
-        <p>Royal Caribbean docks at the Estació Marítima, and you literally walk off the ship and you're 10–15 minutes on foot from the cathedral and the heart of the old town along the beautiful palm-lined Paseo Marítimo.</p>
+        <p>Royal Caribbean docks at the Estació Marítima, and you literally walk off the ship and you're 10–15 minutes on foot <span class="distance-fun">about 8 school buses end-to-end</span> from the cathedral and the heart of the old town along the beautiful palm-lined Paseo Marítimo.</p>
         <ul>
-          <li><strong>Old Town/Cathedral:</strong> 10–15 minute walk from cruise terminal</li>
+          <li><strong>Old Town/Cathedral:</strong> 10–15 minute walk from cruise terminal <span class="distance-fun">roughly 8 school buses lined up</span></li>
           <li><strong>Castell de Bellver:</strong> 3 km, taxi €10 or bus #46</li>
           <li><strong>Sóller Train:</strong> Departs Plaça d'Espanya (€25 round trip, 1 hour each way)</li>
           <li><strong>Es Trenc Beach:</strong> 45 minutes by car/scooter or ship excursion</li>

--- a/ports/portland-maine.html
+++ b/ports/portland-maine.html
@@ -207,7 +207,7 @@ Soli Deo Gloria
         </details>
         <details>
           <summary>Is Portland walkable from the cruise ship?</summary>
-          <p>Extremely walkable. The Ocean Gateway Terminal drops you on Commercial Street, and the cobblestoned Old Port is a 5-minute stroll. The waterfront, shops, restaurants, museums, and Eastern Promenade are all within a 20-minute walk. Portland Head Light and the breweries in the Bayside neighborhood require transportation, but the core of Portland is one of the most walkable cruise ports in North America. Wear comfortable shoes for cobblestones and hills.</p>
+          <p>Extremely walkable. The Ocean Gateway Terminal drops you on Commercial Street, and the cobblestoned Old Port is a 5-minute stroll <span class="distance-fun">about 7 minivans in a row</span>. The waterfront, shops, restaurants, museums, and Eastern Promenade are all within a 20-minute walk <span class="distance-fun">roughly 13 school buses end-to-end</span>. Portland Head Light and the breweries in the Bayside neighborhood require transportation, but the core of Portland is one of the most walkable cruise ports in North America. Wear comfortable shoes for cobblestones and hills.</p>
         </details>
       </div>
 

--- a/ports/san-juan.html
+++ b/ports/san-juan.html
@@ -315,8 +315,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p>San Juan is gloriously walkable — the cruise piers are literally inside Old San Juan. Most ships dock at <strong>Piers 3, 4, or 6</strong> within steps of the historic district.</p>
       <ul>
         <li><strong>Old San Juan:</strong> Walk right off the ship — you're there!</li>
-        <li><strong>El Morro:</strong> 15-minute walk from piers through historic streets</li>
-        <li><strong>San Cristóbal:</strong> 10-minute walk from El Morro or 5 from Pier 4</li>
+        <li><strong>El Morro:</strong> 15-minute walk from piers through historic streets <span class="distance-fun">about 10 school buses end-to-end</span></li>
+        <li><strong>San Cristóbal:</strong> 10-minute walk from El Morro <span class="distance-fun">roughly 7 school buses lined up</span> or 5 from Pier 4</li>
         <li><strong>Condado Beach:</strong> 15-minute taxi or Uber</li>
         <li><strong>Bacardi Distillery:</strong> Ferry from Pier 2, then free shuttle</li>
       </ul>

--- a/ports/southampton.html
+++ b/ports/southampton.html
@@ -210,9 +210,9 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Southampton</h3>
-        <p>Four modern terminals (Ocean, Mayflower, City, Horizon) — all provide free shuttles if needed, but Horizon and City are literally walking distance to the city centre (10–15 minutes).</p>
+        <p>Four modern terminals (Ocean, Mayflower, City, Horizon) — all provide free shuttles if needed, but Horizon and City are literally walking distance to the city centre (10–15 minutes) <span class="distance-fun">about 8 school buses end-to-end</span>.</p>
         <ul>
-          <li><strong>City Centre:</strong> 10–15 minute walk or free shuttle from most terminals</li>
+          <li><strong>City Centre:</strong> 10–15 minute walk <span class="distance-fun">roughly 8 school buses lined up</span> or free shuttle from most terminals</li>
           <li><strong>Stonehenge:</strong> Ship excursion recommended, or train to Salisbury + bus</li>
           <li><strong>Winchester:</strong> Train from Southampton Central (20 minutes)</li>
           <li><strong>London:</strong> Train 70–90 minutes direct</li>

--- a/ports/st-thomas.html
+++ b/ports/st-thomas.html
@@ -373,11 +373,11 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <h3>Getting Around St. Thomas</h3>
       <p>St. Thomas has two cruise piers — <strong>Havensight</strong> (closer to town) and <strong>Crown Bay</strong> (requires short taxi ride). Both areas have shopping right at the pier.</p>
       <ul>
-        <li><strong>Havensight to Downtown Charlotte Amalie:</strong> 15-minute walk or quick taxi</li>
+        <li><strong>Havensight to Downtown Charlotte Amalie:</strong> 15-minute walk <span class="distance-fun">about 10 school buses end-to-end</span> or quick taxi</li>
         <li><strong>Havensight to Magens Bay:</strong> Shared safari taxi (great value, ~20 minutes)</li>
         <li><strong>Paradise Point Skyride:</strong> Walking distance from Havensight</li>
         <li><strong>Crown Bay to Downtown:</strong> 5-minute taxi</li>
-        <li><strong>Fort Christian:</strong> Downtown, 5-minute walk from Main Street</li>
+        <li><strong>Fort Christian:</strong> Downtown, 5-minute walk from Main Street <span class="distance-fun">about 7 minivans lined up</span></li>
         <li><strong>Blackbeard's Castle:</strong> Above downtown, climb 99 Steps or taxi to top</li>
       </ul>
       <p><strong>Pro tip:</strong> Safari taxis (open-air trucks) are the authentic St. Thomas experience and very affordable when shared. They run regular routes to Magens Bay and other popular spots.</p>


### PR DESCRIPTION
Added fun walking distance conversions using .distance-fun class:

Royal Caribbean Private Destinations:
- CocoCay: Waterpark, Oasis Lagoon, Chill Island, Hideaway Beach
- Labadee: Barefoot Beach, Columbus Cove, Nellie's Beach, Dragon's Breath

European Ports:
- Barcelona, Amsterdam (previously added)
- Malaga, Palma, Naples, Oslo, Copenhagen, Southampton, Bergen

Nordic & Alaska:
- Oslo, Copenhagen, Bergen, Juneau

Caribbean:
- San Juan, St. Thomas, Curacao, Aruba

Americas:
- Portland Maine, Kusadasi

All conversions use relatable units (school buses, minivans) to help cruisers visualize walking distances in an engaging way.