### PR TITLE
FEAT: Add whimsical distance units to 24 more port pages

### DIFF
--- a/ports/belfast.html
+++ b/ports/belfast.html
@@ -165,7 +165,7 @@ Soli Deo Gloria
         <h3>Getting Around Belfast</h3>
         <p>Newer ships dock right in the city (10–15 minute walk to Titanic Quarter), older ones a quick shuttle.</p>
         <ul>
-          <li><strong>Titanic Belfast:</strong> 10–15 min walk or quick taxi</li>
+          <li><strong>Titanic Belfast:</strong> 10–15 min walk or quick taxi <span class="distance-fun">about 9 football fields end-to-end</span></li>
           <li><strong>Mural Tours:</strong> Book black taxi from cathedral quarter</li>
           <li><strong>Giant's Causeway:</strong> Ship excursion (2 hours each way) or coach</li>
         </ul>

--- a/ports/corfu.html
+++ b/ports/corfu.html
@@ -175,7 +175,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Corfu</h3>
-        <p>Ship docks 5-minute walk from Old Town. Rent a car for beaches — roads are good and driving is easy.</p>
+        <p>Ship docks 5-minute walk from Old Town <span class="distance-fun">roughly 28 school buses in a row</span>. Rent a car for beaches — roads are good and driving is easy.</p>
       </section>
 
       <section class="port-section">

--- a/ports/gdansk.html
+++ b/ports/gdansk.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Gdansk</h3>
-        <p>Ship docks 20-minute walk or quick tram to old town.</p>
+        <p>Ship docks 20-minute walk or quick tram to old town <span class="distance-fun">about 15 football fields end-to-end</span>.</p>
       </section>
 
       <section class="port-section">

--- a/ports/gibraltar.html
+++ b/ports/gibraltar.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Gibraltar</h3>
-        <p>Ship docks 10-minute walk from Casemates Square – everything is walkable or cheap cable car up the Rock.</p>
+        <p>Ship docks 10-minute walk from Casemates Square <span class="distance-fun">roughly 7 football fields in a row</span> – everything is walkable or cheap cable car up the Rock.</p>
       </section>
 
       <section class="port-section">

--- a/ports/helsinki.html
+++ b/ports/helsinki.html
@@ -170,9 +170,9 @@ Soli Deo Gloria
         <h3>Getting Around Helsinki</h3>
         <p>Ships dock at Hernesaari or West Harbour — free shuttle or 15–20 minute scenic walk/tram to center.</p>
         <ul>
-          <li><strong>Senate Square/Cathedral:</strong> Tram or 15 min walk</li>
+          <li><strong>Senate Square/Cathedral:</strong> Tram or 15 min walk <span class="distance-fun">approximately 11 football fields lined up</span></li>
           <li><strong>Suomenlinna:</strong> Ferry from Market Square (15 min, €5 round trip)</li>
-          <li><strong>Löyly Sauna:</strong> 20-min walk along waterfront or tram</li>
+          <li><strong>Löyly Sauna:</strong> 20-min walk along waterfront or tram <span class="distance-fun">about 15 football fields end-to-end</span></li>
         </ul>
       </section>
 

--- a/ports/heraklion.html
+++ b/ports/heraklion.html
@@ -175,7 +175,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Heraklion</h3>
-        <p>Ship docks 10-minute walk from Venetian harbor and walls. Knossos is 20 min taxi or bus.</p>
+        <p>Ship docks 10-minute walk from Venetian harbor and walls <span class="distance-fun">about 7 football fields end-to-end</span>. Knossos is 20 min taxi or bus.</p>
       </section>
 
       <section class="port-section">

--- a/ports/kirkwall.html
+++ b/ports/kirkwall.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Kirkwall</h3>
-        <p>Ship docks 10-minute walk from town. Excursions or taxis for archaeological sites.</p>
+        <p>Ship docks 10-minute walk from town <span class="distance-fun">approximately 7 football fields lined up</span>. Excursions or taxis for archaeological sites.</p>
       </section>
 
       <section class="port-section">

--- a/ports/lerwick.html
+++ b/ports/lerwick.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Lerwick</h3>
-        <p>Ship docks 15-minute walk uphill to town. Excursions or taxis for sites.</p>
+        <p>Ship docks 15-minute walk uphill to town <span class="distance-fun">approximately 11 football fields lined up</span>. Excursions or taxis for sites.</p>
       </section>
 
       <section class="port-section">

--- a/ports/liverpool.html
+++ b/ports/liverpool.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Liverpool</h3>
-        <p>Ship docks at the Pier Head – 2-minute walk to Albert Dock and city center.</p>
+        <p>Ship docks at the Pier Head – 2-minute walk to Albert Dock and city center <span class="distance-fun">about 11 school buses end-to-end</span>.</p>
       </section>
 
       <section class="port-section">

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -385,9 +385,9 @@ Soli Deo Gloria
         <ul>
           <li><strong>Atlantis Aquaventure:</strong> Water taxi + 5-min walk</li>
           <li><strong>Cabbage Beach:</strong> Through Atlantis or walk from Paradise Island ferry</li>
-          <li><strong>Queen's Staircase:</strong> 10-min walk from pier</li>
-          <li><strong>Straw Market:</strong> Right downtown, 5-min walk from pier</li>
-          <li><strong>Potter's Cay:</strong> Under the Paradise Island bridge, 15-min walk</li>
+          <li><strong>Queen's Staircase:</strong> 10-min walk from pier <span class="distance-fun">about 55 school buses end-to-end</span></li>
+          <li><strong>Straw Market:</strong> Right downtown, 5-min walk from pier <span class="distance-fun">roughly 28 school buses in a row</span></li>
+          <li><strong>Potter's Cay:</strong> Under the Paradise Island bridge, 15-min walk <span class="distance-fun">approximately 11 football fields lined up</span></li>
         </ul>
       </section>
 

--- a/ports/reykjavik.html
+++ b/ports/reykjavik.html
@@ -176,7 +176,7 @@ Soli Deo Gloria
         <ul>
           <li><strong>Golden Circle:</strong> Full-day ship excursion (8 hours) or private tour</li>
           <li><strong>Blue Lagoon:</strong> Book separately, 45 min from city</li>
-          <li><strong>Hallgrímskirkja:</strong> 10-min walk from old harbor</li>
+          <li><strong>Hallgrímskirkja:</strong> 10-min walk from old harbor <span class="distance-fun">about 7 football fields end-to-end</span></li>
         </ul>
       </section>
 

--- a/ports/riga.html
+++ b/ports/riga.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Riga</h3>
-        <p>Ship docks 15-minute walk or quick tram to old town.</p>
+        <p>Ship docks 15-minute walk or quick tram to old town <span class="distance-fun">approximately 11 football fields lined up</span>.</p>
       </section>
 
       <section class="port-section">

--- a/ports/seward.html
+++ b/ports/seward.html
@@ -183,7 +183,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Seward</h3>
-        <p>Walkable downtown. Kenai Fjords tours depart from harbor (5 min walk).</p>
+        <p>Walkable downtown. Kenai Fjords tours depart from harbor (5 min walk) <span class="distance-fun">roughly 28 school buses in a row</span>.</p>
       </section>
 
       <section class="port-section">

--- a/ports/split.html
+++ b/ports/split.html
@@ -178,7 +178,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Split</h3>
-        <p>Ship docks 5 min walk to palace.</p>
+        <p>Ship docks 5 min walk to palace <span class="distance-fun">roughly 28 school buses in a row</span>.</p>
       </section>
 
       <section class="port-section">

--- a/ports/stavanger.html
+++ b/ports/stavanger.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Stavanger</h3>
-        <p>Ship docks 10-minute walk from old town and harbor. Fjord cruises leave right in front of the ship.</p>
+        <p>Ship docks 10-minute walk from old town and harbor <span class="distance-fun">roughly 7 football fields in a row</span>. Fjord cruises leave right in front of the ship.</p>
       </section>
 
       <section class="port-section">

--- a/ports/stockholm.html
+++ b/ports/stockholm.html
@@ -171,7 +171,7 @@ Soli Deo Gloria
         <h3>Getting Around Stockholm</h3>
         <p>Most ships dock at Stadsgården/Frihamnen — free shuttle or €10–15 taxi to city center (10–20 minutes). Once there the public ferries, metro, and trams are fantastic and scenic.</p>
         <ul>
-          <li><strong>Gamla Stan:</strong> 15–20 minute walk or quick bus/taxi</li>
+          <li><strong>Gamla Stan:</strong> 15–20 minute walk or quick bus/taxi <span class="distance-fun">roughly 13 football fields in a row</span></li>
           <li><strong>Vasa Museum (Djurgården):</strong> Ferry from Slussen or walk across bridge</li>
           <li><strong>ABBA Museum:</strong> Same area as Vasa on Djurgården</li>
         </ul>

--- a/ports/tallinn.html
+++ b/ports/tallinn.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Tallinn</h3>
-        <p>Ship docks 10-minute walk from old town gates.</p>
+        <p>Ship docks 10-minute walk from old town gates <span class="distance-fun">about 55 school buses end-to-end</span>.</p>
       </section>
 
       <section class="port-section">

--- a/ports/tangier.html
+++ b/ports/tangier.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Tangier</h3>
-        <p>Ship docks 5-minute walk from medina gate. Guided tour or official taxi is recommended for first-timers.</p>
+        <p>Ship docks 5-minute walk from medina gate <span class="distance-fun">roughly 28 school buses in a row</span>. Guided tour or official taxi is recommended for first-timers.</p>
       </section>
 
       <section class="port-section">

--- a/ports/tokyo.html
+++ b/ports/tokyo.html
@@ -186,7 +186,7 @@ All work on this project is offered as a gift to God.
       <!-- Navigation -->
       <section>
         <h2>Getting Around</h2>
-        <p>Larger ships dock at <strong>Osanbashi</strong> (Yokohama) – 10-minute walk to Chinatown or train to Tokyo (30 minutes). Daikoku/Osanbashi shuttles to stations are seamless. Get a Suica or Pasmo card for effortless train travel.</p>
+        <p>Larger ships dock at <strong>Osanbashi</strong> (Yokohama) – 10-minute walk to Chinatown <span class="distance-fun">about 55 school buses end-to-end</span> or train to Tokyo (30 minutes). Daikoku/Osanbashi shuttles to stations are seamless. Get a Suica or Pasmo card for effortless train travel.</p>
       </section>
 
       <!-- Word of Warning -->

--- a/ports/trieste.html
+++ b/ports/trieste.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Trieste</h3>
-        <p>Ship docks 10-minute walk from Piazza Unità – Trieste is made for strolling.</p>
+        <p>Ship docks 10-minute walk from Piazza Unità <span class="distance-fun">about 7 football fields end-to-end</span> – Trieste is made for strolling.</p>
       </section>
 
       <section class="port-section">

--- a/ports/tromso.html
+++ b/ports/tromso.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Tromsø</h3>
-        <p>Ship docks 5-minute walk from city center. Everything reachable by foot or quick bus.</p>
+        <p>Ship docks 5-minute walk from city center <span class="distance-fun">about 28 school buses end-to-end</span>. Everything reachable by foot or quick bus.</p>
       </section>
 
       <section class="port-section">

--- a/ports/vigo.html
+++ b/ports/vigo.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Vigo</h3>
-        <p>Ship docks in city center – ferry terminal 10-minute walk.</p>
+        <p>Ship docks in city center – ferry terminal 10-minute walk <span class="distance-fun">roughly 7 football fields in a row</span>.</p>
       </section>
 
       <section class="port-section">

--- a/ports/waterford.html
+++ b/ports/waterford.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Waterford</h3>
-        <p>Ship docks 10-minute walk from Viking Triangle.</p>
+        <p>Ship docks 10-minute walk from Viking Triangle <span class="distance-fun">approximately 7 football fields lined up</span>.</p>
       </section>
 
       <section class="port-section">

--- a/ports/zadar.html
+++ b/ports/zadar.html
@@ -173,7 +173,7 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Getting Around Zadar</h3>
-        <p>Ship docks 5-minute walk from old town gate.</p>
+        <p>Ship docks 5-minute walk from old town gate <span class="distance-fun">about 28 school buses end-to-end</span>.</p>
       </section>
 
       <section class="port-section">


### PR DESCRIPTION
Add fun walking distance conversions using school buses and football fields to help visitors visualize walking distances from cruise ports to key attractions.

Updated ports: nassau, reykjavik, helsinki, stockholm, tallinn, split, tokyo, gibraltar, liverpool, riga, seward, belfast, corfu, gdansk, kirkwall, stavanger, trieste, tromso, vigo, zadar, waterford, tangier, heraklion, lerwick