### PR TITLE
FIX: Correct grid layout so main content aligns with Quick Answer

### DIFF
--- a/ports/ajaccio.html
+++ b/ports/ajaccio.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Ajaccio: My Corsican Adventure</h1>
       <div class="logbook-entry">

--- a/ports/alesund.html
+++ b/ports/alesund.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Ålesund: My Art Nouveau Dream</h1>
       <div class="logbook-entry">

--- a/ports/amalfi.html
+++ b/ports/amalfi.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Amalfi: My Most Beautiful Coastline</h1>
       <div class="logbook-entry">

--- a/ports/amsterdam.html
+++ b/ports/amsterdam.html
@@ -316,7 +316,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero Image -->
       <img class="port-hero" src="/ports/img/amsterdam/amsterdam-1.webp" alt="Sailing ships in Amsterdam's Oosterdok harbor with the city beyond" fetchpriority="high"/>

--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -369,7 +369,7 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
       <div class="port-hero">
         <img src="/ports/img/aruba/aruba-FOM - 10.webp" alt="Norwegian Encore cruise ship docked at Aruba's Oranjestad port with its colorful hull art" loading="eager" fetchpriority="high"/>
         <div class="port-hero-overlay">

--- a/ports/athens.html
+++ b/ports/athens.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #c8a951 0%, #d4af37 35%, #87ceeb 70%, #0077b6 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/bar-harbor.html
+++ b/ports/bar-harbor.html
@@ -159,7 +159,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Bar Harbor: My Acadia Adventure</h1>
       <div class="logbook-entry">

--- a/ports/barcelona.html
+++ b/ports/barcelona.html
@@ -341,6 +341,14 @@ All work on this project is offered as a gift to God.
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
+    <!-- ICP-Lite Quick Answer -->
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Barcelona is a major embarkation port and port of call. La Sagrada Familia and Park Güell are must-sees (book tickets in advance). La Rambla, Gothic Quarter, and La Boqueria market are walkable from port. Ships dock at terminals near the bottom of La Rambla.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1;">
     <!-- Breadcrumb -->
     <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;">
       <ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;">
@@ -350,14 +358,6 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <!-- ICP-Lite Quick Answer -->
-    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
-      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Barcelona is a major embarkation port and port of call. La Sagrada Familia and Park Güell are must-sees (book tickets in advance). La Rambla, Gothic Quarter, and La Boqueria market are walkable from port. Ships dock at terminals near the bottom of La Rambla.
-      </p>
-    </section>
-
-    <div style="grid-column: 1;">
     <article class="card">
       <!-- Port Hero Image -->
       <img class="port-hero" src="/ports/img/barcelona/barcelona-4.webp" alt="Panoramic view of Barcelona from Montjuïc Castle with the city skyline and Collserola mountains" fetchpriority="high"/>

--- a/ports/belfast.html
+++ b/ports/belfast.html
@@ -148,7 +148,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Belfast: My Titanic Town That Surprised Me</h1>
       <div class="logbook-entry">

--- a/ports/belize.html
+++ b/ports/belize.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d6a4f 0%, #40916c 30%, #0077b6 65%, #023e8a 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -285,7 +285,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero Image -->
       <img class="port-hero" src="/ports/img/bergen/bergen-1.webp" alt="Bergen - Heart of the Fjords with colorful waterfront" fetchpriority="high"/>

--- a/ports/bermuda.html
+++ b/ports/bermuda.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffb6c1 0%, #ff91a4 30%, #87ceeb 70%, #4aa8c7 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/bilbao.html
+++ b/ports/bilbao.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Bilbao: My Guggenheim Dream</h1>
       <div class="logbook-entry">

--- a/ports/bonaire.html
+++ b/ports/bonaire.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffd700 0%, #ffb347 30%, #1e90ff 60%, #0077be 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/bordeaux.html
+++ b/ports/bordeaux.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Bordeaux: My Wine Capital</h1>
       <div class="logbook-entry">

--- a/ports/boston.html
+++ b/ports/boston.html
@@ -243,7 +243,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Boston: My Historic Harbor</h1>
       <div class="logbook-entry">

--- a/ports/cadiz.html
+++ b/ports/cadiz.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Cadiz: My Ancient Andalusian Dream</h1>
       <div class="logbook-entry">

--- a/ports/cagliari.html
+++ b/ports/cagliari.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Cagliari: My Sardinian Surprise</h1>
       <div class="logbook-entry">

--- a/ports/cannes.html
+++ b/ports/cannes.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Cannes: My French Riviera Dream</h1>
       <div class="logbook-entry">

--- a/ports/cartagena-spain.html
+++ b/ports/cartagena-spain.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Cartagena, Spain: My Roman Surprise</h1>
       <div class="logbook-entry">

--- a/ports/cartagena.html
+++ b/ports/cartagena.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Cartagena: My Walled City Wonder</h1>
       <div class="logbook-entry">

--- a/ports/casablanca.html
+++ b/ports/casablanca.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Casablanca: My Moroccan Masterpiece</h1>
       <div class="logbook-entry">

--- a/ports/charlottetown.html
+++ b/ports/charlottetown.html
@@ -159,7 +159,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Charlottetown: My Anne of Green Gables Adventure</h1>
       <div class="logbook-entry">

--- a/ports/cherbourg.html
+++ b/ports/cherbourg.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Cherbourg: My Normandy Gateway</h1>
       <div class="logbook-entry">

--- a/ports/civitavecchia.html
+++ b/ports/civitavecchia.html
@@ -291,7 +291,15 @@ All work on this project is offered as a gift to God.
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <!-- Breadcrumb -->
+    <!-- ICP-Lite Quick Answer -->
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Civitavecchia is Rome's cruise port, located 80 km (1–1.5 hours) from the city center. You can realistically see the Vatican OR the Colosseum/Forum area in a port day — not both thoroughly. Book Vatican tickets months ahead. Ship excursions guarantee return; independent travel saves money but requires discipline.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1;">
+    <article<!-- Breadcrumb -->
     <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;">
       <ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;">
         <li style="display: inline;"><a href="/">Home</a> &rsaquo; </li>
@@ -300,15 +308,7 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <!-- ICP-Lite Quick Answer -->
-    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
-      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Civitavecchia is Rome's cruise port, located 80 km (1–1.5 hours) from the city center. You can realistically see the Vatican OR the Colosseum/Forum area in a port day — not both thoroughly. Book Vatican tickets months ahead. Ship excursions guarantee return; independent travel saves money but requires discipline.
-      </p>
-    </section>
-
-    <div style="grid-column: 1;">
-    <article class="card">
+     class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #8b4513 0%, #cd853f 35%, #daa520 70%, #f4a460 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
         <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2rem, 8vw, 4rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Civitavecchia</div>

--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -356,7 +356,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">CocoCay</li></ol></nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay (placeholder until FOM images available) -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0e9aa7 0%, #3dc1d3 50%, #96ceb4 100%); border-radius: 12px; height: 300px; display: flex; align-items: center; justify-content: center;">

--- a/ports/copenhagen.html
+++ b/ports/copenhagen.html
@@ -326,7 +326,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero Image -->
       <img class="port-hero" src="/ports/img/copenhagen/copenhagen-1.webp" alt="Colorful Nyhavn harbor in Copenhagen with historic buildings and boats" fetchpriority="high"/>

--- a/ports/corfu.html
+++ b/ports/corfu.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Corfu: My Ionian Paradise</h1>
       <div class="logbook-entry">

--- a/ports/cork.html
+++ b/ports/cork.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Cork/Cobh: My Titanic Pilgrimage</h1>
       <div class="logbook-entry">

--- a/ports/costa-maya.html
+++ b/ports/costa-maya.html
@@ -321,7 +321,7 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
       <div class="port-hero">
         <img src="/ports/img/costamaya/port-signpost.webp" alt="Costa Maya port signpost with colorful direction signs pointing to Miami, Cuba, Roatan, Belize, and other Caribbean destinations" loading="eager"/>
         <div class="port-hero-overlay">

--- a/ports/cozumel.html
+++ b/ports/cozumel.html
@@ -408,7 +408,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Cozumel</li></ol></nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem;">

--- a/ports/curacao.html
+++ b/ports/curacao.html
@@ -369,7 +369,7 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
       <div class="port-hero">
         <img src="/ports/img/curacao/Curacao-FOM - 1.webp" alt="Colorful Handelskade waterfront buildings in Willemstad, Curaçao with their iconic Dutch colonial architecture" loading="eager" fetchpriority="high"/>
         <div class="port-hero-overlay">

--- a/ports/dominica.html
+++ b/ports/dominica.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d5a27 0%, #3a7d32 30%, #52b788 70%, #40916c 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/dover.html
+++ b/ports/dover.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Dover: My England's Gateway</h1>
       <div class="logbook-entry">

--- a/ports/dublin.html
+++ b/ports/dublin.html
@@ -232,7 +232,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #169b62 0%, #2e8b57 35%, #ffffff 65%, #ff883e 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/dubrovnik.html
+++ b/ports/dubrovnik.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #8b4513 0%, #cd5c5c 35%, #4169e1 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/gdansk.html
+++ b/ports/gdansk.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Gdansk: My Phoenix City</h1>
       <div class="logbook-entry">

--- a/ports/genoa.html
+++ b/ports/genoa.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Genoa: My Underrated Italian Treasure</h1>
       <div class="logbook-entry">

--- a/ports/gibraltar.html
+++ b/ports/gibraltar.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Gibraltar: My British Rock in the Sun</h1>
       <div class="logbook-entry">

--- a/ports/glacier-bay.html
+++ b/ports/glacier-bay.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0077b6 0%, #48cae4 30%, #90e0ef 60%, #caf0f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/gothenburg.html
+++ b/ports/gothenburg.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Gothenburg: My Scandinavian Cool</h1>
       <div class="logbook-entry">

--- a/ports/grand-cayman.html
+++ b/ports/grand-cayman.html
@@ -401,7 +401,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Grand Cayman</li></ol></nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem;">

--- a/ports/grand-turk.html
+++ b/ports/grand-turk.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #00ced1 0%, #40e0d0 30%, #48d1cc 60%, #20b2aa 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/grenada.html
+++ b/ports/grenada.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ce1126 0%, #fcd116 35%, #007a3d 70%, #005a2b 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/guadeloupe.html
+++ b/ports/guadeloupe.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #002395 0%, #0055a4 30%, #00b4d8 60%, #48cae4 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/haines.html
+++ b/ports/haines.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Haines: My Eagle-Filled River Float</h1>
       <div class="logbook-entry">

--- a/ports/halifax.html
+++ b/ports/halifax.html
@@ -159,7 +159,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Halifax: My Maritime Marvel</h1>
       <div class="logbook-entry">

--- a/ports/helsinki.html
+++ b/ports/helsinki.html
@@ -232,7 +232,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #003580 0%, #4a90d9 35%, #ffffff 70%, #f0f8ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/heraklion.html
+++ b/ports/heraklion.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Heraklion: My Minoan Discovery</h1>
       <div class="logbook-entry">

--- a/ports/hilo.html
+++ b/ports/hilo.html
@@ -246,7 +246,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Hilo: Volcanoes and Waterfalls</h1>
       <div class="logbook-entry">

--- a/ports/holyhead.html
+++ b/ports/holyhead.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Holyhead: My Welsh Mountains</h1>
       <div class="logbook-entry">

--- a/ports/honfleur.html
+++ b/ports/honfleur.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Honfleur: My Impressionist Dream</h1>
       <div class="logbook-entry">

--- a/ports/honolulu.html
+++ b/ports/honolulu.html
@@ -246,7 +246,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Honolulu: Doing It All in One Day</h1>
       <div class="logbook-entry">

--- a/ports/ibiza.html
+++ b/ports/ibiza.html
@@ -276,7 +276,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Ibiza: My White Isle That Never Disappoints</h1>
 

--- a/ports/icy-strait-point.html
+++ b/ports/icy-strait-point.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1b4332 0%, #2d6a4f 30%, #40916c 60%, #74c69d 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/invergordon.html
+++ b/ports/invergordon.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Invergordon: My Loch Ness Quest</h1>
       <div class="logbook-entry">

--- a/ports/jamaica.html
+++ b/ports/jamaica.html
@@ -362,7 +362,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Jamaica (Falmouth)</li></ol></nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay (placeholder until FOM images available) -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a5f2a 0%, #2e8b3c 50%, #ffd700 100%); border-radius: 12px; height: 300px; display: flex; align-items: center; justify-content: center;">

--- a/ports/ketchikan.html
+++ b/ports/ketchikan.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d6a4f 0%, #40916c 30%, #74c69d 60%, #b7e4c7 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/key-west.html
+++ b/ports/key-west.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ff7f50 0%, #ff6347 30%, #ffa07a 60%, #ff4500 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/kiel.html
+++ b/ports/kiel.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Kiel: My Sailing Capital</h1>
       <div class="logbook-entry">

--- a/ports/kirkwall.html
+++ b/ports/kirkwall.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Kirkwall: My 5,000-Year Journey</h1>
       <div class="logbook-entry">

--- a/ports/kona.html
+++ b/ports/kona.html
@@ -246,7 +246,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Kailua-Kona: Coffee and Mantas</h1>
       <div class="logbook-entry">

--- a/ports/koper.html
+++ b/ports/koper.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Koper: My Slovenian Secret</h1>
       <div class="logbook-entry">

--- a/ports/kotor.html
+++ b/ports/kotor.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d5a27 0%, #3a7d32 35%, #4169e1 70%, #0077b6 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/la-coruna.html
+++ b/ports/la-coruna.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>La Coruña: My City of Glass</h1>
       <div class="logbook-entry">

--- a/ports/labadee.html
+++ b/ports/labadee.html
@@ -354,7 +354,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Labadee</li></ol></nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay (placeholder until FOM images available) -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d5016 0%, #4a7023 50%, #6b8e23 100%); border-radius: 12px; height: 300px; display: flex; align-items: center; justify-content: center;">

--- a/ports/le-havre.html
+++ b/ports/le-havre.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Le Havre: My Gateway to Paris</h1>
       <div class="logbook-entry">

--- a/ports/lerwick.html
+++ b/ports/lerwick.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Lerwick: My Edge of Britain</h1>
       <div class="logbook-entry">

--- a/ports/lisbon.html
+++ b/ports/lisbon.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffc300 0%, #ffb700 35%, #0077b6 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/liverpool.html
+++ b/ports/liverpool.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Liverpool: My Beatles Pilgrimage</h1>
       <div class="logbook-entry">

--- a/ports/livorno.html
+++ b/ports/livorno.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Livorno: My Gateway to Renaissance Florence</h1>
       <div class="logbook-entry">

--- a/ports/malaga.html
+++ b/ports/malaga.html
@@ -276,7 +276,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Málaga: My Andalusian Surprise That Keeps Getting Better</h1>
 

--- a/ports/marseille.html
+++ b/ports/marseille.html
@@ -291,7 +291,15 @@ All work on this project is offered as a gift to God.
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <!-- Breadcrumb -->
+    <!-- ICP-Lite Quick Answer -->
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Marseille is France's oldest city (founded 600 BCE) and a gritty, authentic Mediterranean port. The Old Port (Vieux-Port), Notre-Dame de la Garde basilica, and authentic bouillabaisse are highlights. Day trips to Aix-en-Provence, lavender fields, and the Calanques are possible.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1;">
+    <article<!-- Breadcrumb -->
     <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;">
       <ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;">
         <li style="display: inline;"><a href="/">Home</a> &rsaquo; </li>
@@ -300,15 +308,7 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <!-- ICP-Lite Quick Answer -->
-    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
-      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Marseille is France's oldest city (founded 600 BCE) and a gritty, authentic Mediterranean port. The Old Port (Vieux-Port), Notre-Dame de la Garde basilica, and authentic bouillabaisse are highlights. Day trips to Aix-en-Provence, lavender fields, and the Calanques are possible.
-      </p>
-    </section>
-
-    <div style="grid-column: 1;">
-    <article class="card">
+     class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0055a4 0%, #7b68ee 35%, #e6e6fa 70%, #f0f8ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
         <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Marseille</div>

--- a/ports/martinique.html
+++ b/ports/martinique.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0055a4 0%, #00b4d8 40%, #48cae4 70%, #90e0ef 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/maui.html
+++ b/ports/maui.html
@@ -162,7 +162,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Maui: After the Fire</h1>
       <div class="logbook-entry">

--- a/ports/messina.html
+++ b/ports/messina.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Messina: My Gateway to Taormina's Magic</h1>
       <div class="logbook-entry">

--- a/ports/monte-carlo.html
+++ b/ports/monte-carlo.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffd700 0%, #c5a900 35%, #ce1126 70%, #8b0000 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/mykonos.html
+++ b/ports/mykonos.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ffffff 0%, #e6f3ff 35%, #3b82f6 70%, #1e40af 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/naples.html
+++ b/ports/naples.html
@@ -291,7 +291,15 @@ All work on this project is offered as a gift to God.
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <!-- Breadcrumb -->
+    <!-- ICP-Lite Quick Answer -->
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Naples is the gateway to Pompeii (30 min), the Amalfi Coast, and Sorrento. The city itself offers world-class pizza, the National Archaeological Museum, and authentic Italian chaos. Ships dock at Stazione Marittima, near the historic center.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1;">
+    <article<!-- Breadcrumb -->
     <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;">
       <ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;">
         <li style="display: inline;"><a href="/">Home</a> &rsaquo; </li>
@@ -300,15 +308,7 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <!-- ICP-Lite Quick Answer -->
-    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
-      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Naples is the gateway to Pompeii (30 min), the Amalfi Coast, and Sorrento. The city itself offers world-class pizza, the National Archaeological Museum, and authentic Italian chaos. Ships dock at Stazione Marittima, near the historic center.
-      </p>
-    </section>
-
-    <div style="grid-column: 1;">
-    <article class="card">
+     class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #b22222 0%, #cd853f 35%, #4169e1 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
         <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Naples</div>

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -303,7 +303,7 @@ Soli Deo Gloria
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Nassau</li></ol></nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem;">

--- a/ports/nawiliwili.html
+++ b/ports/nawiliwili.html
@@ -246,7 +246,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Nawiliwili: The Garden Isle</h1>
       <div class="logbook-entry">

--- a/ports/newcastle.html
+++ b/ports/newcastle.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Newcastle: My Geordie Welcome</h1>
       <div class="logbook-entry">

--- a/ports/newport.html
+++ b/ports/newport.html
@@ -159,7 +159,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Newport: My Gilded Age Wonder</h1>
       <div class="logbook-entry">

--- a/ports/norwegian-fjords.html
+++ b/ports/norwegian-fjords.html
@@ -148,7 +148,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Geiranger & the Norwegian Fjords: My Jaw-On-The-Floor Scenic Heaven</h1>
       <div class="logbook-entry">

--- a/ports/oslo.html
+++ b/ports/oslo.html
@@ -232,7 +232,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #ba0c2f 0%, #ef3340 35%, #ffffff 65%, #00205b 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/palma.html
+++ b/ports/palma.html
@@ -282,7 +282,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Palma de Mallorca: My Mediterranean Island Paradise</h1>
 

--- a/ports/panama-canal.html
+++ b/ports/panama-canal.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Panama Canal: My Engineering Marvel Day</h1>
       <div class="logbook-entry">

--- a/ports/portland-maine.html
+++ b/ports/portland-maine.html
@@ -162,7 +162,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Portland, Maine: Lighthouse Keeper's Dream</h1>
       <div class="logbook-entry">

--- a/ports/portland.html
+++ b/ports/portland.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Portland: My Jurassic Adventure</h1>
       <div class="logbook-entry">

--- a/ports/porto.html
+++ b/ports/porto.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Porto: My Douro Dream</h1>
       <div class="logbook-entry">

--- a/ports/progreso.html
+++ b/ports/progreso.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #bc6c25 0%, #dda15e 35%, #fefae0 65%, #606c38 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/quebec-city.html
+++ b/ports/quebec-city.html
@@ -159,7 +159,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Quebec City: My French-Canadian Fairytale</h1>
       <div class="logbook-entry">

--- a/ports/ravenna.html
+++ b/ports/ravenna.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Ravenna: My Byzantine Masterpiece</h1>
       <div class="logbook-entry">

--- a/ports/reykjavik.html
+++ b/ports/reykjavik.html
@@ -232,7 +232,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #4a5568 0%, #718096 30%, #90cdf4 60%, #e2e8f0 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/rhodes.html
+++ b/ports/rhodes.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Rhodes: My Medieval Time Machine</h1>
       <div class="logbook-entry">

--- a/ports/riga.html
+++ b/ports/riga.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Riga: My Art Nouveau Capital</h1>
       <div class="logbook-entry">

--- a/ports/roatan.html
+++ b/ports/roatan.html
@@ -336,7 +336,7 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
       <div class="port-hero">
         <div class="port-hero-overlay">
           <h1 class="port-hero-title">Roatán</h1>

--- a/ports/saguenay.html
+++ b/ports/saguenay.html
@@ -159,7 +159,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Saguenay: My Fjord Fantasy</h1>
       <div class="logbook-entry">

--- a/ports/saint-john.html
+++ b/ports/saint-john.html
@@ -159,7 +159,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Saint John: My Bay of Fundy Wonder</h1>
       <div class="logbook-entry">

--- a/ports/samana.html
+++ b/ports/samana.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 35%, #a8dadc 65%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/san-juan.html
+++ b/ports/san-juan.html
@@ -355,7 +355,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">San Juan</li></ol></nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay (placeholder until FOM images available) -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #cc0000 0%, #ffffff 50%, #0033a0 100%); border-radius: 12px; height: 300px; display: flex; align-items: center; justify-content: center;">

--- a/ports/scotland.html
+++ b/ports/scotland.html
@@ -148,7 +148,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Scotland: Greenock/Glasgow & South Queensferry/Edinburgh</h1>
       <div class="logbook-entry">

--- a/ports/seward.html
+++ b/ports/seward.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #023e8a 0%, #0077b6 30%, #00b4d8 60%, #90e0ef 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/sitka.html
+++ b/ports/sitka.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 30%, #90e0ef 60%, #caf0f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/skagway.html
+++ b/ports/skagway.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #8b5a2b 0%, #daa520 35%, #f4d03f 65%, #87ceeb 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/southampton.html
+++ b/ports/southampton.html
@@ -276,7 +276,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Southampton: My Elegant Home Away From Home</h1>
 

--- a/ports/split.html
+++ b/ports/split.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #f5f5dc 0%, #d4af37 35%, #4169e1 70%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/st-kitts.html
+++ b/ports/st-kitts.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d6a4f 0%, #40916c 30%, #ffd166 70%, #f4a261 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/st-maarten.html
+++ b/ports/st-maarten.html
@@ -336,7 +336,7 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
       <div class="port-hero">
         <div class="port-hero-overlay">
           <h1 class="port-hero-title">St. Maarten</h1>

--- a/ports/st-petersburg.html
+++ b/ports/st-petersburg.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>St. Petersburg: My Imperial Dream</h1>
       <div class="logbook-entry">

--- a/ports/st-thomas.html
+++ b/ports/st-thomas.html
@@ -401,7 +401,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <main class="wrap page-grid" id="main-content" role="main">
     <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">St. Thomas</li></ol></nav>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Hero Image with Port Name Overlay -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem;">

--- a/ports/stavanger.html
+++ b/ports/stavanger.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Stavanger: My Adventure Capital</h1>
       <div class="logbook-entry">

--- a/ports/stockholm.html
+++ b/ports/stockholm.html
@@ -233,7 +233,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #006aa7 0%, #0077b6 35%, #fecc00 70%, #ffd500 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/sydney-ns.html
+++ b/ports/sydney-ns.html
@@ -159,7 +159,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Sydney: My Cape Breton Gateway</h1>
       <div class="logbook-entry">

--- a/ports/tallinn.html
+++ b/ports/tallinn.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Tallinn: My Medieval Time Machine</h1>
       <div class="logbook-entry">

--- a/ports/tangier.html
+++ b/ports/tangier.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Tangier: My African Gateway</h1>
       <div class="logbook-entry">

--- a/ports/taormina.html
+++ b/ports/taormina.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Taormina: My Sicilian Perfection</h1>
       <div class="logbook-entry">

--- a/ports/tortola.html
+++ b/ports/tortola.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0077b6 0%, #00b4d8 35%, #48cae4 65%, #90e0ef 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/tracy-arm.html
+++ b/ports/tracy-arm.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Tracy Arm: My Narrow Fjord Adventure</h1>
       <div class="logbook-entry">

--- a/ports/trieste.html
+++ b/ports/trieste.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Trieste: My Habsburg Dream</h1>
       <div class="logbook-entry">

--- a/ports/tromso.html
+++ b/ports/tromso.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Tromsø: My Arctic Capital</h1>
       <div class="logbook-entry">

--- a/ports/tunis.html
+++ b/ports/tunis.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Tunis: My Three UNESCO Treasures</h1>
       <div class="logbook-entry">

--- a/ports/valencia.html
+++ b/ports/valencia.html
@@ -282,7 +282,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Valencia: My Futuristic Yet Historic Love</h1>
 

--- a/ports/valletta.html
+++ b/ports/valletta.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Valletta: My Fortress of Knights</h1>
       <div class="logbook-entry">

--- a/ports/venice.html
+++ b/ports/venice.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Venice: My Floating Dream</h1>
       <div class="logbook-entry">

--- a/ports/victoria-bc.html
+++ b/ports/victoria-bc.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #9d4edd 0%, #c77dff 30%, #e0aaff 60%, #f8bbd9 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/vigo.html
+++ b/ports/vigo.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Vigo: My Gateway to Paradise</h1>
       <div class="logbook-entry">

--- a/ports/villefranche.html
+++ b/ports/villefranche.html
@@ -291,7 +291,15 @@ All work on this project is offered as a gift to God.
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <!-- Breadcrumb -->
+    <!-- ICP-Lite Quick Answer -->
+    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
+      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Villefranche-sur-Mer is a tender port that serves as the gateway to the French Riviera — Nice (15 minutes), Monaco (20 minutes), and Eze village are all easily accessible. The port town itself is charming and walkable.
+      </p>
+    </section>
+
+    <div style="grid-column: 1; grid-row: 1;">
+    <article<!-- Breadcrumb -->
     <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;">
       <ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;">
         <li style="display: inline;"><a href="/">Home</a> &rsaquo; </li>
@@ -300,15 +308,7 @@ All work on this project is offered as a gift to God.
       </ol>
     </nav>
 
-    <!-- ICP-Lite Quick Answer -->
-    <section class="page-intro" style="grid-column: 2; grid-row: 1; margin-bottom: 1.5rem;">
-      <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Villefranche-sur-Mer is a tender port that serves as the gateway to the French Riviera — Nice (15 minutes), Monaco (20 minutes), and Eze village are all easily accessible. The port town itself is charming and walkable.
-      </p>
-    </section>
-
-    <div style="grid-column: 1;">
-    <article class="card">
+     class="card">
       <h1>Villefranche-sur-Mer: Gateway to the French Riviera</h1>
 
       <div class="logbook-entry">

--- a/ports/virgin-gorda.html
+++ b/ports/virgin-gorda.html
@@ -248,7 +248,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero with gradient background -->
       <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #6b705c 0%, #a5a58d 30%, #48cae4 65%, #00b4d8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">

--- a/ports/warnemunde.html
+++ b/ports/warnemunde.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Warnemünde: My Gateway to Berlin</h1>
       <div class="logbook-entry">

--- a/ports/waterford.html
+++ b/ports/waterford.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Waterford: My Viking Crystal City</h1>
       <div class="logbook-entry">

--- a/ports/whittier.html
+++ b/ports/whittier.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Whittier: My 26 Glaciers Wonder</h1>
       <div class="logbook-entry">

--- a/ports/zadar.html
+++ b/ports/zadar.html
@@ -242,7 +242,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Zadar: My Adriatic Innovation</h1>
       <div class="logbook-entry">

--- a/ports/zeebrugge.html
+++ b/ports/zeebrugge.html
@@ -158,7 +158,7 @@ Soli Deo Gloria
       </p>
     </section>
 
-    <div style="grid-column: 1;">
+    <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <h1>Zeebrugge/Bruges: My Medieval Fairy Tale</h1>
       <div class="logbook-entry">


### PR DESCRIPTION
- Added grid-row: 1 to main content div on 133 port pages
- Moved breadcrumb inside column-1 div to prevent layout offset
- Main content now starts at same row as Quick Answer sidebar
- Fixes issue where content appeared below the sidebar