### PR TITLE
FEAT: Add port name overlays to all 147 port hero sections

### DIFF
--- a/ports/ajaccio.html
+++ b/ports/ajaccio.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/ajaccio/ajaccio-3.webp" alt="Ajaccio panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Ajaccio</span>
+        </div>
+      </div>
+
       <h1>Ajaccio: My Corsican Adventure</h1>
       <div class="logbook-entry">
         <p>We stepped off into a town that smells of maquis and espresso – the honey-sweet scrub that covers the island. Maison Bonaparte was tiny and perfect – you can still feel the future emperor growing up in those rooms. The market was bursting with brocciu cheese, chestnut honey, and wild boar saucisson we devoured on the spot.</p>

--- a/ports/alesund.html
+++ b/ports/alesund.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1f4068 0%, #457b9d 35%, #a8dadc 70%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Ålesund</div>
+      </div>
+
       <h1>Ålesund: My Art Nouveau Dream</h1>
       <div class="logbook-entry">
         <p>We sailed in at sunrise and the town looked like a watercolor painting – all soft pinks, greens, and turrets reflected perfectly in calm water. We climbed the 418 steps to Mount Aksla at 8 a.m. and had the entire viewpoint to ourselves – 360° of islands, fjords, and snow-capped Sunnmøre Alps turning pink. We had breakfast at a café built in 1905 with original Jugendstil interiors – coffee and svele (thick Norwegian pancakes) with brown cheese that tastes like caramel.</p>

--- a/ports/amalfi.html
+++ b/ports/amalfi.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/amalfi/amalfi-1.webp" alt="Amalfi panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Amalfi</span>
+        </div>
+      </div>
+
       <h1>Amalfi: My Most Beautiful Coastline</h1>
       <div class="logbook-entry">
         <p>We were on the first ferry to Amalfi town – 50 minutes of coastline that looks Photoshopped: pastel villages clinging to cliffs, lemon terraces, and the sea glowing turquoise. Amalfi's cathedral steps were perfect for people-watching with a delizia al limone – lemon sponge cake that tastes like happiness. Then bus up to Ravello (hairpin turns, zero regrets) – Villa Cimbrone's Terrace of Infinity made me cry; it really does feel like standing at the edge of the world.</p>

--- a/ports/amsterdam.html
+++ b/ports/amsterdam.html
@@ -319,7 +319,12 @@ Soli Deo Gloria
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero Image -->
-      <img class="port-hero" src="/ports/img/amsterdam/amsterdam-1.webp" alt="Sailing ships in Amsterdam's Oosterdok harbor with the city beyond" fetchpriority="high"/>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/amsterdam/amsterdam-1.webp" alt="Sailing ships in Amsterdam's Oosterdok harbor with the city beyond" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Amsterdam</span>
+        </div>
+      </div>
 
       <h1>Amsterdam: My Canal City That Feels Like a Fairy Tale</h1>
 

--- a/ports/auckland.html
+++ b/ports/auckland.html
@@ -155,6 +155,10 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a3a3a 0%, #3d7a7a 30%, #7eb8b8 60%, #e8f5f5 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Auckland</div>
+      </div>
+
       <header class="article-header">
         <h1>Auckland &amp; Bay of Islands Cruise Port Guide</h1>
         <p class="subtitle">My Kiwi Paradise That Feels Like Family</p>

--- a/ports/bali.html
+++ b/ports/bali.html
@@ -234,6 +234,13 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/bali/bali-3.webp" alt="Bali panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Bali</span>
+        </div>
+      </div>
+
       <header class="article-header">
         <h1>Bali / Benoa Cruise Port Guide</h1>
         <p class="subtitle">My Island of the Gods That Heals My Soul</p>

--- a/ports/bangkok.html
+++ b/ports/bangkok.html
@@ -238,6 +238,13 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/bangkok/bangkok-3.webp" alt="Bangkok panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Bangkok</span>
+        </div>
+      </div>
+
       <header class="article-header">
         <h1>Bangkok / Laem Chabang Cruise Port Guide</h1>
         <p class="subtitle">My Chaotic, Golden Temple Paradise</p>

--- a/ports/bar-harbor.html
+++ b/ports/bar-harbor.html
@@ -161,6 +161,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 30%, #a8e6cf 60%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Bar Harbor</div>
+      </div>
+
       <h1>Bar Harbor: My Acadia Adventure</h1>
       <div class="logbook-entry">
         <p>Tender port, but the ride into town is pretty. We booked the earliest bus to Acadia (pro move) and watched the sun rise from Cadillac Mountain — first place the sun touches the U.S. from October to March. The whole horizon turned pink and orange over the Porcupine Islands and the fall foliage was on fire.</p>

--- a/ports/barcelona.html
+++ b/ports/barcelona.html
@@ -359,8 +359,13 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article class="card">
-      <!-- Port Hero Image -->
-      <img class="port-hero" src="/ports/img/barcelona/barcelona-4.webp" alt="Panoramic view of Barcelona from Montjuïc Castle with the city skyline and Collserola mountains" fetchpriority="high"/>
+      <!-- Port Hero with name overlay -->
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/barcelona/barcelona-4.webp" alt="Panoramic view of Barcelona from Montjuïc Castle" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Barcelona</span>
+        </div>
+      </div>
 
       <h1>Barcelona: Where Gaudí Meets the Mediterranean</h1>
 

--- a/ports/belfast.html
+++ b/ports/belfast.html
@@ -150,6 +150,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0d3b66 0%, #2a628f 35%, #90c8ff 70%, #f0f7ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Belfast</div>
+      </div>
+
       <h1>Belfast: My Titanic Town That Surprised Me</h1>
       <div class="logbook-entry">
         <p>Belfast has completely transformed and become one of my absolute favorite UK/Ireland calls — 4.8–5.0 stars lately. My perfect day: the Titanic Belfast museum (the best museum I've ever visited — interactive, emotional, and the shipyard ride is incredible), then a black taxi political mural tour (fascinating and balanced), Crumlin Road Gaol, and the stunning St. Anne's Cathedral quarter.</p>

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -288,7 +288,12 @@ Soli Deo Gloria
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero Image -->
-      <img class="port-hero" src="/ports/img/bergen/bergen-1.webp" alt="Bergen - Heart of the Fjords with colorful waterfront" fetchpriority="high"/>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/bergen/bergen-1.webp" alt="Bergen - Heart of the Fjords with colorful waterfront" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Bergen</span>
+        </div>
+      </div>
 
       <h1>Bergen: My Gateway to the Fjords</h1>
       <div class="logbook-entry">

--- a/ports/bilbao.html
+++ b/ports/bilbao.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/bilbao/bilbao-3.webp" alt="Bilbao panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Bilbao</span>
+        </div>
+      </div>
+
       <h1>Bilbao: My Guggenheim Dream</h1>
       <div class="logbook-entry">
         <p>We walked off straight to the Guggenheim – the building looks different from every angle, like a metallic flower opening to the Nervión River. Puppy the flower-dog greeted us with 40,000 real pansies. Inside, Richard Serra's massive steel spirals made us dizzy in the best way – walking through them feels like being inside a hurricane made of rust.</p>

--- a/ports/bordeaux.html
+++ b/ports/bordeaux.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/bordeaux/bordeaux-3.webp" alt="Bordeaux panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Bordeaux</span>
+        </div>
+      </div>
+
       <h1>Bordeaux: My Wine Capital</h1>
       <div class="logbook-entry">
         <p>The ship docks 45 minutes from the city center, but the shuttle drops you at the most beautiful urban waterfront in Europe – the Garonne reflecting 18th-century façades like a mirror. We walked the entire Miroir d'Eau (the world's largest reflecting pool) barefoot while kids splashed and the Place de la Bourse shimmered behind us.</p>

--- a/ports/boston.html
+++ b/ports/boston.html
@@ -245,6 +245,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/boston/boston-3.webp" alt="Boston panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Boston</span>
+        </div>
+      </div>
+
       <h1>Boston: My Historic Harbor</h1>
       <div class="logbook-entry">
         <p>We docked at Black Falcon and were on the Silver Line bus to downtown in 15 minutes — easiest port ever. Started at Boston Common, grabbed coffee, and walked the entire Freedom Trail (red brick line — impossible to get lost). Paul Revere's house, Old North Church, USS Constitution — every stop is the real thing.</p>

--- a/ports/brisbane.html
+++ b/ports/brisbane.html
@@ -159,6 +159,10 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #003049 0%, #008cb4 40%, #77b5c9 70%, #eef6f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Brisbane</div>
+      </div>
+
       <header class="article-header">
         <h1>Brisbane Cruise Port Guide</h1>
         <p class="subtitle">My Relaxed River City Surprise</p>

--- a/ports/cadiz.html
+++ b/ports/cadiz.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/cadiz/cadiz-3.webp" alt="Cadiz panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Cadiz</span>
+        </div>
+      </div>
+
       <h1>Cadiz: My Ancient Andalusian Dream</h1>
       <div class="logbook-entry">
         <p>We stepped off into a city that feels like Havana and Seville had a baby on the ocean. The cathedral dome glowed like burnished gold at sunrise – we climbed it first for 360° views over turquoise water and white houses. The narrow streets of Barrio del Pópulo are pure 18th-century theater sets – laundry flapping, old men arguing about football, the smell of churros and sea air mixing perfectly.</p>

--- a/ports/cagliari.html
+++ b/ports/cagliari.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/cagliari/cagliari-3.webp" alt="Cagliari panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Cagliari</span>
+        </div>
+      </div>
+
       <h1>Cagliari: My Sardinian Surprise</h1>
       <div class="logbook-entry">
         <p>We walked off the ship into the Marina quarter – bougainvillea everywhere, gelato at 9 a.m. felt mandatory. We climbed to the old Castello district via ancient stone stairs and suddenly the entire Gulf of Angels spread below us – turquoise water, salt marshes with pink flamingos, and the city glowing white. Poetto beach is an 8-km strip of powder sand reachable by 5-minute bus – we swam in water so warm and clear it felt like the Caribbean landed in the Mediterranean.</p>

--- a/ports/cannes.html
+++ b/ports/cannes.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/cannes/cannes-1.webp" alt="Cannes panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Cannes</span>
+        </div>
+      </div>
+
       <h1>Cannes: My French Riviera Dream</h1>
       <div class="logbook-entry">
         <p>We tendered in and the first thing we saw were the handprints of stars outside the Palais des Festivals – I put my hand in Depp's and felt ridiculously happy. The Croisette at 9 a.m. was already perfect – palm trees, art-deco hotels, and the Mediterranean sparkling like diamonds. We rented loungers at Plage Goëland and spent the morning swimming in water so clear we could see fish darting under us.</p>

--- a/ports/cartagena-spain.html
+++ b/ports/cartagena-spain.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/cartagena-spain/cartagena-spain-3.webp" alt="Cartagena (Spain) panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Cartagena (Spain)</span>
+        </div>
+      </div>
+
       <h1>Cartagena, Spain: My Roman Surprise</h1>
       <div class="logbook-entry">
         <p>We walked off into a city that feels like a living archaeological site. The Roman theater appeared suddenly between modern buildings – 7,000 people watched plays here 2,000 years ago and it's still perfect. We entered through the museum tunnel and emerged onto the stage looking up at tiered seats carved into the hillside – goosebumps. The Punic Wall, Byzantine fortifications, and modernist Casas on Calle Mayor are all within 10 minutes' walk.</p>

--- a/ports/cartagena.html
+++ b/ports/cartagena.html
@@ -250,6 +250,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/cartagena/cartagena-3.webp" alt="Cartagena panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Cartagena</span>
+        </div>
+      </div>
+
       <h1>Cartagena: My Walled City Wonder</h1>
       <div class="logbook-entry">
         <p>We sailed in past the modern skyline and suddenly the old fortifications appeared like something from Pirates of the Caribbean. The cruise terminal is a 10-minute taxi into the walled city, and the second we passed through the clock tower gate I knew this day would rank top-five ever. The streets are a maze of mustard-yellow churches, emerald-green balconies, and palenqueras in fruit-bowl hats offering photos (tip them!).</p>

--- a/ports/casablanca.html
+++ b/ports/casablanca.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/casablanca/casablanca-3.webp" alt="Casablanca panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Casablanca</span>
+        </div>
+      </div>
+
       <h1>Casablanca: My Moroccan Masterpiece</h1>
       <div class="logbook-entry">
         <p>We took the first shuttle to the Hassan II Mosque and arrived just as the morning sun hit the minaret – 210 m tall, the tallest religious structure in the world. The interior is jaw-dropping – cedar ceilings carved like lace, zellige tiles in every color, and the Atlantic visible through glass floors in the ablutions hall. We joined the English tour and stood in silence while the scale sank in.</p>

--- a/ports/charlottetown.html
+++ b/ports/charlottetown.html
@@ -161,6 +161,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #003049 0%, #008cb4 40%, #77b5c9 70%, #eef6f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Charlottetown</div>
+      </div>
+
       <h1>Charlottetown: My Anne of Green Gables Adventure</h1>
       <div class="logbook-entry">
         <p>We walked straight into town and explored Victoria Row with its buskers and outdoor cafés, then visited Province House where Canada was born. The Cows Creamery factory tour was delightfully cheesy (pun intended), but the ice cream was worth every calorie. In the afternoon we drove to Cavendish to visit the Green Gables house and walked the red sand beaches with their dramatic rust-colored cliffs. Dinner was a perfect lobster roll at Point Prim Chowder House overlooking the lighthouse.</p>

--- a/ports/cherbourg.html
+++ b/ports/cherbourg.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/cherbourg/cherbourg-3.webp" alt="Cherbourg panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Cherbourg</span>
+        </div>
+      </div>
+
       <h1>Cherbourg: My Normandy Gateway</h1>
       <div class="logbook-entry">
         <p>We walked off straight onto the Quai de Normandie – massive art-deco transatlantic terminal where the Titanic stopped and the Queen Mary was built. La Cité de la Mer is brilliant – the Redoutable submarine tour inside a real nuclear sub is mind-blowing, and the Titanic exhibit has actual passenger artifacts that made us tear up.</p>

--- a/ports/copenhagen.html
+++ b/ports/copenhagen.html
@@ -329,7 +329,12 @@ Soli Deo Gloria
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
       <!-- Port Hero Image -->
-      <img class="port-hero" src="/ports/img/copenhagen/copenhagen-1.webp" alt="Colorful Nyhavn harbor in Copenhagen with historic buildings and boats" fetchpriority="high"/>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/copenhagen/copenhagen-1.webp" alt="Colorful Nyhavn harbor in Copenhagen with historic buildings and boats" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Copenhagen</span>
+        </div>
+      </div>
 
       <h1>Copenhagen: My Scandinavian Dream Come True</h1>
 

--- a/ports/corfu.html
+++ b/ports/corfu.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/corfu/corfu-3.webp" alt="Corfu panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Corfu</span>
+        </div>
+      </div>
+
       <h1>Corfu: My Ionian Paradise</h1>
       <div class="logbook-entry">
         <p>We stepped off the ship into a fortress and immediately smelled jasmine and espresso. The Liston arcade was made for people-watching — old men playing backgammon, waiters in crisp white shirts, the cricket ground (!). We climbed to the Old Fortress at opening and had the entire Byzantine museum to ourselves. The view over red roofs to Albania is insane.</p>

--- a/ports/cork.html
+++ b/ports/cork.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1b4965 0%, #5fa8d3 40%, #bee9e8 70%, #f0f9ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Cork</div>
+      </div>
+
       <h1>Cork/Cobh: My Titanic Pilgrimage</h1>
       <div class="logbook-entry">
         <p>We stepped off into Cobh (pronounced "Cove") and the colorful houses rise straight up the hill like a child's drawing. St. Colman's Cathedral dominates the skyline – we climbed the hill and the carillon bells rang out over the harbor exactly where the Titanic anchored in 1912. The Titanic Experience in the original White Star Line offices made us cry – actual passenger names, recovered luggage, the last photograph of the ship leaving here.</p>

--- a/ports/dover.html
+++ b/ports/dover.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/dover/dover-3.webp" alt="Dover panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Dover</span>
+        </div>
+      </div>
+
       <h1>Dover: My England's Gateway</h1>
       <div class="logbook-entry">
         <p>We sailed in under the White Cliffs at sunrise – they really do glow. Dover Castle is enormous – Henry II's great tower, Roman lighthouse, WWII underground hospital tunnels where you can still smell the disinfectant. The Secret Wartime Tunnels tour gave us chills – Operation Dynamo planned here, voices echoing exactly like 1940.</p>

--- a/ports/gdansk.html
+++ b/ports/gdansk.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/gdansk/gdansk-3.webp" alt="Gdansk panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Gdansk</span>
+        </div>
+      </div>
+
       <h1>Gdansk: My Phoenix City</h1>
       <div class="logbook-entry">
         <p>We walked off into Dlugi Targ and the colorful merchants' houses looked freshly painted – hard to believe 95% were rubble in 1945. The Amber Museum inside a medieval gate tower showed insects trapped 40 million years ago still perfect. St. Mary's Church climb (408 steps) gave us views over red roofs to the shipyards where Solidarity began.</p>

--- a/ports/genoa.html
+++ b/ports/genoa.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/genoa/genoa-3.webp" alt="Genoa panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Genoa</span>
+        </div>
+      </div>
+
       <h1>Genoa: My Underrated Italian Treasure</h1>
       <div class="logbook-entry">
         <p>We walked off the ship straight into the Porto Antico redesigned by Renzo Piano – the aquarium sphere and the pirate ship looked like toys against the huge old warehouses. The historic center starts literally at the dock gates and swallows you whole. Narrow caruggi alleys twist between 12th-century palaces and tiny shops selling sciacchetrà wine and pesto by the kilo. We got happily lost for hours, emerging at Piazza De Ferrari just as the fountain started dancing.</p>

--- a/ports/gibraltar.html
+++ b/ports/gibraltar.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/gibraltar/gibraltar-3.webp" alt="Gibraltar panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Gibraltar</span>
+        </div>
+      </div>
+
       <h1>Gibraltar: My British Rock in the Sun</h1>
       <div class="logbook-entry">
         <p>We walked off the ship and straight through Casemates Square – red phone boxes, fish & chips, and Union Jack flags while Spanish is spoken everywhere. The cable car up the Rock was pure magic – halfway up we entered the cloud and emerged above it with Africa floating on the horizon. The Barbary macaques were waiting at the top station – one jumped on my partner's head for the perfect photo (they're wild but very used to humans). St. Michael's Cave is a cathedral carved by nature – stalactites lit in rainbow colors, the silence absolute.</p>

--- a/ports/gothenburg.html
+++ b/ports/gothenburg.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #264653 0%, #2a9d8f 35%, #8ab4aa 70%, #f4f4f4 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Gothenburg</div>
+      </div>
+
       <h1>Gothenburg: My Scandinavian Cool</h1>
       <div class="logbook-entry">
         <p>We walked off into a city that feels like Copenhagen and Oslo had a baby who smiles more. The Feskekôrka fish church – literally a church-shaped market smelling of fresh shrimp and dill. We had lunch at the counter – räkmacka shrimp mountain on bread so high it needs a fork, eaten while fishermen unloaded the catch behind us.</p>

--- a/ports/haines.html
+++ b/ports/haines.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/haines/haines-3.webp" alt="Haines panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Haines</span>
+        </div>
+      </div>
+
       <h1>Haines: My Eagle-Filled River Float</h1>
       <div class="logbook-entry">
         <p>We docked in tiny Haines — population 2,500 — and immediately felt the difference from busier ports. No jewelry stores, no T-shirt mobs. Just a real Alaska town with a hardware store, a brewery, and people who actually live here year-round.</p>

--- a/ports/halifax.html
+++ b/ports/halifax.html
@@ -161,6 +161,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #264653 0%, #2a9d8f 35%, #8ab4aa 70%, #f4f4f4 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Halifax</div>
+      </div>
+
       <h1>Halifax: My Maritime Marvel</h1>
       <div class="logbook-entry">
         <p>We docked right downtown and walked the entire harbor boardwalk before 9 a.m. — past fishing boats, bagpipers, and people commuting on scooters like it was normal. The air smelled like salt and donuts (Tim Hortons is religion here).</p>

--- a/ports/heraklion.html
+++ b/ports/heraklion.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/heraklion/heraklion-3.webp" alt="Heraklion panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Heraklion</span>
+        </div>
+      </div>
+
       <h1>Heraklion: My Minoan Discovery</h1>
       <div class="logbook-entry">
         <p>We walked off the ship and straight onto the Venetian walls for sunrise — the Lion Fountain was already glowing and the city still quiet. Twenty minutes later we were at Knossos just as it opened and had the Throne Room almost to ourselves for fifteen perfect minutes. The red columns, dolphin fresco, and that tiny alabaster throne — seeing them in real life after decades of textbooks made me tear up. The site is partially reconstructed (some hate that, I loved it — helps you feel the scale).</p>

--- a/ports/hilo.html
+++ b/ports/hilo.html
@@ -248,6 +248,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/hilo/hilo-3.webp" alt="Hilo panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Hilo</span>
+        </div>
+      </div>
+
       <h1>Hilo: Volcanoes and Waterfalls</h1>
       <div class="logbook-entry">
         <p>We docked and rented a car (the only realistic way) – by 8:45 we were at Rainbow Falls with almost no one there. Ten more minutes to Boiling Pots and then straight into Volcanoes National Park (45-minute drive). We walked the Kilauea Iki trail across the still-steaming 1959 lava lake – the ground was warm through our shoes and cracks glowed faintly orange in the shade. The caldera overlook at Jaggar Museum (now moved to a new location) still gives the best lava-lake views when it's active.</p>

--- a/ports/holyhead.html
+++ b/ports/holyhead.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #003049 0%, #008cb4 40%, #77b5c9 70%, #eef6f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Holyhead</div>
+      </div>
+
       <h1>Holyhead: My Welsh Mountains</h1>
       <div class="logbook-entry">
         <p>We took the first train to Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch just to say we did – the station sign is longer than the platform. Then we took the coach to Snowdon – the mountain rose dramatically above lakes while Welsh red dragons flew on every flag. Caernarfon Castle is enormous – the Eagle Tower where the first Prince of Wales was presented in 1284 still stands proud.</p>

--- a/ports/honfleur.html
+++ b/ports/honfleur.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/honfleur/honfleur-3.webp" alt="Honfleur panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Honfleur</span>
+        </div>
+      </div>
+
       <h1>Honfleur: My Impressionist Dream</h1>
       <div class="logbook-entry">
         <p>We tendered right into the heart of the Vieux Bassin – slate-roofed houses stacked like macarons around the water, sailboats bobbing, the smell of crêpes and Calvados everywhere. Sainte-Catherine church – built by shipwrights after the Hundred Years' War, entirely of wood with a bell tower across the street like a separate lighthouse.</p>

--- a/ports/hong-kong.html
+++ b/ports/hong-kong.html
@@ -238,6 +238,13 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/hong-kong/hong-kong-3.webp" alt="Hong Kong panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Hong Kong</span>
+        </div>
+      </div>
+
       <header class="article-header">
         <h1>Hong Kong Cruise Port Guide</h1>
         <p class="subtitle">My Harbour of Lights That Leaves Me Speechless</p>

--- a/ports/honolulu.html
+++ b/ports/honolulu.html
@@ -248,6 +248,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/honolulu/honolulu-3.webp" alt="Honolulu panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Honolulu</span>
+        </div>
+      </div>
+
       <h1>Honolulu: Doing It All in One Day</h1>
       <div class="logbook-entry">
         <p>We docked at Pier 2 right in downtown and could already hear the ukuleles from the Aloha Tower marketplace. We took an early Uber to Pearl Harbor (20–25 minutes) and arrived just after opening – the Arizona memorial boat leaves every 15 minutes and we walked straight on. Standing over the sunken battleship with the oil still bubbling up felt exactly as heavy and necessary as it should. Back in Waikiki by 11 a.m. we had plenty of time to walk the beach, grab a shave ice at Waiola, and hike Diamond Head (the trail is fully paved now, 1.6 miles round-trip, hot but very doable – we were at the top in 45 minutes).</p>

--- a/ports/ibiza.html
+++ b/ports/ibiza.html
@@ -278,6 +278,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/ibiza/ibiza-3.webp" alt="Ibiza panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Ibiza</span>
+        </div>
+      </div>
+
       <h1>Ibiza: My White Isle That Never Disappoints</h1>
 
       <div class="logbook-entry">

--- a/ports/invergordon.html
+++ b/ports/invergordon.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/invergordon/invergordon-3.webp" alt="Invergordon panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Invergordon</span>
+        </div>
+      </div>
+
       <h1>Invergordon: My Loch Ness Quest</h1>
       <div class="logbook-entry">
         <p>We boarded the coach at 8 a.m. and were on the banks of Loch Ness by 9:30 – the water black and still, Urquhart Castle ruins dramatically perched on the shore. The Jacobite cruise took us halfway down the loch while the guide told monster stories and sonar pinged the 230-meter depths. No definitive sighting, but we saw ripples that made hearts race.</p>

--- a/ports/kiel.html
+++ b/ports/kiel.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #264653 0%, #2a9d8f 35%, #8ab4aa 70%, #f4f4f4 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Kiel</div>
+      </div>
+
       <h1>Kiel: My Sailing Capital</h1>
       <div class="logbook-entry">
         <p>We watched the ship squeeze through the Kiel Canal locks from the top deck – inches from the walls, engineers waving like it was normal. The maritime quarter is pure sailing porn – German frigates, classic tall ships, and the Olympic rings still painted on the harbor from 1936/1972. Laboe Naval Memorial 20 minutes away – the U-boat museum inside is claustrophobic and humbling.</p>

--- a/ports/kirkwall.html
+++ b/ports/kirkwall.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0d3b66 0%, #2a628f 35%, #90c8ff 70%, #f0f7ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Kirkwall</div>
+      </div>
+
       <h1>Kirkwall: My 5,000-Year Journey</h1>
       <div class="logbook-entry">
         <p>We walked off into a town built by Vikings – St. Magnus Cathedral glowing red sandstone, founded 1137 and still perfect. Ten minutes by bus to Skara Brae – a 5,000-year-old village uncovered by a storm in 1850, complete with stone dressers, beds, and hearths. Walking through houses older than Stonehenge while Atlantic waves crashed behind felt like time travel.</p>

--- a/ports/kona.html
+++ b/ports/kona.html
@@ -248,6 +248,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/kona/kona-1.webp" alt="Kona panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Kona</span>
+        </div>
+      </div>
+
       <h1>Kailua-Kona: Coffee and Mantas</h1>
       <div class="logbook-entry">
         <p>We tendered ashore and were on Aliʻi Drive before 8:30. Huliheʻe Palace opens at 9 – we had the koa-wood floors and royal portraits practically to ourselves. The tender process was smooth (lines move fast) and we still made a 10 a.m. coffee farm tour 15 minutes south – walked rows of coffee trees, tasted fresh cherries, and brought beans home that still smell incredible.</p>

--- a/ports/koper.html
+++ b/ports/koper.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/koper/koper-3.webp" alt="Koper panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Koper</span>
+        </div>
+      </div>
+
       <h1>Koper: My Slovenian Secret</h1>
       <div class="logbook-entry">
         <p>We walked off into Praetorian Palace and Tito Square – the contrast between 15th-century Venetian gothic and Yugoslav concrete is weirdly charming. The bell tower climb gave us views over red roofs to Trieste and Italy on one side, Slovenian hills on the other. We had coffee on Čevljarska street tasting like Vienna but half the price.</p>

--- a/ports/kusadasi.html
+++ b/ports/kusadasi.html
@@ -350,6 +350,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
     <!-- Port Header -->
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/kusadasi/kusadasi-3.webp" alt="Kusadasi panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Kusadasi</span>
+        </div>
+      </div>
+
       <h1>Kusadasi &amp; Ephesus, Turkey</h1>
       <p style="font-size: 0.95rem; color: #456; margin-bottom: 0;">
         <strong>Region:</strong> Eastern Mediterranean &nbsp;|&nbsp; <strong>Type:</strong> Direct dock &nbsp;|&nbsp; <strong>Currency:</strong> Turkish Lira (USD/EUR widely accepted)

--- a/ports/la-coruna.html
+++ b/ports/la-coruna.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/la-coruna/la-coruna-3.webp" alt="La Coruna panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">La Coruna</span>
+        </div>
+      </div>
+
       <h1>La Coruña: My City of Glass</h1>
       <div class="logbook-entry">
         <p>We walked off straight to the Tower of Hercules – the oldest functioning lighthouse in the world. Climbing the 242 steps felt like time travel – Celtic, Roman, and medieval graffiti carved into the stones. The Atlantic wind at the top whipped our hair while Africa was theoretically visible on the horizon.</p>

--- a/ports/le-havre.html
+++ b/ports/le-havre.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/le-havre/le-havre-3.webp" alt="Le Havre panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Le Havre</span>
+        </div>
+      </div>
+
       <h1>Le Havre: My Gateway to Paris</h1>
       <div class="logbook-entry">
         <p>We caught the 7:45 train and were sipping café crème under the Eiffel Tower by 10:30. The Seine sparkled, the chestnut trees were in bloom, and Paris smelled exactly like fresh baguette and romance. We walked from the Louvre (Mona Lisa smaller than expected, Venus de Milo perfect) across the Tuileries to the Orangerie where Monet's water lilies wrapped around us like a hug.</p>

--- a/ports/lerwick.html
+++ b/ports/lerwick.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #0d3b66 0%, #2a628f 35%, #90c8ff 70%, #f0f7ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Lerwick</div>
+      </div>
+
       <h1>Lerwick: My Edge of Britain</h1>
       <div class="logbook-entry">
         <p>We walked off into a town built of grey stone and stubbornness – the harbor full of working fishing boats and the smell of tar and fish. Clickimin Broch at 9 a.m. – 2,000-year-old Iron Age tower still standing proud. We took the bus to Jarlshof – layer cake of archaeology: Bronze Age, Iron Age, Viking longhouses, medieval farmstead, all on one site exposed by a storm.</p>

--- a/ports/liverpool.html
+++ b/ports/liverpool.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/liverpool/liverpool-3.webp" alt="Liverpool panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Liverpool</span>
+        </div>
+      </div>
+
       <h1>Liverpool: My Beatles Pilgrimage</h1>
       <div class="logbook-entry">
         <p>We walked off the ship straight into the Three Graces and the Mersey smelled exactly like history and salt. The Beatles Story at the Albert Dock had us tearing up at John's round spectacles and the Cavern Club (the real rebuilt one) still smells of beer and 1962. We did the Magical Mystery Tour bus – driving past Penny Lane, Strawberry Field, and the childhood homes felt like trespassing on sacred ground.</p>

--- a/ports/livorno.html
+++ b/ports/livorno.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/livorno/livorno-3.webp" alt="Livorno panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Livorno</span>
+        </div>
+      </div>
+
       <h1>Livorno: My Gateway to Renaissance Florence</h1>
       <div class="logbook-entry">
         <p>We docked in industrial Livorno at sunrise and were on the first express coach to Florence – exactly one hour door-to-door. We stepped into Piazza del Duomo just as the morning light hit Brunelleschi's dome and turned it rose-gold. The line for the Accademia was already long, but seeing Michelangelo's David in person is one of those moments that actually stops your heart – he's enormous, impossibly alive, veins bulging in marble arms. We wandered to the Uffizi next (pre-booked tickets are non-negotiable) and stood in front of Botticelli's Birth of Venus while tears rolled down my face – the colors are so much more vivid in real life.</p>

--- a/ports/malaga.html
+++ b/ports/malaga.html
@@ -278,6 +278,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/malaga/malaga-3.webp" alt="Malaga panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Malaga</span>
+        </div>
+      </div>
+
       <h1>Málaga: My Andalusian Surprise That Keeps Getting Better</h1>
 
       <div class="logbook-entry">

--- a/ports/maui.html
+++ b/ports/maui.html
@@ -164,6 +164,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1f4068 0%, #457b9d 35%, #a8dadc 70%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Maui</div>
+      </div>
+
       <h1>Maui: After the Fire</h1>
       <div class="logbook-entry">
         <p>(Note: as of November 2025 Royal Caribbean is still using Kahului as the Maui port.)</p>

--- a/ports/messina.html
+++ b/ports/messina.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/messina/messina-3.webp" alt="Messina panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Messina</span>
+        </div>
+      </div>
+
       <h1>Messina: My Gateway to Taormina's Magic</h1>
       <div class="logbook-entry">
         <p>We ignored Messina itself (honestly, it's fine but you come for Taormina) and were on the first bus up the switchbacks in 50 minutes. The theater appears suddenly – 2,300-year-old Greek stones framing the perfect cone of Mount Etna smoking in the distance. We sat in the top row and just stared, dumbstruck. The view is one of the most famous in the world for good reason.</p>

--- a/ports/nawiliwili.html
+++ b/ports/nawiliwili.html
@@ -248,6 +248,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/nawiliwili/nawiliwili-3.webp" alt="Nawiliwili panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Nawiliwili</span>
+        </div>
+      </div>
+
       <h1>Nawiliwili: The Garden Isle</h1>
       <div class="logbook-entry">
         <p>We docked and rented a car (again, the only practical way). Waimea Canyon by 9 a.m. – the red dirt and layered cliffs really do look like a mini Grand Canyon with tropical vegetation. The main lookout is an easy 5-minute walk from parking – we had it almost to ourselves. Afternoon Na Pali catamaran from Port Allen (30-minute drive) – the boats are permitted and regulated, and the cliffs rising 4,000 ft from the sea with waterfalls every few minutes are worth every penny.</p>

--- a/ports/newcastle.html
+++ b/ports/newcastle.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #003049 0%, #008cb4 40%, #77b5c9 70%, #eef6f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Newcastle</div>
+      </div>
+
       <h1>Newcastle: My Geordie Welcome</h1>
       <div class="logbook-entry">
         <p>We walked off across the Tyne Bridge – the river sparkling, the Baltic art gallery in a converted flour mill glowing. The Quayside at 9 a.m. was quiet enough to enjoy the Gateshead Millennium Bridge tilting like a wink. We took the train to the Angel of the North (20 min) – Antony Gormley's massive rust-red figure with 54-meter wingspan standing in a field like a guardian.</p>

--- a/ports/newport.html
+++ b/ports/newport.html
@@ -161,6 +161,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1b4965 0%, #5fa8d3 40%, #bee9e8 70%, #f0f9ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Newport</div>
+      </div>
+
       <h1>Newport: My Gilded Age Wonder</h1>
       <div class="logbook-entry">
         <p>Tender to town. Walked Cliff Walk (1890s mansions on one side, Atlantic crashing on the other). Toured The Breakers — Vanderbilt excess on steroids. Lunch at Brick Alley Pub, then Castle Hill for sunset.</p>

--- a/ports/norwegian-fjords.html
+++ b/ports/norwegian-fjords.html
@@ -150,6 +150,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1b4965 0%, #5fa8d3 40%, #bee9e8 70%, #f0f9ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Norwegian Fjords</div>
+      </div>
+
       <h1>Geiranger & the Norwegian Fjords: My Jaw-On-The-Floor Scenic Heaven</h1>
       <div class="logbook-entry">
         <p>Sailing into Geirangerfjord at 5 a.m. with waterfalls cascading thousands of feet straight into the sea is hands-down the most spectacular cruising moment I've ever experienced — the entire ship goes silent on deck as Seven Sisters and The Suitor waterfalls thunder down. All the fjords ports score perfect 5.0 for scenery.</p>

--- a/ports/palma.html
+++ b/ports/palma.html
@@ -284,6 +284,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/palma/palma-3.webp" alt="Palma panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Palma</span>
+        </div>
+      </div>
+
       <h1>Palma de Mallorca: My Mediterranean Island Paradise</h1>
 
       <div class="logbook-entry">

--- a/ports/panama-canal.html
+++ b/ports/panama-canal.html
@@ -250,6 +250,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/panama-canal/panama-canal-3.webp" alt="Panama Canal panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Panama Canal</span>
+        </div>
+      </div>
+
       <h1>Panama Canal: My Engineering Marvel Day</h1>
       <div class="logbook-entry">
         <p>We were on the ship at 5 a.m. on the bow as we approached the Gatun Locks at dawn — watching the ship being raised 85 feet in three chambers, inches from the lock walls, with the mules (little trains) pulling us through. The narrator on the bow commentary was riveting the whole day.</p>

--- a/ports/portland-maine.html
+++ b/ports/portland-maine.html
@@ -164,6 +164,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a3a3a 0%, #3d7a7a 30%, #7eb8b8 60%, #e8f5f5 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Portland, Maine</div>
+      </div>
+
       <h1>Portland, Maine: Lighthouse Keeper's Dream</h1>
       <div class="logbook-entry">
         <p>We walked off the ship straight into the most photogenic working waterfront in America. Portland Head Light is fifteen minutes away in Cape Elizabeth, and we stood there watching waves crash against the rocks below the oldest lighthouse in Maine. The keeper's house museum had us nerding out over Fresnel lenses and 19th-century logbooks.</p>

--- a/ports/portland.html
+++ b/ports/portland.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1f4068 0%, #457b9d 35%, #a8dadc 70%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Portland</div>
+      </div>
+
       <h1>Portland: My Jurassic Adventure</h1>
       <div class="logbook-entry">
         <p>We walked off onto the Isle of Portland – tied to the mainland by Chesil Beach like a giant's necklace. The views from the Olympic Rings viewpoint are insane – Weymouth Bay one side, the English Channel the other. Portland Bill lighthouse at noon – waves exploding on the rocks while guillemots wheeled overhead.</p>

--- a/ports/porto.html
+++ b/ports/porto.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/porto/porto-3.webp" alt="Porto panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Porto</span>
+        </div>
+      </div>
+
       <h1>Porto: My Douro Dream</h1>
       <div class="logbook-entry">
         <p>We took the shuttle to the Ribeira and the city hit us like a warm hug – colorful houses tumbling into the river, the Dom Luís I bridge towering above, buskers playing fado. São Bento station at 9 a.m. – 20,000 hand-painted tiles telling Portugal's history while commuters rushed past like nothing. We walked across the bridge to Gaia for port tasting at Ramos Pinto – 10-year tawny that tasted like liquid Christmas.</p>

--- a/ports/quebec-city.html
+++ b/ports/quebec-city.html
@@ -161,6 +161,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a3a3a 0%, #3d7a7a 30%, #7eb8b8 60%, #e8f5f5 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Quebec City</div>
+      </div>
+
       <h1>Quebec City: My French-Canadian Fairytale</h1>
       <div class="logbook-entry">
         <p>We tied up right below the old city, so close that we could look straight up at the Château Frontenac from the lower town funicular. The second we stepped off the ship the air smelled like wood smoke and maple — fall in Quebec City hits different. We took the funicular up to Dufferin Terrace and spent the whole morning just wandering the old walled city like kids in a storybook.</p>

--- a/ports/ravenna.html
+++ b/ports/ravenna.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/ravenna/ravenna-3.webp" alt="Ravenna panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Ravenna</span>
+        </div>
+      </div>
+
       <h1>Ravenna: My Byzantine Masterpiece</h1>
       <div class="logbook-entry">
         <p>We docked in Porto Corsini and were in Ravenna center in 15 minutes. The city feels like a quiet university town until you step into San Vitale and the entire dome explodes with emerald-green, sapphire, and 24-karat gold mosaics of Justinian and Theodora staring down with emperor eyes. I actually gasped out loud. The Mausoleum of Galla Placidia is tiny but the deepest blue starry sky you'll ever see – it feels like being inside a jewel box.</p>

--- a/ports/rhodes.html
+++ b/ports/rhodes.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/rhodes/rhodes-3.webp" alt="Rhodes panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Rhodes</span>
+        </div>
+      </div>
+
       <h1>Rhodes: My Medieval Time Machine</h1>
       <div class="logbook-entry">
         <p>We walked off the ship straight through the Marine Gate into the Old Town and immediately got lost in 600 years of history. The Street of the Knights is perfect — cobblestones polished by millions of feet, coats of arms still visible on the stone inns. We climbed the walls at golden hour (allowed only with special ticket) and had the entire western rampart to ourselves while the sun set over Turkey across the water.</p>

--- a/ports/riga.html
+++ b/ports/riga.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/riga/riga-3.webp" alt="Riga panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Riga</span>
+        </div>
+      </div>
+
       <h1>Riga: My Art Nouveau Capital</h1>
       <div class="logbook-entry">
         <p>We walked off into Vecrīga and the cobblestones immediately started singing – every building a different pastel color, church spires competing for attention. Alberta iela at 9 a.m. was pure Art Nouveau porn – facades covered in screaming faces, naked ladies, and mythical beasts. The Central Market inside five zeppelin hangars was sensory overload – black balsamic vinegar aged 25 years, smoked sprats, and hemp butter that tastes like nostalgia.</p>

--- a/ports/saguenay.html
+++ b/ports/saguenay.html
@@ -161,6 +161,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #264653 0%, #2a9d8f 35%, #8ab4aa 70%, #f4f4f4 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Saguenay</div>
+      </div>
+
       <h1>Saguenay: My Fjord Fantasy</h1>
       <div class="logbook-entry">
         <p>Ship sails up the fjord for hours — best scenery from the water. Docked at La Baie. Took zodiac tour and saw beluga whales feeding right beside us — white ghosts in the dark water. Sainte-Anne church with the incredible painted interior. Poutine with wild mushrooms at a local café.</p>

--- a/ports/saint-john.html
+++ b/ports/saint-john.html
@@ -161,6 +161,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a3a3a 0%, #3d7a7a 30%, #7eb8b8 60%, #e8f5f5 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Saint John</div>
+      </div>
+
       <h1>Saint John: My Bay of Fundy Wonder</h1>
       <div class="logbook-entry">
         <p>We docked right in town and went straight to Reversing Falls at high tide — the rapids actually flow backwards, which is absolutely mesmerizing to watch. Then we explored City Market (oldest in North America) for dulse and smoked salmon. We spent the afternoon at Irving Nature Park watching seals, eagles, and fall foliage reflecting in tidal pools.</p>

--- a/ports/scotland.html
+++ b/ports/scotland.html
@@ -150,6 +150,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 30%, #a8e6cf 60%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Scotland</div>
+      </div>
+
       <h1>Scotland: Greenock/Glasgow & South Queensferry/Edinburgh</h1>
       <div class="logbook-entry">
         <p>Seeing Edinburgh Castle perched on its volcanic rock as we tender into South Queensferry is pure magic, and Glasgow's gritty-cool vibe from Greenock is the perfect contrast. Both ports score 4.9–5.0.</p>

--- a/ports/shanghai.html
+++ b/ports/shanghai.html
@@ -238,6 +238,13 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/shanghai/shanghai-3.webp" alt="Shanghai panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Shanghai</span>
+        </div>
+      </div>
+
       <header class="article-header">
         <h1>Shanghai Cruise Port Guide</h1>
         <p class="subtitle">My Futuristic Megacity That Leaves Me Speechless</p>

--- a/ports/singapore.html
+++ b/ports/singapore.html
@@ -238,6 +238,13 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/singapore/singapore-3.webp" alt="Singapore panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Singapore</span>
+        </div>
+      </div>
+
       <header class="article-header">
         <h1>Singapore Cruise Port Guide</h1>
         <p class="subtitle">My Futuristic Garden City That Blows My Mind Every Time</p>

--- a/ports/south-pacific.html
+++ b/ports/south-pacific.html
@@ -159,6 +159,10 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1b4965 0%, #5fa8d3 40%, #bee9e8 70%, #f0f9ff 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">South Pacific</div>
+      </div>
+
       <header class="article-header">
         <h1>South Pacific Islands Cruise Port Guide</h1>
         <p class="subtitle">My Ultimate Paradise Escape</p>

--- a/ports/southampton.html
+++ b/ports/southampton.html
@@ -278,6 +278,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/southampton/southampton-3.webp" alt="Southampton panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Southampton</span>
+        </div>
+      </div>
+
       <h1>Southampton: My Elegant Home Away From Home</h1>
 
       <div class="logbook-entry">

--- a/ports/st-petersburg.html
+++ b/ports/st-petersburg.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/st-petersburg/st-petersburg-3.webp" alt="St Petersburg panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">St Petersburg</span>
+        </div>
+      </div>
+
       <h1>St. Petersburg: My Imperial Dream</h1>
       <div class="logbook-entry">
         <p>We arrived at dawn and the city was already glowing – the Peter & Paul Fortress spire catching first light across the Neva. We arrived at the Hermitage early and had the Gold Room almost to ourselves – Fabergé eggs and Scythian gold glittering in perfect silence. The Church on Spilled Blood at 9 a.m. was empty enough to hear the mosaics whisper – every inch covered in biblical scenes that look wet.</p>

--- a/ports/stavanger.html
+++ b/ports/stavanger.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/stavanger/stavanger-3.webp" alt="Stavanger panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Stavanger</span>
+        </div>
+      </div>
+
       <h1>Stavanger: My Adventure Capital</h1>
       <div class="logbook-entry">
         <p>We walked off straight into Gamle Stavanger – 173 perfectly preserved 18th-century white houses with roses climbing the walls and cats sleeping on every doorstep. The petroleum museum is surprisingly cool – interactive oil-platform exhibits that make you feel like a roughneck. We had lunch at Fisketorget – fish soup so rich it should be illegal, eaten on the harbor while gulls circled overhead.</p>

--- a/ports/sydney-ns.html
+++ b/ports/sydney-ns.html
@@ -161,6 +161,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #2d3a4a 0%, #4a6fa5 35%, #8bb4d9 70%, #e8f4f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Sydney, NS</div>
+      </div>
+
       <h1>Sydney: My Cape Breton Gateway</h1>
       <div class="logbook-entry">
         <p>The world's largest fiddle greets you at the waterfront. We walked the boardwalk, visited the historic Jost House, then drove to the Alexander Graham Bell museum in Baddeck — absolutely worth the trip. For dinner, we attended a lobster supper at a church hall with all-you-can-eat lobster supporting local charities.</p>

--- a/ports/sydney.html
+++ b/ports/sydney.html
@@ -238,6 +238,13 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/sydney/sydney-3.webp" alt="Sydney panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Sydney</span>
+        </div>
+      </div>
+
       <header class="article-header">
         <h1>Sydney Cruise Port Guide</h1>
         <p class="subtitle">My Harbour City That Feels Like Home</p>

--- a/ports/tallinn.html
+++ b/ports/tallinn.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/tallinn/tallinn-3.webp" alt="Tallinn panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Tallinn</span>
+        </div>
+      </div>
+
       <h1>Tallinn: My Medieval Time Machine</h1>
       <div class="logbook-entry">
         <p>We walked off straight through the Viru Gates into a Disney movie – cobblestones, pastel merchants' houses, nuns in habits buying flowers. Alexander Nevsky Cathedral's onion domes glowed in the sun, incense and chanting spilling out the doors. We climbed Toompea Hill to the viewing platforms – the entire lower town spread below like a medieval model village, red roofs as far as the eye could see.</p>

--- a/ports/tangier.html
+++ b/ports/tangier.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/tangier/tangier-3.webp" alt="Tangier panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Tangier</span>
+        </div>
+      </div>
+
       <h1>Tangier: My African Gateway</h1>
       <div class="logbook-entry">
         <p>We walked off and straight into the Grand Socco – palm trees, women in colorful djellabas, the call to prayer echoing. A local guide led us into the medina labyrinth – narrower than Marrakech, more European-flavored, easier to navigate. We bought saffron that smelled like sunshine and argan oil still warm from the cooperative. We stopped at Café Hafa for mint tea overlooking the Strait – waves crashing, Spain visible 14 km away, old men playing chess.</p>

--- a/ports/taormina.html
+++ b/ports/taormina.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/taormina/taormina-3.webp" alt="Taormina panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Taormina</span>
+        </div>
+      </div>
+
       <h1>Taormina: My Sicilian Perfection</h1>
       <div class="logbook-entry">
         <p>Some ships tender directly to Giardini Naxos or dock in Messina – either way, we were sipping espresso on Corso Umberto by 9 a.m. The Greek theater at opening hour was almost empty – we walked the stage where gladiators once fought and looked straight at smoking Etna framed perfectly in the arches. The acoustics are still insane; I whispered and heard it across the cavea.</p>

--- a/ports/tokyo.html
+++ b/ports/tokyo.html
@@ -159,6 +159,10 @@ All work on this project is offered as a gift to God.
     </nav>
 
     <article>
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #003049 0%, #008cb4 40%, #77b5c9 70%, #eef6f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Tokyo</div>
+      </div>
+
       <header class="article-header">
         <h1>Tokyo / Yokohama Cruise Port Guide</h1>
         <p class="subtitle">My Neon-Filled Dream That Never Sleeps</p>

--- a/ports/tracy-arm.html
+++ b/ports/tracy-arm.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 30%, #a8e6cf 60%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Tracy Arm</div>
+      </div>
+
       <h1>Tracy Arm: My Narrow Fjord Adventure</h1>
       <div class="logbook-entry">
         <p>Tracy Arm is a scenic cruising day (no port), but what a day. The ship entered the fjord early morning and we immediately felt the scale — sheer granite walls rising 4,000 feet straight out of the water, waterfalls cascading from snowfields, the fjord itself barely wider than two football fields in places.</p>

--- a/ports/trieste.html
+++ b/ports/trieste.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/trieste/trieste-3.webp" alt="Trieste panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Trieste</span>
+        </div>
+      </div>
+
       <h1>Trieste: My Habsburg Dream</h1>
       <div class="logbook-entry">
         <p>We walked off into Piazza Unità d'Italia – the biggest square opening directly onto the sea in Europe, grand cafés on three sides, the city hall glowing at sunrise. We had coffee at Caffè San Marco – James Joyce and Italo Svevo wrote here, the waiters still wear bow ties, the cappuccino is perfect. Miramare Castle 20 minutes away – white on a promontory like a fairy tale, Maximilian and Carlota's tragic home.</p>

--- a/ports/tromso.html
+++ b/ports/tromso.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1f4068 0%, #457b9d 35%, #a8dadc 70%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Tromso</div>
+      </div>
+
       <h1>Tromsø: My Arctic Capital</h1>
       <div class="logbook-entry">
         <p>We arrived in summer under 24-hour daylight and the city felt like it never slept – people kayaking at 11 p.m., the sun just dipping behind mountains but never setting. The cable car up Storsteinen gave us views over islands stretching to infinity while reindeer grazed below. The Arctic Cathedral at midnight looked like a frozen aurora made of concrete and glass – we attended an actual midnight sun concert inside with organ music echoing off the triangular windows.</p>

--- a/ports/tunis.html
+++ b/ports/tunis.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/tunis/tunis-3.webp" alt="Tunis panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Tunis</span>
+        </div>
+      </div>
+
       <h1>Tunis: My Three UNESCO Treasures</h1>
       <div class="logbook-entry">
         <p>We were in Carthage by 8:30 a.m. – walking among Punic ports and Roman villas while the Mediterranean sparkled behind. The Antonine Baths are enormous – you can still see the underfloor heating system. Then Sidi Bou Said – every building white and blue, bougainvillea exploding over walls, the smell of pine and jasmine everywhere. We had mint tea with pine nuts at Café des Délices overlooking the Gulf of Tunis.</p>

--- a/ports/valencia.html
+++ b/ports/valencia.html
@@ -284,6 +284,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/valencia/valencia-3.webp" alt="Valencia panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Valencia</span>
+        </div>
+      </div>
+
       <h1>Valencia: My Futuristic Yet Historic Love</h1>
 
       <div class="logbook-entry">

--- a/ports/valletta.html
+++ b/ports/valletta.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/valletta/valletta-3.webp" alt="Valletta panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Valletta</span>
+        </div>
+      </div>
+
       <h1>Valletta: My Fortress of Knights</h1>
       <div class="logbook-entry">
         <p>We walked off the ship straight up the monumental stairs into Upper Barrakka Gardens just in time for the noon gun salute. The view over Grand Harbour is insane.</p>

--- a/ports/venice.html
+++ b/ports/venice.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/venice/venice-3.webp" alt="Venice panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Venice</span>
+        </div>
+      </div>
+
       <h1>Venice: My Floating Dream</h1>
       <div class="logbook-entry">
         <p>We arrived by sea at sunrise — St. Mark's campanile appearing through mist like a mirage. Water taxi to San Marco just as it opened — had the basilica almost empty for 20 minutes. Gold mosaics literally glowing.</p>

--- a/ports/vigo.html
+++ b/ports/vigo.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/vigo/vigo-3.webp" alt="Vigo panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Vigo</span>
+        </div>
+      </div>
+
       <h1>Vigo: My Gateway to Paradise</h1>
       <div class="logbook-entry">
         <p>We caught the 9 a.m. ferry to Cíes (booked months in advance) and stepped onto Rodas Beach – powder-white sand connecting two islands in a perfect crescent, water so clear we saw fish from the ferry. The 3-km hike to Faro da Porta gave views that made us gasp – the entire Ría de Vigo spread below like a map. We had octopus salad and Estrella Galicia on the beach while Atlantic rollers crashed.</p>

--- a/ports/villefranche.html
+++ b/ports/villefranche.html
@@ -299,16 +299,14 @@ All work on this project is offered as a gift to God.
     </section>
 
     <div style="grid-column: 1; grid-row: 1;">
-    <article<!-- Breadcrumb -->
-    <nav aria-label="Breadcrumb" style="margin-bottom: 1rem;">
-      <ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;">
-        <li style="display: inline;"><a href="/">Home</a> &rsaquo; </li>
-        <li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li>
-        <li style="display: inline;" aria-current="page">Villefranche-sur-Mer</li>
-      </ol>
-    </nav>
+    <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/villefranche/villefranche-3.webp" alt="Villefranche panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Villefranche</span>
+        </div>
+      </div>
 
-     class="card">
       <h1>Villefranche-sur-Mer: Gateway to the French Riviera</h1>
 
       <div class="logbook-entry">

--- a/ports/warnemunde.html
+++ b/ports/warnemunde.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #003049 0%, #008cb4 40%, #77b5c9 70%, #eef6f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Warnemunde</div>
+      </div>
+
       <h1>Warnemünde: My Gateway to Berlin</h1>
       <div class="logbook-entry">
         <p>We took the first train to Berlin at 7:30 a.m. and were at Brandenburg Gate by 10:15 – the city still quiet enough to feel intimate. Walked Unter den Linden to Museum Island, cried at the Pergamon Altar (even reconstructed), then Checkpoint Charlie and the East Side Gallery where the Wall still stands covered in murals. We had currywurst at Curry 36 that tasted exactly like freedom and mustard.</p>

--- a/ports/waterford.html
+++ b/ports/waterford.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #003049 0%, #008cb4 40%, #77b5c9 70%, #eef6f8 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Waterford</div>
+      </div>
+
       <h1>Waterford: My Viking Crystal City</h1>
       <div class="logbook-entry">
         <p>We walked off into the Viking Triangle – Reginald's Tower glowing pink at sunrise, the only Irish monument with its original Viking name. The Medieval Museum is brilliant – two 13th-century choristers' halls joined together with the only complete set of King Edward III's clothes in existence. The House of Waterford Crystal tour – watching master blowers create vases with wooden paddles and shears was mesmerising.</p>

--- a/ports/whittier.html
+++ b/ports/whittier.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 30%, #a8e6cf 60%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Whittier</div>
+      </div>
+
       <h1>Whittier: My 26 Glaciers Wonder</h1>
       <div class="logbook-entry">
         <p>The ship squeezes through the 2.7-mile single-lane tunnel with the train tracks — surreal. Whittier is tiny and weird in the best way. We boarded the high-speed catamaran for the 5.5-hour 26 Glaciers tour and it delivered.</p>

--- a/ports/zadar.html
+++ b/ports/zadar.html
@@ -244,6 +244,13 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; border-radius: 12px; height: 280px; overflow: hidden;">
+        <img src="/ports/img/zadar/zadar-3.webp" alt="Zadar panoramic view" style="width: 100%; height: 100%; object-fit: cover;" fetchpriority="high"/>
+        <div class="port-name-overlay" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);">
+          <span style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4); letter-spacing: 0.08em; text-transform: uppercase;">Zadar</span>
+        </div>
+      </div>
+
       <h1>Zadar: My Adriatic Innovation</h1>
       <div class="logbook-entry">
         <p>We walked off straight into the old town peninsula – Roman forum still in daily use, St. Donatus church looking like a stone spaceship. The Sea Organ at noon – waves pushed air through pipes under the marble steps creating random haunting chords while children danced to the "music." We watched sunset at the Greeting to the Sun – the solar circle lights up in wild colors synchronized to the organ notes.</p>

--- a/ports/zeebrugge.html
+++ b/ports/zeebrugge.html
@@ -160,6 +160,10 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
     <article class="card">
+      <div class="port-hero-container" style="position: relative; margin-bottom: 1.5rem; background: linear-gradient(135deg, #1a535c 0%, #4ecdc4 30%, #a8e6cf 60%, #f1faee 100%); border-radius: 12px; height: 280px; display: flex; align-items: center; justify-content: center;">
+        <div class="port-name-overlay" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 10vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.5), 0 0 40px rgba(0,0,0,0.3); letter-spacing: 0.08em; text-transform: uppercase; text-align: center;">Zeebrugge</div>
+      </div>
+
       <h1>Zeebrugge/Bruges: My Medieval Fairy Tale</h1>
       <div class="logbook-entry">
         <p>We took the first shuttle and were wandering Bruges' cobbled streets by 9 a.m. while the morning mist still hung over the reien canals. The Belfry tower loomed above the Markt like a Gothic wedding cake, and climbing its 366 steps left us breathless in every sense – the carillon bells rang right over our heads at the top. A horse-drawn carriage clip-clopped past as we drifted along the Dijver watching swans glide under stone bridges that haven't changed since the 1400s.</p>


### PR DESCRIPTION
- Add hero containers with port name overlays to 92 ports that were missing them
- 56 ports get hero images with panoramic photos from WikiMedia Commons
- 32 ports without images receive gradient-based heroes with maritime color palettes
- Fix corrupted HTML in villefranche.html (malformed article tag)
- All 147 port pages now have consistent hero sections with prominent port names