### PR TITLE
DOCS: Clarify skill directory vs skill rule distinction in onboarding…

### DIFF
--- a/.claude/INSTALLATION.md
+++ b/.claude/INSTALLATION.md
@@ -13,7 +13,9 @@ This document details the enhanced Claude Code system installed on this reposito
 
 ### Installed Components
 
-**Total Skills:** 7 (1 CITW original + 6 FOM adapted)
+**Total Skill Rules:** 7 (defined in skill-rules.json)
+- 3 with dedicated skill directories (standards, skill-developer, frontend-dev-guidelines)
+- 4 rule-based triggers only (seo-optimizer, accessibility-auditor, content-strategy, performance-analyzer)
 **Total Plugins:** 5 (cruise-relevant only)
 **Total Commands:** 4 (workflow utilities)
 **Total Hooks:** 2 (auto-activation system)
@@ -42,12 +44,16 @@ This document details the enhanced Claude Code system installed on this reposito
 
 ### Layer 2: Domain Skills
 
-**Skills Installed:**
+**Skills with Dedicated Directories (3):**
 
 1. **standards** (CITW Original)
    - Standards enforcement system with theological foundation
-   - YAML-based standards (css.yml, html.yml, javascript.yml, theological.yml)
+   - Resources in `.claude/skills/standards/`
    - ICP-Lite / ITW-Lite protocol compliance
+
+**Rule-Based Skill Triggers (4):**
+
+These are defined in `skill-rules.json` as activation triggers with guardrails, but don't have dedicated SKILL.md directories:
 
 2. **seo-optimizer** (FOM Adapted → ITW-Lite)
    - SEO optimization with ITW-Lite guardrails
@@ -132,21 +138,28 @@ This document details the enhanced Claude Code system installed on this reposito
 
 The `.claude/skill-rules.json` has been customized for cruise planning with **ITW-Lite v3.010 guardrails**:
 
-### Active Skills (7 Total):
+### Active Skill Rules (7 Total):
+
+**Skills with Directories (3):**
 
 1. **standards** (Critical Priority) - CITW Original
    - Triggers: Code file modifications, HTML/CSS/JS editing
    - Files: *.html, *.css, *.js, *.json, *.md
    - Purpose: Standards enforcement with theological foundation
+   - Resources: `.claude/skills/standards/`
 
 2. **skill-developer** (High Priority) - FOM Adapted
    - Triggers: "skill system", "create skill", "skill rules"
    - Purpose: Meta-skill for managing Claude Code skills
+   - Resources: `.claude/skills/skill-developer/`
 
 3. **frontend-dev-guidelines** (High Priority) - FOM Adapted
    - Triggers: HTML, CSS, JavaScript, accessibility, WCAG
    - Files: *.html, *.css, *.js
    - Purpose: HTML/CSS/JS best practices
+   - Resources: `.claude/skills/frontend-dev-guidelines/`
+
+**Rule-Based Triggers (4):**
 
 4. **seo-optimizer** (High Priority) ⚠️ **WITH ITW-LITE GUARDRAILS**
    - Triggers: SEO, meta tags, schema.org, structured data
@@ -285,23 +298,25 @@ Agent: "accessibility-validator"
 To verify installation:
 
 ```bash
-# Check skills
+# Check skill directories (3 expected)
 ls -la .claude/skills/
 
-# Check plugins
+# Check plugins (5 expected)
 ls -la .claude/plugins/
 
-# Check commands
+# Check commands (4 expected)
 ls -la .claude/commands/
 
-# Check hooks
+# Check hooks (2 expected)
 ls -la .claude/hooks/
 
-# Verify configuration
+# Verify skill rules in configuration (7 expected)
 cat .claude/skill-rules.json | jq '.skills | keys'
 ```
 
-Expected output: 7 skills (standards, skill-developer, frontend-dev-guidelines, seo-optimizer, accessibility-auditor, content-strategy, performance-analyzer)
+**Expected output:**
+- Skill directories: 3 (standards, skill-developer, frontend-dev-guidelines)
+- Skill rules in JSON: 7 (standards, skill-developer, frontend-dev-guidelines, seo-optimizer, accessibility-auditor, content-strategy, performance-analyzer)
 
 ---
 
@@ -341,9 +356,13 @@ Expected output: 7 skills (standards, skill-developer, frontend-dev-guidelines, 
 
 ## Version History
 
+**v1.1.1** (2025-12-01)
+- Documentation clarification: Distinguish between skill directories (3) and skill rules (7)
+- Updated onboarding and installation docs for accuracy
+
 **v1.1.0** (2025-11-24)
 - Initial merge of FOM enhancements into CITW
-- 7 skills total (1 CITW + 6 FOM adapted)
+- 7 skill rules total: 3 with directories (standards, skill-developer, frontend-dev-guidelines) + 4 rule-based triggers
 - ITW-Lite v3.010 philosophy implemented
 - Cruise-specific path and schema adaptations
 

--- a/.claude/ONBOARDING.md
+++ b/.claude/ONBOARDING.md
@@ -15,7 +15,7 @@ You're working on **In the Wake**, a cruise planning website with an enhanced Cl
 1. **Skills auto-activate** based on what you're doing (editing HTML triggers SEO/accessibility skills)
 2. **ITW-Lite v3.010 philosophy**: AI-first, Human-first, Google second
 3. **Theological foundation is IMMUTABLE**: Soli Deo Gloria invocation required on all pages
-4. **7 skills total**: standards (CITW) + 6 from FOM (skill-developer, frontend-dev, SEO, accessibility, content-strategy, performance)
+4. **7 skill rules total**: 3 with dedicated directories (standards, skill-developer, frontend-dev-guidelines) + 4 rule-based triggers in skill-rules.json (seo-optimizer, accessibility-auditor, content-strategy, performance-analyzer)
 5. **Read this first**: `.claude/skill-rules.json` (skill activation rules) and `new-standards/README.md` (site standards)
 
 ---
@@ -67,25 +67,33 @@ new-standards/foundation/WCAG_2.1_AA_STANDARDS_v3.100.md  # Accessibility
 
 ---
 
-## 🛠️ The 7 Skills
+## 🛠️ The 7 Skill Rules
 
-### 1. **standards** (CITW Original - High Priority)
+The system includes 7 skill rules defined in `.claude/skill-rules.json`. Three have dedicated skill directories with documentation; four are rule-based triggers only.
+
+### Skills with Dedicated Directories (3)
+
+#### 1. **standards** (CITW Original - High Priority)
 **Triggers:** Editing HTML, CSS, JS, JSON, MD files
 **Purpose:** Standards enforcement with theological foundation
 **Resources:** `.claude/skills/standards/STANDARDS.md`
 
-### 2. **skill-developer** (FOM - High Priority)
+#### 2. **skill-developer** (FOM - High Priority)
 **Triggers:** Keywords like "skill system", "create skill", "skill rules"
 **Purpose:** Meta-skill for managing Claude Code skills
 **Resources:** `.claude/skills/skill-developer/SKILL.md`
 
-### 3. **frontend-dev-guidelines** (FOM - High Priority)
+#### 3. **frontend-dev-guidelines** (FOM - High Priority)
 **Triggers:** HTML, CSS, JavaScript, accessibility, WCAG keywords
 **Triggers Files:** *.html, *.css, *.js
 **Purpose:** HTML/CSS/JS best practices for static sites
 **Resources:** `.claude/skills/frontend-dev-guidelines/SKILL.md`
 
-### 4. **seo-optimizer** (FOM→ITW - High Priority) ⚠️ **WITH GUARDRAILS**
+### Rule-Based Triggers (4)
+
+These skills are defined as activation rules in `skill-rules.json` with guardrails and triggers, but don't have dedicated SKILL.md directories. They influence behavior through their rule definitions.
+
+#### 4. **seo-optimizer** (FOM→ITW - High Priority) ⚠️ **WITH GUARDRAILS**
 **Triggers:** SEO, meta tags, schema.org, structured data, ICP-Lite, ITW-Lite
 **Triggers Files:** *.html, ships/**, ports/**, restaurants/**
 **Purpose:** Technical SEO that benefits AI + humans + search engines
@@ -93,12 +101,12 @@ new-standards/foundation/WCAG_2.1_AA_STANDARDS_v3.100.md  # Accessibility
 - ❌ REJECT: Keyword stuffing, removing AI-first meta tags, sacrificing readability
 - ✅ ACCEPT: schema.org, semantic HTML, ICP-Lite compliance, natural descriptions
 
-### 5. **accessibility-auditor** (FOM→ITW - High Priority)
+#### 5. **accessibility-auditor** (FOM→ITW - High Priority)
 **Triggers:** accessibility, a11y, WCAG, aria, screen reader
 **Triggers Files:** *.html
 **Purpose:** WCAG AA compliance for cruise planning site
 
-### 6. **content-strategy** (FOM→ITW - High Priority) ⚠️ **WITH GUARDRAILS**
+#### 6. **content-strategy** (FOM→ITW - High Priority) ⚠️ **WITH GUARDRAILS**
 **Triggers:** content, description, cruise, ship, port, storytelling
 **Triggers Files:** ships/**, ports/**, restaurants/**, solo/**
 **Purpose:** Travel storytelling aligned with ITW-Lite philosophy
@@ -106,7 +114,7 @@ new-standards/foundation/WCAG_2.1_AA_STANDARDS_v3.100.md  # Accessibility
 - ❌ REJECT: Keyword-stuffed descriptions, robotic SEO copy, removing planning guidance
 - ✅ ACCEPT: Natural descriptions, travel storytelling, faith-scented reflections
 
-### 7. **performance-analyzer** (FOM→ITW - Medium Priority)
+#### 7. **performance-analyzer** (FOM→ITW - Medium Priority)
 **Triggers:** performance, optimize, lighthouse, Core Web Vitals, LCP, FID, CLS
 **Purpose:** Web performance optimization
 
@@ -152,9 +160,9 @@ InTheWake/
 ├── .claude/                    # Claude Code system (YOU ARE HERE)
 │   ├── INSTALLATION.md         # Full installation guide
 │   ├── ONBOARDING.md          # This file
-│   ├── skill-rules.json       # Skill activation rules (7 skills)
+│   ├── skill-rules.json       # Skill activation rules (7 rule definitions)
 │   ├── settings.json          # Hook configuration
-│   ├── skills/                # 7 skills (standards, skill-developer, frontend-dev, etc.)
+│   ├── skills/                # 3 skills with directories (standards, skill-developer, frontend-dev-guidelines)
 │   ├── plugins/               # 5 plugins (SEO, accessibility, performance)
 │   ├── commands/              # 4 commands (/commit, /create-pr, etc.)
 │   ├── hooks/                 # 2 hooks (auto-activation)
@@ -358,7 +366,7 @@ Ship, port, and restaurant pages should have structured context comments:
 
 ## 🎯 TL;DR — What You Need to Know
 
-1. **7 skills** auto-activate based on context (standards + 6 FOM-adapted)
+1. **7 skill rules** auto-activate based on context: 3 with skill directories + 4 rule-based triggers
 2. **ITW-Lite v3.010**: AI-first, Human-first, Google second
 3. **Theological foundation is immutable**: Soli Deo Gloria on every page
 4. **ICP-Lite protocol required**: ai-summary, last-reviewed, content-protocol meta tags


### PR DESCRIPTION
… docs

The documentation incorrectly claimed 7 skills with directories when only 3 skill directories exist (standards, skill-developer, frontend-dev-guidelines). The other 4 skills (seo-optimizer, accessibility-auditor, content-strategy, performance-analyzer) are rule-based triggers defined in skill-rules.json without dedicated SKILL.md directories.

Updated ONBOARDING.md and INSTALLATION.md to accurately reflect:
- 3 skills with dedicated directories
- 4 rule-based triggers in skill-rules.json
- 7 total skill rules