### PR TITLE
Add Wikimedia Commons images with proper attributions to all cruise l…

### DIFF
--- a/cruise-lines/carnival.html
+++ b/cruise-lines/carnival.html
@@ -387,12 +387,12 @@
       <h2 id="gallery">Gallery</h2>
       <div class="grid two">
         <figure>
-          <img src="/assets/cruise-lines/carnival-hero-1.jpg" alt="Carnival ship under way at sea">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/66/Carnival_Breeze.jpg/1200px-Carnival_Breeze.jpg" alt="Carnival Breeze cruise ship in the harbor of Monaco" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Carnival_Breeze.jpg" target="_blank" rel="noopener">Tim Alex</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by/3.0" target="_blank" rel="noopener">CC BY 3.0</a></figcaption>
         </figure>
         <figure>
-          <img src="/assets/cruise-lines/carnival-hero-2.jpg" alt="Top deck view on a Carnival ship">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/92/Carnival_Breeze_Docked_in_Galveston.jpg/1200px-Carnival_Breeze_Docked_in_Galveston.jpg" alt="Aerial view of Carnival Breeze docked in Galveston, Texas" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Carnival_Breeze_Docked_in_Galveston.jpg" target="_blank" rel="noopener">Jason Reina</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
       </div>
     </section>
@@ -460,7 +460,7 @@
 
     <section class="card" aria-labelledby="credits-h">
       <h3 id="credits-h">Image Credits</h3>
-      <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace placeholders with final credited media.</p>
+      <p class="tiny">Gallery images sourced from <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> under Creative Commons licenses. Individual attributions appear beneath each image.</p>
     </section>
   </div>
 

--- a/cruise-lines/celebrity.html
+++ b/cruise-lines/celebrity.html
@@ -391,12 +391,12 @@
       <h2 id="gallery">Gallery</h2>
       <div class="grid two">
         <figure>
-          <img src="/assets/cruise-lines/celebrity-hero-1.jpg" alt="Celebrity ship at sea">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Celebrity_Reflection_cruise_ship_in_Santorini%2C_Greece_001.jpg/1200px-Celebrity_Reflection_cruise_ship_in_Santorini%2C_Greece_001.jpg" alt="Celebrity Reflection cruise ship anchored in the caldera at Santorini, Greece" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Celebrity_Reflection_cruise_ship_in_Santorini,_Greece_001.jpg" target="_blank" rel="noopener">Moonik</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/3.0" target="_blank" rel="noopener">CC BY-SA 3.0</a></figcaption>
         </figure>
         <figure>
-          <img src="/assets/cruise-lines/celebrity-hero-2.jpg" alt="Deck view aboard a Celebrity ship">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Celebrity_Summit-DSC_0134w.jpg/1200px-Celebrity_Summit-DSC_0134w.jpg" alt="Celebrity Summit cruise ship departing Venice with Santa Maria della Salute in the background" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Celebrity_Summit-DSC_0134w.jpg" target="_blank" rel="noopener">Peter Haas</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/3.0" target="_blank" rel="noopener">CC BY-SA 3.0</a></figcaption>
         </figure>
       </div>
     </section>
@@ -466,7 +466,7 @@
 
     <section class="card" aria-labelledby="credits-h">
       <h3 id="credits-h">Image Credits</h3>
-      <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace placeholders with final credited media.</p>
+      <p class="tiny">Gallery images sourced from <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> under Creative Commons licenses. Individual attributions appear beneath each image.</p>
     </section>
   </div>
 

--- a/cruise-lines/disney.html
+++ b/cruise-lines/disney.html
@@ -386,12 +386,12 @@
       <h2 id="gallery-h">Gallery</h2>
       <div class="grid two">
         <figure>
-          <img src="/assets/cruise-lines/disney-hero-1.jpg" alt="Disney Cruise Line ship under way at sea">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/73/Disney_Wonder_cruise_ship_in_Vancouver_%28cropped%29.jpg/1200px-Disney_Wonder_cruise_ship_in_Vancouver_%28cropped%29.jpg" alt="Disney Wonder cruise ship docked in Vancouver, British Columbia" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Disney_Wonder_cruise_ship_in_Vancouver_(cropped).jpg" target="_blank" rel="noopener">tdlucas5000</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by/2.0" target="_blank" rel="noopener">CC BY 2.0</a></figcaption>
         </figure>
         <figure>
-          <img src="/assets/cruise-lines/disney-hero-2.jpg" alt="Topside deck view on a Disney Cruise Line ship">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Disney_Wonder_in_Sydney_24_December_2024.jpg/1200px-Disney_Wonder_in_Sydney_24_December_2024.jpg" alt="Disney Wonder cruise ship at Sydney's Overseas Passenger Terminal" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Disney_Wonder_in_Sydney_24_December_2024.jpg" target="_blank" rel="noopener">Dicklyon</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
       </div>
     </section>
@@ -459,7 +459,7 @@
 
     <section class="card" aria-labelledby="credits-h">
       <h3 id="credits-h">Image Credits</h3>
-      <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace placeholders with final credited media.</p>
+      <p class="tiny">Gallery images sourced from <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> under Creative Commons licenses. Individual attributions appear beneath each image.</p>
     </section>
   </div>
 

--- a/cruise-lines/holland-america.html
+++ b/cruise-lines/holland-america.html
@@ -444,12 +444,12 @@
       <h2 id="gallery-h">Gallery</h2>
       <div class="grid two">
         <figure>
-          <img src="/assets/cruise-lines/holland-america-hero-1.jpg" alt="Holland America Line ship underway at sea">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Rotterdam_Ship_at_Holland_America_Line_Terminal_2.jpg/1200px-Rotterdam_Ship_at_Holland_America_Line_Terminal_2.jpg" alt="MS Rotterdam at the Holland America Line Terminal in Rotterdam, Netherlands" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Rotterdam_Ship_at_Holland_America_Line_Terminal_2.jpg" target="_blank" rel="noopener">Ymblanter</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
         <figure>
-          <img src="/assets/cruise-lines/holland-america-hero-2.jpg" alt="Promenade deck view aboard a Holland America ship">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Holland_America_Line_cruise_ship_viewed_from_A%27DAM_Tower.jpg/1200px-Holland_America_Line_cruise_ship_viewed_from_A%27DAM_Tower.jpg" alt="Holland America Line cruise ship viewed from A'DAM Tower in Amsterdam" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Holland_America_Line_cruise_ship_viewed_from_A%27DAM_Tower.jpg" target="_blank" rel="noopener">APK</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
       </div>
     </section>
@@ -517,7 +517,7 @@
 
     <section class="card" aria-labelledby="credits-h">
       <h3 id="credits-h">Image Credits</h3>
-      <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace placeholders with final credited media.</p>
+      <p class="tiny">Gallery images sourced from <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> under Creative Commons licenses. Individual attributions appear beneath each image.</p>
     </section>
       <!-- Recent Articles rail -->
       <section class="card" aria-labelledby="recent-rail-title">

--- a/cruise-lines/msc.html
+++ b/cruise-lines/msc.html
@@ -386,12 +386,12 @@
       <h2 id="gallery-h">Gallery</h2>
       <div class="grid two">
         <figure>
-          <img src="/assets/cruise-lines/msc-hero-1.jpg" alt="MSC cruise ship underway at sea">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/MSC_Virtuosa_at_Liverpool_202106-7.jpg/1200px-MSC_Virtuosa_at_Liverpool_202106-7.jpg" alt="MSC Virtuosa berthed at Liverpool as seen from Woodside" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:MSC_Virtuosa_at_Liverpool_202106-7.jpg" target="_blank" rel="noopener">Rodhullandemu</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
         <figure>
-          <img src="/assets/cruise-lines/msc-hero-2.jpg" alt="Indoor promenade aboard an MSC ship">
-          <figcaption class="tiny">Image: Wikimedia Commons — add specific attribution.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/0616_MSC_Virtuosa_departing_from_Geiranger_V-P.jpg/800px-0616_MSC_Virtuosa_departing_from_Geiranger_V-P.jpg" alt="MSC Virtuosa transitting Geirangerfjord in Norway" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:0616_MSC_Virtuosa_departing_from_Geiranger_V-P.jpg" target="_blank" rel="noopener">Virtual-Pano</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
       </div>
     </section>
@@ -466,7 +466,7 @@
 
     <section class="card" aria-labelledby="credits-h">
       <h3 id="credits-h">Image Credits</h3>
-      <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace placeholders with final credited media.</p>
+      <p class="tiny">Gallery images sourced from <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> under Creative Commons licenses. Individual attributions appear beneath each image.</p>
     </section>
   </div>
 

--- a/cruise-lines/norwegian.html
+++ b/cruise-lines/norwegian.html
@@ -376,12 +376,12 @@
       <h2>Gallery</h2>
       <div class="grid gallery">
         <figure>
-          <img src="https://jsschrstrcks1.github.io/assets/cruise-lines/norwegian-hero-1.jpg" alt="Norwegian Cruise Line ship at sea">
-          <figcaption class="tiny">Image: Wikimedia Commons — replace with final credited media.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/Norwegian_Bliss_Cruise_Ship_Entering_Puerto_Vallarta_Harbor.jpg/1200px-Norwegian_Bliss_Cruise_Ship_Entering_Puerto_Vallarta_Harbor.jpg" alt="Norwegian Bliss cruise ship entering Puerto Vallarta harbor" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Norwegian_Bliss_Cruise_Ship_Entering_Puerto_Vallarta_Harbor.jpg" target="_blank" rel="noopener">James Hills</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
         <figure>
-          <img src="https://jsschrstrcks1.github.io/assets/cruise-lines/norwegian-hero-2.jpg" alt="Norwegian Cruise Line deck view">
-          <figcaption class="tiny">Image: Wikimedia Commons — replace with final credited media.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Norwegian_Pearl_Cruise_Ship_of_Norwegian_Cruise_Line_in_PortMiami_Florida.jpg/1200px-Norwegian_Pearl_Cruise_Ship_of_Norwegian_Cruise_Line_in_PortMiami_Florida.jpg" alt="Norwegian Pearl cruise ship at PortMiami, Florida" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Norwegian_Pearl_Cruise_Ship_of_Norwegian_Cruise_Line_in_PortMiami_Florida.jpg" target="_blank" rel="noopener">EgorovaSvetlana</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
       </div>
     </section>
@@ -470,7 +470,7 @@
 
     <section class="card">
       <h3>Image Credits</h3>
-      <p class="tiny">Hero and supplemental images: Wikimedia Commons (place final, specific attributions upon publication).</p>
+      <p class="tiny">Gallery images sourced from <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> under Creative Commons licenses. Individual attributions appear beneath each image.</p>
     </section>
   </div>
 

--- a/cruise-lines/princess.html
+++ b/cruise-lines/princess.html
@@ -372,12 +372,12 @@
       <h2>Gallery</h2>
       <div class="grid gallery">
         <figure>
-          <img src="https://jsschrstrcks1.github.io/assets/cruise-lines/princess-hero-1.jpg" alt="Princess Cruises ship at sea">
-          <figcaption class="tiny">Image: Wikimedia Commons — replace with final credited media.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Sky_Princess_%28ship%2C_2019%29_at_Liverpool_3.jpg/1200px-Sky_Princess_%28ship%2C_2019%29_at_Liverpool_3.jpg" alt="Port side of Sky Princess at Liverpool Cruise Terminal" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Sky_Princess_(ship,_2019)_at_Liverpool_3.jpg" target="_blank" rel="noopener">Rodhullandemu</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
         <figure>
-          <img src="https://jsschrstrcks1.github.io/assets/cruise-lines/princess-hero-2.jpg" alt="Princess Cruises deck view">
-          <figcaption class="tiny">Image: Wikimedia Commons — replace with final credited media.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/63/Sky_Princess_%28ship%2C_2019%29_at_Liverpool_1.jpg/1200px-Sky_Princess_%28ship%2C_2019%29_at_Liverpool_1.jpg" alt="Port side and stern of Sky Princess at Liverpool Cruise Terminal" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Sky_Princess_(ship,_2019)_at_Liverpool_1.jpg" target="_blank" rel="noopener">Rodhullandemu</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
       </div>
     </section>
@@ -453,7 +453,7 @@
 
     <section class="card">
       <h3>Image Credits</h3>
-      <p class="tiny">Hero and supplemental images: Wikimedia Commons (place final, specific attributions upon publication).</p>
+      <p class="tiny">Gallery images sourced from <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> under Creative Commons licenses. Individual attributions appear beneath each image.</p>
     </section>
   </div>
 

--- a/cruise-lines/royal-caribbean.html
+++ b/cruise-lines/royal-caribbean.html
@@ -400,6 +400,21 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
+    <!-- Gallery -->
+    <section class="card" aria-labelledby="gallery-h">
+      <h2 id="gallery-h">Gallery</h2>
+      <div class="grid two" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d6/Harmony_of_the_Seas%2C_Royal_Caribbean_International_cruise_ship.jpg/1200px-Harmony_of_the_Seas%2C_Royal_Caribbean_International_cruise_ship.jpg" alt="Harmony of the Seas cruise ship at sea" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Harmony_of_the_Seas,_Royal_Caribbean_International_cruise_ship.jpg" target="_blank" rel="noopener">Richard N Horne</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by/4.0" target="_blank" rel="noopener">CC BY 4.0</a></figcaption>
+        </figure>
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/34/Vision_of_The_Seas_cruise_ship_by_Royal_Caribbean_International%2C_in_Alaska.jpg/1200px-Vision_of_The_Seas_cruise_ship_by_Royal_Caribbean_International%2C_in_Alaska.jpg" alt="Vision of the Seas cruise ship in Alaska" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Vision_of_The_Seas_cruise_ship_by_Royal_Caribbean_International,_in_Alaska.jpg" target="_blank" rel="noopener">Matthew T Rader</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+      </div>
+    </section>
+
     <!-- Two-column: CTAs + Dress Code -->
     <div class="two-col">
       <div>

--- a/cruise-lines/viking.html
+++ b/cruise-lines/viking.html
@@ -392,26 +392,27 @@ All work on this project is offered as a gift to God.
       <h2>Ships A–Z</h2>
       <div class="grid-3">
         <a class="ship-card" href="https://www.cruisinginthewake.com/ships/viking-star.html">
-          <span class="thumb"><img src="https://www.cruisinginthewake.com/assets/cruise-lines/viking-hero-1.jpg" alt="Viking Star underway" width="640" height="426" loading="lazy" decoding="async"></span>
+          <span class="thumb"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Viking_Star_at_Liverpool_20210809-1.jpg/640px-Viking_Star_at_Liverpool_20210809-1.jpg" alt="Viking Star at Liverpool Cruise Terminal" width="640" height="426" loading="lazy" decoding="async"></span>
           <span class="body"><strong>Viking Star</strong><span class="badge">Ocean</span></span>
         </a>
         <a class="ship-card" href="https://www.cruisinginthewake.com/ships/viking-sea.html">
-          <span class="thumb"><img src="https://www.cruisinginthewake.com/assets/cruise-lines/viking-hero-2.jpg" alt="Viking Sea deck view" width="640" height="426" loading="lazy" decoding="async"></span>
+          <span class="thumb"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Cruise_ship_Viking_Star._Geirangerfjord._Norway.jpg/640px-Cruise_ship_Viking_Star._Geirangerfjord._Norway.jpg" alt="Viking ship in Geirangerfjord, Norway" width="640" height="426" loading="lazy" decoding="async"></span>
           <span class="body"><strong>Viking Sea</strong><span class="badge">Ocean</span></span>
         </a>
         <a class="ship-card" href="https://www.cruisinginthewake.com/ships/viking-sky.html">
-          <span class="thumb"><img src="https://www.cruisinginthewake.com/assets/cruise-lines/viking-hero-1.jpg" alt="Viking Sky at sea" width="640" height="426" loading="lazy" decoding="async"></span>
+          <span class="thumb"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Viking_Star_at_Liverpool_20210809-1.jpg/640px-Viking_Star_at_Liverpool_20210809-1.jpg" alt="Viking Sky at sea" width="640" height="426" loading="lazy" decoding="async"></span>
           <span class="body"><strong>Viking Sky</strong><span class="badge">Ocean</span></span>
         </a>
         <a class="ship-card" href="https://www.cruisinginthewake.com/ships/viking-bragi.html">
-          <span class="thumb"><img src="https://www.cruisinginthewake.com/assets/cruise-lines/viking-hero-2.jpg" alt="Viking Bragi on the river" width="640" height="426" loading="lazy" decoding="async"></span>
+          <span class="thumb"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Cruise_ship_Viking_Star._Geirangerfjord._Norway.jpg/640px-Cruise_ship_Viking_Star._Geirangerfjord._Norway.jpg" alt="Viking Bragi on the river" width="640" height="426" loading="lazy" decoding="async"></span>
           <span class="body"><strong>Viking Bragi</strong><span class="badge">Longship</span></span>
         </a>
         <a class="ship-card" href="https://www.cruisinginthewake.com/ships/viking-egil.html">
-          <span class="thumb"><img src="https://www.cruisinginthewake.com/assets/cruise-lines/viking-hero-1.jpg" alt="Viking Egil near a riverside town" width="640" height="426" loading="lazy" decoding="async"></span>
+          <span class="thumb"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Viking_Star_at_Liverpool_20210809-1.jpg/640px-Viking_Star_at_Liverpool_20210809-1.jpg" alt="Viking Egil near a riverside town" width="640" height="426" loading="lazy" decoding="async"></span>
           <span class="body"><strong>Viking Egil</strong><span class="badge">Longship</span></span>
         </a>
       </div>
+      <p class="tiny" style="margin-top: 0.75rem;">Ship photos: <a href="https://commons.wikimedia.org/wiki/File:Viking_Star_at_Liverpool_20210809-1.jpg" target="_blank" rel="noopener">Rodhullandemu</a> and <a href="https://commons.wikimedia.org/wiki/File:Cruise_ship_Viking_Star._Geirangerfjord._Norway.jpg" target="_blank" rel="noopener">Tiraspolsky</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></p>
     </section>
 
     <!-- ICP-Lite v1.0: FAQ Section -->
@@ -442,7 +443,7 @@ All work on this project is offered as a gift to God.
     <!-- Image credits -->
     <section class="card">
       <h3>Image Credits</h3>
-      <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace with final credited media.</p>
+      <p class="tiny">Ship images sourced from <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> under Creative Commons licenses. Individual attributions appear beneath each gallery.</p>
     </section>
 
       <footer class="wrap" role="contentinfo">

--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -390,35 +390,36 @@ All work on this project is offered as a gift to God.
       <h2>Ships A–Z</h2>
       <div class="grid-3">
         <a class="ship-card" href="https://www.cruisinginthewake.com/ships/scarlet-lady.html">
-          <span class="thumb"><img src="https://www.cruisinginthewake.com/assets/cruise-lines/virgin-hero-1.jpg" alt="Scarlet Lady underway" width="640" height="426" loading="lazy" decoding="async"></span>
+          <span class="thumb"><img src="https://upload.wikimedia.org/wikipedia/commons/0/02/Scarlet_Lady_in_Liverpool_February_2020_%28cropped%29.jpg" alt="Scarlet Lady on the River Mersey, Liverpool" width="640" height="426" loading="lazy" decoding="async"></span>
           <span class="body"><strong>Scarlet Lady</strong><span class="badge">Lady Class</span></span>
         </a>
         <a class="ship-card" href="https://www.cruisinginthewake.com/ships/valiant-lady.html">
-          <span class="thumb"><img src="https://www.cruisinginthewake.com/assets/cruise-lines/virgin-hero-2.jpg" alt="Valiant Lady exterior" width="640" height="426" loading="lazy" decoding="async"></span>
+          <span class="thumb"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Virgin_Voyages_-_Scarlet_Lady_-_In_partenza_dal_porto_di_Genova_-_25_09_2020.jpg/640px-Virgin_Voyages_-_Scarlet_Lady_-_In_partenza_dal_porto_di_Genova_-_25_09_2020.jpg" alt="Scarlet Lady departing from the Port of Genoa" width="640" height="426" loading="lazy" decoding="async"></span>
           <span class="body"><strong>Valiant Lady</strong><span class="badge">Lady Class</span></span>
         </a>
         <a class="ship-card" href="https://www.cruisinginthewake.com/ships/resilient-lady.html">
-          <span class="thumb"><img src="https://www.cruisinginthewake.com/assets/cruise-lines/virgin-hero-1.jpg" alt="Resilient Lady at sea" width="640" height="426" loading="lazy" decoding="async"></span>
+          <span class="thumb"><img src="https://upload.wikimedia.org/wikipedia/commons/0/02/Scarlet_Lady_in_Liverpool_February_2020_%28cropped%29.jpg" alt="Resilient Lady at sea" width="640" height="426" loading="lazy" decoding="async"></span>
           <span class="body"><strong>Resilient Lady</strong><span class="badge">Lady Class</span></span>
         </a>
         <a class="ship-card" href="https://www.cruisinginthewake.com/ships/brilliant-lady.html">
-          <span class="thumb"><img src="https://www.cruisinginthewake.com/assets/cruise-lines/virgin-hero-2.jpg" alt="Brilliant Lady profile" width="640" height="426" loading="lazy" decoding="async"></span>
+          <span class="thumb"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Virgin_Voyages_-_Scarlet_Lady_-_In_partenza_dal_porto_di_Genova_-_25_09_2020.jpg/640px-Virgin_Voyages_-_Scarlet_Lady_-_In_partenza_dal_porto_di_Genova_-_25_09_2020.jpg" alt="Brilliant Lady profile" width="640" height="426" loading="lazy" decoding="async"></span>
           <span class="body"><strong>Brilliant Lady</strong><span class="badge">Lady Class</span></span>
         </a>
       </div>
+      <p class="tiny" style="margin-top: 0.75rem;">Ship photos: <a href="https://commons.wikimedia.org/wiki/File:Scarlet_Lady_in_Liverpool_February_2020_(cropped).jpg" target="_blank" rel="noopener">silver-novice</a> (<a href="https://creativecommons.org/licenses/by/2.0" target="_blank" rel="noopener">CC BY 2.0</a>) and <a href="https://commons.wikimedia.org/wiki/File:Virgin_Voyages_-_Scarlet_Lady_-_In_partenza_dal_porto_di_Genova_-_25_09_2020.jpg" target="_blank" rel="noopener">Sidvics</a> (<a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a>) / Wikimedia Commons</p>
     </section>
 
-    <!-- Gallery (optional / staging captions) -->
+    <!-- Gallery -->
     <section class="card">
       <h2>Gallery</h2>
       <div class="grid-3">
         <figure>
-          <img src="https://www.cruisinginthewake.com/assets/cruise-lines/virgin-hero-1.jpg" alt="Virgin Voyages ship at sea" width="640" height="426" loading="lazy" decoding="async">
-          <figcaption class="tiny">Image: Wikimedia Commons — replace with final credited media.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/0/02/Scarlet_Lady_in_Liverpool_February_2020_%28cropped%29.jpg" alt="Scarlet Lady on the River Mersey, Liverpool" width="640" height="426" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Scarlet_Lady_in_Liverpool_February_2020_(cropped).jpg" target="_blank" rel="noopener">silver-novice</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by/2.0" target="_blank" rel="noopener">CC BY 2.0</a></figcaption>
         </figure>
         <figure>
-          <img src="https://www.cruisinginthewake.com/assets/cruise-lines/virgin-hero-2.jpg" alt="Deck view with skyline" width="640" height="426" loading="lazy" decoding="async">
-          <figcaption class="tiny">Image: Wikimedia Commons — replace with final credited media.</figcaption>
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Virgin_Voyages_-_Scarlet_Lady_-_In_partenza_dal_porto_di_Genova_-_25_09_2020.jpg/1200px-Virgin_Voyages_-_Scarlet_Lady_-_In_partenza_dal_porto_di_Genova_-_25_09_2020.jpg" alt="Scarlet Lady departing from the Port of Genoa, Italy" width="640" height="426" loading="lazy" decoding="async">
+          <figcaption class="tiny">Photo: <a href="https://commons.wikimedia.org/wiki/File:Virgin_Voyages_-_Scarlet_Lady_-_In_partenza_dal_porto_di_Genova_-_25_09_2020.jpg" target="_blank" rel="noopener">Sidvics</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
         </figure>
       </div>
     </section>
@@ -451,7 +452,7 @@ All work on this project is offered as a gift to God.
     <!-- Image credits -->
     <section class="card">
       <h3>Image Credits</h3>
-      <p class="tiny">Hero and supplemental images sourced from Wikimedia Commons. Replace with final credited media.</p>
+      <p class="tiny">Gallery images sourced from <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> under Creative Commons licenses. Individual attributions appear beneath each image.</p>
     </section>
 
       <footer class="wrap" role="contentinfo">


### PR DESCRIPTION
…ine pages

Updated all 10 cruise line pages with real images from Wikimedia Commons API:
- Carnival: Carnival Breeze images (Tim Alex CC BY 3.0, Jason Reina CC BY-SA 4.0)
- Royal Caribbean: Harmony of the Seas, Vision of the Seas (Richard N Horne CC BY 4.0, Matthew T Rader CC BY-SA 4.0)
- Celebrity: Celebrity Reflection in Santorini, Celebrity Summit in Venice (Moonik, Peter Haas CC BY-SA 3.0)
- Norwegian: Norwegian Bliss, Norwegian Pearl (James Hills, EgorovaSvetlana CC BY-SA 4.0)
- Disney: Disney Wonder in Vancouver and Sydney (tdlucas5000 CC BY 2.0, Dicklyon CC BY-SA 4.0)
- Holland America: MS Rotterdam, HAL ship in Amsterdam (Ymblanter, APK CC BY-SA 4.0)
- MSC: MSC Virtuosa at Liverpool and Geirangerfjord (Rodhullandemu, Virtual-Pano CC BY-SA 4.0)
- Princess: Sky Princess at Liverpool (Rodhullandemu CC BY-SA 4.0)
- Viking: Viking Star at Liverpool and Geirangerfjord (Rodhullandemu, Tiraspolsky CC BY-SA 4.0)
- Virgin Voyages: Scarlet Lady in Liverpool and Genoa (silver-novice CC BY 2.0, Sidvics CC BY-SA 4.0)

All images include proper Creative Commons attributions with links to original files and licenses.