### PR TITLE
FIX: Change ship schema from Product to Thing on ships.html

### DIFF
--- a/ships.html
+++ b/ships.html
@@ -187,7 +187,7 @@
         "@type": "ListItem",
         "position": 1,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/icon-of-the-seas.html",
           "name": "Icon of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/icon-of-the-seas.html",
@@ -199,7 +199,7 @@
         "@type": "ListItem",
         "position": 2,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/star-of-the-seas.html",
           "name": "Star of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/star-of-the-seas.html",
@@ -211,7 +211,7 @@
         "@type": "ListItem",
         "position": 3,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/utopia-of-the-seas.html",
           "name": "Utopia of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/utopia-of-the-seas.html",
@@ -223,7 +223,7 @@
         "@type": "ListItem",
         "position": 4,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/wonder-of-the-seas.html",
           "name": "Wonder of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/wonder-of-the-seas.html",
@@ -235,7 +235,7 @@
         "@type": "ListItem",
         "position": 5,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/symphony-of-the-seas.html",
           "name": "Symphony of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/symphony-of-the-seas.html",
@@ -247,7 +247,7 @@
         "@type": "ListItem",
         "position": 6,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/harmony-of-the-seas.html",
           "name": "Harmony of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/harmony-of-the-seas.html",
@@ -259,7 +259,7 @@
         "@type": "ListItem",
         "position": 7,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/allure-of-the-seas.html",
           "name": "Allure of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/allure-of-the-seas.html",
@@ -271,7 +271,7 @@
         "@type": "ListItem",
         "position": 8,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/oasis-of-the-seas.html",
           "name": "Oasis of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/oasis-of-the-seas.html",
@@ -283,7 +283,7 @@
         "@type": "ListItem",
         "position": 9,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/odyssey-of-the-seas.html",
           "name": "Odyssey of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/odyssey-of-the-seas.html",
@@ -295,7 +295,7 @@
         "@type": "ListItem",
         "position": 10,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/spectrum-of-the-seas.html",
           "name": "Spectrum of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/spectrum-of-the-seas.html",
@@ -307,7 +307,7 @@
         "@type": "ListItem",
         "position": 11,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/ovation-of-the-seas.html",
           "name": "Ovation of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/ovation-of-the-seas.html",
@@ -319,7 +319,7 @@
         "@type": "ListItem",
         "position": 12,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/anthem-of-the-seas.html",
           "name": "Anthem of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/anthem-of-the-seas.html",
@@ -331,7 +331,7 @@
         "@type": "ListItem",
         "position": 13,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/quantum-of-the-seas.html",
           "name": "Quantum of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/quantum-of-the-seas.html",
@@ -343,7 +343,7 @@
         "@type": "ListItem",
         "position": 14,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/freedom-of-the-seas.html",
           "name": "Freedom of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/freedom-of-the-seas.html",
@@ -355,7 +355,7 @@
         "@type": "ListItem",
         "position": 15,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/liberty-of-the-seas.html",
           "name": "Liberty of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/liberty-of-the-seas.html",
@@ -367,7 +367,7 @@
         "@type": "ListItem",
         "position": 16,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/independence-of-the-seas.html",
           "name": "Independence of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/independence-of-the-seas.html",
@@ -379,7 +379,7 @@
         "@type": "ListItem",
         "position": 17,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/mariner-of-the-seas.html",
           "name": "Mariner of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/mariner-of-the-seas.html",
@@ -391,7 +391,7 @@
         "@type": "ListItem",
         "position": 18,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/navigator-of-the-seas.html",
           "name": "Navigator of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/navigator-of-the-seas.html",
@@ -403,7 +403,7 @@
         "@type": "ListItem",
         "position": 19,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/explorer-of-the-seas.html",
           "name": "Explorer of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/explorer-of-the-seas.html",
@@ -415,7 +415,7 @@
         "@type": "ListItem",
         "position": 20,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/adventure-of-the-seas.html",
           "name": "Adventure of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/adventure-of-the-seas.html",
@@ -427,7 +427,7 @@
         "@type": "ListItem",
         "position": 21,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/voyager-of-the-seas.html",
           "name": "Voyager of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/voyager-of-the-seas.html",
@@ -439,7 +439,7 @@
         "@type": "ListItem",
         "position": 22,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/brilliance-of-the-seas.html",
           "name": "Brilliance of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/brilliance-of-the-seas.html",
@@ -451,7 +451,7 @@
         "@type": "ListItem",
         "position": 23,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/serenade-of-the-seas.html",
           "name": "Serenade of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/serenade-of-the-seas.html",
@@ -463,7 +463,7 @@
         "@type": "ListItem",
         "position": 24,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/jewel-of-the-seas.html",
           "name": "Jewel of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/jewel-of-the-seas.html",
@@ -475,7 +475,7 @@
         "@type": "ListItem",
         "position": 25,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/radiance-of-the-seas.html",
           "name": "Radiance of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/radiance-of-the-seas.html",
@@ -487,7 +487,7 @@
         "@type": "ListItem",
         "position": 26,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/vision-of-the-seas.html",
           "name": "Vision of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/vision-of-the-seas.html",
@@ -499,7 +499,7 @@
         "@type": "ListItem",
         "position": 27,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/enchantment-of-the-seas.html",
           "name": "Enchantment of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/enchantment-of-the-seas.html",
@@ -511,7 +511,7 @@
         "@type": "ListItem",
         "position": 28,
         "item": {
-          "@type": "Product",
+          "@type": "Thing",
           "@id": "https://cruisinginthewake.com/ships/rcl/grandeur-of-the-seas.html",
           "name": "Grandeur of the Seas",
           "url": "https://cruisinginthewake.com/ships/rcl/grandeur-of-the-seas.html",


### PR DESCRIPTION
Google Search Console reported 28 invalid Product items because Product schema requires offers/review/aggregateRating fields. Ships aren't products for sale, so changed to generic Thing type.

Fixes: "Either 'offers', 'review', or 'aggregateRating' should be specified"