### PR TITLE
Fix AI-breadcrumbs to comply with specification

### DIFF
--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -10,19 +10,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 <html lang="en" class="no-js">
 <head>
 <!-- ai-breadcrumbs
-entity: Ship
-name: Radiance of the Seas
-class: Radiance Class
-operator: Royal Caribbean
-parent: /ships.html
-siblings: Brilliance of the Seas, Serenade of the Seas, Jewel of the Seas
-related: /ships.html, /cruise-lines/royal-caribbean.html, /ports.html, /drink-calculator.html
-subject: Radiance of the Seas is a Radiance-class Royal Caribbean ship offering deck plans, live ship tracking, dining venue details, and video tours to help cruisers plan their voyage
-intended-reader: Cruisers researching Radiance of the Seas or comparing Royal Caribbean ships
-core-facts: launched 2001; 90,090 GT; about 2,466 guests at double occupancy; glass-wall design emphasizing ocean views, global itineraries
-decisions-informed: whether Radiance of the Seas's size, layout, and vibe fit your travel style; how it compares to sister ships; whether its itineraries align with your plans
-updated: 2025-11-18
--->
+     entity: Radiance of the Seas
+     type: Ship Information Page
+     parent: /ships.html
+     category: Royal Caribbean Fleet
+     cruise-line: Royal Caribbean
+     ship-class: Radiance Class
+     siblings: Brilliance of the Seas, Serenade of the Seas, Jewel of the Seas
+     related: /ships.html, /cruise-lines/royal-caribbean.html, /ports.html, /drink-calculator.html
+     updated: 2025-11-18
+     expertise: Royal Caribbean ship reviews, deck plans, dining analysis, cabin comparisons
+     target-audience: Cruisers researching Radiance of the Seas or comparing Royal Caribbean ships
+     answer-first: Radiance of the Seas is a Radiance Class ship (90,090 GT, 2,466 guests, launched 2001) featuring glass-wall design emphasizing ocean views, with deck plans, live tracking, dining venues, and video tours.
+     -->
   <!-- ======================================================
        In the Wake — Radiance of the Seas • Royal Caribbean
        Version: 3.010.300  |  Soli Deo Gloria ✝️


### PR DESCRIPTION
- Change entity from generic "Ship" to proper name "Radiance of the Seas"
- Add required `type` field: "Ship Information Page"
- Add required `category` field: "Royal Caribbean Fleet"
- Add recommended fields: cruise-line, expertise, answer-first
- Rename intended-reader to target-audience per spec
- Consolidate subject/core-facts/decisions-informed into answer-first
- Standardize indentation to 5 spaces per spec guidelines