### PR TITLE
Fix hero image root cause: use webp instead of jpg in styles.css

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -30,7 +30,7 @@ img{max-width:100%;height:auto;display:block}
   width:100vw;
   margin-left:calc(50% - 50vw);
   min-height:clamp(200px,24vw,340px);
-  background:url('/assets/index_hero.jpg') 50% 50% / cover no-repeat;
+  background:url('/assets/index_hero.webp') 50% 50% / cover no-repeat;
   display:flex;align-items:flex-end;overflow:hidden;isolation:isolate;
 }
 
@@ -312,7 +312,7 @@ img{max-width:100%;height:auto;display:block}
 .pill-nav.pills a:hover{background:#f9fdfd;text-decoration:none}
 
 /* Hero */
-.hero{position:relative;width:100vw;margin-left:calc(50% - 50vw);min-height:clamp(200px,24vw,340px);background:url('/assets/index_hero.jpg') 50% 50% / cover no-repeat;display:flex;align-items:flex-end;overflow:hidden;isolation:isolate}
+.hero{position:relative;width:100vw;margin-left:calc(50% - 50vw);min-height:clamp(200px,24vw,340px);background:url('/assets/index_hero.webp') 50% 50% / cover no-repeat;display:flex;align-items:flex-end;overflow:hidden;isolation:isolate}
 body.no-hero-filter .hero,.hero-header .hero,.hero-header .hero *{filter:none!important;mix-blend-mode:normal!important;opacity:1!important}
 .hero::before,.hero::after{content:none!important}
 .latlon-grid{position:absolute;inset:0;z-index:1;pointer-events:none}

--- a/solo.html
+++ b/solo.html
@@ -309,28 +309,6 @@
     }
   </style>
 
-  <!-- Header hero - NO FILTERS -->
-  <style>
-    /* Force full vibrance on hero - no desaturation */
-    .hero-header,
-    .hero-header .hero,
-    .hero-header .hero *,
-    header.hero-header,
-    header .hero,
-    .hero {
-      filter: none !important;
-      -webkit-filter: none !important;
-      mix-blend-mode: normal !important;
-      opacity: 1 !important;
-    }
-    .hero {
-      background: url('/assets/index_hero.webp?v=3.010.300') center/cover no-repeat !important;
-      min-height: 320px;
-    }
-    .hero::before, .hero::after { content: none !important; display: none !important; }
-    html, body { overflow-x: hidden; }
-  </style>
-
   <!-- Two-column layout (sticky rail at ≥980px) -->
   <style id="solo-two-col-layout">
     /* Page scoping avoids surprises from the global bundle */


### PR DESCRIPTION
The global styles.css was referencing index_hero.jpg which has different color characteristics than the webp version. Changed both .hero-header > .hero and .hero selectors to use webp.

Removed inline CSS overrides from solo.html since the root cause is now fixed in the global stylesheet.