### PR TITLE
Fix hero image pixelation in Tina's solo cruising article

### DIFF
--- a/solo/articles/why-i-started-solo-cruising.html
+++ b/solo/articles/why-i-started-solo-cruising.html
@@ -7,7 +7,7 @@
     <picture>
       <source
         type="image/webp"
-        srcset="/assets/articles/thumbs/why-i-started-solo-cruising.webp?v=3.008.014"
+        srcset="/assets/articles/why-i-started-solo-cruising.webp?v=3.008.014"
         sizes="(min-width:980px) 860px, 92vw">
       <img
         src="/assets/articles/why-i-started-solo-cruising.webp?v=3.008.014"


### PR DESCRIPTION
Changed source srcset from thumbnail path to full-size image path to prevent stretching small thumbnail to hero dimensions.