### PR TITLE
Fix hero image: use .jpg instead of .webp for vibrant colors

### DIFF
--- a/disability-at-sea.html
+++ b/disability-at-sea.html
@@ -62,7 +62,7 @@ ADDENDUM: Facebook Domain Verification v3.008.021
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.100"/>
 
   <!-- Preload Hero -->
-  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.100" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/index_hero.jpg?v=3.010.100" fetchpriority="high"/>
 
   <!-- Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
@@ -489,7 +489,7 @@ ADDENDUM: Facebook Domain Verification v3.008.021
       host.innerHTML = view.map(a=>{
         const title = pick(a,['title','headline'],'Article');
         const href  = pick(a,['url','permalink','path'],'#');
-        const img   = pick(a,['image','cover','thumb'], '/assets/index_hero.webp?v=3.010.100');
+        const img   = pick(a,['image','cover','thumb'], '/assets/index_hero.jpg?v=3.010.100');
         return `
           <a class="card" style="display:grid;grid-template-columns:72px 1fr;gap:.6rem;align-items:center" href="${href}">
             <div style="width:72px;height:48px;overflow:hidden;border-radius:10px;background:#eef4f6;border:1px solid #dfe7ea">
@@ -624,7 +624,7 @@ ADDENDUM: Facebook Domain Verification v3.008.021
           const base = primary.replace(/\.(jpg|jpeg|png|webp)$/i,'');
           alts.push(base + '.jpeg', base + '.JPG', base + '.webp', base + '.png');
         }
-        setImageWithFallback(el, primary || '/assets/index_hero.webp', alts);
+        setImageWithFallback(el, primary || '/assets/index_hero.jpg', alts);
       });
 
       if(fallback) fallback.style.display = 'none';

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
   <!-- Performance: DNS Prefetch & Preconnect -->
   <link rel="dns-prefetch" href="https://www.flickersofmajesty.com"/>
   <link rel="preconnect" href="https://cruisinginthewake.com"/>
-  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.400" imagesrcset="/assets/index_hero.webp?v=3.010.400" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/index_hero.jpg" imagesrcset="/assets/index_hero.jpg" fetchpriority="high"/>
 
   <!-- Styles -->
   <!-- Service Worker Registration -->
@@ -554,7 +554,7 @@
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
             <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -718,7 +718,7 @@
           const base = primary.replace(/\.(jpg|jpeg|png|webp)$/i,'');
           alts.push(`${base}.jpeg`, `${base}.JPG`, `${base}.webp`, `${base}.png`);
         }
-        setImageWithFallback(el, primary || '/assets/index_hero.webp', alts);
+        setImageWithFallback(el, primary || '/assets/index_hero.jpg', alts);
       });
 
       if(fallback) fallback.style.display = 'none';

--- a/ships.html
+++ b/ships.html
@@ -672,7 +672,7 @@
   <link rel="stylesheet" href="/assets/css/item-cards.css?v=1.0.0">
 
   <!-- LCP preload -->
-  <link rel="preload" as="image" href="https://cruisinginthewake.com/assets/index_hero.webp?v=3.010.300" fetchpriority="high">
+  <link rel="preload" as="image" href="https://cruisinginthewake.com/assets/index_hero.jpg?v=3.010.300" fetchpriority="high">
 
   <!-- Page-local styles (tiny, standards-safe) -->
   </head>
@@ -1195,7 +1195,7 @@
         title:'Freedom of Your Own Wake',
         date:'2025-10-17',
         dek:'On choosing solitude without being alone.',
-        image:'/assets/index_hero.webp?v='+V,
+        image:'/assets/index_hero.jpg?v='+V,
         author:{name:'Ken Baker',url:'/authors/ken-baker.html',image:'/authors/img/ken1.webp?v='+V}
       },
       {
@@ -1212,7 +1212,7 @@
         date:'2025-10-16',
         dek:'A first-person guide to planning, packing, ports, and ship life.',
         image:'/assets/articles/thumbs/top-20-questions/cover.webp?v='+V,
-        fallback:'/assets/index_hero.webp?v='+V,
+        fallback:'/assets/index_hero.jpg?v='+V,
         author:{name:'Ken Baker',url:'/authors/ken-baker.html',image:'/authors/img/ken1.webp?v='+V}
       }
     ];
@@ -1476,7 +1476,7 @@
           const base = primary.replace(/\.(jpg|jpeg|png|webp)$/i,'');
           alts.push(`\${base}.jpeg`, `\${base}.JPG`, `\${base}.webp`, `\${base}.png`);
         }
-        setImageWithFallback(el, primary || '/assets/index_hero.webp', alts);
+        setImageWithFallback(el, primary || '/assets/index_hero.jpg', alts);
       });
 
       if(fallback) fallback.style.display = 'none';

--- a/travel.html
+++ b/travel.html
@@ -282,7 +282,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
 
   <!-- Preload LCP image (hero) -->
-  <link rel="preload" as="image" href="/assets/index_hero.webp?v=3.010.300" imagesrcset="/assets/index_hero.webp?v=3.010.300" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/index_hero.jpg?v=3.010.300" imagesrcset="/assets/index_hero.jpg?v=3.010.300" fetchpriority="high"/>
 
   <!-- Page CSS (layout, rails, and NAV FIXES) -->
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
@@ -1217,7 +1217,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
           const base = primary.replace(/\.(jpg|jpeg|png|webp)$/i,'');
           alts.push(base + '.jpeg', base + '.JPG', base + '.webp', base + '.png');
         }
-        setImageWithFallback(el, primary || '/assets/index_hero.webp', alts);
+        setImageWithFallback(el, primary || '/assets/index_hero.jpg', alts);
       });
 
       if(fallback) fallback.style.display = 'none';


### PR DESCRIPTION
- Fixed preload in index.html from .webp to .jpg
- Fixed JavaScript fallback in index.html
- Removed inline border-radius override on author avatar
- Fixed preloads in disability-at-sea.html, ships.html, travel.html

The .webp version is overly compressed causing muted colors. The .jpg version preserves vibrant colors in the hero section.