### PR TITLE
Fix quantum-of-the-seas.html layout: reorder main content before aside

### DIFF
--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -363,62 +363,9 @@ STANDARDS: Every Page v3.010.302 · Production Template · Unified Nav v3.010.30
 
   <!-- MAIN CONTENT -->
   <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
-  <!-- Right Rail -->
-    <aside class="rail col-2" role="complementary" aria-label="Key facts, author & articles">
-      <!-- Quick Answer / Best For / Key Facts -->
-      <section class="page-intro mb-1">
-        <p class="answer-line">
-          <strong>Quick Answer:</strong> Quantum of the Seas is a Royal Caribbean ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
-        </p>
 
-        <p class="content-text">
-          <strong>Best For:</strong> Cruisers researching Quantum of the Seas or comparing Royal Caribbean ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
-        </p>
-
-        <div class="callout-box">
-          <h3 class="mt-0 mb-05">Key Facts</h3>
-          <ul class="list-indent">
-            <li><strong>Cruise Line:</strong> Royal Caribbean</li>
-            <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-            <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
-          </ul>
-        </div>
-      </section>
-
-      <!-- Author card (Vertical Layout) -->
-      <section class="card author-card-vertical" aria-labelledby="author-heading">
-        <h3 id="author-heading">About the Author</h3>
-        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
-          <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.302" type="image/webp"/>
-            <img class="author-avatar rounded-lg" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
-          </picture>
-        </a>
-        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
-        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
-        <p class="tiny">
-          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
-        </p>
-      </section>
-
-      <!-- Recent Articles rail -->
-      <section class="card" aria-labelledby="recent-rail-title">
-        <h3 id="recent-rail-title">Recent Stories</h3>
-        <p class="tiny content-text">
-          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
-        </p>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
-        <p id="recent-rail-fallback" class="tiny hidden">Loading articles…</p>
-      </section>
-
-    <!-- Whimsical Distance Units -->
-    <section class="card" id="whimsical-units-container">
-    </section>
-
-  </aside>
-
-    <!-- Main Content Column -->
-    <div class="col-1">
+    <!-- Main Content Column (LEFT) -->
+    <section class="col-1" aria-label="Ship details">
       <h1>Quantum of the Seas — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
       <p class="content-text">
@@ -655,7 +602,60 @@ STANDARDS: Every Page v3.010.302 · Production Template · Unified Nav v3.010.30
       </ul>
     </section>
 
-    </div><!-- Close main content column -->
+    </section><!-- Close main content column -->
+
+    <!-- Right Rail -->
+    <aside class="rail col-2" role="complementary" aria-label="Key facts, author & articles">
+      <!-- Quick Answer / Best For / Key Facts -->
+      <section class="page-intro mb-1">
+        <p class="answer-line">
+          <strong>Quick Answer:</strong> Quantum of the Seas is a Royal Caribbean ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        </p>
+
+        <p class="content-text">
+          <strong>Best For:</strong> Cruisers researching Quantum of the Seas or comparing Royal Caribbean ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        </p>
+
+        <div class="callout-box">
+          <h3 class="mt-0 mb-05">Key Facts</h3>
+          <ul class="list-indent">
+            <li><strong>Cruise Line:</strong> Royal Caribbean</li>
+            <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
+            <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- Author card (Vertical Layout) -->
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.302" type="image/webp"/>
+            <img class="author-avatar rounded-lg" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <!-- Recent Articles rail -->
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny content-text">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community. Explore stories that inform, inspire, and connect.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny hidden">Loading articles…</p>
+      </section>
+
+      <!-- Whimsical Distance Units -->
+      <section class="card" id="whimsical-units-container">
+      </section>
+    </aside>
 
 </main>
 


### PR DESCRIPTION
The page had the aside (rail) placed BEFORE the main content in source order, which broke the CSS Grid layout causing:
- Content not starting at top
- Extra lines appearing in wrong grid squares

Fixed by restructuring to match working pages pattern:
1. Main content section (.col-1) comes FIRST in source
2. Aside rail (.col-2) comes SECOND in source

This is the standard pattern used in ships.html, travel.html, etc.