### PR TITLE
Fix dropdown menus on mdr.html by adding missing dropdown.js script

### DIFF
--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -638,7 +638,7 @@ All work on this project is offered as a gift to God.
 </script>
 
   <!-- JAVASCRIPT -->
-  
+  <script src="/assets/js/dropdown.js"></script>
 <script>
   (function(){
     "use strict";


### PR DESCRIPTION
The navigation dropdown menus weren't working because the page was missing the script tag to load /assets/js/dropdown.js.