### PR TITLE
Add video swiper carousel styling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -400,6 +400,56 @@ a:focus, button:focus, [tabindex="0"]:focus {
 .swiper-fallback .swiper .swiper-button-next,
 .swiper-fallback .swiper .swiper-pagination { display: none !important; }
 
+/* ===== Video Carousel (Swiper) ===== */
+.swiper.videos {
+  aspect-ratio: 16/9;
+  height: auto;
+  min-height: 280px;
+  max-height: 450px;
+  position: relative;
+  overflow: hidden;
+  max-width: 100%;
+  width: 100%;
+  border-radius: 10px;
+  background: #1a1a1a;
+}
+.swiper.videos .swiper-wrapper {
+  height: 100% !important;
+  min-height: inherit;
+}
+.swiper.videos .swiper-slide {
+  height: 100% !important;
+  min-height: inherit;
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.swiper.videos iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 10px;
+}
+.swiper.videos .swiper-pagination {
+  bottom: 10px;
+}
+.swiper.videos .swiper-pagination-bullet {
+  background: rgba(255, 255, 255, 0.6);
+  opacity: 1;
+}
+.swiper.videos .swiper-pagination-bullet-active {
+  background: #fff;
+}
+.swiper.videos .swiper-button-prev,
+.swiper.videos .swiper-button-next {
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(0,0,0,0.5);
+}
+
 /* ===== Article Heroes (non-carousel) ===== */
 figure.hero,
 .article-hero,


### PR DESCRIPTION
Adds CSS for .swiper.videos class to properly display video carousels across 51 ship pages. Includes aspect ratio, proper sizing, dark background, rounded corners, and styled pagination/navigation.