### PR TITLE
Make video swiper fill card container

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -404,8 +404,7 @@ a:focus, button:focus, [tabindex="0"]:focus {
 .swiper.videos {
   aspect-ratio: 16/9;
   height: auto;
-  min-height: 280px;
-  max-height: 450px;
+  min-height: 320px;
   position: relative;
   overflow: hidden;
   max-width: 100%;


### PR DESCRIPTION
Remove max-height constraint and increase min-height to 320px so video carousel fills the available card space while maintaining 16:9 aspect ratio.