### PR TITLE
Enhance Aruba port page with comprehensive guide content

### DIFF
--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -77,6 +77,22 @@ All work on this project is offered as a gift to God.
       },
       {
         "@type": "Question",
+        "name": "What's the cheapest way to get to the beaches?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The public Arubus L10A line runs every 20 minutes and costs just $5 round-trip to Eagle Beach, Palm Beach, or any beach on the northwest coast."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is there a beach I can walk to from the cruise ship?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes! Surfside Beach is about a 15-minute walk from the cruise port. Governor's Bay Beach is also walkable, just over the bridge from Wilhelmina Park."
+        }
+      },
+      {
+        "@type": "Question",
         "name": "What currency is used in Aruba?",
         "acceptedAnswer": {
           "@type": "Answer",
@@ -205,14 +221,50 @@ All work on this project is offered as a gift to God.
         </div>
 
         <section class="port-section">
+          <h3>The Cruise Port</h3>
+          <p>Aruba's cruise facility in Oranjestad has four berths with three modern, air-conditioned terminals. Inside you'll find information desks, gift shops, free WiFi, and coffee. The walk to Lloyd G. Smith Boulevard (the main waterfront street) takes 5–10 minutes depending on which pier you're at.</p>
+          <p><strong>Pro tip:</strong> A free trolley runs between the cruise port and downtown, making six stops along the way past museums and monuments. It's a great orientation ride if you're not in a rush.</p>
+        </section>
+
+        <section class="port-section">
           <h3>Getting Around Aruba</h3>
           <p>The cruise terminal is a 5-minute walk <span class="distance-fun">approximately 33 school buses, 16 blue whales end-to-end, or 352 emperor penguins stacked skyward</span> from downtown Oranjestad. From there:</p>
           <ul>
-            <li><strong>Eagle Beach:</strong> About $12–15 by taxi, or take the inexpensive public bus (Arubus Line 10).</li>
+            <li><strong>Free Trolley:</strong> Runs between the port and downtown with 6 stops — perfect for a quick orientation.</li>
+            <li><strong>Arubus (Public Bus):</strong> The L10A line runs every 20 minutes along the northwest coast, hitting Eagle Beach, Palm Beach, Malmok, and Arashi Beach. Just $5 round-trip to any beach — outstanding value.</li>
+            <li><strong>Taxis:</strong> Government-regulated rates (no meters). Downtown to Palm Beach runs about $11. Multi-person tours to the California Lighthouse and Casibari rock formations cost around $20 for a 2.5-hour loop.</li>
+            <li><strong>Eagle Beach:</strong> About $12–15 by taxi, or grab the L10A bus.</li>
             <li><strong>Palm Beach:</strong> Quick $10–12 taxi ride. Buses also run this route frequently.</li>
-            <li><strong>Baby Beach:</strong> 45-minute drive. Best with a rental car or organized tour — too far for a reasonable taxi fare.</li>
+            <li><strong>Baby Beach:</strong> 45-minute drive to the southern tip. Best with a rental car or organized tour.</li>
             <li><strong>Jeep Rentals:</strong> Popular option for exploring the rugged north coast and Natural Pool. Book in advance.</li>
           </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Beaches Near the Port</h3>
+          <p>If you don't want to taxi or bus, you've got options:</p>
+          <ul>
+            <li><strong>Surfside Beach:</strong> The closest beach to the cruise port — about a 15-minute walk. Turn right on Lloyd G. Smith Boulevard and keep going. Small but swimmable.</li>
+            <li><strong>Governor's Bay Beach:</strong> Just over the bridge from Wilhelmina Park. A quiet cove with calm, shallow water — perfect for a quick dip without the taxi fare.</li>
+            <li><strong>Arashi Beach:</strong> At the northwest tip near the California Lighthouse. Crystal-blue water, white sand, public palapas, and uncrowded vibes. Worth the bus ride.</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Beyond the Beach</h3>
+          <p>If you need a break from the sand (or the kids are restless), Aruba has surprises:</p>
+          <ul>
+            <li><strong>Archaeological Museum:</strong> Just 0.3 miles from the terminals. Surprisingly impressive for a small island — collections spanning 2500 BC to modern day. Free admission.</li>
+            <li><strong>Butterfly Farm:</strong> About 4 miles from port. Walk through a tropical garden while butterflies from around the world land on you. Kids love it.</li>
+            <li><strong>Donkey Sanctuary:</strong> Six miles out, a rescue haven where you can feed and pet friendly donkeys. Unexpectedly charming.</li>
+            <li><strong>Natural Bridge:</strong> A photogenic limestone arch about 7 miles from port, often combined with a hike through Arikok National Park.</li>
+            <li><strong>California Lighthouse:</strong> At the island's northwest tip. Great views and a nice spot to catch sunset if you're not doing a catamaran.</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Shopping in Oranjestad</h3>
+          <p>The <strong>Renaissance Marketplace</strong> right downtown is one of the Caribbean's best duty-free shopping destinations. Look for jewelry, perfumes, leather goods, designer fashion, Dutch Delft pottery, Gouda cheese, and Cuban cigars. The pedestrian-friendly main streets (Caya G.F. Betico Croes) are shaded and pleasant for wandering between purchases.</p>
         </section>
 
         <section class="port-section">
@@ -222,7 +274,8 @@ All work on this project is offered as a gift to God.
             <li><strong>Trade Winds:</strong> Nature's air conditioning! They keep the island comfortable but will give you epic beach hair.</li>
             <li><strong>Currency:</strong> Aruban Florin (AWG) is official, but USD is accepted literally everywhere. Credit cards widely accepted.</li>
             <li><strong>Language:</strong> Papiamento is the local language, but Dutch, English, and Spanish are all widely spoken. You'll have no communication issues.</li>
-            <li><strong>Safety:</strong> One of the safest islands in the Caribbean. Tourist areas are comfortable for walking, even at night.</li>
+            <li><strong>Safety:</strong> One of the safest islands in the Caribbean — one of the lowest crime rates in the region. Tourist areas are comfortable for walking, even at night.</li>
+            <li><strong>Climate:</strong> Aruba sits outside the hurricane belt, so weather is remarkably consistent year-round — around 81°F (27°C) with constant trade winds.</li>
             <li><strong>Sunscreen:</strong> The trade winds mask how intense the sun is. You will burn faster than you expect. Reapply constantly.</li>
             <li><strong>Flamingos:</strong> Yes, they're real, and yes, they hang out at Renaissance Island. Day passes available but pricey.</li>
           </ul>
@@ -240,8 +293,17 @@ All work on this project is offered as a gift to God.
           <p><strong>Q: Is Aruba safe for walking at night?</strong><br/>
           A: Absolutely! Aruba is one of the safest islands in the Caribbean. Oranjestad, Palm Beach, and Eagle Beach are all comfortable for evening strolls.</p>
 
+          <p><strong>Q: What's the cheapest way to get to the beaches?</strong><br/>
+          A: The public Arubus L10A line runs every 20 minutes and costs just $5 round-trip to Eagle Beach, Palm Beach, or any beach on the northwest coast. Hard to beat.</p>
+
+          <p><strong>Q: Is there a beach I can walk to from the ship?</strong><br/>
+          A: Yes! Surfside Beach is about a 15-minute walk from the cruise port. Governor's Bay Beach is also walkable, just over the bridge from Wilhelmina Park.</p>
+
           <p><strong>Q: Where can I find the best keshi yena?</strong><br/>
           A: The Old Cunucu House in the countryside serves the most authentic version of this stuffed-cheese national dish. It's a proper Aruban experience.</p>
+
+          <p><strong>Q: Will I get caught in a hurricane?</strong><br/>
+          A: Very unlikely! Aruba sits outside the Caribbean hurricane belt, which is why the weather is so consistently good year-round.</p>
         </section>
 
       


### PR DESCRIPTION
Added new sections:
- The Cruise Port (4 berths, 3 terminals, free trolley)
- Beaches Near the Port (Surfside, Governor's Bay walkable options)
- Beyond the Beach (museum, butterfly farm, donkey sanctuary, natural bridge)
- Shopping in Oranjestad (Renaissance Marketplace, duty-free)

Enhanced existing content:
- Getting Around with L10A bus details ($5 round-trip)
- Fixed taxi rates (government-regulated)
- Climate info (outside hurricane belt)
- 3 new FAQs with structured data schema

Sources: IQ Cruising, Cruise Hive, Visit Aruba, Cruise Critic