### PR TITLE
Fix port hero styling - add border, fix overlay structure

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1213,10 +1213,17 @@ figure.hero img + img,
   position: relative;
   margin-bottom: 1.5rem;
   border-radius: 12px;
+  border: 1px solid #e0f0f5;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.1);
+}
+
+.port-hero-image {
+  position: relative;
+  border-radius: 12px;
   overflow: hidden;
 }
 
-.port-hero img {
+.port-hero-image img {
   width: 100%;
   height: 300px;
   object-fit: cover;
@@ -1232,7 +1239,8 @@ figure.hero img + img,
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(to top, rgba(0,0,0,0.4) 0%, transparent 60%);
+  background: linear-gradient(to top, rgba(0,0,0,0.5) 0%, rgba(0,0,0,0.2) 40%, transparent 70%);
+  pointer-events: none;
 }
 
 .port-hero-title {
@@ -1240,12 +1248,21 @@ figure.hero img + img,
   font-size: clamp(2.5rem, 8vw, 5rem);
   font-weight: 700;
   color: #fff;
-  text-shadow: 2px 2px 8px rgba(0,0,0,0.6), 0 0 40px rgba(0,0,0,0.4);
+  text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   text-align: center;
   margin: 0;
   padding: 0 1rem;
+}
+
+.port-hero-credit {
+  font-size: 0.75rem;
+  color: #678;
+  padding: 0.5rem 0.75rem;
+  text-align: right;
+  background: #f7fdff;
+  border-radius: 0 0 12px 12px;
 }
 
 /* ===== END Unified Styles ===== */

--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -171,11 +171,13 @@ All work on this project is offered as a gift to God.
 
     <div style="grid-column: 1; grid-row: 1;">
       <div class="port-hero">
-        <img src="/ports/img/aruba/aruba-FOM - 10.webp" alt="Norwegian Encore cruise ship docked at Aruba's Oranjestad port with its colorful hull art" loading="eager" fetchpriority="high"/>
-        <div class="port-hero-overlay">
-          <h1 class="port-hero-title">Aruba</h1>
+        <div class="port-hero-image">
+          <img src="/ports/img/aruba/aruba-FOM - 10.webp" alt="Norwegian Encore cruise ship docked at Aruba's Oranjestad port with its colorful hull art" loading="eager" fetchpriority="high"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Aruba</h1>
+          </div>
         </div>
-        <p style="font-size: 0.75rem; color: #678; margin-top: 0.5rem; text-align: right;">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+        <p class="port-hero-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
       </div>
 
       <article class="card">

--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -202,11 +202,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
     <div style="grid-column: 1; grid-row: 1;">
       <div class="port-hero">
-        <img src="/ports/img/cococay/cococay-1.webp" alt="Perfect Day at CocoCay aerial view showing turquoise waters and white sand beaches" loading="eager" fetchpriority="high"/>
-        <div class="port-hero-overlay">
-          <h1 class="port-hero-title">Perfect Day at CocoCay</h1>
+        <div class="port-hero-image">
+          <img src="/ports/img/cococay/cococay-1.webp" alt="Perfect Day at CocoCay aerial view showing turquoise waters and white sand beaches" loading="eager" fetchpriority="high"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Perfect Day at CocoCay</h1>
+          </div>
         </div>
-        <p style="font-size: 0.75rem; color: #678; margin-top: 0.5rem; text-align: right;">Photo: <a href="https://commons.wikimedia.org/w/index.php?search=Cococay&title=Special:MediaSearch&type=image" target="_blank" rel="noopener">WikiMedia Commons</a> (CC BY-SA)</p>
+        <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org/w/index.php?search=Cococay&title=Special:MediaSearch&type=image" target="_blank" rel="noopener">WikiMedia Commons</a> (CC BY-SA)</p>
       </div>
 
     <article class="card">


### PR DESCRIPTION
CSS changes:
- Added border: 1px solid #e0f0f5 and box-shadow to .port-hero
- New .port-hero-image wrapper for overflow:hidden on image only
- Improved gradient overlay (darker for better text contrast)
- Added pointer-events:none to overlay
- New .port-hero-credit class with light background

HTML structure (CocoCay + Aruba):
- Wrapped img + overlay in .port-hero-image div
- Photo credit uses .port-hero-credit class
- Port name h1 now properly overlays hero image