### PR TITLE
Wrap CocoCay port-section elements in article card

### DIFF
--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -264,6 +264,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p>CocoCay has earned its reputation. The aggregate reviews from thousands of cruisers across Cruise Critic, Reddit, and post-cruise surveys consistently put it at 4.8–5.0 stars, and I understand why. It's the private island experience perfected — Royal Caribbean threw an extraordinary amount of money and thought at this place, and it shows in every detail. From the moment you walk off the ship to the moment you reluctantly walk back on, everything just works.</p>
     </article>
 
+    <!-- Port Guide Sections -->
+    <article class="card">
     <!-- What's New Section -->
     <section class="port-section">
       <h3>What's New in 2024–2025</h3>
@@ -439,8 +441,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <p class="tiny" style="margin-bottom: 0.5rem; font-style: italic; color: #678;">Practical tips before you step off the ship.</p>
       <p>On busy days with two or three ships in port, the island buzzes with fantastic energy — embrace it as an opportunity to people-watch, soak up the vibrant atmosphere, and feel the collective joy of thousands of happy cruisers while still finding plenty of quiet corners (head to South Beach or Chill Island early for prime shaded spots). Booking cabanas or waterpark tickets in advance through the Cruise Planner simply guarantees you the best seats in this tropical playground.</p>
     </section>
+    </article>
 
-    
     <!-- Photo Gallery -->
     <section class="port-section" style="background: transparent; border: none; padding: 0;">
       <h3>CocoCay Gallery</h3>


### PR DESCRIPTION
Content sections (What's New, Getting Around, Island Areas, etc.) were orphaned outside of card containers. Now properly wrapped in an article.card element for consistent styling with other port pages.