### PR TITLE
Add interactive Leaflet map to Aruba port page

### DIFF
--- a/assets/css/components/port-map.css
+++ b/assets/css/components/port-map.css
@@ -1,0 +1,251 @@
+/**
+ * Port Map Styles
+ * Styling for interactive Leaflet maps on port pages
+ *
+ * @version 1.0.0
+ */
+
+/* Map Container */
+.port-map-container {
+  width: 100%;
+  height: 400px;
+  min-height: 300px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #e0f0f5;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  background: #f7fdff;
+  margin: 1.5rem 0;
+}
+
+/* Larger on desktop */
+@media (min-width: 768px) {
+  .port-map-container {
+    height: 500px;
+  }
+}
+
+/* Loading and error states */
+.port-map-loading,
+.port-map-error {
+  font-family: inherit;
+  font-size: 0.95rem;
+}
+
+/* Custom marker styles */
+.port-map-marker {
+  background: transparent;
+  border: none;
+}
+
+.marker-pin {
+  transition: transform 0.2s ease;
+}
+
+.marker-pin:hover {
+  transform: rotate(-45deg) scale(1.1);
+}
+
+/* Popup styles */
+.port-map-popup-container .leaflet-popup-content-wrapper {
+  border-radius: 10px;
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.15);
+  padding: 0;
+}
+
+.port-map-popup-container .leaflet-popup-content {
+  margin: 0.75rem 1rem;
+  font-family: inherit;
+}
+
+.port-map-popup-container .leaflet-popup-tip {
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.1);
+}
+
+.port-map-popup h4 {
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.port-map-popup a {
+  text-decoration: none;
+}
+
+.port-map-popup a:hover {
+  text-decoration: underline;
+}
+
+/* Legend styles */
+.port-map-legend {
+  background: white;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  font-family: inherit;
+  max-width: 150px;
+}
+
+.port-map-legend h5 {
+  font-weight: 600;
+  border-bottom: 1px solid #e0e8f0;
+  padding-bottom: 0.5rem;
+}
+
+/* Map section card wrapper */
+.port-map-section {
+  background: white;
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin: 1.5rem 0;
+  border: 1px solid #e0f0f5;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.port-map-section h3 {
+  margin: 0 0 0.5rem;
+  color: var(--ink, #1a2a3a);
+  font-size: 1.15rem;
+}
+
+.port-map-section .map-intro {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+  color: var(--ink-mid, #456);
+}
+
+/* Map controls enhancement */
+.port-map-container .leaflet-control-zoom {
+  border: none;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.port-map-container .leaflet-control-zoom a {
+  background: white;
+  color: #333;
+  border: none;
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  font-size: 18px;
+}
+
+.port-map-container .leaflet-control-zoom a:hover {
+  background: #f0f7fa;
+}
+
+.port-map-container .leaflet-control-zoom-in {
+  border-radius: 6px 6px 0 0;
+}
+
+.port-map-container .leaflet-control-zoom-out {
+  border-radius: 0 0 6px 6px;
+}
+
+/* Attribution styling */
+.port-map-container .leaflet-control-attribution {
+  font-size: 0.7rem;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 2px 6px;
+  border-radius: 4px 0 0 0;
+}
+
+/* Map action buttons */
+.port-map-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.port-map-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  border-radius: 8px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-primary {
+  background: var(--teal, #0077b6);
+  color: white;
+  border: none;
+}
+
+.btn-primary:hover {
+  background: #005f8a;
+}
+
+.btn-secondary {
+  background: white;
+  color: var(--ink, #1a2a3a);
+  border: 1px solid #ccd8e0;
+}
+
+.btn-secondary:hover {
+  background: #f0f7fa;
+  border-color: #aac0cc;
+}
+
+/* Tooltip for scroll zoom notice */
+.port-map-scroll-notice {
+  position: absolute;
+  bottom: 50px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.75);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.port-map-container:hover .port-map-scroll-notice.show {
+  opacity: 1;
+}
+
+/* Print styles */
+@media print {
+  .port-map-container {
+    height: 350px;
+    box-shadow: none;
+    border: 1px solid #ccc;
+  }
+
+  .port-map-legend {
+    box-shadow: none;
+    border: 1px solid #ccc;
+  }
+
+  .port-map-actions {
+    display: none;
+  }
+}
+
+/* Accessibility */
+.port-map-container:focus {
+  outline: 2px solid var(--teal, #0077b6);
+  outline-offset: 2px;
+}
+
+/* No-JS fallback */
+.no-js .port-map-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f0f7fa;
+}
+
+.no-js .port-map-container::before {
+  content: 'Interactive map requires JavaScript';
+  color: #678;
+  font-size: 0.9rem;
+}

--- a/assets/js/modules/port-map.js
+++ b/assets/js/modules/port-map.js
@@ -1,0 +1,291 @@
+/**
+ * Port Map Module
+ * Renders interactive Leaflet maps with POI markers for port pages
+ *
+ * @version 1.0.0
+ * @requires Leaflet 1.9.x (loaded via CDN)
+ */
+
+(function() {
+  'use strict';
+
+  // POI type configurations - colors and icons
+  const POI_TYPES = {
+    port: { color: '#d32f2f', icon: '⚓', label: 'Cruise Terminal', zIndex: 1000 },
+    beach: { color: '#0288d1', icon: '🏖️', label: 'Beach', zIndex: 800 },
+    landmark: { color: '#7b1fa2', icon: '🏛️', label: 'Landmark', zIndex: 700 },
+    nature: { color: '#388e3c', icon: '🌿', label: 'Nature', zIndex: 600 },
+    district: { color: '#f57c00', icon: '🏘️', label: 'District', zIndex: 500 },
+    shopping: { color: '#c2185b', icon: '🛍️', label: 'Shopping', zIndex: 600 },
+    museum: { color: '#512da8', icon: '🏛️', label: 'Museum', zIndex: 600 },
+    attraction: { color: '#00796b', icon: '⭐', label: 'Attraction', zIndex: 600 },
+    park: { color: '#689f38', icon: '🌳', label: 'Park', zIndex: 500 }
+  };
+
+  // Default fallback
+  const DEFAULT_TYPE = { color: '#607d8b', icon: '📍', label: 'Point of Interest', zIndex: 400 };
+
+  /**
+   * Create a custom divIcon marker
+   */
+  function createMarkerIcon(poi, typeConfig) {
+    const isPort = poi.type === 'port';
+    const size = isPort ? 36 : 28;
+
+    return L.divIcon({
+      className: 'port-map-marker',
+      html: `<div class="marker-pin" style="
+        background-color: ${typeConfig.color};
+        width: ${size}px;
+        height: ${size}px;
+        border-radius: 50% 50% 50% 0;
+        transform: rotate(-45deg);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 2px solid white;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+      "><span style="transform: rotate(45deg); font-size: ${isPort ? '16px' : '12px'};">${typeConfig.icon}</span></div>`,
+      iconSize: [size, size],
+      iconAnchor: [size / 2, size],
+      popupAnchor: [0, -size]
+    });
+  }
+
+  /**
+   * Create popup content for a POI
+   */
+  function createPopupContent(poi, labelOverride) {
+    const typeConfig = POI_TYPES[poi.type] || DEFAULT_TYPE;
+    const displayName = labelOverride || poi.name;
+
+    let html = `
+      <div class="port-map-popup">
+        <h4 style="margin: 0 0 0.5rem; color: ${typeConfig.color}; font-size: 1rem;">
+          ${typeConfig.icon} ${displayName}
+        </h4>
+        <p style="margin: 0 0 0.5rem; font-size: 0.85rem; color: #456;">
+          <strong>Type:</strong> ${typeConfig.label}
+        </p>
+    `;
+
+    if (poi.notes) {
+      html += `<p style="margin: 0 0 0.5rem; font-size: 0.85rem; color: #567;">${poi.notes}</p>`;
+    }
+
+    // Add directions links
+    html += `
+      <div style="margin-top: 0.75rem; padding-top: 0.5rem; border-top: 1px solid #e0e8f0; font-size: 0.8rem;">
+        <a href="https://www.google.com/maps/dir/?api=1&destination=${poi.lat},${poi.lon}"
+           target="_blank" rel="noopener" style="color: #0077b6; margin-right: 1rem;">
+          📍 Google Maps
+        </a>
+        <a href="https://maps.apple.com/?daddr=${poi.lat},${poi.lon}"
+           target="_blank" rel="noopener" style="color: #0077b6;">
+          🍎 Apple Maps
+        </a>
+      </div>
+    `;
+
+    html += '</div>';
+    return html;
+  }
+
+  /**
+   * Initialize the port map
+   * @param {Object} options - Configuration options
+   * @param {string} options.containerId - DOM element ID for the map
+   * @param {string} options.portSlug - Port identifier (e.g., 'aruba')
+   * @param {string} [options.poiIndexUrl] - URL to POI index JSON
+   * @param {string} [options.portManifestUrl] - URL to port manifest JSON
+   */
+  async function initPortMap(options) {
+    const {
+      containerId,
+      portSlug,
+      poiIndexUrl = '/assets/data/maps/poi-index.json',
+      portManifestUrl = `/assets/data/maps/${portSlug}.map.json`
+    } = options;
+
+    const container = document.getElementById(containerId);
+    if (!container) {
+      console.warn(`Port map container #${containerId} not found`);
+      return null;
+    }
+
+    // Show loading state
+    container.innerHTML = '<div class="port-map-loading" style="display: flex; align-items: center; justify-content: center; height: 100%; color: #678;">Loading map...</div>';
+
+    try {
+      // Fetch POI index and port manifest in parallel
+      const [poiIndexRes, portManifestRes] = await Promise.all([
+        fetch(poiIndexUrl),
+        fetch(portManifestUrl)
+      ]);
+
+      if (!poiIndexRes.ok || !portManifestRes.ok) {
+        throw new Error('Failed to load map data');
+      }
+
+      const poiIndex = await poiIndexRes.json();
+      const portManifest = await portManifestRes.json();
+
+      // Clear loading state
+      container.innerHTML = '';
+
+      // Initialize Leaflet map
+      const map = L.map(containerId, {
+        scrollWheelZoom: false, // Prevent accidental zooms while scrolling page
+        tap: false // Fix for mobile double-tap issue
+      });
+
+      // Add OpenStreetMap tiles with attribution
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 18,
+        attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'
+      }).addTo(map);
+
+      // Collect all POI coordinates for bounds calculation
+      const bounds = [];
+      const markers = [];
+
+      // Add port pin first (always present)
+      if (portManifest.port_pin) {
+        const portPoi = {
+          id: 'port-pin',
+          name: portManifest.port_pin.label || 'Cruise Terminal',
+          lat: portManifest.port_pin.lat,
+          lon: portManifest.port_pin.lon,
+          type: 'port'
+        };
+
+        const typeConfig = POI_TYPES.port;
+        const marker = L.marker([portPoi.lat, portPoi.lon], {
+          icon: createMarkerIcon(portPoi, typeConfig),
+          zIndexOffset: typeConfig.zIndex
+        });
+
+        marker.bindPopup(createPopupContent(portPoi), {
+          maxWidth: 280,
+          className: 'port-map-popup-container'
+        });
+
+        markers.push(marker);
+        bounds.push([portPoi.lat, portPoi.lon]);
+      }
+
+      // Add POI markers
+      for (const poiId of portManifest.poi_ids || []) {
+        const poi = poiIndex[poiId];
+        if (!poi) {
+          console.warn(`POI not found in index: ${poiId}`);
+          continue;
+        }
+
+        // Skip if it's the port terminal (already added)
+        if (poi.type === 'port') continue;
+
+        const typeConfig = POI_TYPES[poi.type] || DEFAULT_TYPE;
+        const labelOverride = portManifest.label_overrides?.[poiId];
+
+        const marker = L.marker([poi.lat, poi.lon], {
+          icon: createMarkerIcon(poi, typeConfig),
+          zIndexOffset: typeConfig.zIndex
+        });
+
+        marker.bindPopup(createPopupContent(poi, labelOverride), {
+          maxWidth: 280,
+          className: 'port-map-popup-container'
+        });
+
+        markers.push(marker);
+        bounds.push([poi.lat, poi.lon]);
+      }
+
+      // Add all markers to a layer group
+      const markerGroup = L.layerGroup(markers).addTo(map);
+
+      // Fit map to show all POIs with padding
+      if (bounds.length > 0) {
+        map.fitBounds(bounds, {
+          padding: [30, 30],
+          maxZoom: 14
+        });
+      } else if (portManifest.bbox_hint) {
+        // Fallback to bounding box hint
+        const bbox = portManifest.bbox_hint;
+        map.fitBounds([
+          [bbox.south, bbox.west],
+          [bbox.north, bbox.east]
+        ]);
+      }
+
+      // Enable scroll wheel zoom after user clicks on map
+      map.once('focus', function() {
+        map.scrollWheelZoom.enable();
+      });
+
+      // Add legend
+      addLegend(map, portManifest, poiIndex);
+
+      // Store reference for potential later use
+      container._portMap = map;
+
+      return map;
+
+    } catch (error) {
+      console.error('Error initializing port map:', error);
+      container.innerHTML = `
+        <div class="port-map-error" style="display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; color: #678; text-align: center; padding: 1rem;">
+          <p style="margin: 0 0 0.5rem;">Unable to load map</p>
+          <p style="margin: 0; font-size: 0.85rem; color: #999;">Please check your connection and try again</p>
+        </div>
+      `;
+      return null;
+    }
+  }
+
+  /**
+   * Add a legend control to the map
+   */
+  function addLegend(map, portManifest, poiIndex) {
+    // Collect unique POI types in this port
+    const typesPresent = new Set(['port']); // Port is always shown
+
+    for (const poiId of portManifest.poi_ids || []) {
+      const poi = poiIndex[poiId];
+      if (poi && poi.type) {
+        typesPresent.add(poi.type);
+      }
+    }
+
+    const legend = L.control({ position: 'bottomright' });
+
+    legend.onAdd = function() {
+      const div = L.DomUtil.create('div', 'port-map-legend');
+      div.innerHTML = '<h5 style="margin: 0 0 0.5rem; font-size: 0.85rem; color: #1a2a3a;">Map Legend</h5>';
+
+      for (const [type, config] of Object.entries(POI_TYPES)) {
+        if (typesPresent.has(type)) {
+          div.innerHTML += `
+            <div style="display: flex; align-items: center; margin-bottom: 0.25rem; font-size: 0.75rem;">
+              <span style="display: inline-block; width: 12px; height: 12px; background: ${config.color}; border-radius: 50%; margin-right: 0.5rem;"></span>
+              ${config.label}
+            </div>
+          `;
+        }
+      }
+
+      return div;
+    };
+
+    legend.addTo(map);
+  }
+
+  // Expose to global scope
+  window.PortMap = {
+    init: initPortMap,
+    POI_TYPES: POI_TYPES
+  };
+
+})();

--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -18,7 +18,7 @@ All work on this project is offered as a gift to God.
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="ai-summary" content="First-person logbook guide to Aruba with tips for Eagle Beach fofoti trees, Baby Beach snorkeling, colorful Oranjestad architecture, and sunset catamaran tours on One Happy Island."/>
-  <meta name="last-reviewed" content="2025-11-29"/>
+  <meta name="last-reviewed" content="2025-12-12"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Aruba Port Guide — Eagle Beach & One Happy Island | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Aruba — Eagle Beach fofoti trees, Baby Beach snorkeling, colorful Dutch architecture, and sunset catamaran adventures on One Happy Island."/>
@@ -35,6 +35,10 @@ All work on this project is offered as a gift to God.
   </script>
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.305"/>
+
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css"/>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -240,6 +244,27 @@ All work on this project is offered as a gift to God.
             <li><strong>Baby Beach:</strong> 45-minute drive to the southern tip. Best with a rental car or organized tour.</li>
             <li><strong>Jeep Rentals:</strong> Popular option for exploring the rugged north coast and Natural Pool. Book in advance.</li>
           </ul>
+        </section>
+
+        <!-- Interactive Port Map -->
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>📍 Aruba Port Map</h3>
+          <p class="map-intro">Interactive map showing the cruise terminal, beaches, landmarks, and attractions mentioned in this guide. Click any marker for details and directions.</p>
+          <div id="aruba-port-map" class="port-map-container" role="application" aria-label="Interactive map of Aruba port and points of interest">
+            <noscript>
+              <p style="padding: 2rem; text-align: center; color: #678;">
+                Interactive map requires JavaScript. View our <a href="/assets/data/maps/poi-index.json">POI data</a> for location coordinates.
+              </p>
+            </noscript>
+          </div>
+          <div class="port-map-actions">
+            <button type="button" class="btn btn-secondary" onclick="document.getElementById('aruba-port-map')._portMap?.fitBounds(document.getElementById('aruba-port-map')._portMap.getBounds())">
+              🔄 Reset View
+            </button>
+          </div>
+          <p class="tiny" style="margin-top: 0.75rem; color: #678;">
+            <strong>Tip:</strong> Click on the map to enable scroll zoom. Marker locations are approximate — always verify with local signage.
+          </p>
         </section>
 
         <section class="port-section">
@@ -595,6 +620,34 @@ All work on this project is offered as a gift to God.
 
   <!-- Whimsical Distance Units Script -->
   <script src="/assets/js/whimsical-port-units.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Aruba Port Map -->
+  <script>
+  (function() {
+    // Wait for DOM and Leaflet to be ready
+    function initMap() {
+      if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+        PortMap.init({
+          containerId: 'aruba-port-map',
+          portSlug: 'aruba'
+        });
+      } else {
+        // Retry if scripts haven't loaded yet
+        setTimeout(initMap, 100);
+      }
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initMap);
+    } else {
+      initMap();
+    }
+  })();
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
Implements Phase 2 of port map infrastructure with live interactive map:

New files:
- assets/js/modules/port-map.js: Leaflet map module that loads POI data and renders markers with popups, legend, and directions links
- assets/css/components/port-map.css: Map container styling, markers, popups, legend, and responsive breakpoints

Aruba page updates:
- Added Leaflet CSS/JS from CDN (1.9.4)
- New map section after "Getting Around" with 33 POI markers
- Markers color-coded by type (beach, landmark, attraction, etc.)
- Popups show POI details with Google/Apple Maps directions
- Legend shows POI types present on this port
- Scroll zoom disabled until user clicks map (UX improvement)
- Graceful degradation with noscript fallback

POI types rendered:
⚓ Cruise Terminal (red), 🏖️ Beach (blue), 🏛️ Landmark (purple), 🌿 Nature (green), 🏘️ District (orange), 🛍️ Shopping (pink), 🏛️ Museum (purple), ⭐ Attraction (teal), 🌳 Park (lime)

This builds on the POI index pilot to provide the first live map visualization. Ready for testing and refinement.