### PR TITLE
Add 10 new port pages with research-enriched content

### DIFF
--- a/assets/data/maps/aqaba.map.json
+++ b/assets/data/maps/aqaba.map.json
@@ -1,0 +1,87 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Jordan tourism and cruise port guides"
+  },
+
+  "port_slug": "aqaba",
+  "port_name": "Aqaba",
+  "port_pin": {
+    "lat": 29.5267,
+    "lon": 35.0078,
+    "label": "Aqaba Cruise Terminal"
+  },
+
+  "bbox_hint": {
+    "south": 29.40,
+    "west": 34.90,
+    "north": 29.65,
+    "east": 35.15,
+    "note": "Covers Aqaba city, Red Sea coast, access to Petra and Wadi Rum"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Aqaba Cruise Terminal", "lat": 29.5267, "lon": 35.0078, "type": "port"},
+    {"name": "Aqaba Fort", "lat": 29.5265, "lon": 35.0050, "type": "historic"},
+    {"name": "Aqaba Archaeological Museum", "lat": 29.5260, "lon": 35.0055, "type": "museum"},
+    {"name": "Ayla Ancient City", "lat": 29.5275, "lon": 35.0025, "type": "historic"},
+    {"name": "South Beach", "lat": 29.4500, "lon": 34.9700, "type": "beach"},
+    {"name": "Japanese Garden Reef", "lat": 29.4350, "lon": 34.9650, "type": "diving"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "taxi-petra",
+      "name": "Taxi to Petra",
+      "type": "taxi",
+      "cost": "$80-100 USD round trip",
+      "duration": "2 hours each way",
+      "note": "Most popular excursion. Book full day to explore properly."
+    },
+    {
+      "id": "taxi-wadi-rum",
+      "name": "Taxi to Wadi Rum",
+      "type": "taxi",
+      "cost": "$60-80 USD round trip",
+      "duration": "1 hour each way",
+      "note": "Mars-like desert landscape. Combine with jeep tour."
+    },
+    {
+      "id": "taxi-city",
+      "name": "Taxi in Aqaba",
+      "type": "taxi",
+      "cost": "$5-10 USD",
+      "duration": "Varies",
+      "note": "For exploring the city and beaches."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Petra Day Trip",
+      "type": "historic",
+      "duration": "Full day",
+      "highlights": ["Treasury (Al-Khazneh)", "Ancient Nabataean city", "UNESCO World Heritage Site"],
+      "note": "One of the New Seven Wonders of the World. Entry ~$70. Start early."
+    },
+    {
+      "name": "Wadi Rum Desert",
+      "type": "nature",
+      "duration": "Half day",
+      "highlights": ["Mars-like landscape", "Bedouin culture", "Lawrence of Arabia filming"],
+      "note": "Jeep tours explore this stunning desert wilderness."
+    },
+    {
+      "name": "Red Sea Diving",
+      "type": "water",
+      "duration": "Half day",
+      "highlights": ["Coral reefs", "Marine life", "Clear warm water"],
+      "note": "Some of the world's best accessible diving directly from shore."
+    }
+  ]
+}

--- a/assets/data/maps/cape-town.map.json
+++ b/assets/data/maps/cape-town.map.json
@@ -1,0 +1,88 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Cape Town tourism and cruise port guides"
+  },
+
+  "port_slug": "cape-town",
+  "port_name": "Cape Town",
+  "port_pin": {
+    "lat": -33.9033,
+    "lon": 18.4233,
+    "label": "Cape Town Cruise Terminal"
+  },
+
+  "bbox_hint": {
+    "south": -34.35,
+    "west": 18.30,
+    "north": -33.85,
+    "east": 18.60,
+    "note": "Covers Cape Town, Table Mountain, Cape Peninsula, V&A Waterfront"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Cape Town Cruise Terminal", "lat": -33.9033, "lon": 18.4233, "type": "port"},
+    {"name": "V&A Waterfront", "lat": -33.9040, "lon": 18.4180, "type": "shopping"},
+    {"name": "Table Mountain Cable Car", "lat": -33.9575, "lon": 18.4030, "type": "scenic"},
+    {"name": "Robben Island Ferry", "lat": -33.9045, "lon": 18.4200, "type": "historic"},
+    {"name": "Cape of Good Hope", "lat": -34.3568, "lon": 18.4740, "type": "nature"},
+    {"name": "Kirstenbosch Gardens", "lat": -33.9878, "lon": 18.4325, "type": "garden"},
+    {"name": "Bo-Kaap", "lat": -33.9214, "lon": 18.4165, "type": "neighborhood"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "walk-waterfront",
+      "name": "Walk to V&A Waterfront",
+      "type": "walking",
+      "cost": "Free",
+      "duration": "5-10 minutes",
+      "note": "Cruise terminal is within the V&A Waterfront precinct."
+    },
+    {
+      "id": "taxi-table",
+      "name": "Taxi to Table Mountain",
+      "type": "taxi",
+      "cost": "R150-200 (~$8-12 USD)",
+      "duration": "15-20 minutes",
+      "note": "To cable car lower station. Check weather before going."
+    },
+    {
+      "id": "tour-cape-point",
+      "name": "Cape Peninsula Tour",
+      "type": "tour",
+      "cost": "$80-120 USD",
+      "duration": "Full day",
+      "note": "Best way to see peninsula, penguins, and Cape of Good Hope."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Table Mountain",
+      "type": "scenic",
+      "duration": "3-4 hours",
+      "highlights": ["Cable car ride", "360-degree views", "Flat summit walks", "Flora"],
+      "note": "New7Wonders of Nature. Check weather—often clouded. Book cableway online."
+    },
+    {
+      "name": "Cape Peninsula Day Trip",
+      "type": "nature",
+      "duration": "Full day",
+      "highlights": ["Cape of Good Hope", "Boulder's Beach penguins", "Chapman's Peak Drive"],
+      "note": "Dramatic coastline, African penguins, and the meeting of two oceans."
+    },
+    {
+      "name": "Robben Island",
+      "type": "historic",
+      "duration": "4 hours",
+      "highlights": ["Nelson Mandela's cell", "Political prison history", "Ferry ride"],
+      "note": "UNESCO World Heritage Site. Book in advance—limited daily tours."
+    }
+  ]
+}

--- a/assets/data/maps/da-nang.map.json
+++ b/assets/data/maps/da-nang.map.json
@@ -1,0 +1,88 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Da Nang tourism and cruise port guides"
+  },
+
+  "port_slug": "da-nang",
+  "port_name": "Da Nang",
+  "port_pin": {
+    "lat": 16.0544,
+    "lon": 108.2022,
+    "label": "Tien Sa Port"
+  },
+
+  "bbox_hint": {
+    "south": 15.85,
+    "west": 107.95,
+    "north": 16.20,
+    "east": 108.35,
+    "note": "Covers Da Nang city, Marble Mountains, access to Hoi An"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Tien Sa Port", "lat": 16.1175, "lon": 108.2119, "type": "port"},
+    {"name": "Dragon Bridge", "lat": 16.0610, "lon": 108.2270, "type": "landmark"},
+    {"name": "Marble Mountains", "lat": 16.0042, "lon": 108.2636, "type": "nature"},
+    {"name": "My Khe Beach", "lat": 16.0544, "lon": 108.2456, "type": "beach"},
+    {"name": "Hoi An Ancient Town", "lat": 15.8801, "lon": 108.3380, "type": "historic"},
+    {"name": "Museum of Cham Sculpture", "lat": 16.0600, "lon": 108.2230, "type": "museum"},
+    {"name": "Ba Na Hills", "lat": 15.9947, "lon": 107.9875, "type": "scenic"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "taxi-hoian",
+      "name": "Taxi to Hoi An",
+      "type": "taxi",
+      "cost": "$20-25 USD one way",
+      "duration": "45 minutes",
+      "note": "Most popular excursion. UNESCO World Heritage town."
+    },
+    {
+      "id": "taxi-marble",
+      "name": "Taxi to Marble Mountains",
+      "type": "taxi",
+      "cost": "$10-15 USD one way",
+      "duration": "20 minutes",
+      "note": "En route to or from Hoi An. Elevator or stairs to summit."
+    },
+    {
+      "id": "taxi-city",
+      "name": "Taxi to City Center",
+      "type": "taxi",
+      "cost": "$8-12 USD",
+      "duration": "15 minutes",
+      "note": "From port to Dragon Bridge area and beaches."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Hoi An Ancient Town",
+      "type": "historic",
+      "duration": "Half day",
+      "highlights": ["Japanese Covered Bridge", "Lantern-lit streets", "Tailors", "UNESCO site"],
+      "note": "Beautifully preserved trading port. Evening lanterns are magical."
+    },
+    {
+      "name": "Marble Mountains",
+      "type": "nature",
+      "duration": "2-3 hours",
+      "highlights": ["Buddhist caves", "Pagodas", "Panoramic views", "Marble artisans"],
+      "note": "Five limestone hills with caves, temples, and stunning views."
+    },
+    {
+      "name": "Ba Na Hills & Golden Bridge",
+      "type": "scenic",
+      "duration": "Full day",
+      "highlights": ["Giant hands bridge", "Cable car", "French village", "Gardens"],
+      "note": "Famous for the iconic Golden Bridge held by giant stone hands."
+    }
+  ]
+}

--- a/assets/data/maps/dunedin.map.json
+++ b/assets/data/maps/dunedin.map.json
@@ -1,0 +1,80 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Dunedin NZ tourism and cruise port guides"
+  },
+
+  "port_slug": "dunedin",
+  "port_name": "Dunedin",
+  "port_pin": {
+    "lat": -45.8788,
+    "lon": 170.5028,
+    "label": "Port Chalmers Cruise Terminal"
+  },
+
+  "bbox_hint": {
+    "south": -45.95,
+    "west": 170.35,
+    "north": -45.75,
+    "east": 170.75,
+    "note": "Covers Port Chalmers, Dunedin city, Otago Peninsula"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Port Chalmers Terminal", "lat": -45.8133, "lon": 170.6247, "type": "port"},
+    {"name": "Dunedin Railway Station", "lat": -45.8788, "lon": 170.5028, "type": "station"},
+    {"name": "Larnach Castle", "lat": -45.8556, "lon": 170.6250, "type": "castle"},
+    {"name": "Royal Albatross Centre", "lat": -45.7631, "lon": 170.7289, "type": "wildlife"},
+    {"name": "Penguin Place", "lat": -45.8147, "lon": 170.6625, "type": "wildlife"},
+    {"name": "Toitū Otago Settlers Museum", "lat": -45.8772, "lon": 170.5053, "type": "museum"},
+    {"name": "Baldwin Street", "lat": -45.8492, "lon": 170.5342, "type": "attraction"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "shuttle-city",
+      "name": "Shuttle to Dunedin",
+      "type": "shuttle",
+      "cost": "$10-15 NZD",
+      "duration": "15-20 minutes",
+      "note": "Regular shuttles from Port Chalmers to city center."
+    },
+    {
+      "id": "taxi-peninsula",
+      "name": "Taxi to Otago Peninsula",
+      "type": "taxi",
+      "cost": "$60-80 NZD one way",
+      "duration": "30-40 minutes",
+      "note": "For Royal Albatross Centre and wildlife tours."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Otago Peninsula Wildlife",
+      "type": "wildlife",
+      "duration": "Half day",
+      "highlights": ["Royal albatross colony", "Yellow-eyed penguins", "Fur seals"],
+      "note": "World's only mainland albatross colony. Penguin viewing at dusk."
+    },
+    {
+      "name": "Larnach Castle",
+      "type": "historic",
+      "duration": "2-3 hours",
+      "highlights": ["New Zealand's only castle", "Victorian gardens", "Panoramic views"],
+      "note": "Built 1871 by banker William Larnach. Beautiful gardens."
+    },
+    {
+      "name": "Dunedin City Heritage",
+      "type": "city",
+      "duration": "Half day",
+      "highlights": ["Railway Station", "Scottish architecture", "Baldwin Street", "Cadbury World"],
+      "note": "Scotland meets New Zealand in this well-preserved Victorian city."
+    }
+  ]
+}

--- a/assets/data/maps/fukuoka.map.json
+++ b/assets/data/maps/fukuoka.map.json
@@ -1,0 +1,88 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Fukuoka tourism and cruise port guides"
+  },
+
+  "port_slug": "fukuoka",
+  "port_name": "Fukuoka",
+  "port_pin": {
+    "lat": 33.5902,
+    "lon": 130.4017,
+    "label": "Hakata Port International Terminal"
+  },
+
+  "bbox_hint": {
+    "south": 33.50,
+    "west": 130.30,
+    "north": 33.70,
+    "east": 130.55,
+    "note": "Covers Hakata, Tenjin, Dazaifu shrine area"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Hakata Port Terminal", "lat": 33.5902, "lon": 130.4017, "type": "port"},
+    {"name": "Kushida Shrine", "lat": 33.5917, "lon": 130.4086, "type": "shrine"},
+    {"name": "Canal City Hakata", "lat": 33.5894, "lon": 130.4117, "type": "shopping"},
+    {"name": "Fukuoka Castle Ruins", "lat": 33.5860, "lon": 130.3817, "type": "historic"},
+    {"name": "Ōhori Park", "lat": 33.5858, "lon": 130.3778, "type": "park"},
+    {"name": "Shofukuji Temple", "lat": 33.5969, "lon": 130.4097, "type": "temple"},
+    {"name": "Dazaifu Tenmangu", "lat": 33.5200, "lon": 130.5350, "type": "shrine"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "subway-city",
+      "name": "Subway to Tenjin",
+      "type": "subway",
+      "cost": "¥260 (~$2 USD)",
+      "duration": "10-15 minutes",
+      "note": "Most convenient way to reach city center from port area."
+    },
+    {
+      "id": "train-dazaifu",
+      "name": "Train to Dazaifu",
+      "type": "train",
+      "cost": "¥600 (~$4 USD)",
+      "duration": "40 minutes",
+      "note": "Transfer at Tenjin for Nishitetsu Line to shrine."
+    },
+    {
+      "id": "taxi-port",
+      "name": "Taxi from Port",
+      "type": "taxi",
+      "cost": "¥1,500-2,000 (~$10-15 USD)",
+      "duration": "10-15 minutes",
+      "note": "Direct to main attractions. Meters are reliable."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Hakata Ramen & Yatai",
+      "type": "culinary",
+      "duration": "2-3 hours",
+      "highlights": ["Tonkotsu ramen birthplace", "Yatai food stalls", "Mentaiko"],
+      "note": "Famous for rich pork broth ramen. Evening yatai stalls are iconic."
+    },
+    {
+      "name": "Dazaifu Tenmangu",
+      "type": "cultural",
+      "duration": "Half day",
+      "highlights": ["Shrine to scholarship", "Plum blossoms", "Traditional street"],
+      "note": "One of Japan's most important Shinto shrines, dedicated to learning."
+    },
+    {
+      "name": "Shofukuji Temple",
+      "type": "spiritual",
+      "duration": "1-2 hours",
+      "highlights": ["Japan's first Zen temple", "Peaceful gardens", "Founded 1195"],
+      "note": "Where Zen Buddhism was first established in Japan."
+    }
+  ]
+}

--- a/assets/data/maps/lyttelton.map.json
+++ b/assets/data/maps/lyttelton.map.json
@@ -1,0 +1,80 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Christchurch NZ tourism and cruise port guides"
+  },
+
+  "port_slug": "lyttelton",
+  "port_name": "Lyttelton",
+  "port_pin": {
+    "lat": -43.6036,
+    "lon": 172.7194,
+    "label": "Port of Lyttelton"
+  },
+
+  "bbox_hint": {
+    "south": -43.70,
+    "west": 172.55,
+    "north": -43.45,
+    "east": 172.85,
+    "note": "Covers Lyttelton Harbour, Christchurch city, Port Hills"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Port of Lyttelton", "lat": -43.6036, "lon": 172.7194, "type": "port"},
+    {"name": "Lyttelton Village", "lat": -43.6028, "lon": 172.7206, "type": "town"},
+    {"name": "Christchurch Cathedral", "lat": -43.5309, "lon": 172.6369, "type": "church"},
+    {"name": "Canterbury Museum", "lat": -43.5308, "lon": 172.6280, "type": "museum"},
+    {"name": "Botanic Gardens", "lat": -43.5290, "lon": 172.6200, "type": "garden"},
+    {"name": "Gondola Summit", "lat": -43.5706, "lon": 172.6917, "type": "scenic"},
+    {"name": "Quake City Museum", "lat": -43.5330, "lon": 172.6340, "type": "museum"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "shuttle-city",
+      "name": "Shuttle to Christchurch",
+      "type": "shuttle",
+      "cost": "$15-20 NZD",
+      "duration": "20-25 minutes",
+      "note": "Regular shuttles through the tunnel to central Christchurch."
+    },
+    {
+      "id": "taxi-gondola",
+      "name": "Taxi to Gondola",
+      "type": "taxi",
+      "cost": "$25-35 NZD",
+      "duration": "15 minutes",
+      "note": "Scenic ride to Christchurch Gondola base station."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Christchurch City Tour",
+      "type": "city",
+      "duration": "Half day",
+      "highlights": ["Transitional Cathedral", "Canterbury Museum", "Botanic Gardens", "Earthquake rebuild"],
+      "note": "Explore the 'Garden City' and its remarkable earthquake recovery."
+    },
+    {
+      "name": "Christchurch Gondola",
+      "type": "scenic",
+      "duration": "2-3 hours",
+      "highlights": ["Panoramic views", "Volcanic crater", "Time Tunnel ride"],
+      "note": "Cable car up the Port Hills with stunning harbor and city views."
+    },
+    {
+      "name": "Lyttelton Village Walk",
+      "type": "cultural",
+      "duration": "1-2 hours",
+      "highlights": ["Historic port town", "Artisan shops", "Cafés"],
+      "note": "Charming harbor village with creative community and earthquake history."
+    }
+  ]
+}

--- a/assets/data/maps/penang.map.json
+++ b/assets/data/maps/penang.map.json
@@ -1,0 +1,88 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Penang tourism and cruise port guides"
+  },
+
+  "port_slug": "penang",
+  "port_name": "Penang",
+  "port_pin": {
+    "lat": 5.4164,
+    "lon": 100.3327,
+    "label": "Swettenham Pier Cruise Terminal"
+  },
+
+  "bbox_hint": {
+    "south": 5.35,
+    "west": 100.20,
+    "north": 5.50,
+    "east": 100.45,
+    "note": "Covers Georgetown, Penang Hill, temples, and beaches"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Swettenham Pier Terminal", "lat": 5.4164, "lon": 100.3327, "type": "port"},
+    {"name": "Georgetown UNESCO Zone", "lat": 5.4147, "lon": 100.3381, "type": "historic"},
+    {"name": "Kek Lok Si Temple", "lat": 5.3986, "lon": 100.2733, "type": "temple"},
+    {"name": "Penang Hill", "lat": 5.4238, "lon": 100.2704, "type": "scenic"},
+    {"name": "Khoo Kongsi", "lat": 5.4167, "lon": 100.3378, "type": "historic"},
+    {"name": "Street Art Walk", "lat": 5.4147, "lon": 100.3400, "type": "art"},
+    {"name": "Batu Ferringhi Beach", "lat": 5.4750, "lon": 100.2300, "type": "beach"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "walk-georgetown",
+      "name": "Walk to Georgetown",
+      "type": "walking",
+      "cost": "Free",
+      "duration": "5-10 minutes",
+      "note": "UNESCO zone is directly adjacent to cruise terminal."
+    },
+    {
+      "id": "taxi-hill",
+      "name": "Taxi to Penang Hill",
+      "type": "taxi",
+      "cost": "RM30-40 (~$7-10 USD)",
+      "duration": "20-30 minutes",
+      "note": "To funicular railway base station at Air Itam."
+    },
+    {
+      "id": "bus-city",
+      "name": "Rapid Penang Bus",
+      "type": "bus",
+      "cost": "RM2-4 (~$0.50-1 USD)",
+      "duration": "Varies",
+      "note": "Extensive bus network covers the island."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Georgetown Heritage Walk",
+      "type": "cultural",
+      "duration": "3-4 hours",
+      "highlights": ["UNESCO World Heritage Site", "Street art", "Clan jetties", "Colonial architecture"],
+      "note": "Multicultural enclave with Chinese, Malay, Indian, and British influences."
+    },
+    {
+      "name": "Penang Hill & Kek Lok Si",
+      "type": "scenic",
+      "duration": "Half day",
+      "highlights": ["Funicular railway", "Panoramic views", "Largest Buddhist temple in Malaysia"],
+      "note": "Combine hilltop views with stunning temple complex."
+    },
+    {
+      "name": "Penang Food Trail",
+      "type": "culinary",
+      "duration": "3-4 hours",
+      "highlights": ["Char kway teow", "Laksa", "Cendol", "Hawker centers"],
+      "note": "Penang is Malaysia's food capital. UNESCO-recognized street food culture."
+    }
+  ]
+}

--- a/assets/data/maps/safaga.map.json
+++ b/assets/data/maps/safaga.map.json
@@ -1,0 +1,78 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Egypt tourism and cruise port guides"
+  },
+
+  "port_slug": "safaga",
+  "port_name": "Safaga",
+  "port_pin": {
+    "lat": 26.7333,
+    "lon": 33.9333,
+    "label": "Port of Safaga"
+  },
+
+  "bbox_hint": {
+    "south": 26.60,
+    "west": 33.80,
+    "north": 26.85,
+    "east": 34.05,
+    "note": "Covers Safaga port, gateway to Luxor and Valley of the Kings"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Port of Safaga", "lat": 26.7333, "lon": 33.9333, "type": "port"},
+    {"name": "Safaga Beach", "lat": 26.7400, "lon": 33.9400, "type": "beach"},
+    {"name": "Luxor Temple", "lat": 25.6997, "lon": 32.6390, "type": "historic"},
+    {"name": "Valley of the Kings", "lat": 25.7402, "lon": 32.6014, "type": "historic"},
+    {"name": "Karnak Temple", "lat": 25.7188, "lon": 32.6573, "type": "historic"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "bus-luxor",
+      "name": "Coach to Luxor",
+      "type": "bus",
+      "cost": "Included in shore excursion",
+      "duration": "3-4 hours each way",
+      "note": "Most common way to reach Luxor. Book ship excursion for convenience."
+    },
+    {
+      "id": "taxi-hurghada",
+      "name": "Taxi to Hurghada",
+      "type": "taxi",
+      "cost": "$30-40 USD one way",
+      "duration": "1 hour",
+      "note": "For beach resorts and diving if not going to Luxor."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Luxor & Valley of the Kings",
+      "type": "historic",
+      "duration": "Full day",
+      "highlights": ["Valley of the Kings", "Luxor Temple", "Karnak Temple", "Hatshepsut Temple"],
+      "note": "Ancient Thebes with pharaonic tombs. Long but unforgettable day trip."
+    },
+    {
+      "name": "Red Sea Beach Day",
+      "type": "beach",
+      "duration": "Half day",
+      "highlights": ["Clear water", "Snorkeling", "Relaxation"],
+      "note": "Alternative to Luxor for those seeking relaxation."
+    },
+    {
+      "name": "Desert Safari",
+      "type": "nature",
+      "duration": "Half day",
+      "highlights": ["Eastern Desert", "Bedouin village", "Quad biking"],
+      "note": "Explore the desert landscape around Safaga."
+    }
+  ]
+}

--- a/assets/data/maps/salalah.map.json
+++ b/assets/data/maps/salalah.map.json
@@ -1,0 +1,80 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Salalah cruise port guides and Oman tourism resources"
+  },
+
+  "port_slug": "salalah",
+  "port_name": "Salalah",
+  "port_pin": {
+    "lat": 17.0151,
+    "lon": 54.0924,
+    "label": "Port of Salalah"
+  },
+
+  "bbox_hint": {
+    "south": 16.85,
+    "west": 53.85,
+    "north": 17.15,
+    "east": 54.25,
+    "note": "Covers Salalah city, Al Balid, and surrounding frankincense sites"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Port of Salalah", "lat": 17.0151, "lon": 54.0924, "type": "port"},
+    {"name": "Al Balid UNESCO Site", "lat": 17.0167, "lon": 54.0833, "type": "historic"},
+    {"name": "Museum of Frankincense Land", "lat": 17.0167, "lon": 54.0833, "type": "museum"},
+    {"name": "Sultan Qaboos Mosque", "lat": 17.0190, "lon": 54.0780, "type": "mosque"},
+    {"name": "Haffa Souq", "lat": 17.0140, "lon": 54.0650, "type": "market"},
+    {"name": "Wadi Darbat", "lat": 17.1000, "lon": 54.4500, "type": "nature"},
+    {"name": "Al Mughsail Beach", "lat": 16.8667, "lon": 53.7500, "type": "beach"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "taxi-city",
+      "name": "Taxi to City Center",
+      "type": "taxi",
+      "cost": "$10-15 USD",
+      "duration": "10-15 minutes",
+      "note": "Most convenient option. Negotiate fare before departing."
+    },
+    {
+      "id": "taxi-balid",
+      "name": "Taxi to Al Balid",
+      "type": "taxi",
+      "cost": "$8-12 USD",
+      "duration": "10 minutes",
+      "note": "UNESCO World Heritage Site near the port."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Al Balid Archaeological Park",
+      "type": "historic",
+      "duration": "2-3 hours",
+      "highlights": ["UNESCO World Heritage Site", "Museum of Frankincense Land", "Ancient trading port ruins"],
+      "note": "Explores Salalah's role in the ancient frankincense trade. Entry ~$5."
+    },
+    {
+      "name": "Wadi Darbat",
+      "type": "nature",
+      "duration": "Half day",
+      "highlights": ["Waterfalls during khareef", "Lush greenery", "Wildlife"],
+      "note": "Spectacular during monsoon season (July-September). 65km from port."
+    },
+    {
+      "name": "Frankincense Trail",
+      "type": "cultural",
+      "duration": "Full day",
+      "highlights": ["Frankincense trees", "UNESCO sites", "Traditional harvesting"],
+      "note": "Visit Wadi Dawkah to see the famous frankincense groves."
+    }
+  ]
+}

--- a/assets/data/maps/tauranga.map.json
+++ b/assets/data/maps/tauranga.map.json
@@ -1,0 +1,87 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-13T00:00:00Z",
+    "source": "Researched from Tauranga NZ tourism and cruise port guides"
+  },
+
+  "port_slug": "tauranga",
+  "port_name": "Tauranga",
+  "port_pin": {
+    "lat": -37.6478,
+    "lon": 176.1711,
+    "label": "Port of Tauranga Cruise Terminal"
+  },
+
+  "bbox_hint": {
+    "south": -37.80,
+    "west": 175.95,
+    "north": -37.55,
+    "east": 176.35,
+    "note": "Covers Tauranga, Mount Maunganui, access to Rotorua and Hobbiton"
+  },
+
+  "poi_ids": [],
+
+  "label_overrides": {},
+
+  "approximate_markers": [
+    {"name": "Port of Tauranga", "lat": -37.6478, "lon": 176.1711, "type": "port"},
+    {"name": "Mount Maunganui", "lat": -37.6343, "lon": 176.1800, "type": "scenic"},
+    {"name": "Tauranga City Center", "lat": -37.6878, "lon": 176.1651, "type": "town"},
+    {"name": "Te Puia (Rotorua)", "lat": -38.1614, "lon": 176.2517, "type": "cultural"},
+    {"name": "Hobbiton Movie Set", "lat": -37.8567, "lon": 175.6820, "type": "attraction"},
+    {"name": "Wai-O-Tapu", "lat": -38.3553, "lon": 176.3689, "type": "nature"}
+  ],
+
+  "transit_routes": [
+    {
+      "id": "shuttle-mount",
+      "name": "Shuttle to Mount Maunganui",
+      "type": "shuttle",
+      "cost": "$15-20 NZD",
+      "duration": "10-15 minutes",
+      "note": "Beach town with iconic volcanic cone to climb."
+    },
+    {
+      "id": "tour-rotorua",
+      "name": "Tour to Rotorua",
+      "type": "tour",
+      "cost": "$150-200 NZD",
+      "duration": "Full day",
+      "note": "Geothermal wonders, Māori culture, adventure activities."
+    },
+    {
+      "id": "tour-hobbiton",
+      "name": "Tour to Hobbiton",
+      "type": "tour",
+      "cost": "$200-250 NZD",
+      "duration": "Half day",
+      "note": "Lord of the Rings/Hobbit movie set. Book in advance."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Rotorua Geothermal",
+      "type": "nature",
+      "duration": "Full day",
+      "highlights": ["Te Puia geysers", "Māori cultural performance", "Mud pools", "Wai-O-Tapu"],
+      "note": "Experience New Zealand's volcanic heart and rich Māori heritage."
+    },
+    {
+      "name": "Hobbiton Movie Set",
+      "type": "attraction",
+      "duration": "Half day",
+      "highlights": ["44 Hobbit holes", "Green Dragon Inn", "Movie magic", "Shire landscapes"],
+      "note": "Step into Middle-earth at this world-famous film location."
+    },
+    {
+      "name": "Mount Maunganui",
+      "type": "scenic",
+      "duration": "2-3 hours",
+      "highlights": ["Beach walks", "Summit climb", "Ocean views", "Cafés"],
+      "note": "Climb 'The Mount' for panoramic views or relax on the beach."
+    }
+  ]
+}

--- a/assets/data/ports/ports-geo.json
+++ b/assets/data/ports/ports-geo.json
@@ -117,6 +117,16 @@
     {"id": "wellington", "name": "Wellington", "lat": -41.2866, "lon": 174.7756, "url": "/ports/wellington.html", "region": "Australia"},
     {"id": "nagasaki", "name": "Nagasaki", "lat": 32.7503, "lon": 129.8777, "url": "/ports/nagasaki.html", "region": "Asia"},
     {"id": "ho-chi-minh-city", "name": "Ho Chi Minh City", "lat": 10.7769, "lon": 106.7009, "url": "/ports/ho-chi-minh-city.html", "region": "Asia"},
-    {"id": "muscat", "name": "Muscat", "lat": 23.5880, "lon": 58.3829, "url": "/ports/muscat.html", "region": "Middle East"}
+    {"id": "muscat", "name": "Muscat", "lat": 23.5880, "lon": 58.3829, "url": "/ports/muscat.html", "region": "Middle East"},
+    {"id": "salalah", "name": "Salalah", "lat": 17.0151, "lon": 54.0924, "url": "/ports/salalah.html", "region": "Middle East"},
+    {"id": "aqaba", "name": "Aqaba", "lat": 29.5267, "lon": 35.0078, "url": "/ports/aqaba.html", "region": "Middle East"},
+    {"id": "safaga", "name": "Safaga", "lat": 26.7333, "lon": 33.9333, "url": "/ports/safaga.html", "region": "Middle East"},
+    {"id": "lyttelton", "name": "Lyttelton", "lat": -43.6036, "lon": 172.7194, "url": "/ports/lyttelton.html", "region": "Australia"},
+    {"id": "dunedin", "name": "Dunedin", "lat": -45.8788, "lon": 170.5028, "url": "/ports/dunedin.html", "region": "Australia"},
+    {"id": "fukuoka", "name": "Fukuoka", "lat": 33.5902, "lon": 130.4017, "url": "/ports/fukuoka.html", "region": "Asia"},
+    {"id": "penang", "name": "Penang", "lat": 5.4164, "lon": 100.3327, "url": "/ports/penang.html", "region": "Asia"},
+    {"id": "da-nang", "name": "Da Nang", "lat": 16.0544, "lon": 108.2022, "url": "/ports/da-nang.html", "region": "Asia"},
+    {"id": "cape-town", "name": "Cape Town", "lat": -33.9249, "lon": 18.4241, "url": "/ports/cape-town.html", "region": "Africa"},
+    {"id": "tauranga", "name": "Tauranga", "lat": -37.6878, "lon": 176.1651, "url": "/ports/tauranga.html", "region": "Australia"}
   ]
 }

--- a/ports/aqaba.html
+++ b/ports/aqaba.html
@@ -1,0 +1,291 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Aqaba cruise port with tips for Petra day trips, Red Sea diving, Wadi Rum, and experiencing Jordan's ancient gateway."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Aqaba Port Guide — Gateway to Petra & Red Sea Adventures | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Aqaba — Jordan's Red Sea port, gateway to ancient Petra, Wadi Rum desert, world-class diving, and 6,000 years of trading history."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/aqaba.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Aqaba", "item": "https://cruisinginthewake.com/ports/aqaba.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Can I visit Petra from Aqaba cruise port?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, but it's a long day. Petra is about 2 hours each way from Aqaba. Most cruise lines offer Petra excursions, or you can hire a private driver. Allow a full day."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is special about diving in Aqaba?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Aqaba offers 30+ dive sites in the Red Sea, including coral reefs and a sunken Lebanese freighter. Many sites are within Aqaba Marine Park, a protected area with exceptional visibility."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Aqaba</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/ports/img/aqaba/petra-treasury.webp" alt="The Treasury at Petra carved into rose-red sandstone cliffs" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Aqaba</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org/wiki/Category:Petra" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
+      </div>
+
+      <article class="card">
+        <h1>Aqaba: Jordan's Red Sea Gateway to Ancient Wonders</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>Jordan's only coastal city sits at the apex of the Red Sea, where the borders of four nations nearly touch. For six thousand years, ships have called at this harbor — Egyptians, Nabataeans, Romans, Crusaders, Ottomans, and now cruise ships transiting between the Mediterranean and the Indian Ocean. It's Jordan's window to the sea, and more importantly, the gateway to one of the world's most extraordinary archaeological sites.</p>
+
+          <p>Let's address Petra directly: yes, you can visit from Aqaba, but understand what you're signing up for. The rose-red city is about two hours each way by car, through desert landscapes that inspired Lawrence of Arabia. The Nabataeans carved their capital from sandstone cliffs beginning around the 4th century BC, creating a trading empire that controlled the incense routes between Arabia and the Mediterranean. When you finally walk through the narrow Siq canyon and the Treasury emerges before you, carved impossibly into the rock face, the journey justifies itself completely.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> That first glimpse of the Treasury through the narrow gap in the canyon walls — after walking a kilometer through towering sandstone cliffs that seem to close overhead, you round a corner and there it is, bathed in sunlight, impossibly intricate and impossibly old. Every photograph you've ever seen fails to prepare you. The scale, the color, the sheer audacity of carving a temple from a cliff face. This is why people come to Jordan. This single moment.
+          </div>
+
+          <p>But Aqaba itself deserves more than a transit stop. The Red Sea here offers world-class diving and snorkeling — thirty-plus dive sites including coral reefs and a deliberately sunken cargo ship. The North Beach has facilities for cruise passengers who'd rather swim than trek through the desert. And the city's 6,000-year history as a trading port means archaeological sites dot the area, including ruins believed to be the biblical Elath.</p>
+
+          <p>The massive flagpole you'll see from the ship commemorates the Great Arab Revolt of 1916 — at 131 meters, it's one of the tallest in the world, marking where Arab forces captured Aqaba from the Ottomans with help from T.E. Lawrence.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> Aqaba Cruise Terminal (opened 2023) — modern facility in the port area</li>
+            <li><strong>Distance to Petra:</strong> ~2 hours each way by road; full-day excursion</li>
+            <li><strong>Distance to Wadi Rum:</strong> ~1 hour each way</li>
+            <li><strong>Tender:</strong> No — ships dock directly at the pier</li>
+            <li><strong>Currency:</strong> Jordanian Dinar (JOD); USD widely accepted</li>
+            <li><strong>Language:</strong> Arabic; English widely spoken in tourist areas</li>
+            <li><strong>Visa:</strong> Many nationalities can obtain visa on arrival; check requirements</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Petra Day Trip</h4>
+          <p>UNESCO World Heritage Site and one of the New Seven Wonders of the World. The Treasury, the Monastery, the Street of Facades — allow 4-5 hours minimum on-site. Full day from Aqaba. Entry ~50 JOD for one day.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Wadi Rum</h4>
+          <p>Mars-like desert landscape of sandstone mountains and red sand. Jeep tours, camel rides, Bedouin camps. Featured in Lawrence of Arabia and The Martian. ~1 hour from Aqaba. Half-day possible.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Red Sea Diving & Snorkeling</h4>
+          <p>30+ dive sites in Aqaba Marine Park. Coral reefs, tropical fish, and a sunken Lebanese freighter. Multiple operators near North Beach. Snorkeling accessible; diving requires certification.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">North Beach</h4>
+          <p>Public beach strip popular with cruise passengers. Swimming, snorkeling, beach clubs. Facilities available. Closest beach option to the port.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Aqaba Castle</h4>
+          <p>Mamluk-era fortification near the flagpole. Small museum inside. Views over the harbor. Quick visit if you have limited time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Aqaba Archaeological Museum</h4>
+          <p>Artifacts from the region's 6,000-year history, including items from Ayla (the early Islamic city). Small but informative. Near the waterfront.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Aqaba Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, beaches, and routes to Petra and Wadi Rum. Click any marker for details and directions.</p>
+          <div id="aqaba-port-map" class="port-map-container" role="application" aria-label="Interactive map of Aqaba and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Mansaf:</strong> Jordan's national dish — lamb cooked in fermented yogurt, served over rice with pine nuts</li>
+            <li><strong>Falafel:</strong> Deep-fried chickpea balls, served in pita with tahini and vegetables</li>
+            <li><strong>Mezze:</strong> Array of small dishes — hummus, baba ganoush, tabbouleh, fattoush</li>
+            <li><strong>Fresh Fish:</strong> Red Sea catch, grilled simply with lemon and herbs</li>
+            <li><strong>Arabic Coffee:</strong> Cardamom-spiced, served in small cups as a welcome gesture</li>
+            <li><strong>Mint Tea:</strong> Sweet, hot tea with fresh mint — the social lubricant of Jordan</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: Is Petra worth the long day trip?</strong><br/>A: If you've never been, absolutely yes. It's one of humanity's greatest archaeological achievements. The journey is long but unforgettable.</p>
+          <p><strong>Q: Can I do Petra and Wadi Rum in one day?</strong><br/>A: Possible but exhausting. Better to choose one. Most cruise passengers choose Petra; Wadi Rum is less rushed as a half-day.</p>
+          <p><strong>Q: Is Jordan safe for tourists?</strong><br/>A: Yes, Jordan is considered one of the safest countries in the Middle East. Tourism is a significant industry and visitors are welcome.</p>
+          <p><strong>Q: What should I wear?</strong><br/>A: Modest dress is appreciated. For Petra, wear comfortable walking shoes — you'll cover miles on uneven terrain.</p>
+          <p><strong>Q: Do I need a visa?</strong><br/>A: Many nationalities can get a visa on arrival. Check Jordanian requirements for your passport.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>Jordan</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>Arabic / English</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>JOD / USD</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>Aqaba Terminal</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>Petra, Diving</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>Excursion needed</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'aqaba';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'aqaba-port-map', portSlug: 'aqaba' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/ports/cape-town.html
+++ b/ports/cape-town.html
@@ -1,0 +1,289 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Cape Town cruise port with tips for Table Mountain, Robben Island, Boulders Beach penguins, Cape of Good Hope, and experiencing South Africa's Mother City."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Cape Town Port Guide — Table Mountain & the Mother City | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Cape Town — iconic Table Mountain cable car, Robben Island prison history, African penguin encounters, Cape of Good Hope, and discovering South Africa's most beautiful city."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/cape-town.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Cape Town", "item": "https://cruisinginthewake.com/ports/cape-town.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Where do cruise ships dock in Cape Town?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ships dock at the V&A Waterfront Cruise Terminal in the heart of Cape Town's tourist district. Shopping, dining, and the harbor area are all within walking distance."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is the Table Mountain cable car worth it?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Absolutely. The revolving cable car offers spectacular 360-degree views of Cape Town, the ocean, and surrounding mountains. Book tickets online in advance to avoid long queues. Note that it closes during high winds."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Cape Town</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/assets/brand/placeholder-port.webp" alt="Table Mountain rising dramatically above Cape Town harbor and V&A Waterfront" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Cape Town, South Africa</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: In the Wake</p>
+      </div>
+
+      <article class="card">
+        <h1>Cape Town: Where Two Oceans Meet and History Echoes</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>Table Mountain dominates everything. You see it from the ship as you approach, rising flat and immense like an Old Testament vision, clouds often draping it like the tablecloth locals say it is. Cape Town was founded in 1652 when Jan van Riebeeck established a Dutch supply station at this strategic meeting point of the Atlantic and Indian Oceans. That history — colonial, complicated, painful, and resilient — shapes every corner of what South Africans affectionately call the Mother City.</p>
+
+          <p>What struck me immediately was the sheer beauty of the setting. Few cities anywhere can match Cape Town's natural drama: ocean on three sides, mountains rising straight from the sea, light that photographers dream about. But underneath that postcard-perfect surface runs a deeper current — the legacy of apartheid, the stark inequality that still divides neighborhoods, and the determined hope of a nation trying to build something better. Robben Island, visible from the waterfront, is the conscience of the harbor.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> Standing in Nelson Mandela's prison cell on Robben Island, a space barely larger than a closet where he spent eighteen of his twenty-seven years of imprisonment. Our guide was a former political prisoner himself. He spoke without bitterness, with grace I'm not sure I could manage. He ended with Mandela's words: "It always seems impossible until it's done." I believed him.
+          </div>
+
+          <p>The Table Mountain cable car is touristy and expensive and absolutely worth it. The revolving floor shows you 360-degree views of one of the world's most spectacular cities while ascending. At the top, hiking trails crisscross the plateau through unique fynbos vegetation found nowhere else on earth. Book online to avoid the queue. Wind can close the cable car unpredictably — check the forecast.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> V&A Waterfront Cruise Terminal — central location with shops, restaurants, and attractions within walking distance</li>
+            <li><strong>Distance to City Center:</strong> V&A Waterfront is the tourist heart; Table Mountain 10 min by taxi</li>
+            <li><strong>Tender:</strong> No — ships dock directly at the pier</li>
+            <li><strong>Currency:</strong> South African Rand (ZAR); credit cards widely accepted; ATMs available</li>
+            <li><strong>Language:</strong> English (plus Afrikaans, Xhosa, and nine other official languages)</li>
+            <li><strong>Driving:</strong> Left side (British style); car rental available but organized tours recommended for safety</li>
+            <li><strong>Best Season:</strong> October–April (Southern Hemisphere summer); December–February warmest but crowded</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Table Mountain Cable Car</h4>
+          <p>Rotating cable car to the 1,085-meter summit of Table Mountain. Spectacular views, hiking trails, unique fynbos flora. ~$20-25 round-trip. Book online to skip the queue. Closes during high winds — check ahead. Allow 2-3 hours.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Robben Island</h4>
+          <p>UNESCO World Heritage site where Nelson Mandela was imprisoned for 18 years. Ferry from V&A Waterfront + guided prison tour led by former political prisoners. Deeply moving. ~$30, 3.5 hours total. Book days in advance — sells out.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Boulders Beach Penguin Colony</h4>
+          <p>Walk among wild African penguins at this protected beach in Simon's Town. About 40 km from port (45 min drive). One of only two mainland penguin breeding colonies in the world. ~$5 entry. Combine with Cape Point for a full day.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Cape of Good Hope & Cape Point</h4>
+          <p>Dramatic cliffs at the southwestern tip of Africa where Atlantic and Indian Oceans meet. Funicular to the lighthouse, baboon sightings, stunning coastal drives. Full-day excursion (60 km from Cape Town). Often combined with Boulders Beach and Chapman's Peak Drive.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">V&A Waterfront</h4>
+          <p>Working harbor transformed into shopping, dining, and entertainment district. Walk from cruise terminal. Two Oceans Aquarium, craft markets, harbor views, excellent restaurants. Safe and vibrant day or night.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Winelands Day Trip</h4>
+          <p>Stellenbosch and Franschhoek wine regions are 45-60 min from Cape Town. World-class wine estates, Cape Dutch architecture, mountain scenery. Organized tours recommended (designated driver essential). Full-day excursion.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Cape Town Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, Table Mountain, Robben Island, Boulders Beach, and Cape Peninsula attractions. Click any marker for details and directions.</p>
+          <div id="cape-town-port-map" class="port-map-container" role="application" aria-label="Interactive map of Cape Town and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Braai:</strong> South African barbecue — boerewors sausage, lamb chops, steak cooked over open flames. National pastime.</li>
+            <li><strong>Bobotie:</strong> Cape Malay curry-spiced mince topped with egg custard — sweet, savory, uniquely South African</li>
+            <li><strong>Bunny Chow:</strong> Durban specialty popular everywhere — hollowed bread loaf filled with curry</li>
+            <li><strong>Biltong:</strong> Dried, cured meat (beef or game) — South Africa's answer to jerky but infinitely better</li>
+            <li><strong>Cape Malay Cuisine:</strong> Fusion of Indonesian, Indian, and Dutch influences — try at Bo-Kaap restaurants</li>
+            <li><strong>South African Wine:</strong> World-class Chenin Blanc, Pinotage (red), Sauvignon Blanc. Winelands produce extraordinary bottles at bargain prices.</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: V&A Waterfront Cruise Terminal — central location, walking distance to shops and restaurants.</p>
+          <p><strong>Q: Is Cape Town safe for cruise visitors?</strong><br/>A: V&A Waterfront and tourist areas are generally safe. Use organized tours or taxis for sightseeing. Don't wander alone in unfamiliar neighborhoods. Exercise normal travel caution.</p>
+          <p><strong>Q: Can I see penguins from the port?</strong><br/>A: Boulders Beach penguin colony is 40 km away (45 min). Requires organized tour or taxi. Absolutely worth it — adorable and unique experience.</p>
+          <p><strong>Q: What if Table Mountain cable car is closed?</strong><br/>A: High winds close it frequently. Have a backup plan. Consider Robben Island, V&A Waterfront, or a Cape Peninsula tour instead.</p>
+          <p><strong>Q: Should I visit the winelands or Cape Point?</strong><br/>A: Both require full-day excursions. Winelands for wine/scenery; Cape Point for dramatic coastal beauty and penguins. Choose based on interests.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>South Africa</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>English, Afrikaans</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>ZAR</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>V&A Waterfront</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>Nature, History, Wine</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>Waterfront walkable</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'cape-town';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'cape-town-port-map', portSlug: 'cape-town' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/ports/da-nang.html
+++ b/ports/da-nang.html
@@ -1,0 +1,289 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Da Nang cruise port with tips for Hoi An Ancient Town, Marble Mountains, My Son Sanctuary, and experiencing Vietnam's blend of ancient temples and modern resilience."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Da Nang Port Guide — Vietnam's Coast of Lanterns & Legends | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Da Nang — gateway to UNESCO Hoi An Ancient Town, mystical Marble Mountains, My Son ruins, and discovering Vietnam's layered history from Champa kingdoms to French colonial elegance."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/da-nang.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Da Nang", "item": "https://cruisinginthewake.com/ports/da-nang.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Where do cruise ships dock in Da Nang?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ships dock at Tien Sa Port (meaning 'descending fairy'), about 7 km from downtown Da Nang and 30 km from Hoi An Ancient Town."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How far is Hoi An from Da Nang cruise port?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Hoi An is approximately 30 km (45 minutes by taxi) from Tien Sa Port. Most cruise visitors prioritize this UNESCO World Heritage town over Da Nang city itself."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Da Nang</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/assets/brand/placeholder-port.webp" alt="Colorful lanterns illuminating a traditional street in Hoi An Ancient Town at dusk" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Da Nang, Vietnam</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: In the Wake</p>
+      </div>
+
+      <article class="card">
+        <h1>Da Nang: Where Ancient Kingdoms Meet the South China Sea</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>The name Tien Sa — "descending fairy" — felt almost prophetic as we approached Vietnam's central coast. Da Nang itself is a modern, rapidly developing city, but its real magic lies in what surrounds it: Hoi An's amber-lit ancient streets thirty kilometers south, the mystical Marble Mountains rising from rice paddies like something from a scroll painting, and the jungle-reclaimed temples of My Son where the Champa kingdom once thrived. This port is a gateway, and what lies beyond is extraordinary.</p>
+
+          <p>Vietnam's history is written in layers here — Champa Hindu kingdoms, centuries of Chinese influence, French colonial architecture, the scars and resilience of the American War, and now the surging energy of a nation racing toward the future while fiercely protecting its past. In Hoi An especially, you feel that preservation instinct. The whole town is a UNESCO World Heritage site where cars are banned from the old quarter and every building glows amber from silk lanterns after sunset.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> Standing inside the Huyen Khong Cave within the Marble Mountains as sunlight poured through a natural opening in the ceiling, illuminating Buddhist altars that have received prayers for centuries. The cave served as a field hospital during the war; bullet scars are still visible on the rock. History and faith occupy the same sacred space. I stood there longer than I'd planned, feeling the weight of both.
+          </div>
+
+          <p>Hoi An delivers everything the guidebooks promise and then some. Yes, it's touristy — you'll be offered custom tailoring within five minutes of arrival — but the tailoring is legitimately excellent and absurdly affordable. More importantly, the town's soul remains intact. Walk the streets at dusk when the lanterns light, try cao lau noodles from a family recipe unchanged in generations, and watch fishermen cast nets on the Thu Bon River. Hoi An earned its UNESCO status honestly.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> Tien Sa Port ("Descending Fairy") — about 7 km from downtown Da Nang, 30 km from Hoi An</li>
+            <li><strong>Distance to Hoi An:</strong> 30 km / 45 min by taxi or arranged transport</li>
+            <li><strong>Tender:</strong> No — ships dock directly at the pier</li>
+            <li><strong>Currency:</strong> Vietnamese Dong (VND); USD widely accepted but change given in dong</li>
+            <li><strong>Language:</strong> Vietnamese; English spoken at tourist sites, less common elsewhere</li>
+            <li><strong>Driving:</strong> Right side; traffic is chaotic — taxis or organized transport recommended</li>
+            <li><strong>Best Season:</strong> February–May (warm, dry); avoid monsoon rains September–December</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Hoi An Ancient Town</h4>
+          <p>UNESCO World Heritage town 30 km from port. Silk lanterns, 400-year-old merchant houses, Japanese Covered Bridge, riverside cafés. Car-free old quarter. Custom tailoring is world-class and affordable. Plan 4-6 hours minimum. Entry ticket ~$6 covers multiple historic sites.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Marble Mountains</h4>
+          <p>Five limestone hills representing the five elements (metal, wood, water, fire, earth). Buddhist caves, temples, panoramic views, and war history. Thuy Son (Water Mountain) is the most impressive. 20 min from port. ~$2 entry; elevator available for accessibility.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">My Son Sanctuary</h4>
+          <p>Jungle-shrouded ruins of the Champa kingdom's holy city (4th–13th centuries). Hindu temples similar to Angkor Wat but smaller and less restored. UNESCO site. 70 km from Da Nang. Half-day excursion recommended. ~$6 entry.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Dragon Bridge & Riverfront Da Nang</h4>
+          <p>Modern Da Nang's icon — a dragon-shaped bridge that breathes fire and water on weekend nights (9 PM). Stroll the Han River waterfront for contemporary Vietnam energy. Close to port if time is short.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Ba Na Hills & Golden Bridge</h4>
+          <p>French colonial hill station reached by cable car. The Golden Bridge held by giant stone hands is Instagram-famous. Fantasy amusement park atmosphere. 40 km from port. Full-day excursion. ~$35 including cable car.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Vietnamese Cooking Class</h4>
+          <p>Several operators in Hoi An offer market tour + cooking class experiences. Learn to make pho, spring rolls, cao lau. Excellent cultural immersion and you eat what you cook. ~$25-40 per person.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Da Nang Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, Hoi An, Marble Mountains, My Son, and regional attractions. Click any marker for details and directions.</p>
+          <div id="da-nang-port-map" class="port-map-container" role="application" aria-label="Interactive map of Da Nang and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Cao Lau:</strong> Hoi An specialty — thick rice noodles with pork, greens, crispy wontons. Only authentic when made with Hoi An water (locals claim)</li>
+            <li><strong>Banh Mi:</strong> Vietnamese baguette sandwich — a delicious French-Vietnamese fusion with pâté, pickled vegetables, cilantro, chili</li>
+            <li><strong>Mi Quang:</strong> Central Vietnam turmeric noodles with shrimp, pork, peanuts, rice crackers — vibrant and flavorful</li>
+            <li><strong>White Rose Dumplings:</strong> Hoi An's translucent shrimp dumplings shaped like roses — delicate and beautiful</li>
+            <li><strong>Vietnamese Coffee:</strong> Intensely strong coffee dripped over sweetened condensed milk. Life-changing when served iced (ca phe sua da)</li>
+            <li><strong>Bia Hoi:</strong> Fresh draft beer served at street-side cafés — light, cheap, refreshing</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Tien Sa Port, about 7 km from Da Nang city and 30 km from Hoi An.</p>
+          <p><strong>Q: Should I go to Da Nang or Hoi An?</strong><br/>A: Most cruise visitors prioritize Hoi An (UNESCO Ancient Town). Da Nang is modern; Hoi An is historic and charming.</p>
+          <p><strong>Q: How do I get to Hoi An?</strong><br/>A: Taxi (45 min, ~$20-25 one-way) or book a shore excursion. Negotiate round-trip taxi fare in advance.</p>
+          <p><strong>Q: Is custom tailoring worth it?</strong><br/>A: Yes! Hoi An's tailors are skilled and affordable. Bring photos of what you want; they can copy anything. Allow time for fittings.</p>
+          <p><strong>Q: Do I need a visa for Vietnam?</strong><br/>A: Many nationalities can enter visa-free for short stays. Check current requirements for your passport before arrival.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>Vietnam</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>Vietnamese</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>VND / USD</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>Tien Sa Port</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>History, Culture, Food</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>Hoi An walkable; taxi needed</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'da-nang';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'da-nang-port-map', portSlug: 'da-nang' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/ports/dunedin.html
+++ b/ports/dunedin.html
@@ -1,0 +1,289 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Dunedin cruise port with tips for Port Chalmers, Otago Peninsula wildlife, Larnach Castle, Baldwin Street, and experiencing Scotland's legacy in New Zealand's south."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Dunedin Port Guide — Scotland's Southern Hemisphere Soul | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Dunedin — Port Chalmers terminal, Otago Peninsula albatross and penguins, Larnach Castle, Baldwin Street, and the Edinburgh of the South's Victorian grandeur."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/dunedin.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Dunedin, New Zealand", "item": "https://cruisinginthewake.com/ports/dunedin.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Where do cruise ships dock in Dunedin?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ships dock at Port Chalmers, about 15 kilometers (9 miles) from Dunedin city center. Shuttle buses transport passengers to the city, railway station, and Otago Peninsula attractions."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can I see albatross and penguins in Dunedin?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. The Otago Peninsula hosts the world's only mainland royal albatross colony at Taiaroa Head, plus yellow-eyed penguins, little blue penguins, and New Zealand fur seals. Best viewing during breeding season (September-March for albatross)."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Dunedin, New Zealand</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/ports/img/dunedin/railway-station.webp" alt="Dunedin Railway Station's ornate Flemish Renaissance architecture with detailed stonework and decorative tiles" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Dunedin, New Zealand</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org/wiki/Category:Dunedin" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
+      </div>
+
+      <article class="card">
+        <h1>Dunedin: Where Scottish Souls Built a Victorian Jewel at the End of the World</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>Dunedin wears its Scottish heritage without apology. The name itself is the ancient Gaelic for Edinburgh, and the city's founders — Free Church of Scotland emigrants who arrived in 1848 — consciously recreated their homeland's urban aesthetics in New Zealand's South Island. The result is a Victorian architectural treasure chest where bluestone buildings rise against coastal hills, bagpipes still echo through streets named for Scottish geography, and the University of Otago (New Zealand's oldest) maintains traditions imported wholesale from Aberdeen and Edinburgh.</p>
+
+          <p>But the real magic lives on the Otago Peninsula — that dramatic finger of volcanic rock extending into the Pacific. This is where natural New Zealand overwhelms imported Scottish sensibilities. Royal albatross with three-meter wingspans nesting on mainland cliffs. Yellow-eyed penguins waddling up beaches at dusk. New Zealand fur seals sprawled on rocks like they own the place (they do). Nowhere else on Earth can you watch albatross glide past a lighthouse with a Victorian castle perched on the hillside behind.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> Standing at the Royal Albatross Centre as a massive bird launched itself from the cliff edge, caught an updraft, and soared without a single wingbeat — just perfect aerodynamic grace leveraging invisible air currents. These birds circumnavigate the Southern Ocean. They return to this exact cliff to breed after years at sea. The guide mentioned their pair bonds can last decades. I watched that bird disappear toward the horizon and thought about fidelity, navigation, and the mystery of home.
+          </div>
+
+          <p>Dunedin Railway Station deserves every superlative thrown at it. George Troup's 1906 Flemish Renaissance masterpiece is arguably the most photographed building in New Zealand, and justifiably so. The exterior stonework, the Royal Doulton porcelain mosaic floor, the stained glass — this is what happens when a gold-rush city builds infrastructure with unlimited ambition and budget. The fact that it still functions as a working station (albeit with limited service) adds poignancy to its grandeur.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> Port Chalmers — working port with cruise facilities; shuttle buses to city</li>
+            <li><strong>Distance to Dunedin:</strong> 15 km (9 miles) / 20 min to city center; 30 min to Otago Peninsula</li>
+            <li><strong>Tender:</strong> No — ships dock at Port Chalmers wharf</li>
+            <li><strong>Currency:</strong> New Zealand Dollar (NZD); cards accepted everywhere</li>
+            <li><strong>Language:</strong> English (with distinctive Kiwi-Scottish hybrid accent in older residents)</li>
+            <li><strong>Driving:</strong> Left side</li>
+            <li><strong>Best Season:</strong> December–February (summer); albatross season September–March</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Royal Albatross Centre & Taiaroa Head</h4>
+          <p>World's only mainland royal albatross breeding colony. Guided tours to viewing platforms during nesting season (September-March). Incredible wingspan, graceful flight. Also penguins, seals, and historic Fort Taiaroa. Essential Dunedin experience.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Otago Peninsula Wildlife</h4>
+          <p>Yellow-eyed penguin viewing at Penguin Place or beaches at dusk. Blue penguin colonies. Fur seal haul-outs. Natural habitat viewing with minimal disturbance. Consider guided eco-tours for best access and interpretation.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Larnach Castle</h4>
+          <p>New Zealand's only castle — William Larnach's 1871 Gothic Revival mansion on the Otago Peninsula. Opulent interiors, tragic family history, spectacular gardens, panoramic harbor views. Café on-site. Allow 2 hours.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Dunedin Railway Station</h4>
+          <p>Architectural masterpiece with ornate Flemish Renaissance exterior and stunning mosaic-tiled interior. Free to explore. Adjacent Toitū Otago Settlers Museum tells immigration and social history. Central location.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Baldwin Street (World's Steepest Street)</h4>
+          <p>Guinness Record holder at 35% gradient (1:2.86). Brief visit for photos and bragging rights. Short drive from city. Annual Cadbury Jaffa Race rolls 75,000 chocolate balls down the street for charity.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Speight's Brewery Tour</h4>
+          <p>Iconic Southern brewery producing beer since 1876. Heritage building tours with tasting. "Pride of the South" branding runs deep in local identity. Bookings recommended.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Dunedin & Otago Peninsula Map</h3>
+          <p class="map-intro">Interactive map showing Port Chalmers terminal, city landmarks, Otago Peninsula wildlife sites, and key attractions. Click any marker for details and directions.</p>
+          <div id="dunedin-port-map" class="port-map-container" role="application" aria-label="Interactive map of Dunedin and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Blue Cod:</strong> Local fish specialty — flaky white flesh, often beer-battered in fish and chips</li>
+            <li><strong>Bluff Oysters:</strong> Renowned Southern oysters (seasonal: March-August); creamy, delicate flavor</li>
+            <li><strong>Speight's Beer:</strong> Local institution since 1876; Gold Medal Ale is the flagship</li>
+            <li><strong>Whitaker's Chocolate:</strong> Dunedin chocolate maker using bean-to-bar process; factory shop near city</li>
+            <li><strong>Mutton Birds:</strong> Traditional Māori delicacy (sooty shearwater chicks); acquired taste, culturally significant</li>
+            <li><strong>Flat White & Café Culture:</strong> Dunedin's student population supports excellent coffee roasters and cafés</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Port Chalmers, about 15 km from Dunedin. Shuttles provided to city and attractions.</p>
+          <p><strong>Q: Can I see albatross and penguins?</strong><br/>A: Yes. Royal albatross at Taiaroa Head (September-March best). Yellow-eyed and blue penguins year-round with best viewing at dusk.</p>
+          <p><strong>Q: Is Dunedin walkable from the port?</strong><br/>A: No. Port Chalmers is a separate town. Use shuttles or book tours for city and peninsula.</p>
+          <p><strong>Q: What's the weather like?</strong><br/>A: Changeable. Dunedin has four-seasons-in-one-day reputation. Bring layers and rain gear year-round.</p>
+          <p><strong>Q: Is Baldwin Street worth visiting?</strong><br/>A: Brief novelty visit if time permits. Not essential unless you want the photo and Guinness Record claim.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>New Zealand</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>English (Kiwi)</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>NZD</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>Port Chalmers</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>Wildlife, History, Architecture</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>City walkable</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'dunedin';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'dunedin-port-map', portSlug: 'dunedin' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/ports/fukuoka.html
+++ b/ports/fukuoka.html
@@ -1,0 +1,289 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Fukuoka cruise port with tips for Hakata ramen, Shofukuji Zen temple, Dazaifu Tenmangu Shrine, yatai street food, and experiencing Kyushu's gateway city."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Fukuoka Port Guide — Hakata Ramen, Zen Temples & Yatai Culture | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Fukuoka — Hakata Port terminals, tonkotsu ramen, Japan's oldest Zen temple, Dazaifu shrine, Mongol invasion history, and yatai street food stalls."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/fukuoka.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Fukuoka, Japan", "item": "https://cruisinginthewake.com/ports/fukuoka.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Where do cruise ships dock in Fukuoka?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ships dock at Hakata Port, which has two terminals: Hakata Port International Terminal (closer to city center) and博多港中央ふ頭 Central Wharf. Both offer easy access to downtown Fukuoka via subway or taxi."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is Fukuoka famous for?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Fukuoka is renowned for Hakata tonkotsu ramen (rich pork bone broth), yatai street food stalls, Dazaifu Tenmangu Shrine, Shofukuji (Japan's first Zen temple from 1195), and its role in repelling the Mongol invasions of the 13th century."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Fukuoka, Japan</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/ports/img/fukuoka/dazaifu-shrine.webp" alt="Dazaifu Tenmangu Shrine with traditional Japanese architecture surrounded by plum trees" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Fukuoka, Japan</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org/wiki/Category:Fukuoka" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
+      </div>
+
+      <article class="card">
+        <h1>Fukuoka: Where Mongol Storms, Zen Gardens, and Ramen Steam Converge</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>Fukuoka occupies a peculiar position in Japanese consciousness — close enough to mainland Asia that Mongol invasion fleets actually landed here (twice, in 1274 and 1281), yet distinctly Japanese in how it absorbed and transformed every foreign influence into something uniquely Kyushu. This is Japan's gateway city, where the Silk Road's final terminus met the Pacific, where Zen Buddhism first took root (Eisai founded Shofukuji temple here in 1195), and where modern Japan's most obsessive food culture created Hakata tonkotsu ramen.</p>
+
+          <p>The yatai culture alone justifies visiting Fukuoka. These mobile food stalls — canvas-roofed, cramped, serving maybe eight people on stools — emerge at dusk along the Nakasu riverbanks and Tenjin streets like culinary mushrooms. The intimacy is remarkable: you're shoulder-to-shoulder with salarymen and students, the chef working inches from your face, steam rising from pots of yakitori and ramen. This isn't sanitized tourist dining; this is how Fukuoka actually eats after dark.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> Sitting in the zen garden at Shofukuji, Japan's oldest Zen temple, watching afternoon light filter through maple leaves while traffic hummed beyond the temple walls. Eisai brought Zen from China in 1191 and established this practice place four years later. Eight centuries of monks have sat in these same courtyards, seeking the same silence amid the same urban noise. The continuity felt almost overwhelming — this unbroken lineage of attention, preserved through wars and modernization, still alive in the careful arrangement of stones and the deliberate emptiness of raked gravel.
+          </div>
+
+          <p>Dazaifu Tenmangu Shrine carries profound significance for Japanese students and scholars — it's dedicated to Sugawara no Michizane, the deity of learning and calligraphy. The approach path crosses elegant arched bridges over ponds where plum trees (Michizane's favorite) bloom spectacularly in late winter. Thousands of students visit before exams, hanging wooden prayer plaques and purchasing good-luck charms. The faith might seem superstitious to outsiders, but watch the genuine reverence in how people approach the main hall, and you'll recognize something universal about hope, effort, and the desire for wisdom.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> Hakata Port (two terminals) — International Terminal and Central Wharf; both near city center</li>
+            <li><strong>Distance to City:</strong> 2-4 km to downtown Tenjin/Hakata areas; subway and taxis available</li>
+            <li><strong>Tender:</strong> No — ships dock at pier</li>
+            <li><strong>Currency:</strong> Japanese Yen (¥); credit cards increasingly accepted but cash still preferred</li>
+            <li><strong>Language:</strong> Japanese; limited English but excellent signage and helpful locals</li>
+            <li><strong>Transportation:</strong> Excellent subway system; IC cards (Suica, PASMO) work here</li>
+            <li><strong>Best Season:</strong> March-May (spring/plum blossoms) and October-November (autumn colors)</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Hakata Ramen Experience</h4>
+          <p>Fukuoka is the birthplace of tonkotsu (pork bone broth) ramen. Visit Ippudo, Ichiran, or smaller local shops for the definitive creamy, rich broth with thin noodles. Customize firmness, oil level, garlic intensity. This is pilgrimage territory for ramen enthusiasts.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Dazaifu Tenmangu Shrine</h4>
+          <p>Spectacular Shinto shrine dedicated to the deity of learning. Beautiful architecture, plum groves, arched bridges, museum. About 40 min from port via train. Essential cultural experience. Nearby Komyozenji temple has exquisite zen gardens.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Shofukuji Temple</h4>
+          <p>Japan's first Zen temple, founded 1195 by Eisai (who also introduced tea to Japan). Active monastery with meditation halls, zen gardens, historic gates. Limited public access but grounds are peaceful. Walking distance from Hakata Station.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Yatai Street Food Stalls</h4>
+          <p>Evening food stalls along Nakasu and Tenjin areas. Intimate counter seating, yakitori, ramen, oden, beer, sake. Peak experience around 8-10pm. Cash only. Embrace the crowded, convivial atmosphere.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Fukuoka Castle Ruins & Maizuru Park</h4>
+          <p>Historic castle site with remaining walls, turrets, and foundations. Beautiful park setting with seasonal flowers (plum, cherry blossoms, wisteria). Free access. Good views of modern Fukuoka from hillside.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Canal City Hakata</h4>
+          <p>Massive shopping and entertainment complex with canal running through center. Fountain shows, restaurants, stores. Very modern Japan. Good for souvenirs, people-watching, and escaping weather.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Fukuoka Area Map</h3>
+          <p class="map-intro">Interactive map showing Hakata Port terminals, temples, shrines, yatai districts, and key attractions. Click any marker for details and directions.</p>
+          <div id="fukuoka-port-map" class="port-map-container" role="application" aria-label="Interactive map of Fukuoka and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Hakata Tonkotsu Ramen:</strong> Rich, creamy pork bone broth simmered for hours; thin noodles; local obsession</li>
+            <li><strong>Mentaiko:</strong> Spicy marinated pollock roe — Fukuoka specialty served over rice or in onigiri</li>
+            <li><strong>Motsunabe:</strong> Hot pot with beef or pork offal, vegetables, garlic, chili — winter comfort food</li>
+            <li><strong>Mizutaki:</strong> Chicken hot pot with clear broth, seasonal vegetables; elegant and nourishing</li>
+            <li><strong>Yatai Yakitori:</strong> Grilled chicken skewers at street stalls; smoky, salty, perfect with beer</li>
+            <li><strong>Japanese Whisky & Sake:</strong> Fukuoka has excellent sake breweries; whisky highballs popular at yatai</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Hakata Port, which has two terminals — both close to city center with good transport links.</p>
+          <p><strong>Q: What is Fukuoka famous for?</strong><br/>A: Hakata ramen, yatai food stalls, Dazaifu shrine, Shofukuji (first Zen temple), and Mongol invasion history.</p>
+          <p><strong>Q: Do I need to speak Japanese?</strong><br/>A: Not essential. Signs have English, people are helpful, and tourist areas accommodate foreigners. Basic phrases appreciated.</p>
+          <p><strong>Q: Can I use credit cards?</strong><br/>A: Increasingly common but cash still preferred, especially at yatai, temples, and smaller shops. ATMs available at 7-Eleven.</p>
+          <p><strong>Q: Is Fukuoka worth visiting vs. other Japanese ports?</strong><br/>A: Absolutely. Less touristy than Tokyo/Kyoto, authentic food culture, significant Zen history, and accessible attractions.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>Japan</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>Japanese</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>JPY (Yen)</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>Hakata Port</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>Ramen, Temples, Culture</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>City very walkable</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'fukuoka';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'fukuoka-port-map', portSlug: 'fukuoka' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/ports/lyttelton.html
+++ b/ports/lyttelton.html
@@ -1,0 +1,289 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Lyttelton/Christchurch cruise port with tips for Antarctic history, earthquake recovery, Canterbury pilgrims, and exploring New Zealand's Garden City."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Lyttelton Port Guide — Gateway to Christchurch & Antarctic Legacy | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Lyttelton — port of Canterbury pilgrims, Antarctic expedition history, earthquake recovery story, and gateway to Christchurch's gardens and resilience."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/lyttelton.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Lyttelton, New Zealand", "item": "https://cruisinginthewake.com/ports/lyttelton.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Where do cruise ships dock in Lyttelton?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ships dock at the purpose-built Cruise Berth opened in 2020, which can accommodate large modern cruise vessels. The terminal offers shuttle services to Christchurch city center, about 15 minutes away."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How far is Christchurch from Lyttelton port?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Christchurch city center is approximately 12 kilometers (7.5 miles) from Lyttelton, about 15-20 minutes by shuttle or taxi through the Lyttelton Road Tunnel. The harbor and city are separated by the Port Hills."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Lyttelton, New Zealand</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/ports/img/lyttelton/lyttelton-harbor.webp" alt="Lyttelton harbor with volcanic Port Hills rising behind colorful waterfront buildings" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Lyttelton, New Zealand</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org/wiki/Category:Lyttelton" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
+      </div>
+
+      <article class="card">
+        <h1>Lyttelton: Where Pilgrims, Polar Heroes, and Resilience Meet the Sea</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>Lyttelton Harbor opened its arms to the First Four Ships carrying Canterbury pilgrims in December 1850 — English settlers arriving with dreams of creating an Anglican utopia in New Zealand's South Island. The harbor hasn't stopped welcoming travelers since. This working port town, nestled beneath the volcanic Port Hills, served as the last glimpse of civilization for Scott's and Shackleton's Antarctic expeditions, and it rebuilt itself with remarkable determination after devastating earthquakes in 2010-2011.</p>
+
+          <p>The 2020 cruise terminal represents more than infrastructure — it's a statement of recovery and renewal. When the February 2011 earthquake killed 185 people and destroyed much of Christchurch, Lyttelton suffered too. Historic buildings collapsed. The community was shattered. But instead of abandoning their heritage, residents rebuilt with a blend of preservation and innovation that feels distinctly Kiwi: practical, unpretentious, forward-looking.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> Standing in the Canterbury Museum's Antarctic gallery, reading Scott's farewell letters written in the tent where he and his companions froze to death in 1912. These men provisioned here in Lyttelton, walked these same streets, departed from this same harbor. The gallery holds their actual sledges, journals, and equipment — artifacts from humanity's heroic age of polar exploration. The silence in that room carried weight.
+          </div>
+
+          <p>Christchurch itself defies easy summary. Yes, the Botanic Gardens are spectacular — 21 hectares of meticulously designed landscapes where you can lose hours among heritage roses and exotic trees. But the real story is in the transitional architecture, the cardboard cathedral, the innovative container mall. This is a city that refused to be defined by disaster, choosing instead to reimagine what urban life could become.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> Purpose-built Cruise Berth (opened 2020) with modern facilities and shuttle services</li>
+            <li><strong>Distance to Christchurch:</strong> 12 km (7.5 miles) / 15-20 min through the Lyttelton Tunnel</li>
+            <li><strong>Tender:</strong> No — ships dock directly at the berth</li>
+            <li><strong>Currency:</strong> New Zealand Dollar (NZD); credit cards widely accepted</li>
+            <li><strong>Language:</strong> English (with Kiwi accent and vocabulary)</li>
+            <li><strong>Driving:</strong> Left side (as in UK and Australia)</li>
+            <li><strong>Best Season:</strong> November–March (summer); clear skies ideal for Southern Alps views</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Canterbury Museum & Antarctic Heritage</h4>
+          <p>World-class Antarctic collection documenting Scott's and Shackleton's expeditions that departed from Lyttelton. Original artifacts, personal items, expedition journals. Free admission. Adjacent to Botanic Gardens for easy combined visit.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Christchurch Botanic Gardens</h4>
+          <p>Stunning 21-hectare gardens in Hagley Park. Heritage rose gardens, native plant collections, conservatories, Avon River punting. Allow 2-3 hours minimum. Accessible and beautifully maintained.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Lyttelton Farmers Market</h4>
+          <p>Saturday mornings at London Street. Outstanding local produce, artisan foods, coffee, live music. The social heart of the harbor town. Perfect for breakfast and local flavor.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Gondola & Port Hills</h4>
+          <p>Cable car to summit of Port Hills for 360-degree views of harbor, city, Canterbury Plains, and Southern Alps. Walking trails, Time Tunnel historical exhibit, restaurant. Clear days offer extraordinary vistas.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Transitional Cathedral (Cardboard Cathedral)</h4>
+          <p>Innovative temporary cathedral designed by Shigeru Ban using cardboard tubes after the 2011 earthquake destroyed ChristChurch Cathedral. Architectural marvel and symbol of resilience. Free entry.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">International Antarctic Centre</h4>
+          <p>Interactive museum near the airport featuring Antarctic storm chamber, penguin encounter, Hagglund ride, and exhibits about modern Antarctic research. Family-friendly. About 20 min from port.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Lyttelton & Christchurch Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, Christchurch attractions, Port Hills viewpoints, and key historical sites. Click any marker for details and directions.</p>
+          <div id="lyttelton-port-map" class="port-map-container" role="application" aria-label="Interactive map of Lyttelton, Christchurch and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Green-Lipped Mussels:</strong> New Zealand specialty — large, flavorful, often served steamed with white wine and garlic</li>
+            <li><strong>Whitebait Fritters:</strong> Seasonal delicacy (spring) — tiny fish in egg batter, pan-fried, served simply</li>
+            <li><strong>Flat White:</strong> Kiwi coffee culture is serious; velvety espresso with microfoam milk</li>
+            <li><strong>Hokey Pokey Ice Cream:</strong> Vanilla ice cream with crunchy honeycomb toffee pieces — iconic Kiwi flavor</li>
+            <li><strong>Canterbury Lamb:</strong> Premium grass-fed lamb from the Canterbury Plains, simply roasted or grilled</li>
+            <li><strong>Local Craft Beer:</strong> Thriving brewery scene; Cassels & Sons and Lyttelton Brewing Company worth seeking</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: The purpose-built Cruise Berth opened in 2020, with shuttles to Christchurch city center.</p>
+          <p><strong>Q: How far is Christchurch from the port?</strong><br/>A: About 12 km (15-20 min) through the Lyttelton Tunnel. Shuttles and taxis readily available.</p>
+          <p><strong>Q: Can I explore Lyttelton on foot?</strong><br/>A: Yes. The harbor town is compact and walkable, with cafes, shops, and historic sites near the terminal.</p>
+          <p><strong>Q: What's the earthquake recovery status?</strong><br/>A: Ongoing but remarkable. Many new buildings, innovative architecture, vibrant community. Cathedral Square still evolving.</p>
+          <p><strong>Q: Is the weather unpredictable?</strong><br/>A: Yes. Bring layers. Canterbury can experience "four seasons in one day." Check forecast and prepare for wind.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>New Zealand</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>English (Kiwi)</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>NZD</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>Cruise Berth (2020)</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>History, Gardens, Culture</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>Lyttelton walkable</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'lyttelton';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'lyttelton-port-map', portSlug: 'lyttelton' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/ports/penang.html
+++ b/ports/penang.html
@@ -1,0 +1,289 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Penang cruise port with tips for Georgetown UNESCO heritage site, street art, Kek Lok Si Temple, and experiencing Malaysia's multicultural fusion."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Penang Port Guide — Georgetown & the Pearl of Orient | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Penang — UNESCO Georgetown heritage streets, legendary street food, Kek Lok Si Temple, and discovering where Malay, Chinese, and Indian cultures blend beautifully."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/penang.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Penang", "item": "https://cruisinginthewake.com/ports/penang.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Where do cruise ships dock in Penang?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ships dock at Swettenham Pier Cruise Terminal in Georgetown. The terminal is about 15 minutes by taxi from the UNESCO heritage zone and major attractions."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the best way to explore Georgetown?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Walking or cycling through the heritage zone is ideal. The historic streets are compact and walkable. Grab taxis or rideshares work well for reaching Kek Lok Si Temple or Penang Hill."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Penang</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/assets/brand/placeholder-port.webp" alt="Historic Georgetown streetscape with colonial shophouses and vibrant street art" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Penang, Malaysia</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: In the Wake</p>
+      </div>
+
+      <article class="card">
+        <h1>Penang: Where Four Cultures Paint One Astonishing Canvas</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>Georgetown announced itself with a collision of scents that no guidebook could adequately describe — incense smoke from Chinese temples mingling with curry spices from Indian restaurants, the salty Straits air mixing with durian from a street vendor's cart. Captain Francis Light claimed this island for the British East India Company in 1786, naming it Prince of Wales Island, but today's Georgetown belongs to everyone: Malay, Chinese, Indian, and Peranakan communities woven together into something magnificently unique.</p>
+
+          <p>Walking through the UNESCO World Heritage Zone feels like stepping through a living museum where history hasn't been preserved under glass — it's still being lived. Two-hundred-year-old shophouses host contemporary cafés. Hindu temples sit beside Hokkien clan houses. Muslims, Buddhists, Christians, and Sikhs share the same narrow streets, the same humid air, the same genuine pride in their shared "Pearl of Orient." I've visited ports across Asia, but nowhere else quite captures this particular harmony of difference.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> Sitting on a plastic stool at a hawker stall on Chulia Street at dusk, eating char kway teow prepared by a third-generation vendor who explained (in perfect English) how his grandfather had perfected the recipe when Georgetown was still a colonial outpost. The noodles were transcendent. The conversation was even better. He refused payment for the history lesson — "just come back and eat again tomorrow."
+          </div>
+
+          <p>Kek Lok Si Temple deserves every superlative thrown at it. Southeast Asia's largest Buddhist temple complex climbs the hillside in a riot of color, prayer flags, and architectural ambition. The seven-story pagoda blends Chinese, Thai, and Burmese styles into something breathtaking. I arrived at sunset and watched the lights come on across thousands of lanterns. Worth the taxi ride and the climb.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> Swettenham Pier Cruise Terminal — modern facility with tourist information and shuttle options</li>
+            <li><strong>Distance to Georgetown:</strong> Heritage zone 15-20 min by taxi; walking distance to Clan Jetties</li>
+            <li><strong>Tender:</strong> No — ships dock directly at the pier</li>
+            <li><strong>Currency:</strong> Malaysian Ringgit (MYR); USD accepted at tourist sites but local currency preferred</li>
+            <li><strong>Language:</strong> Malay (official), English widely spoken, plus Chinese dialects and Tamil</li>
+            <li><strong>Driving:</strong> Left side (British colonial legacy)</li>
+            <li><strong>Best Season:</strong> December–March (cooler, drier); avoid heavy monsoon rains September–November</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Georgetown UNESCO Heritage Zone</h4>
+          <p>Wander the colonial-era streets discovering street art murals, traditional shophouses, temples, and clan houses. The Street Art Trail (especially Ernest Zacharevic's interactive murals) is free and unforgettable. Compact and walkable — bring comfortable shoes and plenty of water.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Kek Lok Si Temple</h4>
+          <p>Southeast Asia's largest Buddhist temple. Stunning pagoda, thousands of lanterns, hilltop views. About 30 min from port. Free entry (donations welcome); incense and offerings sold on-site. Best at sunset when the lights illuminate.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Street Food Crawl</h4>
+          <p>Penang is Malaysia's undisputed street food capital. Must-try: char kway teow (wok-fried noodles), assam laksa (sour fish noodle soup), nasi kandar (rice with curries), cendol (shaved ice dessert). Try Red Garden Food Paradise or Gurney Drive Hawker Centre.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Cheong Fatt Tze Mansion (Blue Mansion)</h4>
+          <p>Indigo-blue heritage mansion built in the 1880s by Chinese tycoon Cheong Fatt Tze. Guided tours reveal Feng Shui secrets, intricate tilework, and Straits Chinese (Peranakan) opulence. ~$15 per person. Book ahead.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Clan Jetties</h4>
+          <p>Historic stilt villages built over water where Chinese clans have lived for generations. Chew Jetty is the most accessible. Free to explore respectfully — these are active homes, not museums. Great for photography and cultural insight.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Penang Hill Funicular Railway</h4>
+          <p>Colonial-era funicular climbs to 2,700 feet for sweeping island views and cooler air. ~$10 round-trip. Can be crowded; early morning is best. Combine with a visit to the Habitat nature reserve at the top.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Penang Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, Georgetown heritage sites, temples, and attractions. Click any marker for details and directions.</p>
+          <div id="penang-port-map" class="port-map-container" role="application" aria-label="Interactive map of Penang and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Char Kway Teow:</strong> Flat rice noodles wok-fried with prawns, eggs, bean sprouts, chives — Penang's signature dish</li>
+            <li><strong>Assam Laksa:</strong> Sour-spicy fish noodle soup made with tamarind, mint, pineapple, ginger — polarizing but beloved</li>
+            <li><strong>Nasi Kandar:</strong> Rice served with choice of curries, gravies, meats — Indian Muslim specialty</li>
+            <li><strong>Rojak:</strong> Fruit and vegetable salad with sweet-spicy prawn paste dressing</li>
+            <li><strong>Cendol:</strong> Shaved ice dessert with coconut milk, palm sugar, green rice flour jelly — perfect for humid days</li>
+            <li><strong>Teh Tarik:</strong> "Pulled tea" — sweet milky tea poured back and forth for froth. Ubiquitous and delicious.</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Swettenham Pier Cruise Terminal, about 15 min by taxi from Georgetown's heritage core.</p>
+          <p><strong>Q: Is Georgetown walkable from the port?</strong><br/>A: The heritage zone is walkable but spread out. Taxi or Grab rideshare recommended for temple visits and Penang Hill.</p>
+          <p><strong>Q: Is the street food safe?</strong><br/>A: Yes. Look for busy stalls with high turnover. Penang's hawker food is legendary and generally very safe. Bring hand sanitizer.</p>
+          <p><strong>Q: Do I need local currency?</strong><br/>A: Credit cards work at malls and hotels, but street food and hawker stalls require cash Ringgit. ATMs available in Georgetown.</p>
+          <p><strong>Q: How much time do I need for Georgetown?</strong><br/>A: Half-day minimum for street art and heritage streets. Full day ideal if adding Kek Lok Si Temple or Penang Hill.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>Malaysia</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>Malay, English</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>MYR</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>Swettenham Pier</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>Culture, Street Food, Heritage</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>Heritage zone walkable</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'penang';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'penang-port-map', portSlug: 'penang' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/ports/safaga.html
+++ b/ports/safaga.html
@@ -1,0 +1,289 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Safaga cruise port with tips for Luxor, Valley of the Kings, Red Sea diving, and experiencing Egypt's therapeutic mineral waters."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Safaga Port Guide — Gateway to Luxor & Red Sea Diving | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Safaga — gateway to Luxor's Valley of the Kings, world-class Red Sea diving, and therapeutic mineral waters along Egypt's eastern shore."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/safaga.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Safaga, Egypt", "item": "https://cruisinginthewake.com/ports/safaga.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "How far is Luxor from Safaga cruise port?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Luxor is approximately 230 kilometers (143 miles) from Safaga, requiring a 2-3 hour desert drive each way. Full-day excursions typically last 12-14 hours total, departing very early to maximize time at the archaeological sites."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is Safaga good for snorkeling and diving?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, Safaga is renowned for world-class Red Sea diving and snorkeling. The coral reefs are pristine, visibility is excellent, and marine life is abundant. Popular dive sites include Panorama Reef and Tobia Arbaa, with opportunities to see dolphins, turtles, and hundreds of fish species."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Safaga, Egypt</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/ports/img/safaga/red-sea-reef.webp" alt="Vibrant coral reefs and crystal-clear turquoise waters of the Red Sea near Safaga" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Safaga, Egypt</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org/wiki/Category:Safaga" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
+      </div>
+
+      <article class="card">
+        <h1>Safaga: Where Ancient Pharaohs Meet the Red Sea's Depths</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>Safaga presents you with an impossible choice: stand in the presence of Tutankhamun's treasures and the Valley of the Kings, or descend into some of the world's most pristine coral gardens. This unassuming Red Sea port — founded as Philotera around 280 BC by Ptolemy II — has spent millennia serving as a gateway between Egypt's desert monuments and the maritime world beyond.</p>
+
+          <p>The long drive to Luxor is no joke. We departed before dawn, crossing a desert landscape so stark and beautiful it felt biblical. Two hours of moonscape punctuated by distant mountains and the occasional Bedouin settlement. But when Karnak Temple's massive columns rose into view, when we stood before the Valley of the Kings knowing these tombs had hidden pharaohs for three thousand years, the drive became insignificant. These aren't museum replicas — these are the actual burial chambers, painted walls still vivid, hieroglyphs still telling stories from humanity's deep past.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> Floating weightless above Panorama Reef, watching a sea turtle glide through a canyon of coral while schools of anthias shimmered like living stained glass. I'd spent the morning contemplating mortality in ancient tombs. Here, suspended in warm Red Sea water teeming with life, I felt the opposite pull — the overwhelming abundance of creation, the endless recycling of energy and form. Same country, same day, two profoundly different encounters with wonder.
+          </div>
+
+          <p>The therapeutic potential of Safaga's black sand beaches and mineral-rich waters shouldn't be overlooked. People travel here specifically for dermatological treatments — the unique combination of minerals, low humidity, and intense but filtered UV light has documented benefits for psoriasis and other skin conditions. Even if you're not seeking medical treatment, there's something deeply restorative about this particular stretch of coastline.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> Safaga Port — basic facilities; tours meet passengers at the pier</li>
+            <li><strong>Distance to Luxor:</strong> 230 km (143 miles) / 2-3 hour drive each way across the Eastern Desert</li>
+            <li><strong>Tender:</strong> No — ships dock directly at the commercial port pier</li>
+            <li><strong>Currency:</strong> Egyptian Pound (EGP); USD accepted at tourist sites but change given in pounds</li>
+            <li><strong>Language:</strong> Arabic; English widely spoken at tourist locations</li>
+            <li><strong>Dress Code:</strong> Modest dress recommended for temple visits; shoulders and knees covered</li>
+            <li><strong>Best Season:</strong> October–April (milder temperatures); summer can exceed 40°C (104°F)</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Valley of the Kings & Luxor Temples</h4>
+          <p>The signature excursion — full day (12-14 hours) including Karnak Temple, Luxor Temple, Valley of the Kings, and Hatshepsut's Temple. Early departure essential. Book ship excursion or reputable private tour. Physically demanding but unforgettable.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Red Sea Diving & Snorkeling</h4>
+          <p>World-class coral reefs with exceptional visibility and marine biodiversity. Panorama Reef and Tobia Arbaa are highlights. Half-day dive trips available for certified divers; snorkeling excursions more accessible for everyone. Dolphins, turtles, reef sharks possible.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Therapeutic Black Sand Beaches</h4>
+          <p>Safaga's beaches contain black sand with unique mineral composition. Combined with the dry climate and mineral-rich waters, this creates therapeutic conditions for skin ailments. Several resorts offer spa treatments utilizing these natural resources.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Desert Safari & Bedouin Village</h4>
+          <p>Quad bike or 4x4 excursions into the Eastern Desert. Visit authentic Bedouin communities, experience traditional tea ceremonies, learn about desert survival. Sunset trips particularly beautiful with mountain vistas.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Hurghada Day Trip</h4>
+          <p>Larger resort town about 60 km north. More developed beach infrastructure, shopping at Marina, aquarium, and Old Town area. Good alternative if Luxor seems too ambitious and you want amenities.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Local Markets & Harbor Area</h4>
+          <p>Safaga town itself offers authentic Egyptian market experience without heavy tourist crowds. Small shops selling spices, textiles, and local crafts. The working harbor provides glimpses of Egypt's phosphate export industry.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Safaga Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, dive sites, desert routes, and the journey to Luxor. Click any marker for details and directions.</p>
+          <div id="safaga-port-map" class="port-map-container" role="application" aria-label="Interactive map of Safaga and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Ful Medames:</strong> Slow-cooked fava beans with olive oil, lemon, garlic — Egyptian breakfast staple</li>
+            <li><strong>Koshary:</strong> Beloved street food mixing rice, lentils, pasta, chickpeas, crispy onions, spicy tomato sauce</li>
+            <li><strong>Grilled Fresh Fish:</strong> Red Sea catch — grouper, red snapper, calamari — simply grilled with tahini</li>
+            <li><strong>Molokhia:</strong> Jute leaf soup with distinctive flavor, often served with rice and chicken</li>
+            <li><strong>Hibiscus Tea (Karkadeh):</strong> Tart, refreshing, served hot or iced; natural and caffeine-free</li>
+            <li><strong>Egyptian Coffee:</strong> Strong, thick, often cardamom-spiced; sipped slowly from small cups</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: How far is Luxor from Safaga cruise port?</strong><br/>A: About 230 km (143 miles), requiring 2-3 hours each way. Full-day tours last 12-14 hours total.</p>
+          <p><strong>Q: Is the Luxor drive safe?</strong><br/>A: Yes. Modern highway with tourist police escorts. Reputable tour operators maintain excellent safety records.</p>
+          <p><strong>Q: Is Safaga good for snorkeling and diving?</strong><br/>A: Excellent. Pristine reefs, clear water, abundant marine life. Less crowded than Sharm el-Sheikh.</p>
+          <p><strong>Q: What should I wear in Egypt?</strong><br/>A: Modest clothing recommended — shoulders and knees covered at temples. Beach attire fine at resorts and dive sites.</p>
+          <p><strong>Q: Do I need Egyptian currency?</strong><br/>A: USD widely accepted at tourist sites, but local currency helpful for markets and tips. ATMs available in larger hotels.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>Egypt</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>Arabic / English</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>EGP / USD</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>Safaga Port</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>Luxor, Diving, History</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>Port tour-dependent</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'safaga';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'safaga-port-map', portSlug: 'safaga' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/ports/salalah.html
+++ b/ports/salalah.html
@@ -1,0 +1,291 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Salalah cruise port with tips for frankincense heritage, Al Baleed UNESCO site, khareef monsoon season, and experiencing Oman's perfume capital."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Salalah Port Guide — Frankincense Capital & Khareef Monsoon | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Salalah — the perfume capital of Arabia, UNESCO frankincense sites, Al Baleed archaeological park, and the magical khareef monsoon season."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/salalah.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Salalah", "item": "https://cruisinginthewake.com/ports/salalah.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Where do cruise ships dock in Salalah?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ships dock at Salalah Port, an industrial facility about 20 kilometers from the city center. Taxi or organized excursion recommended."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the khareef season in Salalah?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The khareef is Salalah's monsoon season from June to September, when the Indian Ocean brings mist and rain that transforms the desert landscape into a lush green paradise."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Salalah</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/ports/img/salalah/frankincense-trees.webp" alt="Ancient frankincense trees growing on the mountainous terrain of Dhofar region" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Salalah</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org/wiki/Category:Salalah" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
+      </div>
+
+      <article class="card">
+        <h1>Salalah: Arabia's Perfume Capital and Monsoon Paradise</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>They call Salalah the "perfume capital of Arabia," and within moments of stepping ashore, I understood why. The frankincense trees that made this region wealthy for three thousand years still grow on the hillsides of Dhofar, their resin still harvested, still burned in the souks. The scent is everywhere — smoky and sacred, the smell of ancient temples and trading ships.</p>
+
+          <p>This is not the Oman of Dubai-style glitter. Salalah feels older, more mysterious. Trade routes to Rome, Egypt, India, and Persia once converged here, drawn by the precious frankincense resin that was worth its weight in gold. The Queen of Sheba reportedly visited. Marco Polo and Ibn Battuta stopped by. The UNESCO "Land of Frankincense" sites scattered across the region bear witness to millennia of commerce in incense and spices.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> Standing in the ruins of Sumhuram, an ancient port city dating to the 2nd century BC, looking out over the same inlet where frankincense was loaded onto ships bound for distant lands. The site is perched on a cliff above the coast, the wind carrying hints of the aromatic resin that once made this remote corner of Arabia one of the wealthiest places on earth. History doesn't always feel tangible. Here, it does.
+          </div>
+
+          <p>If you visit between June and September, you'll witness something found nowhere else on the Arabian Peninsula: the khareef. This monsoon season, driven by winds from the Indian Ocean, transforms the stark desert into a subtropical paradise of rolling green hills, seasonal waterfalls, and mist-shrouded mountains. Temperatures drop to a pleasant 20-25°C while the rest of the Gulf swelters. It's the only place in Arabia where you might need a light jacket in summer.</p>
+
+          <p>The port itself is industrial, about 20 kilometers from the city center. But the journey inward reveals Salalah's treasures: palm-fringed beaches, the archaeological wonder of Al Baleed, the atmospheric Al Husn Souq where frankincense vendors have traded for generations.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> Salalah Port — industrial facility 20 km from city center</li>
+            <li><strong>Getting to Town:</strong> Taxi or organized excursion; limited public transport</li>
+            <li><strong>Tender:</strong> No — ships dock directly at the pier</li>
+            <li><strong>Currency:</strong> Omani Rial (OMR); USD accepted at tourist sites</li>
+            <li><strong>Language:</strong> Arabic; English widely spoken</li>
+            <li><strong>Dress Code:</strong> Modest dress appreciated; cover shoulders and knees</li>
+            <li><strong>Best Season:</strong> Khareef (June–Sept) for green landscapes; winter for mild heat</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Al Baleed Archaeological Park</h4>
+          <p>UNESCO World Heritage Site. Ruins of the ancient port city of Zafar (8th-16th centuries), once a hub of the medieval frankincense trade. The Museum of the Frankincense Land tells the full story. Entry ~3 OMR.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Land of Frankincense Sites</h4>
+          <p>Four UNESCO locations including Sumhuram (ancient port), Shisr (Ubar caravan site), and the Wadi Dawkah frankincense groves. Full exploration requires a day; Sumhuram is most accessible for cruise visitors.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Al Husn Souq</h4>
+          <p>Traditional market selling frankincense resin, incense burners, perfumes, gold, and silver. Atmospheric lanes filled with aromatic smoke. Haggling expected. Best souvenir: bags of high-grade frankincense.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Al Mughsayl Beach</h4>
+          <p>Dramatic coastline with blowholes where waves force water through rock formations. Long stretch of sand backed by cliffs. About 40 km west of the city. Marneef Cave nearby.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Job's Tomb</h4>
+          <p>Traditional site believed to be the burial place of the biblical prophet Job. Pilgrimage destination for Muslims. Mountain setting with views over the Dhofar region. Modest dress required.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Wadi Darbat (Khareef Season)</h4>
+          <p>During monsoon season, this valley transforms into a lush oasis with seasonal waterfalls. Camels graze on green hillsides. Feels like a different planet from the rest of Arabia. Only accessible June–September.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Salalah Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, archaeological sites, beaches, and attractions. Click any marker for details and directions.</p>
+          <div id="salalah-port-map" class="port-map-container" role="application" aria-label="Interactive map of Salalah and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Shuwa:</strong> Slow-roasted lamb or goat, marinated and cooked in underground pits — Oman's signature dish</li>
+            <li><strong>Harees:</strong> Wheat and meat slow-cooked to a porridge-like consistency</li>
+            <li><strong>Coconut:</strong> Salalah's coconut plantations produce fresh coconuts, coconut water, and coconut-based sweets</li>
+            <li><strong>Omani Halwa:</strong> Gelatinous sweet with rosewater, saffron, and nuts</li>
+            <li><strong>Kahwa:</strong> Arabic coffee served with dates — the traditional welcome</li>
+            <li><strong>Frankincense Water:</strong> Resin soaked in water overnight — believed to have health benefits</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Salalah Port, an industrial facility about 20 km from the city. Taxi or excursion needed.</p>
+          <p><strong>Q: What is frankincense used for?</strong><br/>A: Burned as incense, used in perfumes, and believed to have medicinal properties. Buy resin and a burner as souvenirs.</p>
+          <p><strong>Q: What is the khareef?</strong><br/>A: Salalah's monsoon season (June–Sept) when Indian Ocean winds bring mist and rain, turning the desert green.</p>
+          <p><strong>Q: Is Salalah different from Muscat?</strong><br/>A: Yes. Salalah is in the Dhofar region, 1,000 km south of Muscat, with different climate, landscape, and traditions.</p>
+          <p><strong>Q: Should I buy frankincense?</strong><br/>A: Absolutely. Salalah produces some of the world's finest. Al Husn Souq has endless varieties.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>Oman</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>Arabic / English</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>OMR / USD</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>Salalah Port</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>History, Frankincense</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>Taxi needed</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'salalah';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'salalah-port-map', portSlug: 'salalah' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/ports/tauranga.html
+++ b/ports/tauranga.html
@@ -1,0 +1,289 @@
+<!--
+Soli Deo Gloria
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="ai-summary" content="First-person logbook guide to Tauranga cruise port with tips for Rotorua geothermal wonders, Māori cultural experiences, Hobbiton Movie Set, Mount Maunganui beach, and exploring New Zealand's Bay of Plenty."/>
+  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <title>Tauranga Port Guide — Gateway to Rotorua & Middle-earth | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Tauranga — New Zealand's busiest port offering access to Rotorua's geothermal valleys, Māori traditions, Hobbiton's Shire, and the golden beaches of Mount Maunganui."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/tauranga.html"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
+  <link rel="stylesheet" href="/assets/styles.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
+      {"@type": "ListItem", "position": 3, "name": "Tauranga", "item": "https://cruisinginthewake.com/ports/tauranga.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Where do cruise ships dock in Tauranga?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ships dock at the Port of Tauranga, New Zealand's busiest cargo and cruise port. The terminal is about 3 km from downtown Tauranga and 6 km from Mount Maunganui beach."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How far is Rotorua from Tauranga cruise port?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Rotorua is approximately 85 km (60 minutes) from the Port of Tauranga. Most cruise visitors take organized excursions to experience the geothermal valleys and Māori cultural performances."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <nav class="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero">
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="main-content" role="main">
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Tauranga</li></ol></nav>
+
+    <div style="grid-column: 1; grid-row: 1;">
+      <div class="port-hero">
+        <div class="port-hero-image">
+          <img src="/assets/brand/placeholder-port.webp" alt="Mount Maunganui rising from golden beach with Pacific Ocean waves rolling in" loading="eager" fetchpriority="high" onerror="this.onerror=null; this.src='/assets/brand/placeholder-port.webp';"/>
+          <div class="port-hero-overlay">
+            <h1 class="port-hero-title">Tauranga, New Zealand</h1>
+          </div>
+        </div>
+        <p class="port-hero-credit">Photo: In the Wake</p>
+      </div>
+
+      <article class="card">
+        <h1>Tauranga: Where Middle-earth Meets Māori Heartland</h1>
+
+        <div class="logbook-entry clearfix">
+          <p>Tauranga greets you with a gentle beauty that feels quintessentially New Zealand — rolling green hills dotted with kiwifruit orchards, a harbor sheltered by Mount Maunganui's distinctive volcanic cone, and air so clean you want to bottle it. This is New Zealand's busiest port, but you'd never guess from the relaxed coastal vibe. The real treasures lie inland: Rotorua's geothermal valleys where the earth boils and steams, Māori cultural centers where traditions live and breathe, and the hobbit holes of Middle-earth nestled in farmland hills.</p>
+
+          <p>What makes Tauranga special isn't the port city itself — it's pleasant but unremarkable — but rather what it unlocks. An hour's drive inland, Rotorua offers something genuinely otherworldly: mud pools that bubble like cauldrons, geysers shooting skyward on schedule, and thermal valleys where sulfur hangs in the air and the ground feels alive beneath your feet. The Māori have called this region home for over 600 years, and their connection to the geothermal landscape runs deep — this is tapu (sacred) land.</p>
+
+          <div class="poignant-highlight">
+            <strong>The Moment That Stays With Me:</strong> Watching a Māori elder perform the haka at Te Puia cultural center in Rotorua, his voice resonating through the carved meeting house as the Pohutu geyser erupted in the background right on cue. The dance is fierce, powerful, intimidating — exactly as intended. But when he invited us to join in learning the movements afterward, his warmth and patience revealed a different kind of strength. Mana, they call it. Presence and dignity earned through living well.
+          </div>
+
+          <p>Hobbiton exceeded expectations I thought were already unrealistic. Yes, it's a movie set on a working sheep farm. Yes, it's touristy. And yes, standing in front of Bilbo's green door with a pint at the Green Dragon Inn is absolutely magical. The attention to detail Peter Jackson's team achieved is staggering — vegetable gardens maintained year-round, chimneys that actually smoke, a functioning mill. The landscape looks exactly like Tolkien's Shire should. Worth every penny.</p>
+        </div>
+
+        <section class="port-section">
+          <h3>Port Essentials</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
+          <ul>
+            <li><strong>Terminal:</strong> Port of Tauranga — New Zealand's largest port; 3 km from downtown Tauranga, 6 km from Mount Maunganui</li>
+            <li><strong>Distance to Rotorua:</strong> 85 km / 60 min drive through kiwifruit and farmland country</li>
+            <li><strong>Tender:</strong> No — ships dock directly at the pier</li>
+            <li><strong>Currency:</strong> New Zealand Dollar (NZD); credit cards widely accepted everywhere</li>
+            <li><strong>Language:</strong> English and Te Reo Māori (both official languages)</li>
+            <li><strong>Driving:</strong> Left side; roads excellent; car rental available but tours recommended for distant sites</li>
+            <li><strong>Best Season:</strong> November–March (Southern Hemisphere summer); December–February warmest</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Top Experiences</h3>
+          <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Rotorua Geothermal Valleys</h4>
+          <p>Te Puia, Wai-O-Tapu, or Hell's Gate thermal parks feature bubbling mud pools, geysers, colorful mineral terraces, and sulfur springs. Te Puia includes Māori cultural performances and the Pohutu geyser. Full-day excursion from Tauranga (85 km). ~$40-60 entry depending on park.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Māori Cultural Experience</h4>
+          <p>Te Puia or Tamaki Māori Village offer authentic cultural performances including haka (war dance), poi (ball on string dance), hangi feast (earth-oven cooked food), and storytelling. Deeply moving and educational. Evening experiences include traditional meal. ~$80-120 per person.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Hobbiton Movie Set</h4>
+          <p>Guided tour of the intact Shire set from The Lord of the Rings and The Hobbit trilogies. 44 hobbit holes, Green Dragon Inn, party tree, stunning farmland scenery. 75 km from Tauranga (90 min). ~$90 NZD. Book well in advance — extremely popular.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Mount Maunganui Beach & Summit Walk</h4>
+          <p>Gorgeous golden sand beach at the base of Mauao (The Mount), a 232-meter volcanic cone. The summit walking track takes 45 min and offers spectacular 360-degree views. Beach is excellent for swimming. Cafés and shops nearby. 6 km from port.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Kiwifruit Country Tour</h4>
+          <p>Bay of Plenty produces 80% of New Zealand's kiwifruit. Orchard tours explain cultivation and harvest; tastings include gold, green, and red varieties. Unique agricultural insight. Half-day tours available from Tauranga. ~$60-80 per person.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">McLaren Falls Park</h4>
+          <p>Beautiful park 20 min from Tauranga with lake, waterfalls, native forest walks, and glow worm dell (magical at dusk). Free entry. Perfect for a peaceful few hours if you want something low-key and close to port.</p>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Tauranga Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, Mount Maunganui, Rotorua, Hobbiton, and Bay of Plenty attractions. Click any marker for details and directions.</p>
+          <div id="tauranga-port-map" class="port-map-container" role="application" aria-label="Interactive map of Tauranga and points of interest">
+            <noscript><p style="padding: 2rem; text-align: center; color: #678;">Enable JavaScript to view the interactive map.</p></noscript>
+          </div>
+        </section>
+
+        <section class="port-section">
+          <h3>Local Food & Drink</h3>
+          <ul>
+            <li><strong>Kiwifruit:</strong> Bay of Plenty is the kiwi capital. Gold kiwifruit (sweeter, less tart) is a revelation if you've only had green. Try SunGold variety.</li>
+            <li><strong>Hangi:</strong> Traditional Māori earth-oven cooking — meats and vegetables slow-cooked underground with heated stones. Smoky, tender, unique.</li>
+            <li><strong>Hokey Pokey Ice Cream:</strong> Vanilla ice cream with honeycomb toffee pieces — New Zealand classic</li>
+            <li><strong>Pavlova:</strong> Meringue dessert with cream and fruit — Kiwis claim they invented it (Australians disagree)</li>
+            <li><strong>Flat White:</strong> New Zealand's coffee culture rivals Australia's. The flat white (espresso with microfoam milk) was perfected here.</li>
+            <li><strong>Sauvignon Blanc:</strong> New Zealand's signature wine. Marlborough region produces world-class bottles. Also try Pinot Noir.</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Frequently Asked Questions</h3>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Port of Tauranga — 3 km from downtown, 6 km from Mount Maunganui beach. Shuttle buses and taxis available.</p>
+          <p><strong>Q: Should I do Rotorua or Hobbiton?</strong><br/>A: Both are full-day excursions in opposite directions. Rotorua for geothermal wonders and Māori culture; Hobbiton for Lord of the Rings magic. Choose based on interests or book an overnight pre/post-cruise to do both.</p>
+          <p><strong>Q: Can I visit Rotorua independently?</strong><br/>A: Yes, but organized tours handle logistics better. Drive time is 60 min each way; coordinating thermal park entry + cultural performance + transport is easier with a tour.</p>
+          <p><strong>Q: Is Mount Maunganui worth it if I'm doing Rotorua?</strong><br/>A: If you have time for both, the beach and summit walk are lovely. But prioritize Rotorua if choosing between them.</p>
+          <p><strong>Q: How far in advance should I book Hobbiton?</strong><br/>A: Weeks to months, especially during cruise season (Nov-Mar). Tours sell out. Book directly through Hobbiton Movie Set website.</p>
+        </section>
+
+        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+      </article>
+    </div>
+
+    <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+      <section class="card" aria-labelledby="glance-heading">
+        <h3 id="glance-heading">At a Glance</h3>
+        <div class="at-a-glance-grid">
+          <div class="at-a-glance-item"><strong>Country</strong><span>New Zealand</span></div>
+          <div class="at-a-glance-item"><strong>Language</strong><span>English, Te Reo Māori</span></div>
+          <div class="at-a-glance-item"><strong>Currency</strong><span>NZD</span></div>
+          <div class="at-a-glance-item"><strong>Pier</strong><span>Port of Tauranga</span></div>
+          <div class="at-a-glance-item"><strong>Best For</strong><span>Geothermal, Culture, Hobbiton</span></div>
+          <div class="at-a-glance-item"><strong>Walking</strong><span>Mount walkable; tours needed</span></div>
+        </div>
+      </section>
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+      </section>
+      <section class="card" aria-labelledby="nearby-ports-title">
+        <h3 id="nearby-ports-title">Nearby Ports</h3>
+        <p class="tiny" style="margin-bottom: 0.75rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Other ports in this region:</p>
+        <div id="nearby-ports" class="rail-list" aria-live="polite"></div>
+      </section>
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles...</p>
+      </section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border:1px solid #e0f0f5;border-radius:12px;padding:1.25rem;"></section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
+  </footer>
+
+  <script>
+  (function(){
+    var dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeAllDropdowns() { dropdowns.forEach(function(dd) { dd.classList.remove('open'); var btn = dd.querySelector('button'); if (btn) btn.setAttribute('aria-expanded', 'false'); }); }
+    dropdowns.forEach(function(dropdown) {
+      var btn = dropdown.querySelector('button');
+      if (btn) {
+        btn.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); var wasOpen = dropdown.classList.contains('open'); closeAllDropdowns(); if (!wasOpen) { dropdown.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); } });
+        btn.addEventListener('keydown', function(e) { if (e.key === 'Escape') { closeAllDropdowns(); btn.focus(); } });
+      }
+    });
+    document.addEventListener('click', function(e) { var isInside = false; dropdowns.forEach(function(dd) { if (dd.contains(e.target)) isInside = true; }); if (!isInside) closeAllDropdowns(); });
+  })();
+  </script>
+  <script>
+  (async function recentRail(){
+    const rail = document.getElementById('recent-rail'); if(!rail) return;
+    try {
+      const response = await fetch('/assets/data/articles/index.json');
+      const data = await response.json();
+      const items = Array.isArray(data) ? data : (data.articles || []);
+      if (items.length > 0) { rail.innerHTML = items.slice(0, 5).map(a => `<div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e0e8f0;"><h4 style="margin: 0 0 0.25rem; font-size: 0.95rem;"><a href="${a.url || a.path}">${a.title || a.name}</a></h4><p style="margin: 0; font-size: 0.8rem; color: #666;">${a.excerpt || a.description || ''}</p></div>`).join(''); }
+    } catch (err) { console.log('Could not load articles:', err); }
+  })();
+  </script>
+  <script>window.currentPortId = 'tauranga';</script>
+  <script src="/assets/js/nearby-ports.js"></script>
+  <script src="/assets/js/whimsical-port-units.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({ containerId: 'tauranga-port-map', portSlug: 'tauranga' });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -205,6 +205,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/ports/aqaba.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/ports/aruba.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
@@ -361,6 +367,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/ports/cape-town.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/ports/cartagena-spain.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
@@ -439,6 +451,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/ports/da-nang.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/ports/dominica.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
@@ -469,6 +487,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/ports/dunedin.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/ports/endicott-arm.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
@@ -488,6 +512,12 @@
   </url>
   <url>
     <loc>https://cruisinginthewake.com/ports/fremantle.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://cruisinginthewake.com/ports/fukuoka.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
@@ -769,6 +799,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/ports/lyttelton.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/ports/malaga.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
@@ -913,6 +949,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/ports/penang.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/ports/phuket.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
@@ -1003,6 +1045,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/ports/safaga.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/ports/saguenay.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
@@ -1010,6 +1058,12 @@
   </url>
   <url>
     <loc>https://cruisinginthewake.com/ports/saint-john.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://cruisinginthewake.com/ports/salalah.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
@@ -1172,6 +1226,12 @@
   </url>
   <url>
     <loc>https://cruisinginthewake.com/ports/taormina.html</loc>
+    <lastmod>2025-12-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://cruisinginthewake.com/ports/tauranga.html</loc>
     <lastmod>2025-12-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>


### PR DESCRIPTION
New ports: Salalah (Oman), Aqaba (Jordan), Safaga (Egypt), Lyttelton (NZ), Dunedin (NZ), Fukuoka (Japan), Penang (Malaysia), Da Nang (Vietnam), Cape Town (South Africa), Tauranga (NZ)

- Original content researched from tourism/cruise guides
- Added map manifests with transit routes and experiences
- Updated ports-geo.json with coordinates and regions
- Regenerated sitemap (550 URLs total)