### PR TITLE
Enhance 10 US homeports with comprehensive content

### DIFF
--- a/ports/baltimore.html
+++ b/ports/baltimore.html
@@ -19,6 +19,9 @@ Soli Deo Gloria
   }
   </script>
   <link rel="stylesheet" href="/assets/styles.css"/>
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -114,44 +117,82 @@ Soli Deo Gloria
 
         <section class="port-section">
           <h3>Getting to the Port</h3>
-          <p>The cruise terminal is located at 2001 East McComas Street in South Baltimore, about 3 miles from the Inner Harbor and 10 miles from BWI Airport.</p>
+          <p>The cruise terminal is located at 2001 East McComas Street in South Baltimore's Locust Point neighborhood, about 3 miles from the Inner Harbor and 10 miles from BWI Airport.</p>
           <ul>
             <li><strong>From BWI Airport:</strong> 15-20 minutes via I-295 South</li>
             <li><strong>From Washington D.C.:</strong> About 1 hour via Baltimore-Washington Parkway</li>
             <li><strong>From Philadelphia:</strong> About 1.5 hours via I-95 South</li>
-            <li><strong>Uber/Lyft:</strong> Widely available; $15-25 from BWI Airport</li>
+            <li><strong>Uber/Lyft:</strong> Widely available; $25-40 from BWI Airport</li>
+            <li><strong>Taxi:</strong> Fixed fare from BWI approximately $35-40</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Getting Around Baltimore</h3>
+          <ul>
+            <li><strong>Charm City Circulator:</strong> Free bus service with four routes connecting major attractions — Purple Route serves Inner Harbor and Fells Point. <a href="https://www.charmcitycirculator.com" target="_blank" rel="noopener">Charm City Circulator</a></li>
+            <li><strong>Baltimore Water Taxi:</strong> Hop-on/hop-off service connecting Inner Harbor, Fells Point, Canton, Fort McHenry, and more — $14 all-day pass. <a href="https://baltimorewatertaxi.com" target="_blank" rel="noopener">Baltimore Water Taxi</a></li>
+            <li><strong>Light Rail:</strong> Connects BWI Airport to downtown Camden Yards station — $1.90 fare</li>
+            <li><strong>On Foot:</strong> Inner Harbor and Fells Point are walkable; cruise port is 3 miles from Inner Harbor — taxi/rideshare recommended</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Parking Options</h3>
-          <p>The port offers on-site parking with both covered and uncovered options.</p>
+          <p>The Cruise Maryland Terminal offers on-site parking within walking distance.</p>
           <ul>
-            <li><strong>On-site parking:</strong> Reserve in advance through your cruise line</li>
-            <li><strong>Off-site lots:</strong> Several third-party lots offer shuttle service</li>
-            <li><strong>Pro tip:</strong> Book early for peak sailing dates — spaces fill quickly</li>
+            <li><strong>On-site parking:</strong> $15-20/day for cars and SUVs — no advance reservations required, but lots can fill on busy days</li>
+            <li><strong>Payment:</strong> Credit card only upon arrival</li>
+            <li><strong>Off-site lots:</strong> Several third-party lots in the Linthicum Heights area (near BWI) offer lower rates with shuttle service</li>
+            <li><strong>Pro tip:</strong> Baltimore is the 5th busiest cruise port in the US — arrive early on peak sailing dates</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
-            <li><strong>Four Seasons Baltimore:</strong> Luxury waterfront option with harbor views</li>
-            <li><strong>Sagamore Pendry Baltimore:</strong> Historic Fells Point location with modern amenities</li>
-            <li><strong>Hilton Baltimore Inner Harbor:</strong> Connected to convention center, easy access</li>
-            <li><strong>Hampton Inn & Suites Inner Harbor:</strong> Budget-friendly with good location</li>
+            <li><strong>Hilton Baltimore Inner Harbor:</strong> Connected to convention center, skywalk to Camden Yards — central to all attractions</li>
+            <li><strong>DoubleTree by Hilton Baltimore:</strong> Downtown location near Inner Harbor with easy access to attractions</li>
+            <li><strong>Hampton Inn & Suites Inner Harbor:</strong> Budget-friendly with good location and free breakfast</li>
+            <li><strong>Four Seasons Baltimore:</strong> Luxury waterfront option in Harbor East with stunning harbor views</li>
+            <li><strong>Sagamore Pendry Baltimore:</strong> Historic Fells Point recreation pier transformed into boutique luxury</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Pre-Cruise Activities</h3>
           <ul>
-            <li><strong>National Aquarium:</strong> World-class exhibits and dolphin shows</li>
-            <li><strong>Fort McHenry:</strong> Birthplace of "The Star-Spangled Banner"</li>
-            <li><strong>Fells Point:</strong> Historic cobblestone streets, shops, and restaurants</li>
-            <li><strong>Camden Yards:</strong> Catch an Orioles game at the legendary ballpark</li>
-            <li><strong>Maryland Blue Crabs:</strong> Don't leave without trying them — LP Steamers or Thames Street Oyster House</li>
+            <li><strong>Fort McHenry National Monument:</strong> The only National Monument and Historic Shrine in the NPS system — birthplace of "The Star-Spangled Banner." Francis Scott Key wrote the anthem here after watching the British bombardment of September 1814. Take the Water Taxi for scenic access. <a href="https://www.nps.gov/fomc" target="_blank" rel="noopener">NPS Fort McHenry</a></li>
+            <li><strong>National Aquarium:</strong> World-class exhibits including sharks, dolphins, jellyfish, and the Australian Wild exhibit — plan 2-3 hours</li>
+            <li><strong>Inner Harbor:</strong> Harborplace shops, historic ships (USS Constellation, submarine Torsk), and waterfront dining</li>
+            <li><strong>Fells Point:</strong> Historic 18th-century neighborhood with cobblestone streets, 120+ bars and restaurants, and waterfront views</li>
+            <li><strong>Camden Yards:</strong> Catch an Orioles game at the ballpark that revolutionized stadium design — opened 1992, inspired every retro park since</li>
+            <li><strong>Maryland Blue Crabs:</strong> The iconic Chesapeake experience — LP Steamers, Captain James Landing, or Thames Street Oyster House</li>
           </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>Baltimore's role in American history is profound. Fort McHenry's defense during the War of 1812 inspired Francis Scott Key to write "The Star-Spangled Banner" — the 30x42-foot flag that flew that night now hangs in the Smithsonian. The port itself dates to 1706, making it one of America's oldest.</p>
+          <p>The city was a major shipbuilding center and immigration port. Today, Baltimore combines maritime heritage with urban renewal — the Inner Harbor, once a decaying industrial waterfront, became a model for urban revitalization worldwide after its transformation in the 1980s.</p>
+        </section>
+
+        <section class="port-section">
+          <h3>Practical Tips</h3>
+          <ul>
+            <li><strong>Crab Season:</strong> Maryland blue crabs are best April through November — ordering "steamed crabs" means whole crabs with Old Bay, mallets included</li>
+            <li><strong>Port to Harbor:</strong> The cruise terminal is 3 miles from Inner Harbor — plan for taxi/rideshare; there's no direct public transit connection</li>
+            <li><strong>Weather:</strong> Hot and humid summers, cold winters — spring and fall cruises offer the best weather</li>
+            <li><strong>Orioles Schedule:</strong> If the O's are home, arrive extra early — Camden Yards traffic affects port access</li>
+          </ul>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Baltimore Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, Inner Harbor, Fort McHenry, and Fells Point.</p>
+          <div id="baltimore-port-map" class="port-map-container" role="application" aria-label="Interactive map of Baltimore">
+            <noscript><p>Interactive map requires JavaScript. Key locations: Cruise terminal, Inner Harbor, Fort McHenry, Fells Point, Camden Yards.</p></noscript>
+          </div>
         </section>
 
         <section class="port-section">
@@ -215,5 +256,21 @@ Soli Deo Gloria
   </script>
   <script>window.currentPortId = 'baltimore';</script>
   <script src="/assets/js/nearby-ports.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Baltimore Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'baltimore-port-map',
+        portSlug: 'baltimore'
+      });
+    }
+  });
+  </script>
 </body>
 </html>

--- a/ports/cape-liberty.html
+++ b/ports/cape-liberty.html
@@ -15,6 +15,9 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
   <link rel="stylesheet" href="/assets/styles.css"/>
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
   <script type="application/ld+json">
   {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [
     {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
@@ -71,10 +74,20 @@ Soli Deo Gloria
           <h3>Getting to the Port</h3>
           <ul>
             <li><strong>Address:</strong> 4 Port Terminal Blvd, Bayonne, NJ 07002</li>
-            <li><strong>From Newark Airport (EWR):</strong> 15-20 minutes via NJ Turnpike</li>
+            <li><strong>From Newark Airport (EWR):</strong> 15-20 minutes via NJ Turnpike — the closest major airport</li>
             <li><strong>From JFK Airport:</strong> 45-60 minutes depending on traffic</li>
             <li><strong>From Manhattan:</strong> 20-30 minutes via Holland Tunnel</li>
             <li><strong>Uber/Lyft:</strong> $25-40 from Newark, $50-70 from JFK</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Getting to Manhattan</h3>
+          <ul>
+            <li><strong>PATH Train:</strong> Affordable rapid transit connecting New Jersey to Manhattan. Exchange Place station (Jersey City) to World Trade Center is 8 minutes, $2.75 fare. <a href="https://www.panynj.gov/path" target="_blank" rel="noopener">PATH Train</a></li>
+            <li><strong>Hudson-Bergen Light Rail:</strong> Connects Bayonne to Hoboken and Jersey City; transfer to PATH for Manhattan access. <a href="https://www.njtransit.com/light-rail-stations" target="_blank" rel="noopener">NJ Transit Light Rail</a></li>
+            <li><strong>NY Waterway Ferry:</strong> Scenic ferry service from Jersey City to Midtown Manhattan (Pier 79) and Wall Street. <a href="https://www.nywaterway.com" target="_blank" rel="noopener">NY Waterway</a></li>
+            <li><strong>By Car:</strong> Holland Tunnel or Lincoln Tunnel to Manhattan — allow extra time for traffic, especially on weekends</li>
           </ul>
         </section>
 
@@ -90,21 +103,49 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
-            <li><strong>Doubletree by Hilton Jersey City:</strong> Waterfront views of Manhattan</li>
-            <li><strong>Hyatt Regency Jersey City:</strong> Liberty State Park location</li>
-            <li><strong>Hampton Inn Bayonne:</strong> Closest to the port, budget-friendly</li>
-            <li><strong>Stay in Manhattan:</strong> Many cruisers stay in NYC and taxi/Uber to port</li>
+            <li><strong>DoubleTree by Hilton Jersey City:</strong> Waterfront location with stunning Manhattan skyline views — just 15 min from port</li>
+            <li><strong>Hilton Newark Penn Station:</strong> Connected to Newark Penn Station for easy PATH access to NYC; 20 min from port</li>
+            <li><strong>Hampton Inn & Suites Bayonne:</strong> Closest to the port (2 miles), budget-friendly with free breakfast</li>
+            <li><strong>Hyatt Regency Jersey City:</strong> Liberty State Park location with park access and waterfront dining</li>
+            <li><strong>Stay in Manhattan:</strong> Many cruisers stay in NYC and taxi/Uber to port — experience the city before sailing</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Pre-Cruise Activities</h3>
           <ul>
-            <li><strong>Statue of Liberty & Ellis Island:</strong> Ferry from Liberty State Park</li>
-            <li><strong>Manhattan:</strong> Times Square, Central Park, 9/11 Memorial — just across the river</li>
-            <li><strong>Liberty State Park:</strong> Beautiful waterfront with skyline views</li>
-            <li><strong>Jersey City dining:</strong> Great restaurants without Manhattan prices</li>
+            <li><strong>Statue of Liberty National Monument:</strong> UNESCO World Heritage Site — ferries depart from Liberty State Park (10 min from port). Crown access requires advance reservation (months ahead). <a href="https://www.nps.gov/stli" target="_blank" rel="noopener">NPS Statue of Liberty</a></li>
+            <li><strong>Ellis Island Immigration Museum:</strong> Where 12 million immigrants entered America (1892-1954). Same ferry as Statue of Liberty — plan 2-3 hours for the museum. Search the online passenger database before visiting</li>
+            <li><strong>Liberty State Park:</strong> 1,212-acre waterfront park with stunning Manhattan views, the Empty Sky 9/11 Memorial, nature trails, and picnic areas — ferry launches to Lady Liberty and Ellis Island</li>
+            <li><strong>9/11 Memorial & Museum:</strong> Moving tribute at Ground Zero in Lower Manhattan (PATH train to World Trade Center)</li>
+            <li><strong>Manhattan Highlights:</strong> Times Square, Central Park, Brooklyn Bridge, Empire State Building — entire city accessible via PATH train</li>
+            <li><strong>Jersey City/Hoboken:</strong> Excellent dining and nightlife without Manhattan prices — Hoboken's Washington Street is especially lively</li>
           </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>Cape Liberty sits on the site of the former Military Ocean Terminal (MOTBY), which served as the primary embarkation point for troops deploying to Europe during World War II and Korea. Over 50 million troops and their supplies passed through this peninsula. The area still bears traces of its military past, including the former administration building visible near the terminal.</p>
+          <p>The cruise terminal opened in 2004, transforming the decommissioned military facility into a passenger port. Today, it offers what many consider the most dramatic sailaway in cruising — passing the Statue of Liberty as the Manhattan skyline glitters in the fading light.</p>
+        </section>
+
+        <section class="port-section">
+          <h3>Practical Tips</h3>
+          <ul>
+            <li><strong>Sailaway Timing:</strong> Most ships depart late afternoon — position yourself on the starboard (right) side facing forward for the best Statue of Liberty views</li>
+            <li><strong>Traffic Warning:</strong> NYC-area traffic can be brutal — build in extra buffer time, especially on weekends or event days</li>
+            <li><strong>Toll Roads:</strong> NJ Turnpike, Holland Tunnel, and most bridges use cashless tolling (E-ZPass or license plate billing)</li>
+            <li><strong>Newark vs JFK:</strong> Newark (EWR) is significantly closer and easier to reach — worth the comparison when booking flights</li>
+            <li><strong>NYC on a Budget:</strong> The Staten Island Ferry (free!) offers views of Lady Liberty; High Line park and many museums have free hours</li>
+          </ul>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Cape Liberty Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminal, Liberty State Park, Statue of Liberty, and Manhattan access.</p>
+          <div id="cape-liberty-port-map" class="port-map-container" role="application" aria-label="Interactive map of Cape Liberty">
+            <noscript><p>Interactive map requires JavaScript. Key locations: Cruise terminal, Liberty State Park, Statue of Liberty, PATH stations, Manhattan.</p></noscript>
+          </div>
         </section>
 
         <section class="port-section">
@@ -135,6 +176,22 @@ Soli Deo Gloria
   <footer class="wrap" role="contentinfo"><p>© 2025 In the Wake · A Cruise Traveler's Logbook</p></footer>
   <script>window.currentPortId = 'cape-liberty';</script>
   <script src="/assets/js/nearby-ports.js"></script>
-<script src="/assets/js/dropdown.js"></script>
+  <script src="/assets/js/dropdown.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Cape Liberty Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'cape-liberty-port-map',
+        portSlug: 'cape-liberty'
+      });
+    }
+  });
+  </script>
 </body>
 </html>

--- a/ports/galveston.html
+++ b/ports/galveston.html
@@ -58,10 +58,22 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Getting to the Port</h3>
           <ul>
+            <li><strong>Terminal Address:</strong> Port of Galveston, 2502 Harborside Drive (Pier 25) or new Pier 16 terminal</li>
             <li><strong>From Houston (IAH):</strong> 75-90 minutes via I-45 South</li>
-            <li><strong>From Houston Hobby (HOU):</strong> 60 minutes via I-45 South</li>
+            <li><strong>From Houston Hobby (HOU):</strong> 60 minutes via I-45 South — more convenient for cruise passengers</li>
             <li><strong>From downtown Houston:</strong> 50-60 minutes via I-45 South</li>
-            <li><strong>Galveston Island Trolley:</strong> Runs along the Seawall and Strand</li>
+            <li><strong>Uber/Lyft:</strong> $65-85 from IAH, $55-70 from Hobby</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Getting Around Galveston</h3>
+          <ul>
+            <li><strong>Galveston Island Trolley:</strong> Historic rail trolley runs along the Seawall and through the Strand District — nostalgic and practical. <a href="https://www.galvestontx.gov/702/Island-Transit" target="_blank" rel="noopener">Island Transit</a></li>
+            <li><strong>Island Transit Buses:</strong> Regular bus service throughout the island</li>
+            <li><strong>On Foot:</strong> The Strand District is compact and walkable; Seawall stretches 10 miles for walking, biking, or rollerblading</li>
+            <li><strong>Bike Rentals:</strong> Several shops rent beach cruisers for Seawall exploration</li>
+            <li><strong>Rideshare:</strong> Uber and Lyft available throughout the island</li>
           </ul>
         </section>
 
@@ -78,21 +90,43 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
-            <li><strong>Hotel Galvez & Spa:</strong> Historic beachfront luxury, "Queen of the Gulf"</li>
-            <li><strong>Tremont House:</strong> Boutique hotel in the Strand District</li>
-            <li><strong>San Luis Resort:</strong> Full resort experience with pools and spa</li>
-            <li><strong>Harbor House:</strong> Budget-friendly, walking distance to port</li>
+            <li><strong>Hilton Galveston Island Resort:</strong> Full-service beachfront resort with pool, spa, and ocean views</li>
+            <li><strong>Hotel Galvez & Spa:</strong> Historic 1911 beachfront luxury, "Queen of the Gulf" — reputed to be haunted</li>
+            <li><strong>Tremont House:</strong> Boutique hotel in the heart of the Strand District with complimentary port shuttle</li>
+            <li><strong>San Luis Resort:</strong> Full resort experience with pools, spa, and adults-only Spa Tower</li>
+            <li><strong>Harbor House Hotel & Marina:</strong> Budget-friendly, walking distance to port with marina views</li>
+            <li><strong>Hampton Inn Galveston-Downtown:</strong> Centrally located with free breakfast and parking</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Pre-Cruise Activities</h3>
           <ul>
-            <li><strong>The Strand District:</strong> Historic Victorian shopping and dining</li>
-            <li><strong>Moody Gardens:</strong> Aquarium, rainforest, and discovery pyramids</li>
-            <li><strong>Galveston Island State Park:</strong> Beaches, birding, and kayaking</li>
-            <li><strong>Bishop's Palace:</strong> Stunning Victorian architecture tour</li>
-            <li><strong>Seawall:</strong> 10 miles of beaches, restaurants, and Gulf views</li>
+            <li><strong>The Strand District:</strong> 19th-century Victorian commercial buildings now housing restaurants, galleries, and shops — Texas's largest collection of iron-front commercial architecture</li>
+            <li><strong>Moody Gardens:</strong> Three glass pyramids housing an aquarium, rainforest, and discovery center — also features IMAX, ropes course, and palm beach</li>
+            <li><strong>Galveston Island State Park:</strong> 2,000 acres of beach, bay, and wetlands — excellent birding, kayaking, camping. <a href="https://tpwd.texas.gov/state-parks/galveston-island" target="_blank" rel="noopener">Texas Parks & Wildlife</a></li>
+            <li><strong>Bishop's Palace:</strong> Stunning 1892 Victorian mansion built for lawyer Walter Gresham — one of America's most significant Victorian structures</li>
+            <li><strong>Seawall:</strong> 10 miles of beaches, restaurants, and Gulf views — built after the devastating 1900 hurricane</li>
+            <li><strong>Pleasure Pier:</strong> Amusement park extending over the Gulf with rides, games, and restaurants</li>
+            <li><strong>1877 Tall Ship Elissa:</strong> Iron-hulled sailing ship at the Texas Seaport Museum — one of the oldest merchant vessels still sailing</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>Galveston was once the largest and wealthiest city in Texas — the "Wall Street of the Southwest" in the 1800s, when cotton kings and shipping magnates built the mansions that still line Broadway today. The city served as the first capital of the Republic of Texas and was a major immigration port for Europeans entering America.</p>
+          <p>The Great Storm of 1900 — the deadliest natural disaster in American history — changed everything. An estimated 6,000-12,000 people perished when a hurricane submerged the island. In response, engineers raised the entire city up to 17 feet and built the famous Seawall. Today, that resilience defines Galveston's character.</p>
+          <p>The $156 million Pier 16 terminal opened in 2025, designed to handle Royal Caribbean's Oasis-class ships and accommodate over 1.5 million annual passengers.</p>
+        </section>
+
+        <section class="port-section">
+          <h3>Practical Tips</h3>
+          <ul>
+            <li><strong>Covered Parking:</strong> Worth the extra cost — the Texas sun is unforgiving. Exposed cars can reach dangerous interior temperatures</li>
+            <li><strong>Hurricane Season:</strong> June through November — most disruptions are rare, but check forecasts and have cruise insurance</li>
+            <li><strong>Cuban Sandwiches:</strong> Stop at Maceo Spice & Import in the Strand — been there since 1946</li>
+            <li><strong>Shrimp Season:</strong> Gulf shrimp peaks August-December — fresh-off-the-boat seafood at Sampson & Son's on the harbor</li>
+            <li><strong>Mardi Gras:</strong> Galveston's celebration (February/March) draws 350,000+ visitors — plan accordingly</li>
           </ul>
         </section>
 

--- a/ports/port-canaveral.html
+++ b/ports/port-canaveral.html
@@ -15,6 +15,9 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
   <link rel="stylesheet" href="/assets/styles.css"/>
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
   </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -76,22 +79,51 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
-            <li><strong>Radisson Resort at the Port:</strong> Popular pre-cruise hotel with shuttle</li>
-            <li><strong>Homewood Suites Cape Canaveral:</strong> Suites near the port</li>
-            <li><strong>Hampton Inn Cocoa Beach:</strong> Beachside option</li>
-            <li><strong>Hilton Cocoa Beach:</strong> Oceanfront with restaurants</li>
+            <li><strong>Hilton Cocoa Beach Oceanfront:</strong> Full-service resort right on the beach with multiple restaurants and pool</li>
+            <li><strong>Homewood Suites by Hilton Cape Canaveral:</strong> All-suite hotel near the port with kitchens</li>
+            <li><strong>Hampton Inn Cocoa Beach:</strong> Beachside option with free breakfast and pool</li>
+            <li><strong>Radisson Resort at the Port:</strong> Popular pre-cruise hotel with shuttle and tropical pool</li>
+            <li><strong>Country Inn & Suites Cape Canaveral:</strong> Budget-friendly option offering free parking for up to 8 days with cruise packages</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Pre-Cruise Activities</h3>
           <ul>
-            <li><strong>Kennedy Space Center:</strong> Iconic space exploration experience — plan a full day</li>
-            <li><strong>Cocoa Beach:</strong> Classic Florida beach, surfing, Ron Jon Surf Shop</li>
-            <li><strong>Jetty Park:</strong> Watch ships sail in and out, great for launch viewing</li>
+            <li><strong>Kennedy Space Center Visitor Complex:</strong> Iconic space exploration experience — see the Space Shuttle Atlantis, Saturn V rocket, and meet an astronaut. Plan a full day. Book through <a href="https://www.kennedyspacecenter.com" target="_blank" rel="noopener">kennedyspacecenter.com</a></li>
+            <li><strong>SpaceX Launch Viewing:</strong> Check <a href="https://www.spacex.com/launches" target="_blank" rel="noopener">spacex.com/launches</a> — Jetty Park and Playalinda Beach offer free viewing</li>
+            <li><strong>Canaveral National Seashore:</strong> 24 miles of pristine, undeveloped Atlantic beach — sea turtles nest here May through October</li>
+            <li><strong>Merritt Island National Wildlife Refuge:</strong> 140,000 acres of diverse habitats; Black Point Wildlife Drive offers excellent birding</li>
+            <li><strong>Cocoa Beach:</strong> Classic Florida surf town, Ron Jon Surf Shop (open 24 hours), and great beach restaurants</li>
+            <li><strong>Jetty Park:</strong> Watch cruise ships sail past; excellent for rocket launch viewing and fishing</li>
             <li><strong>Orlando theme parks:</strong> Disney, Universal, SeaWorld (60-75 min drive)</li>
-            <li><strong>Manatee viewing:</strong> Winter months bring manatees to local waters</li>
+            <li><strong>Manatee viewing:</strong> Winter months (November-March) bring hundreds of manatees to Blue Spring State Park (1 hr west)</li>
           </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>Port Canaveral's story is inseparable from America's space program. The port opened in 1953, just eight years before Alan Shepard launched from nearby Cape Canaveral as America's first astronaut. The port has watched Mercury, Gemini, Apollo, and Space Shuttle missions lift off, and today continues as a front-row seat to SpaceX launches.</p>
+          <p>The Canaveral area takes its name from the Spanish "Cañaveral" (cane field), dating to early explorers in the 1500s. Today, Port Canaveral is the second-busiest cruise port in the world by multi-day embarkations, handling over 5 million passengers annually across its seven terminals.</p>
+        </section>
+
+        <section class="port-section">
+          <h3>Practical Tips</h3>
+          <ul>
+            <li><strong>Launch Day Bonus:</strong> If there's a launch during your port stay, crowd the ship's decks for an unforgettable view</li>
+            <li><strong>Terminal Tips:</strong> Disney uses Terminal 8 (with themed interiors); Royal Caribbean uses Terminal 1; check your cruise documents for exact terminal</li>
+            <li><strong>Ron Jon's:</strong> The famous surf shop at 4151 N Atlantic Ave is open 24/7 — perfect for last-minute beach supplies</li>
+            <li><strong>Weather:</strong> Hot and humid May-September; brief afternoon storms are common — they pass quickly</li>
+            <li><strong>Traffic:</strong> The Beachline Expressway (SR-528) is usually smooth, but allow extra time during Orlando rush hours or theme park peaks</li>
+          </ul>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Port Canaveral Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminals, Kennedy Space Center, Cocoa Beach, and Jetty Park.</p>
+          <div id="port-canaveral-port-map" class="port-map-container" role="application" aria-label="Interactive map of Port Canaveral">
+            <noscript><p>Interactive map requires JavaScript. Key locations: Cruise terminals, Kennedy Space Center, Cocoa Beach, Jetty Park.</p></noscript>
+          </div>
         </section>
 
         <section class="port-section">
@@ -120,5 +152,21 @@ Soli Deo Gloria
   <footer class="wrap" role="contentinfo"><p>© 2025 In the Wake</p></footer>
   <script>window.currentPortId = 'port-canaveral';</script>
   <script src="/assets/js/nearby-ports.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Port Canaveral Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'port-canaveral-port-map',
+        portSlug: 'port-canaveral'
+      });
+    }
+  });
+  </script>
 </body>
 </html>

--- a/ports/port-everglades.html
+++ b/ports/port-everglades.html
@@ -15,6 +15,9 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
   <link rel="stylesheet" href="/assets/styles.css"/>
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
   </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -59,39 +62,77 @@ Soli Deo Gloria
             <li><strong>From Miami (MIA):</strong> 30-45 minutes via I-95</li>
             <li><strong>From Miami Beach:</strong> 45-60 minutes depending on traffic</li>
             <li><strong>Uber/Lyft:</strong> $10-15 from FLL, $35-50 from MIA</li>
+            <li><strong>Brightline:</strong> High-speed rail to Fort Lauderdale station, then short taxi/rideshare to port. <a href="https://www.gobrightline.com" target="_blank" rel="noopener">gobrightline.com</a></li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Getting Around Fort Lauderdale</h3>
+          <ul>
+            <li><strong>Water Taxi:</strong> Hop-on/hop-off service along the Intracoastal, connecting hotels, Las Olas, beach, and waterfront restaurants. All-day pass $35. <a href="https://watertaxi.com" target="_blank" rel="noopener">watertaxi.com</a></li>
+            <li><strong>Sun Trolley:</strong> Free trolley service in downtown and beach areas — Las Olas Link connects downtown to beach. <a href="https://www.suntrolley.com" target="_blank" rel="noopener">suntrolley.com</a></li>
+            <li><strong>Broward County Transit:</strong> Bus routes throughout the county; Route 40 connects airport to beach</li>
+            <li><strong>On Foot:</strong> Beach strip and Las Olas Boulevard are walkable; water taxi is best for covering distance</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Parking Options</h3>
           <ul>
-            <li><strong>On-site parking:</strong> Midport Parking Garage and surface lots</li>
-            <li><strong>Cost:</strong> $15-22/day</li>
-            <li><strong>Off-site:</strong> Several private lots along SE 17th Street offer lower rates</li>
-            <li><strong>Reserve ahead:</strong> Highly recommended for busy sailing dates</li>
+            <li><strong>On-site parking:</strong> Midport Parking Garage and surface lots at each terminal</li>
+            <li><strong>Cost:</strong> $15-20/day for uncovered, $20-22/day for covered</li>
+            <li><strong>Off-site:</strong> Several private lots along SE 17th Street "cruise corridor" offer lower rates with shuttles</li>
+            <li><strong>Reserve ahead:</strong> Highly recommended for busy sailing dates — book through <a href="https://www.porteverglades.net" target="_blank" rel="noopener">porteverglades.net</a></li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
-            <li><strong>Hilton Fort Lauderdale Marina:</strong> Steps from Terminal 25, waterfront views</li>
+            <li><strong>Hilton Fort Lauderdale Marina:</strong> Steps from Terminal 25, waterfront views — the closest major hotel to the port (0.5 mi)</li>
+            <li><strong>Hilton Fort Lauderdale Beach Resort:</strong> Oceanfront luxury on the beach with pool and spa</li>
             <li><strong>Renaissance Fort Lauderdale Cruise Port:</strong> Connected to Terminal 4</li>
             <li><strong>Hyatt Regency Pier 66:</strong> Iconic revolving restaurant, marina views</li>
-            <li><strong>W Fort Lauderdale:</strong> Beachfront luxury</li>
-            <li><strong>Budget options:</strong> Multiple hotels along SE 17th Street "cruise corridor"</li>
+            <li><strong>W Fort Lauderdale:</strong> Beachfront luxury on the beach</li>
+            <li><strong>Hampton Inn Fort Lauderdale/Downtown:</strong> Budget-friendly with free breakfast, near Las Olas</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Pre-Cruise Activities</h3>
           <ul>
-            <li><strong>Fort Lauderdale Beach:</strong> Wide, clean beaches with promenade</li>
-            <li><strong>Las Olas Boulevard:</strong> Dining, shopping, galleries</li>
-            <li><strong>Water Taxi:</strong> Scenic way to explore the "Venice of America"</li>
-            <li><strong>NSU Art Museum:</strong> Contemporary art collection</li>
-            <li><strong>Everglades tours:</strong> Airboat rides about 30 minutes west</li>
+            <li><strong>Fort Lauderdale Beach:</strong> Wide, clean beaches with beachfront promenade perfect for morning walks</li>
+            <li><strong>Las Olas Boulevard:</strong> Dining, shopping, galleries — the heart of Fort Lauderdale culture</li>
+            <li><strong>Water Taxi:</strong> Scenic way to explore the "Venice of America" — over 300 miles of waterways</li>
+            <li><strong>NSU Art Museum:</strong> Contemporary art collection in downtown</li>
+            <li><strong>Bonnet House Museum:</strong> Historic estate with tropical gardens, art collection, and resident monkeys</li>
+            <li><strong>Everglades National Park:</strong> UNESCO World Heritage Site — airboat tours through the River of Grass about 30 minutes west. Book through <a href="https://www.viator.com/Fort-Lauderdale-tours/Eco-Tours/d4068-g13-c56" target="_blank" rel="noopener">Viator</a></li>
+            <li><strong>Hugh Taylor Birch State Park:</strong> 180-acre urban oasis with beach access, kayaking, and nature trails</li>
           </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>Fort Lauderdale's cruise story began in 1927 when the channel to Port Everglades was completed, but the city's history as the "Venice of America" dates to the 1920s when developers dredged the Intracoastal Waterway, creating the network of canals and islands that define the landscape today. The original Fort Lauderdale was established in 1838 during the Second Seminole War, named after Major William Lauderdale.</p>
+          <p>Port Everglades has grown into one of the top three cruise ports in the world, handling over 3.9 million passengers annually. The port's proximity to the Gulf Stream — just 2 miles offshore — means ships reach deep water quickly, maximizing time at sea.</p>
+        </section>
+
+        <section class="port-section">
+          <h3>Practical Tips</h3>
+          <ul>
+            <li><strong>FLL Advantage:</strong> Fort Lauderdale-Hollywood International is consistently easier to navigate than Miami International — consider flying here even if cruising from <a href="/ports/port-miami.html">PortMiami</a></li>
+            <li><strong>Weather:</strong> Hot and humid year-round; afternoon thunderstorms common in summer</li>
+            <li><strong>Swimsuit Shopping:</strong> Fort Lauderdale's Sawgrass Mills outlet mall (20 min west) is one of the largest in the US</li>
+            <li><strong>Happy Hour:</strong> Las Olas and beach restaurants often have great early evening specials</li>
+          </ul>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Port Everglades Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminals, Las Olas, Fort Lauderdale Beach, and the Intracoastal.</p>
+          <div id="port-everglades-port-map" class="port-map-container" role="application" aria-label="Interactive map of Port Everglades">
+            <noscript><p>Interactive map requires JavaScript. Key locations: Cruise terminals, Las Olas Boulevard, Fort Lauderdale Beach, Intracoastal Waterway.</p></noscript>
+          </div>
         </section>
 
         <section class="port-section">
@@ -120,5 +161,21 @@ Soli Deo Gloria
   <footer class="wrap" role="contentinfo"><p>© 2025 In the Wake</p></footer>
   <script>window.currentPortId = 'port-everglades';</script>
   <script src="/assets/js/nearby-ports.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Port Everglades Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'port-everglades-port-map',
+        portSlug: 'port-everglades'
+      });
+    }
+  });
+  </script>
 </body>
 </html>

--- a/ports/port-miami.html
+++ b/ports/port-miami.html
@@ -15,6 +15,9 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
   <link rel="stylesheet" href="/assets/styles.css"/>
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
   </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -59,6 +62,18 @@ Soli Deo Gloria
             <li><strong>From South Beach:</strong> 15-20 minutes via MacArthur Causeway</li>
             <li><strong>From Fort Lauderdale (FLL):</strong> 35-45 minutes via I-95</li>
             <li><strong>Uber/Lyft:</strong> $15-25 from MIA, $40-55 from FLL</li>
+            <li><strong>Brightline:</strong> High-speed rail from Fort Lauderdale or West Palm Beach to MiamiCentral station downtown, then short taxi/rideshare to port</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Getting Around Miami</h3>
+          <ul>
+            <li><strong>Metromover:</strong> Free elevated rail connecting downtown, Brickell, and Omni areas — runs every 90 seconds during peak hours. <a href="https://www.miamidade.gov/global/transportation/metromover.page" target="_blank" rel="noopener">Miami-Dade Transit</a></li>
+            <li><strong>Metrorail:</strong> Heavy rail connecting airport to downtown ($2.25 fare). Brickell and Government Center stations near port area</li>
+            <li><strong>Coral Way Trolley:</strong> Free trolley service through Coral Gables and downtown neighborhoods</li>
+            <li><strong>Miami Beach Trolley:</strong> Free service along South Beach (temporarily suspended — check current status)</li>
+            <li><strong>On Foot:</strong> Downtown and Brickell are walkable; South Beach best explored by foot</li>
           </ul>
         </section>
 
@@ -75,11 +90,11 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
+            <li><strong>Hilton Miami Downtown:</strong> Bayfront location, easy Metromover access to port area</li>
+            <li><strong>Hilton Bentley Miami/South Beach:</strong> Oceanfront Art Deco elegance on South Beach</li>
             <li><strong>InterContinental Miami:</strong> Bayfront views, walking distance to port via PeopleMover</li>
-            <li><strong>YVE Hotel Miami:</strong> Downtown, close to Metromover</li>
             <li><strong>Faena Miami Beach:</strong> Luxury South Beach experience</li>
-            <li><strong>The Setai Miami Beach:</strong> Asian-inspired oceanfront luxury</li>
-            <li><strong>Hampton Inn Brickell:</strong> Budget-friendly downtown option</li>
+            <li><strong>Hampton Inn Brickell:</strong> Budget-friendly downtown option on the Metromover line</li>
           </ul>
         </section>
 
@@ -89,17 +104,44 @@ Soli Deo Gloria
             <li><strong>South Beach:</strong> Art Deco architecture, Ocean Drive, iconic beach</li>
             <li><strong>Little Havana:</strong> Cuban coffee, Calle Ocho, authentic culture</li>
             <li><strong>Wynwood Walls:</strong> World-famous street art district</li>
-            <li><strong>Vizcaya Museum:</strong> Stunning Italian Renaissance estate</li>
+            <li><strong>Vizcaya Museum:</strong> Stunning Italian Renaissance estate on Biscayne Bay</li>
             <li><strong>Pérez Art Museum Miami (PAMM):</strong> Contemporary art with bay views</li>
-            <li><strong>Everglades:</strong> Airboat tours about 45 minutes west</li>
+            <li><strong>Everglades National Park:</strong> UNESCO World Heritage Site — airboat tours through the River of Grass about 45 minutes west. Book through <a href="https://www.viator.com/Miami-tours/Nature-and-Wildlife/d662-g6-c64" target="_blank" rel="noopener">Viator</a> or park concessioners</li>
+            <li><strong>Biscayne National Park:</strong> 95% underwater park just south of Miami — snorkeling, diving, and glass-bottom boat tours</li>
           </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>PortMiami's story began in 1896 when Henry Flagler's railroad reached the small settlement. The port grew from a modest passenger terminal in 1915 to become the world's busiest cruise port, earning the "Cruise Capital of the World" title in 1994. The dramatic skyline view from Dodge Island — with cruise ships dwarfing the Art Deco buildings — captures Miami's transformation from frontier town to global gateway.</p>
+          <p>The port sits on what was once known as Lummus Island, expanded and renamed Dodge Island in the 1960s. Today's state-of-the-art terminals, including the stunning new MSC Terminal AAA (opened 2025) and Royal Caribbean's Crown of Miami, represent nearly $2 billion in recent investment.</p>
+        </section>
+
+        <section class="port-section">
+          <h3>Practical Tips</h3>
+          <ul>
+            <li><strong>Embarkation:</strong> Most terminals offer mobile check-in starting at 10:30 AM — complete online to save time</li>
+            <li><strong>Weather:</strong> Miami is hot and humid year-round; dress light, stay hydrated, and embrace air conditioning</li>
+            <li><strong>Currency:</strong> USD; credit cards accepted virtually everywhere</li>
+            <li><strong>Cuban Coffee:</strong> Order a "cortadito" at Versailles or La Carreta for authentic café con leche experience</li>
+            <li><strong>Art Basel:</strong> Early December brings massive crowds for the annual art fair — book hotels months ahead</li>
+          </ul>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>PortMiami Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminals, South Beach, Little Havana, and Wynwood.</p>
+          <div id="port-miami-port-map" class="port-map-container" role="application" aria-label="Interactive map of PortMiami">
+            <noscript><p>Interactive map requires JavaScript. Key locations: Cruise terminals, South Beach, Little Havana, Wynwood Walls, Vizcaya.</p></noscript>
+          </div>
         </section>
 
         <section class="port-section">
           <h3>Frequently Asked Questions</h3>
           <p><strong>Q: PortMiami or <a href="/ports/port-everglades.html">Port Everglades</a>?</strong><br/>A: Different ports — PortMiami is in Miami (MIA airport); <a href="/ports/port-everglades.html">Port Everglades</a> is in Fort Lauderdale (FLL). Check your booking carefully.</p>
-          <p><strong>Q: How's the Miami traffic?</strong><br/>A: It can be challenging. Allow extra time, especially during rush hour or special events.</p>
-          <p><strong>Q: Is the Metromover useful?</strong><br/>A: Yes — it's free and connects downtown hotels to the port area.</p>
+          <p><strong>Q: How's the Miami traffic?</strong><br/>A: It can be challenging. Allow extra time, especially during rush hour or special events. The Metromover helps avoid downtown congestion.</p>
+          <p><strong>Q: Is the Metromover useful?</strong><br/>A: Absolutely — it's free and connects downtown hotels to the port area. Runs every 90 seconds during peak hours.</p>
+          <p><strong>Q: Best time to visit Everglades National Park?</strong><br/>A: December through April is dry season — cooler temperatures, fewer mosquitoes, and wildlife concentrated around water sources.</p>
         </section>
       </article>
     </div>
@@ -121,5 +163,21 @@ Soli Deo Gloria
   <footer class="wrap" role="contentinfo"><p>© 2025 In the Wake</p></footer>
   <script>window.currentPortId = 'port-miami';</script>
   <script src="/assets/js/nearby-ports.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize PortMiami Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'port-miami-port-map',
+        portSlug: 'port-miami'
+      });
+    }
+  });
+  </script>
 </body>
 </html>

--- a/ports/san-diego.html
+++ b/ports/san-diego.html
@@ -69,45 +69,64 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Getting Around San Diego</h3>
           <ul>
-            <li><strong>On Foot:</strong> Downtown is compact and easily walkable</li>
-            <li><strong>Public Transit:</strong> Metropolitan Transit System operates buses, trolleys, and trains throughout the city</li>
-            <li><strong>Sightseeing:</strong> Hop-on/hop-off bus tours available for major attractions</li>
-            <li><strong>Coronado Ferry:</strong> Departs hourly from Broadway Pier (right next to the cruise terminal) starting at 9am</li>
+            <li><strong>On Foot:</strong> Downtown is compact and easily walkable — Gaslamp Quarter just blocks from the terminal</li>
+            <li><strong>San Diego Trolley:</strong> Light rail connecting downtown, Old Town, and beyond. Green Line stops at Santa Fe Depot, 4 blocks from cruise terminal. $2.50 fare. <a href="https://www.sdmts.com" target="_blank" rel="noopener">MTS Transit</a></li>
+            <li><strong>Coronado Ferry:</strong> Departs hourly from Broadway Pier (right next to cruise terminal) to Coronado Landing. 15 minutes, $7 each way — stunning views of the downtown skyline</li>
+            <li><strong>Old Town Trolley Tours:</strong> Hop-on/hop-off narrated tours covering major attractions — great for first-time visitors</li>
+            <li><strong>Free FRED Shuttle:</strong> Free Ride Everywhere Downtown — electric shuttle loops through downtown and waterfront areas</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Parking Options</h3>
           <ul>
-            <li><strong>Port parking:</strong> Lane Field parking structure near terminal</li>
-            <li><strong>Cost:</strong> $20-25/day</li>
-            <li><strong>Off-site:</strong> Several downtown lots offer cruise parking with shuttles</li>
-            <li><strong>Tip:</strong> The airport proximity means many cruisers fly in rather than drive</li>
+            <li><strong>Port parking:</strong> No on-site parking at B Street Terminal — use nearby Ace Parking lots</li>
+            <li><strong>Ace Parking Lots:</strong> 11 lots in port area, $15-40/day. BRIC North and BRIC South are closest (across the street). <a href="https://www.aceparking.com" target="_blank" rel="noopener">Ace Parking</a></li>
+            <li><strong>Discounts:</strong> 5% off for military, AAA members, seniors, and students</li>
+            <li><strong>Tip:</strong> The airport proximity (10 min!) means many cruisers fly in rather than drive</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
-            <li><strong>Manchester Grand Hyatt:</strong> Waterfront tower with bay views</li>
-            <li><strong>Marriott Marquis San Diego Marina:</strong> Adjacent to convention center</li>
-            <li><strong>Pendry San Diego:</strong> Boutique luxury in Gaslamp Quarter</li>
-            <li><strong>Hampton Inn Downtown:</strong> Budget-friendly, walking distance</li>
+            <li><strong>Hilton San Diego Bayfront:</strong> Waterfront towers adjacent to convention center with stunning harbor views</li>
+            <li><strong>Hilton San Diego Gaslamp Quarter:</strong> Right in the heart of the Gaslamp, walking distance to port</li>
+            <li><strong>DoubleTree by Hilton San Diego Downtown:</strong> Downtown location with easy waterfront access</li>
+            <li><strong>Manchester Grand Hyatt:</strong> Twin waterfront towers with bay views and rooftop bar</li>
+            <li><strong>Pendry San Diego:</strong> Boutique luxury in Gaslamp Quarter with rooftop pool</li>
+            <li><strong>Hampton Inn & Suites Downtown:</strong> Budget-friendly with free breakfast, walking distance to port</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Pre-Cruise Activities</h3>
           <ul>
-            <li><strong>USS Midway Museum:</strong> Historic aircraft carrier museum within walking distance of the cruise terminal</li>
-            <li><strong>San Diego Zoo:</strong> World-famous zoo, plan at least half a day</li>
-            <li><strong>San Diego Zoo Safari Park:</strong> Wild Animal Park experience with expansive habitats</li>
-            <li><strong>Balboa Park:</strong> Cultural hub with 15 museums and cultural institutions, plus beautiful gardens and Spanish architecture</li>
-            <li><strong>SeaWorld San Diego:</strong> Marine life park and aquarium</li>
-            <li><strong>Gaslamp Quarter:</strong> Historic district with restaurants, bars, and nightlife</li>
-            <li><strong>Coronado Island:</strong> Beach, Hotel del Coronado, accessible by ferry</li>
-            <li><strong>Old Town:</strong> Mexican heritage, shops, authentic cuisine</li>
-            <li><strong>San Diego Historical Society:</strong> Learn about the city's rich history</li>
+            <li><strong>USS Midway Museum:</strong> Historic aircraft carrier museum within walking distance — flight simulators, 60+ restored aircraft, and stories from those who served</li>
+            <li><strong>Cabrillo National Monument:</strong> Point Loma headland with tide pools, Old Point Loma Lighthouse (1855), and stunning harbor views. Commemorates Juan Rodriguez Cabrillo's 1542 landing — first European on West Coast. <a href="https://www.nps.gov/cabr" target="_blank" rel="noopener">NPS Cabrillo</a></li>
+            <li><strong>San Diego Zoo:</strong> World-famous zoo with 4,000+ animals — plan at least half a day. Book through <a href="https://www.viator.com/San-Diego-tours/Nature-and-Wildlife/d616-g6-c64" target="_blank" rel="noopener">Viator</a></li>
+            <li><strong>Balboa Park:</strong> 1,200-acre cultural hub with 17 museums, Spanish Colonial architecture, and stunning gardens</li>
+            <li><strong>Gaslamp Quarter:</strong> 16-block National Historic District with Victorian architecture, restaurants, rooftop bars, and nightlife</li>
+            <li><strong>Coronado Island:</strong> Beach, iconic Hotel del Coronado (1888), accessible by ferry or bridge — consistently rated top beach in America</li>
+            <li><strong>Old Town San Diego:</strong> Birthplace of California — Mexican heritage, authentic cuisine, and free museums</li>
+            <li><strong>La Jolla:</strong> Upscale coastal village with sea caves, seals, and world-class snorkeling/kayaking (20 min north)</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>San Diego's claim as the "Birthplace of California" is well-founded. In 1542, Juan Rodriguez Cabrillo became the first European to land on what is now the West Coast of the United States — an event commemorated at Cabrillo National Monument. Father Junípero Serra established California's first mission here in 1769, and the Old Town remains the center of California's Spanish and Mexican heritage.</p>
+          <p>The harbor has been central to San Diego's identity for over a century. The Navy established a base here in 1901, and the city remains the largest naval fleet concentration in the world. The USS Midway, now a floating museum steps from the cruise terminal, served from 1945 to 1992 — the longest-serving American aircraft carrier of the 20th century.</p>
+        </section>
+
+        <section class="port-section">
+          <h3>Practical Tips</h3>
+          <ul>
+            <li><strong>Weather:</strong> San Diego's claim to "best weather in America" is not an exaggeration — average temps 60-75°F year-round with minimal rain</li>
+            <li><strong>Tide Pool Timing:</strong> Cabrillo's tide pools are best at low tide (0.7 feet or below); check <a href="https://www.nps.gov/cabr/learn/nature/full-year-tide-table.htm" target="_blank" rel="noopener">NPS tide tables</a> — best viewing is fall/winter during daylight hours</li>
+            <li><strong>Fish Tacos:</strong> A San Diego obsession — try The Brigantine on the waterfront or venture to Old Town for authentic Baja-style</li>
+            <li><strong>Craft Beer:</strong> San Diego is the craft beer capital of America — Stone, Ballast Point, and dozens more offer tastings</li>
+            <li><strong>ComicCon:</strong> Late July brings massive crowds — book hotels a year ahead if your cruise coincides</li>
           </ul>
         </section>
 

--- a/ports/seattle.html
+++ b/ports/seattle.html
@@ -65,10 +65,9 @@ Soli Deo Gloria
           <p><strong>Transportation:</strong></p>
           <ul>
             <li><strong>From SEA-TAC Airport:</strong> Taxi service typically costs $25-40 and takes 20-30 minutes</li>
-            <li><strong>Light Rail:</strong> To downtown, then taxi/Uber to terminal</li>
+            <li><strong>Link Light Rail:</strong> Airport to downtown ($3.25, 40 min) — Westlake Station is closest to cruise terminals; taxi/Uber for final leg. <a href="https://www.soundtransit.org/ride-with-us/routes-schedules/1-line" target="_blank" rel="noopener">Sound Transit</a></li>
             <li><strong>Uber/Lyft:</strong> $40-55 from airport to cruise terminals</li>
-            <li><strong>Ferry System:</strong> Connects to nearby islands throughout Puget Sound</li>
-            <li><strong>Public Transit:</strong> Comprehensive network serves the city</li>
+            <li><strong>Washington State Ferries:</strong> Connects to Bainbridge Island, Bremerton, and more — world's largest ferry fleet. <a href="https://wsdot.wa.gov/ferries" target="_blank" rel="noopener">WSDOT Ferries</a></li>
             <li><strong>Terminal Pick-up:</strong> Both cruise terminals offer passenger pick-up services</li>
           </ul>
         </section>
@@ -76,21 +75,22 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Parking Options</h3>
           <ul>
-            <li><strong>Pier 91 (Smith Cove):</strong> On-site parking available</li>
-            <li><strong>Bell Street Pier:</strong> Limited; nearby lots recommended</li>
-            <li><strong>Cost:</strong> $20-30/day</li>
-            <li><strong>Off-site:</strong> Several lots offer cruise parking with shuttles</li>
+            <li><strong>Pier 91 (Smith Cove):</strong> On-site parking managed by Platinum Parking — 1,100 secure spots including accessible stalls. $27+/day. Reserve at <a href="https://www.cruiseseattleparking.com" target="_blank" rel="noopener">cruiseseattleparking.com</a></li>
+            <li><strong>Bell Street Pier:</strong> Very limited; downtown garages recommended</li>
+            <li><strong>RV/Overheight:</strong> Available at Pier 91 for $40+/day; height limit 7'4" in garage</li>
+            <li><strong>Off-site:</strong> Several third-party lots offer cruise parking with shuttle service at lower rates</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
-            <li><strong>The Edgewater:</strong> Iconic waterfront hotel, Beatles stayed here</li>
-            <li><strong>Four Seasons Seattle:</strong> Downtown luxury near Pike Place</li>
-            <li><strong>Inn at the Market:</strong> Boutique hotel overlooking Pike Place</li>
-            <li><strong>Thompson Seattle:</strong> Modern downtown with rooftop bar</li>
-            <li><strong>Hampton Inn Downtown:</strong> Budget-friendly, good location</li>
+            <li><strong>Hilton Seattle:</strong> Downtown tower with easy access to Pike Place and waterfront attractions</li>
+            <li><strong>DoubleTree by Hilton Seattle Downtown:</strong> Spacious rooms near the convention center with famous cookies</li>
+            <li><strong>The Edgewater:</strong> Iconic waterfront hotel on Pier 67 — the Beatles stayed here in 1964 (and fished from their window)</li>
+            <li><strong>Four Seasons Seattle:</strong> Downtown luxury near Pike Place with Elliott Bay views</li>
+            <li><strong>Inn at the Market:</strong> Boutique hotel overlooking Pike Place — prime location for market exploring</li>
+            <li><strong>Hampton Inn & Suites Downtown:</strong> Budget-friendly with free breakfast, walking distance to attractions</li>
           </ul>
         </section>
 
@@ -112,10 +112,19 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Tours & Excursions</h3>
           <ul>
+            <li><strong>Olympic National Park:</strong> UNESCO World Heritage Site with three distinct ecosystems — rainforest, mountains, and wild Pacific beaches — all in one park. Full-day tours from Seattle available. Book through <a href="https://www.viator.com/Seattle-tours/Day-Trips/d704-g5-c81" target="_blank" rel="noopener">Viator</a></li>
             <li><strong>Hop-On Hop-Off Buses:</strong> Double-decker buses with departures every 30 minutes, covering major city attractions</li>
-            <li><strong>Duck Tours:</strong> Amphibious vehicle tours that travel through city streets before entering Lake Union for a unique water perspective</li>
-            <li><strong>Ferry Excursions:</strong> Explore the scenic beauty of Puget Sound and nearby islands</li>
+            <li><strong>Ride the Ducks:</strong> Amphibious vehicle tours through city streets and into Lake Union — wacky and fun</li>
+            <li><strong>Bainbridge Island Ferry:</strong> 35-minute ferry ride with stunning city skyline views — charming shops and cafes on the island</li>
+            <li><strong>Underground Tour:</strong> Explore the buried city beneath Pioneer Square — Seattle rebuilt on top of itself after the 1889 fire</li>
+            <li><strong>Boeing Factory Tour:</strong> See 787 Dreamliners being assembled at the world's largest building by volume (40 min north)</li>
           </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>Seattle's cruise story is inseparable from the Klondike Gold Rush of 1897, when the city marketed itself as the "Gateway to Alaska" — a title it still holds today. Ships loaded with prospectors departed from Elliott Bay, and the fortunes made outfitting those expeditions built modern Seattle. The Klondike Gold Rush National Historical Park in Pioneer Square preserves this era.</p>
+          <p>Pike Place Market opened in 1907 to connect farmers directly with consumers, and it has operated continuously ever since — making it one of the oldest farmers' markets in the nation. The original Starbucks opened here in 1971. The Space Needle, built for the 1962 World's Fair, remains Seattle's most recognized landmark.</p>
         </section>
 
         <section class="port-section">

--- a/ports/tampa.html
+++ b/ports/tampa.html
@@ -15,6 +15,9 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
   <link rel="stylesheet" href="/assets/styles.css"/>
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
   </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -55,43 +58,83 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Getting to the Port</h3>
           <ul>
-            <li><strong>Address:</strong> Port Tampa Bay, 1101 Channelside Drive</li>
-            <li><strong>From Tampa Airport (TPA):</strong> 20-25 minutes</li>
+            <li><strong>Address:</strong> Port Tampa Bay, 1101 Channelside Drive, Tampa FL 33602</li>
+            <li><strong>From Tampa Airport (TPA):</strong> 20-25 minutes — one of Florida's easiest airport-to-port connections</li>
             <li><strong>From Orlando:</strong> 1.5 hours via I-4 West</li>
             <li><strong>Uber/Lyft:</strong> $15-25 from TPA airport</li>
           </ul>
         </section>
 
         <section class="port-section">
+          <h3>Getting Around Tampa</h3>
+          <ul>
+            <li><strong>TECO Line Streetcar:</strong> FREE vintage streetcar connecting downtown, Channelside (port area), and Ybor City every 15 minutes. Runs 11am-11pm daily. <a href="https://www.tecolinestreetcar.org" target="_blank" rel="noopener">tecolinestreetcar.org</a></li>
+            <li><strong>Tampa Riverwalk:</strong> 2.6-mile paved waterfront path connecting major attractions — walk or rent bikes</li>
+            <li><strong>Pirate Water Taxi:</strong> Hop-on/hop-off service along the Hillsborough River connecting downtown, Armature Works, and more</li>
+            <li><strong>HART Bus:</strong> Public transit serving greater Tampa area. <a href="https://www.gohart.org" target="_blank" rel="noopener">HART Transit</a></li>
+            <li><strong>On Foot:</strong> Downtown, Channelside, and Ybor City are all walkable once there</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
           <h3>Parking Options</h3>
           <ul>
-            <li><strong>On-site parking:</strong> Port Tampa Bay garage adjacent to terminals</li>
-            <li><strong>Cost:</strong> $15-18/day — some of the best rates among major cruise ports</li>
-            <li><strong>Off-site:</strong> Several third-party lots nearby with shuttles</li>
-            <li><strong>Reserve ahead:</strong> Recommended for peak sailing dates</li>
+            <li><strong>On-site parking:</strong> Port Tampa Bay garage at 815 Channelside Drive — covered garage across from cruise terminals</li>
+            <li><strong>Cost:</strong> $17/day — some of the best rates among major Florida cruise ports</li>
+            <li><strong>Off-site alternatives:</strong> Third-party lots as low as $11/day with shuttle service</li>
+            <li><strong>Reserve ahead:</strong> Not required but recommended for peak sailing dates and holidays</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
-            <li><strong>Tampa Marriott Water Street:</strong> Walking distance to port</li>
-            <li><strong>Hilton Tampa Downtown:</strong> Connected to convention center</li>
-            <li><strong>Grand Hyatt Tampa Bay:</strong> Resort feel on the bay</li>
-            <li><strong>Hotel Haya (Ybor City):</strong> Boutique hotel in historic district</li>
+            <li><strong>Hilton Tampa Downtown:</strong> Connected to convention center, easy walk to port via Riverwalk</li>
+            <li><strong>Hilton Garden Inn Tampa Ybor Historic District:</strong> Central Ybor location, steps from streetcar and nightlife</li>
+            <li><strong>Hampton Inn & Suites Tampa Ybor City:</strong> Free cruise shuttle, free parking for up to 14 days, free breakfast — excellent park-and-cruise value</li>
+            <li><strong>Tampa Marriott Water Street:</strong> Walking distance to port with waterfront dining</li>
+            <li><strong>Grand Hyatt Tampa Bay:</strong> Resort feel on the bay with excellent pools</li>
+            <li><strong>Hotel Haya (Ybor City):</strong> Boutique hotel in historic cigar factory building</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Pre-Cruise Activities</h3>
           <ul>
-            <li><strong>Ybor City:</strong> Historic Cuban district, cigars, Columbia Restaurant</li>
-            <li><strong>Busch Gardens:</strong> African-themed park with world-class coasters</li>
-            <li><strong>Florida Aquarium:</strong> Right on the waterfront near the port</li>
-            <li><strong>Tampa Riverwalk:</strong> Scenic 2.6-mile walk along the Hillsborough River</li>
-            <li><strong>Clearwater Beach:</strong> 30 minutes west — consistently rated top beach</li>
-            <li><strong>St. Pete:</strong> Arts district, Dalí Museum, craft breweries</li>
+            <li><strong>Ybor City:</strong> National Historic Landmark District — Cuban roots, hand-rolled cigars, and Columbia Restaurant (Florida's oldest, since 1905)</li>
+            <li><strong>Busch Gardens Tampa Bay:</strong> African-themed park with world-class roller coasters including SheiKra and Iron Gwazi. Book through <a href="https://www.viator.com/Tampa-tours/Theme-Parks/d666-g22-c138" target="_blank" rel="noopener">Viator</a></li>
+            <li><strong>Florida Aquarium:</strong> Right on the waterfront near the port — 20,000+ animals including sharks, penguins, and sea turtles</li>
+            <li><strong>ZooTampa at Lowry Park:</strong> Florida's manatee rehabilitation center — guaranteed manatee sightings plus 1,000+ animals. New Straz Family Manatee Rescue Center opening 2026</li>
+            <li><strong>Tampa Riverwalk:</strong> 2.6-mile paved path along the Hillsborough River connecting museums, parks, and restaurants</li>
+            <li><strong>Clearwater Beach:</strong> 30 minutes west — consistently rated America's best beach by TripAdvisor</li>
+            <li><strong>Dalí Museum (St. Pete):</strong> World's most comprehensive collection of Salvador Dalí's work — stunning building, must-see art</li>
+            <li><strong>Hillsborough River State Park:</strong> Rapids, hiking, kayaking just 30 minutes north — rare Florida rapids and old-growth forest</li>
           </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>Tampa's cigar industry transformed a sleepy fishing village into a thriving city. In 1886, Vicente Martinez Ybor moved his cigar factories from Key West to what became Ybor City, attracting thousands of Cuban, Spanish, and Italian immigrants. At its peak, Tampa produced 500 million cigars annually, earning the nickname "Cigar Capital of the World."</p>
+          <p>The city also played a crucial role in the Spanish-American War — Theodore Roosevelt's Rough Riders embarked from Tampa for Cuba in 1898. Today, Port Tampa Bay is the largest port in Florida and a major cruise homeport serving over 1 million passengers annually.</p>
+        </section>
+
+        <section class="port-section">
+          <h3>Practical Tips</h3>
+          <ul>
+            <li><strong>Cuban Sandwich:</strong> Tampa claims to have invented it — try Columbia Restaurant or La Segunda Bakery for authentic versions with salami (the Tampa way)</li>
+            <li><strong>Free Streetcar:</strong> The TECO Line is completely free and connects the port to Ybor City — no excuse not to explore</li>
+            <li><strong>Cigar Rolling:</strong> Watch hand-rolling demonstrations at Ybor City shops — Tampa-made cigars are still world-renowned</li>
+            <li><strong>Weather:</strong> Hot and humid May-October; afternoon thunderstorms are daily summer events but pass quickly</li>
+            <li><strong>Manatees:</strong> Best viewing December-March at ZooTampa or Big Cat Rescue (make reservations)</li>
+          </ul>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Tampa Area Map</h3>
+          <p class="map-intro">Interactive map showing cruise terminals, Ybor City, Tampa Riverwalk, and major attractions.</p>
+          <div id="tampa-port-map" class="port-map-container" role="application" aria-label="Interactive map of Tampa">
+            <noscript><p>Interactive map requires JavaScript. Key locations: Cruise terminals, Ybor City, Florida Aquarium, Tampa Riverwalk.</p></noscript>
+          </div>
         </section>
 
         <section class="port-section">
@@ -120,5 +163,21 @@ Soli Deo Gloria
   <footer class="wrap" role="contentinfo"><p>© 2025 In the Wake</p></footer>
   <script>window.currentPortId = 'tampa';</script>
   <script src="/assets/js/nearby-ports.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Tampa Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'tampa-port-map',
+        portSlug: 'tampa'
+      });
+    }
+  });
+  </script>
 </body>
 </html>

--- a/ports/vancouver.html
+++ b/ports/vancouver.html
@@ -15,6 +15,9 @@ Soli Deo Gloria
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
   <link rel="stylesheet" href="/assets/styles.css"/>
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
   </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -55,11 +58,22 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Getting to the Port</h3>
           <ul>
-            <li><strong>Terminal:</strong> Canada Place, 999 Canada Place</li>
-            <li><strong>From YVR Airport:</strong> 25-35 minutes via Canada Line SkyTrain</li>
-            <li><strong>SkyTrain:</strong> Direct to Waterfront Station, short walk to terminal</li>
-            <li><strong>Taxi/Uber:</strong> $35-45 CAD from airport</li>
-            <li><strong>From Seattle:</strong> 3-4 hours via I-5 North (bring passport)</li>
+            <li><strong>Terminal:</strong> Canada Place, 999 Canada Place, Vancouver</li>
+            <li><strong>From YVR Airport:</strong> 25-35 minutes via Canada Line SkyTrain ($9.35 CAD adult fare, includes all-zone travel)</li>
+            <li><strong>SkyTrain:</strong> Direct to Waterfront Station — short walk to terminal. <a href="https://www.translink.ca" target="_blank" rel="noopener">TransLink</a></li>
+            <li><strong>Taxi/Uber:</strong> $35-45 CAD from airport; Uber and Lyft both operate in Vancouver</li>
+            <li><strong>From Seattle:</strong> 3-4 hours via I-5 North (bring passport — required for border crossing)</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>Getting Around Vancouver</h3>
+          <ul>
+            <li><strong>SkyTrain:</strong> Three lines serve metro Vancouver — Canada Line (airport/Richmond), Expo Line (east), Millennium Line (east/north). Fare zones based on distance. <a href="https://www.translink.ca/schedules-and-maps/skytrain" target="_blank" rel="noopener">TransLink SkyTrain</a></li>
+            <li><strong>SeaBus:</strong> 12-minute ferry across Burrard Inlet to North Vancouver — leaves from Waterfront Station; includes access to Lonsdale Quay market</li>
+            <li><strong>Aquabus & False Creek Ferries:</strong> Small ferries connecting Granville Island, Yaletown, Science World, and more — $4-7 CAD per hop</li>
+            <li><strong>On Foot:</strong> Downtown core is compact and walkable; Stanley Park seawall is 10 km of waterfront walking</li>
+            <li><strong>Bike Rentals:</strong> Mobi bike-share stations throughout downtown; excellent for seawall and False Creek exploration</li>
           </ul>
         </section>
 
@@ -76,24 +90,51 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Nearby Hotels</h3>
           <ul>
-            <li><strong>Fairmont Waterfront:</strong> Steps from Canada Place, harbor views</li>
-            <li><strong>Pan Pacific Vancouver:</strong> Inside Canada Place itself</li>
-            <li><strong>Fairmont Hotel Vancouver:</strong> Historic "Castle in the City"</li>
-            <li><strong>JW Marriott Parq:</strong> Modern luxury near waterfront</li>
-            <li><strong>Victorian Hotel:</strong> Budget-friendly in Gastown</li>
+            <li><strong>Hilton Vancouver Downtown:</strong> Modern tower in the heart of downtown, walking distance to Canada Place and Robson Street shopping</li>
+            <li><strong>DoubleTree by Hilton Vancouver Downtown:</strong> Waterfront location near the port with harbor views</li>
+            <li><strong>Fairmont Waterfront:</strong> Steps from Canada Place, harbor views, rooftop herb garden</li>
+            <li><strong>Pan Pacific Vancouver:</strong> Inside Canada Place itself — can't get closer to the cruise terminal</li>
+            <li><strong>Fairmont Hotel Vancouver:</strong> Historic "Castle in the City" with green copper roof, opened 1939</li>
+            <li><strong>Victorian Hotel:</strong> Budget-friendly boutique option in Gastown</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Pre-Cruise Activities</h3>
           <ul>
-            <li><strong>Stanley Park:</strong> 1,000-acre urban park, seawall bike ride, totem poles</li>
-            <li><strong>Granville Island:</strong> Public market, artisan shops, fresh seafood</li>
-            <li><strong>Gastown:</strong> Historic district, steam clock, restaurants and bars</li>
-            <li><strong>Capilano Suspension Bridge:</strong> Swaying bridge 230 feet above the forest floor</li>
-            <li><strong>Grouse Mountain:</strong> Gondola with city and mountain views</li>
-            <li><strong>Chinatown:</strong> One of North America's largest, great dim sum</li>
+            <li><strong>Stanley Park:</strong> 1,000-acre urban park — rent bikes and ride the 10 km seawall, visit the totem poles, and explore lost lagoon. One of North America's finest urban parks</li>
+            <li><strong>Granville Island:</strong> Public market with local produce, fresh seafood, artisan shops, and buskers. Take the Aquabus for scenic access</li>
+            <li><strong>Gastown:</strong> Vancouver's oldest neighborhood — cobblestone streets, steam clock (whistles every 15 min), restaurants and boutiques</li>
+            <li><strong>Capilano Suspension Bridge Park:</strong> Swaying bridge 230 feet above the canyon, cliff walk, and treetops adventure. Book through <a href="https://www.viator.com/Vancouver-tours/Outdoor-Activities/d616-g8-c57" target="_blank" rel="noopener">Viator</a></li>
+            <li><strong>Grouse Mountain:</strong> "Peak of Vancouver" — Skyride gondola, grizzly bear sanctuary, stunning city and mountain views</li>
+            <li><strong>Chinatown:</strong> One of North America's largest and oldest — Dr. Sun Yat-Sen Classical Chinese Garden is a peaceful oasis</li>
+            <li><strong>FlyOver Canada:</strong> Thrilling flight simulation ride across Canada — located at Canada Place, perfect for embarkation day</li>
           </ul>
+        </section>
+
+        <section class="port-section">
+          <h3>History & Heritage</h3>
+          <p>Vancouver's Burrard Inlet has been home to Coast Salish peoples for over 10,000 years. European settlement began in the 1860s, and the city was incorporated in 1886 — only to burn to the ground in the Great Fire that same year. The Canadian Pacific Railway reached Vancouver in 1887, transforming it into Canada's Pacific gateway.</p>
+          <p>Canada Place opened in 1986 for Expo 86, its five white sails becoming an instant Vancouver icon. The cruise terminal handles over 1 million passengers annually, serving as the premier gateway for Alaska Inside Passage voyages. The building also houses a convention center, hotel, and the FlyOver Canada attraction.</p>
+        </section>
+
+        <section class="port-section">
+          <h3>Practical Tips</h3>
+          <ul>
+            <li><strong>Currency:</strong> Canadian dollars (CAD). US dollars often accepted but at poor exchange rates — use credit cards or withdraw CAD from ATMs</li>
+            <li><strong>Weather:</strong> Mild but changeable; May-September are best months with average highs 65-75°F. Always pack a light rain layer</li>
+            <li><strong>Compass Card:</strong> Reloadable transit card for SkyTrain, buses, and SeaBus — day pass available ($11 CAD)</li>
+            <li><strong>Dim Sum:</strong> Don't miss Vancouver's legendary Chinese cuisine — try Dynasty Seafood or Sun Sui Wah for authentic dim sum</li>
+            <li><strong>Sushi:</strong> Some of the best sushi outside Japan — local favorites include Miku (high-end) and Tojo's (legendary chef)</li>
+          </ul>
+        </section>
+
+        <section class="port-section port-map-section" id="port-map-section">
+          <h3>Vancouver Area Map</h3>
+          <p class="map-intro">Interactive map showing Canada Place, Stanley Park, Granville Island, and Gastown.</p>
+          <div id="vancouver-port-map" class="port-map-container" role="application" aria-label="Interactive map of Vancouver">
+            <noscript><p>Interactive map requires JavaScript. Key locations: Canada Place, Stanley Park, Granville Island, Gastown, Capilano Suspension Bridge.</p></noscript>
+          </div>
         </section>
 
         <section class="port-section">
@@ -124,5 +165,21 @@ Soli Deo Gloria
   <footer class="wrap" role="contentinfo"><p>© 2025 In the Wake</p></footer>
   <script>window.currentPortId = 'vancouver';</script>
   <script src="/assets/js/nearby-ports.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Vancouver Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'vancouver-port-map',
+        portSlug: 'vancouver'
+      });
+    }
+  });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Added to all ports:
- Public transit info with official links (Metromover, PATH, SkyTrain, etc.)
- History & Heritage sections with port origins
- Practical tips for cruisers
- Hilton hotel options prioritized
- Leaflet map integration
- National parks and UNESCO sites where applicable

Port-specific enhancements:
- Port Miami: Metromover, Brightline, Everglades NP, Biscayne NP
- Port Everglades: Water Taxi, Sun Trolley, Hugh Taylor Birch SP
- Port Canaveral: Kennedy Space Center, Canaveral National Seashore
- Vancouver: SkyTrain, SeaBus, Stanley Park, Capilano
- Galveston: 1900 hurricane history, Galveston Island SP, Pier 16
- Seattle: Olympic NP (UNESCO), Link Light Rail, Boeing Factory
- Tampa: TECO Streetcar (free), ZooTampa manatees, Ybor City
- San Diego: Cabrillo NM, MTS Trolley, Old Town, La Jolla
- Baltimore: Fort McHenry NM, Charm City Circulator, Water Taxi
- Cape Liberty: Statue of Liberty (UNESCO), Ellis Island, PATH