### PR TITLE
Add Leaflet interactive maps to 5 Mediterranean ports

### DIFF
--- a/assets/data/maps/barcelona.map.json
+++ b/assets/data/maps/barcelona.map.json
@@ -1,0 +1,26 @@
+{
+  "port_slug": "barcelona",
+  "port_name": "Barcelona",
+  "port_pin": {
+    "lat": 41.3614,
+    "lon": 2.1677,
+    "label": "Cruise Terminal"
+  },
+  "poi_ids": [
+    "barcelona-cruise-terminal",
+    "la-rambla",
+    "sagrada-familia",
+    "park-guell",
+    "gothic-quarter",
+    "barceloneta-beach",
+    "casa-batllo",
+    "boqueria-market"
+  ],
+  "bbox_hint": {
+    "south": 41.35,
+    "west": 2.10,
+    "north": 41.42,
+    "east": 2.20
+  },
+  "generated": "2025-12-14T00:00:00Z"
+}

--- a/assets/data/maps/civitavecchia.map.json
+++ b/assets/data/maps/civitavecchia.map.json
@@ -1,0 +1,27 @@
+{
+  "port_slug": "civitavecchia",
+  "port_name": "Civitavecchia (Rome)",
+  "port_pin": {
+    "lat": 42.0935,
+    "lon": 11.7958,
+    "label": "Cruise Terminal"
+  },
+  "poi_ids": [
+    "civitavecchia-cruise-terminal",
+    "rome-colosseum",
+    "vatican-city",
+    "trevi-fountain",
+    "spanish-steps",
+    "roman-forum",
+    "pantheon-rome",
+    "trastevere"
+  ],
+  "bbox_hint": {
+    "south": 41.85,
+    "west": 11.75,
+    "north": 42.15,
+    "east": 12.55
+  },
+  "notes": "Rome attractions are ~80km from port. Train or ship excursion required.",
+  "generated": "2025-12-14T00:00:00Z"
+}

--- a/assets/data/maps/dubrovnik.map.json
+++ b/assets/data/maps/dubrovnik.map.json
@@ -1,0 +1,26 @@
+{
+  "port_slug": "dubrovnik",
+  "port_name": "Dubrovnik",
+  "port_pin": {
+    "lat": 42.6597,
+    "lon": 18.0847,
+    "label": "Cruise Port (Gruž)"
+  },
+  "poi_ids": [
+    "dubrovnik-cruise-terminal",
+    "dubrovnik-old-town",
+    "dubrovnik-walls",
+    "stradun",
+    "cable-car-dubrovnik",
+    "lokrum-island",
+    "banje-beach"
+  ],
+  "bbox_hint": {
+    "south": 42.62,
+    "west": 18.05,
+    "north": 42.67,
+    "east": 18.15
+  },
+  "notes": "Old Town is 3km from port. Bus, taxi, or walk along waterfront.",
+  "generated": "2025-12-14T00:00:00Z"
+}

--- a/assets/data/maps/poi-index.json
+++ b/assets/data/maps/poi-index.json
@@ -49,7 +49,12 @@
       "dubai": 10,
       "abu-dhabi": 9,
       "barbados": 8,
-      "st-lucia": 9
+      "st-lucia": 9,
+      "barcelona": 8,
+      "civitavecchia": 8,
+      "venice": 8,
+      "santorini": 6,
+      "dubrovnik": 7
     }
   },
 
@@ -4618,5 +4623,413 @@
     "geometry": "polygon",
     "notes": "Best snorkeling in St. Lucia. Marine reserve. Resort beach open to day visitors. Near Soufrière.",
     "port": "st-lucia"
+  },
+
+  "barcelona-cruise-terminal": {
+    "id": "barcelona-cruise-terminal",
+    "name": "Barcelona Cruise Terminal",
+    "aliases": ["Port of Barcelona", "Moll Adossat"],
+    "lat": 41.3614,
+    "lon": 2.1677,
+    "type": "port",
+    "geometry": "point",
+    "port": "barcelona"
+  },
+  "la-rambla": {
+    "id": "la-rambla",
+    "name": "La Rambla",
+    "aliases": ["Las Ramblas", "Ramblas"],
+    "lat": 41.3809,
+    "lon": 2.1736,
+    "type": "landmark",
+    "geometry": "line",
+    "notes": "Iconic tree-lined pedestrian boulevard. Street performers, flower stalls, cafes. Connects port area to Plaça de Catalunya.",
+    "port": "barcelona"
+  },
+  "sagrada-familia": {
+    "id": "sagrada-familia",
+    "name": "Sagrada Família",
+    "aliases": ["Gaudi church", "basilica"],
+    "lat": 41.4036,
+    "lon": 2.1744,
+    "type": "landmark",
+    "geometry": "point",
+    "notes": "Gaudí's unfinished masterpiece basilica. UNESCO World Heritage. Book tickets in advance.",
+    "port": "barcelona"
+  },
+  "park-guell": {
+    "id": "park-guell",
+    "name": "Park Güell",
+    "aliases": ["Parc Guell", "Gaudi park"],
+    "lat": 41.4145,
+    "lon": 2.1527,
+    "type": "park",
+    "geometry": "polygon",
+    "notes": "Gaudí's whimsical public park with mosaic-covered structures. Monumental Zone requires timed tickets.",
+    "port": "barcelona"
+  },
+  "gothic-quarter": {
+    "id": "gothic-quarter",
+    "name": "Gothic Quarter",
+    "aliases": ["Barri Gòtic", "old town"],
+    "lat": 41.3833,
+    "lon": 2.1769,
+    "type": "district",
+    "geometry": "polygon",
+    "notes": "Medieval labyrinth of narrow streets. Barcelona Cathedral, Plaça Reial, hidden plazas. Very walkable from port.",
+    "port": "barcelona"
+  },
+  "barceloneta-beach": {
+    "id": "barceloneta-beach",
+    "name": "Barceloneta Beach",
+    "aliases": ["beach", "waterfront"],
+    "lat": 41.3784,
+    "lon": 2.1925,
+    "type": "beach",
+    "geometry": "line",
+    "notes": "City beach closest to cruise port. Seafood restaurants, beach bars.",
+    "port": "barcelona"
+  },
+  "casa-batllo": {
+    "id": "casa-batllo",
+    "name": "Casa Batlló",
+    "aliases": ["Gaudi house", "dragon house"],
+    "lat": 41.3917,
+    "lon": 2.1649,
+    "type": "landmark",
+    "geometry": "point",
+    "notes": "Gaudí's dragon-inspired apartment building on Passeig de Gràcia. Interior tours available.",
+    "port": "barcelona"
+  },
+  "boqueria-market": {
+    "id": "boqueria-market",
+    "name": "La Boqueria Market",
+    "aliases": ["market", "Mercat de Sant Josep"],
+    "lat": 41.3816,
+    "lon": 2.1719,
+    "type": "shopping",
+    "geometry": "polygon",
+    "notes": "Historic food market on La Rambla. Fresh produce, tapas bars, local specialties.",
+    "port": "barcelona"
+  },
+
+  "civitavecchia-cruise-terminal": {
+    "id": "civitavecchia-cruise-terminal",
+    "name": "Civitavecchia Cruise Terminal",
+    "aliases": ["Port of Rome", "cruise port"],
+    "lat": 42.0935,
+    "lon": 11.7958,
+    "type": "port",
+    "geometry": "point",
+    "port": "civitavecchia"
+  },
+  "rome-colosseum": {
+    "id": "rome-colosseum",
+    "name": "Colosseum",
+    "aliases": ["Coliseum", "Flavian Amphitheatre"],
+    "lat": 41.8902,
+    "lon": 12.4922,
+    "type": "landmark",
+    "geometry": "point",
+    "notes": "Iconic Roman amphitheater. Book skip-the-line tickets. Combo tickets include Roman Forum and Palatine Hill.",
+    "port": "civitavecchia"
+  },
+  "vatican-city": {
+    "id": "vatican-city",
+    "name": "Vatican City",
+    "aliases": ["St Peter's", "Sistine Chapel"],
+    "lat": 41.9029,
+    "lon": 12.4534,
+    "type": "landmark",
+    "geometry": "polygon",
+    "notes": "St. Peter's Basilica (free), Vatican Museums & Sistine Chapel (tickets required). Modest dress code.",
+    "port": "civitavecchia"
+  },
+  "trevi-fountain": {
+    "id": "trevi-fountain",
+    "name": "Trevi Fountain",
+    "aliases": ["Fontana di Trevi"],
+    "lat": 41.9009,
+    "lon": 12.4833,
+    "type": "landmark",
+    "geometry": "point",
+    "notes": "Baroque fountain - toss a coin to return to Rome. Visit early morning or late evening to avoid crowds.",
+    "port": "civitavecchia"
+  },
+  "spanish-steps": {
+    "id": "spanish-steps",
+    "name": "Spanish Steps",
+    "aliases": ["Piazza di Spagna", "Scalinata"],
+    "lat": 41.9060,
+    "lon": 12.4827,
+    "type": "landmark",
+    "geometry": "point",
+    "notes": "135 steps connecting Piazza di Spagna to Trinità dei Monti church. High-end shopping at base.",
+    "port": "civitavecchia"
+  },
+  "roman-forum": {
+    "id": "roman-forum",
+    "name": "Roman Forum",
+    "aliases": ["Forum Romanum", "ancient ruins"],
+    "lat": 41.8925,
+    "lon": 12.4853,
+    "type": "landmark",
+    "geometry": "polygon",
+    "notes": "Heart of ancient Rome. Temples, basilicas, government buildings. Combo ticket with Colosseum.",
+    "port": "civitavecchia"
+  },
+  "pantheon-rome": {
+    "id": "pantheon-rome",
+    "name": "Pantheon",
+    "aliases": ["temple", "dome"],
+    "lat": 41.8986,
+    "lon": 12.4769,
+    "type": "landmark",
+    "geometry": "point",
+    "notes": "Best-preserved ancient Roman building. Timed reservations required. Spectacular oculus dome.",
+    "port": "civitavecchia"
+  },
+  "trastevere": {
+    "id": "trastevere",
+    "name": "Trastevere",
+    "aliases": ["neighborhood", "dining"],
+    "lat": 41.8893,
+    "lon": 12.4692,
+    "type": "district",
+    "geometry": "polygon",
+    "notes": "Charming medieval neighborhood. Excellent trattorias, gelaterias, nightlife. Authentic Roman atmosphere.",
+    "port": "civitavecchia"
+  },
+
+  "venice-cruise-terminal": {
+    "id": "venice-cruise-terminal",
+    "name": "Venice Cruise Terminal",
+    "aliases": ["Marittima", "Stazione Marittima"],
+    "lat": 45.4370,
+    "lon": 12.3080,
+    "type": "port",
+    "geometry": "point",
+    "port": "venice"
+  },
+  "st-marks-square": {
+    "id": "st-marks-square",
+    "name": "St. Mark's Square",
+    "aliases": ["Piazza San Marco", "San Marco"],
+    "lat": 45.4341,
+    "lon": 12.3388,
+    "type": "landmark",
+    "geometry": "polygon",
+    "notes": "Venice's main square. St. Mark's Basilica, Doge's Palace, Campanile bell tower. Floods during acqua alta.",
+    "port": "venice"
+  },
+  "st-marks-basilica": {
+    "id": "st-marks-basilica",
+    "name": "St. Mark's Basilica",
+    "aliases": ["San Marco", "cathedral"],
+    "lat": 45.4346,
+    "lon": 12.3397,
+    "type": "landmark",
+    "geometry": "point",
+    "notes": "Byzantine cathedral with gold mosaics. Free entry to basilica (long lines), paid areas include museum.",
+    "port": "venice"
+  },
+  "doges-palace": {
+    "id": "doges-palace",
+    "name": "Doge's Palace",
+    "aliases": ["Palazzo Ducale", "palace"],
+    "lat": 45.4337,
+    "lon": 12.3401,
+    "type": "landmark",
+    "geometry": "point",
+    "notes": "Gothic palace of Venetian rulers. Secret Itineraries tour shows Bridge of Sighs and prisons.",
+    "port": "venice"
+  },
+  "rialto-bridge": {
+    "id": "rialto-bridge",
+    "name": "Rialto Bridge",
+    "aliases": ["Ponte di Rialto", "Grand Canal"],
+    "lat": 45.4380,
+    "lon": 12.3360,
+    "type": "landmark",
+    "geometry": "point",
+    "notes": "Oldest bridge across Grand Canal. Shops line the walkway. Rialto Market nearby.",
+    "port": "venice"
+  },
+  "grand-canal-venice": {
+    "id": "grand-canal-venice",
+    "name": "Grand Canal",
+    "aliases": ["Canal Grande", "waterway"],
+    "lat": 45.4370,
+    "lon": 12.3340,
+    "type": "landmark",
+    "geometry": "line",
+    "notes": "Main waterway through Venice. Vaporetto line 1 is a budget 'gondola ride'.",
+    "port": "venice"
+  },
+  "murano-island": {
+    "id": "murano-island",
+    "name": "Murano",
+    "aliases": ["glass island", "glassblowing"],
+    "lat": 45.4581,
+    "lon": 12.3528,
+    "type": "district",
+    "geometry": "polygon",
+    "notes": "Island famous for glassmaking since 1291. Glass factories offer free demonstrations.",
+    "port": "venice"
+  },
+  "burano-island": {
+    "id": "burano-island",
+    "name": "Burano",
+    "aliases": ["colorful houses", "lace"],
+    "lat": 45.4853,
+    "lon": 12.4167,
+    "type": "district",
+    "geometry": "polygon",
+    "notes": "Rainbow-colored fishing village. Famous for lace-making. 45 min vaporetto from Venice.",
+    "port": "venice"
+  },
+
+  "santorini-cruise-terminal": {
+    "id": "santorini-cruise-terminal",
+    "name": "Santorini Tender Pier",
+    "aliases": ["Fira anchorage", "Skala"],
+    "lat": 36.4167,
+    "lon": 25.4333,
+    "type": "port",
+    "geometry": "point",
+    "notes": "Ships anchor and tender to Skala pier. Cable car, donkey ride, or 588 steps up to Fira.",
+    "port": "santorini"
+  },
+  "fira-town": {
+    "id": "fira-town",
+    "name": "Fira",
+    "aliases": ["Thera", "main town"],
+    "lat": 36.4167,
+    "lon": 25.4319,
+    "type": "district",
+    "geometry": "polygon",
+    "notes": "Main town on caldera rim. Shops, restaurants, stunning views. Cable car terminus.",
+    "port": "santorini"
+  },
+  "oia-village": {
+    "id": "oia-village",
+    "name": "Oia",
+    "aliases": ["sunset", "blue domes"],
+    "lat": 36.4616,
+    "lon": 25.3756,
+    "type": "district",
+    "geometry": "polygon",
+    "notes": "Iconic village with blue-domed churches and famous sunset. 12km from Fira. Very crowded at sunset.",
+    "port": "santorini"
+  },
+  "red-beach-santorini": {
+    "id": "red-beach-santorini",
+    "name": "Red Beach",
+    "aliases": ["Kokkini Paralia"],
+    "lat": 36.3497,
+    "lon": 25.3944,
+    "type": "beach",
+    "geometry": "polygon",
+    "notes": "Dramatic red volcanic cliffs. Near Akrotiri. Check if open due to cliff erosion.",
+    "port": "santorini"
+  },
+  "akrotiri-ruins": {
+    "id": "akrotiri-ruins",
+    "name": "Akrotiri Archaeological Site",
+    "aliases": ["Minoan ruins", "Pompeii of Aegean"],
+    "lat": 36.3517,
+    "lon": 25.4036,
+    "type": "landmark",
+    "geometry": "polygon",
+    "notes": "Bronze Age Minoan settlement preserved by volcanic eruption. One of Aegean's most important sites.",
+    "port": "santorini"
+  },
+  "santo-wines": {
+    "id": "santo-wines",
+    "name": "Santo Wines",
+    "aliases": ["winery", "wine tasting"],
+    "lat": 36.3867,
+    "lon": 25.4611,
+    "type": "attraction",
+    "geometry": "point",
+    "notes": "Cliffside winery with caldera views. Assyrtiko white wine. Advance booking recommended.",
+    "port": "santorini"
+  },
+
+  "dubrovnik-cruise-terminal": {
+    "id": "dubrovnik-cruise-terminal",
+    "name": "Dubrovnik Cruise Port",
+    "aliases": ["Gruž", "Gruz harbor"],
+    "lat": 42.6597,
+    "lon": 18.0847,
+    "type": "port",
+    "geometry": "point",
+    "port": "dubrovnik"
+  },
+  "dubrovnik-old-town": {
+    "id": "dubrovnik-old-town",
+    "name": "Old Town",
+    "aliases": ["Stari Grad", "walled city"],
+    "lat": 42.6411,
+    "lon": 18.1083,
+    "type": "district",
+    "geometry": "polygon",
+    "notes": "UNESCO World Heritage walled city. Game of Thrones filming locations. 3km from port.",
+    "port": "dubrovnik"
+  },
+  "dubrovnik-walls": {
+    "id": "dubrovnik-walls",
+    "name": "City Walls Walk",
+    "aliases": ["walls", "fortifications"],
+    "lat": 42.6407,
+    "lon": 18.1086,
+    "type": "landmark",
+    "geometry": "line",
+    "notes": "Walk the 2km medieval walls circling Old Town. Allow 1-2 hours. Morning is cooler.",
+    "port": "dubrovnik"
+  },
+  "stradun": {
+    "id": "stradun",
+    "name": "Stradun",
+    "aliases": ["Placa", "main street"],
+    "lat": 42.6415,
+    "lon": 18.1078,
+    "type": "landmark",
+    "geometry": "line",
+    "notes": "Main limestone-paved street through Old Town. Cafes, shops, people-watching.",
+    "port": "dubrovnik"
+  },
+  "cable-car-dubrovnik": {
+    "id": "cable-car-dubrovnik",
+    "name": "Cable Car to Mt. Srđ",
+    "aliases": ["Srd", "viewpoint"],
+    "lat": 42.6425,
+    "lon": 18.1122,
+    "type": "attraction",
+    "geometry": "point",
+    "notes": "4-minute ride to 412m summit. Panoramic views of Old Town, islands, coast.",
+    "port": "dubrovnik"
+  },
+  "lokrum-island": {
+    "id": "lokrum-island",
+    "name": "Lokrum Island",
+    "aliases": ["nature reserve", "swimming"],
+    "lat": 42.6278,
+    "lon": 18.1208,
+    "type": "nature",
+    "geometry": "polygon",
+    "notes": "Uninhabited island nature reserve. 15-min ferry from Old Town. Botanical gardens, peacocks, beaches.",
+    "port": "dubrovnik"
+  },
+  "banje-beach": {
+    "id": "banje-beach",
+    "name": "Banje Beach",
+    "aliases": ["beach", "swimming"],
+    "lat": 42.6389,
+    "lon": 18.1133,
+    "type": "beach",
+    "geometry": "line",
+    "notes": "Main beach near Old Town. Pebble beach with views of city walls.",
+    "port": "dubrovnik"
   }
 }

--- a/assets/data/maps/santorini.map.json
+++ b/assets/data/maps/santorini.map.json
@@ -1,0 +1,25 @@
+{
+  "port_slug": "santorini",
+  "port_name": "Santorini",
+  "port_pin": {
+    "lat": 36.4167,
+    "lon": 25.4333,
+    "label": "Tender Pier (Skala)"
+  },
+  "poi_ids": [
+    "santorini-cruise-terminal",
+    "fira-town",
+    "oia-village",
+    "red-beach-santorini",
+    "akrotiri-ruins",
+    "santo-wines"
+  ],
+  "bbox_hint": {
+    "south": 36.32,
+    "west": 25.35,
+    "north": 36.48,
+    "east": 25.50
+  },
+  "notes": "Ships anchor and tender. Cable car, donkey ride, or 588 steps to Fira.",
+  "generated": "2025-12-14T00:00:00Z"
+}

--- a/assets/data/maps/venice.map.json
+++ b/assets/data/maps/venice.map.json
@@ -1,0 +1,26 @@
+{
+  "port_slug": "venice",
+  "port_name": "Venice",
+  "port_pin": {
+    "lat": 45.4370,
+    "lon": 12.3080,
+    "label": "Cruise Terminal (Marittima)"
+  },
+  "poi_ids": [
+    "venice-cruise-terminal",
+    "st-marks-square",
+    "st-marks-basilica",
+    "doges-palace",
+    "rialto-bridge",
+    "grand-canal-venice",
+    "murano-island",
+    "burano-island"
+  ],
+  "bbox_hint": {
+    "south": 45.40,
+    "west": 12.28,
+    "north": 45.50,
+    "east": 12.45
+  },
+  "generated": "2025-12-14T00:00:00Z"
+}

--- a/ports/barcelona.html
+++ b/ports/barcelona.html
@@ -42,6 +42,10 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css"/>
 
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css"/>
+
   <!-- JSON-LD: BreadcrumbList -->
   <script type="application/ld+json">
   {
@@ -379,6 +383,24 @@ All work on this project is offered as a gift to God.
     </section>
 </article>
 
+    <!-- Interactive Port Map -->
+    <section class="port-section port-map-section" id="port-map-section">
+      <h3>Barcelona Port Map</h3>
+      <p class="map-intro">Interactive map showing the cruise terminal, beaches, landmarks, and attractions mentioned in this guide. Click any marker for details and directions.</p>
+      <div id="barcelona-port-map" class="port-map-container" role="application" aria-label="Interactive map of Barcelona port and points of interest">
+        <noscript>
+          <p style="padding: 2rem; text-align: center; color: #678;">
+            Interactive map requires JavaScript. <a href="https://www.openstreetmap.org/?mlat=41.3614&mlon=2.1677#map=14/41.3614/2.1677" target="_blank" rel="noopener">View on OpenStreetMap</a>.
+          </p>
+        </noscript>
+      </div>
+      <div class="port-map-actions">
+        <button type="button" class="btn btn-secondary" onclick="document.getElementById('barcelona-port-map')._portMap?.fitBounds(document.getElementById('barcelona-port-map')._portMap.getBounds())">
+          Reset View
+        </button>
+      </div>
+    </section>
+
     <!-- FAQ Section -->
     <section class="card" id="faq" style="margin-top: 2rem;">
       <h2>Frequently Asked Questions</h2>
@@ -689,6 +711,22 @@ All work on this project is offered as a gift to God.
 
   <!-- Whimsical Distance Units Script -->
   <script src="/assets/js/whimsical-port-units.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Barcelona Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'barcelona-port-map',
+        portSlug: 'barcelona'
+      });
+    }
+  });
+  </script>
 
 </body>
 </html>

--- a/ports/civitavecchia.html
+++ b/ports/civitavecchia.html
@@ -42,6 +42,10 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css"/>
 
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css"/>
+
   <!-- JSON-LD: BreadcrumbList -->
   <script type="application/ld+json">
   {
@@ -307,6 +311,24 @@ All work on this project is offered as a gift to God.
     </section>
 
   </article>
+
+    <!-- Interactive Port Map -->
+    <section class="port-section port-map-section" id="port-map-section">
+      <h3>Civitavecchia Port Map</h3>
+      <p class="map-intro">Interactive map showing the cruise terminal and key Rome attractions. Note: Rome is 80km from port - this map shows the broader area.</p>
+      <div id="civitavecchia-port-map" class="port-map-container" role="application" aria-label="Interactive map of Civitavecchia port and Rome points of interest">
+        <noscript>
+          <p style="padding: 2rem; text-align: center; color: #678;">
+            Interactive map requires JavaScript. <a href="https://www.openstreetmap.org/?mlat=42.0935&mlon=11.7958#map=10/41.9/12.4" target="_blank" rel="noopener">View on OpenStreetMap</a>.
+          </p>
+        </noscript>
+      </div>
+      <div class="port-map-actions">
+        <button type="button" class="btn btn-secondary" onclick="document.getElementById('civitavecchia-port-map')._portMap?.fitBounds(document.getElementById('civitavecchia-port-map')._portMap.getBounds())">
+          Reset View
+        </button>
+      </div>
+    </section>
 
     <!-- FAQ Section -->
     <section class="card" id="faq" style="margin-top: 2rem;">
@@ -599,6 +621,22 @@ All work on this project is offered as a gift to God.
 
   <!-- Whimsical Distance Units Script -->
   <script src="/assets/js/whimsical-port-units.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Civitavecchia Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'civitavecchia-port-map',
+        portSlug: 'civitavecchia'
+      });
+    }
+  });
+  </script>
 
 </body>
 </html>

--- a/ports/dubrovnik.html
+++ b/ports/dubrovnik.html
@@ -21,6 +21,11 @@ Soli Deo Gloria
   </script>
 
   <link rel="stylesheet" href="/assets/styles.css"/>
+
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css"/>
+
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -213,6 +218,24 @@ Soli Deo Gloria
         <p><strong>Q: Walk from port?</strong><br/>A: No — shuttle or taxi needed.</p>
       </section>
     
+    <!-- Interactive Port Map -->
+    <section class="port-section port-map-section" id="port-map-section">
+      <h3>Dubrovnik Port Map</h3>
+      <p class="map-intro">Interactive map showing the cruise port, Old Town walls, cable car, and key attractions. Click any marker for details and directions.</p>
+      <div id="dubrovnik-port-map" class="port-map-container" role="application" aria-label="Interactive map of Dubrovnik port and points of interest">
+        <noscript>
+          <p style="padding: 2rem; text-align: center; color: #678;">
+            Interactive map requires JavaScript. <a href="https://www.openstreetmap.org/?mlat=42.6597&mlon=18.0847#map=14/42.66/18.10" target="_blank" rel="noopener">View on OpenStreetMap</a>.
+          </p>
+        </noscript>
+      </div>
+      <div class="port-map-actions">
+        <button type="button" class="btn btn-secondary" onclick="document.getElementById('dubrovnik-port-map')._portMap?.fitBounds(document.getElementById('dubrovnik-port-map')._portMap.getBounds())">
+          Reset View
+        </button>
+      </div>
+    </section>
+
     <!-- Photo Gallery Section -->
     <section class="port-section photo-gallery">
       <h2>Photo Gallery</h2>
@@ -533,6 +556,22 @@ Soli Deo Gloria
 
   <!-- Whimsical Distance Units Script -->
   <script src="/assets/js/whimsical-port-units.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Dubrovnik Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'dubrovnik-port-map',
+        portSlug: 'dubrovnik'
+      });
+    }
+  });
+  </script>
 
 </body>
 </html>

--- a/ports/santorini.html
+++ b/ports/santorini.html
@@ -67,6 +67,10 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css"/>
+
   <!-- JSON-LD: BreadcrumbList -->
   <script type="application/ld+json">
   {
@@ -404,6 +408,24 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       <p>Santorini's legendary beauty comes packaged with legendary crowds—but strategic timing transforms the experience entirely. Catching the first tender puts you in Oia's famous blue-domed streets while they're still peaceful, and choosing a sunset catamaran cruise instead of joining the clifftop masses gives you equally spectacular views from the caldera with a wine glass in hand and room to breathe. The cable car line looks intimidating at noon but vanishes if you time your return for late afternoon. Weather can occasionally prevent tendering, so maintaining flexibility and having a backup plan protects both your schedule and your peace of mind. The island's vertical geography means comfortable walking shoes aren't optional—they're the difference between magical exploration and painful hobbling. Finally, remember that those whitewashed churches doubling as Instagram backdrops remain sacred spaces for Orthodox Christians; a moment of respectful behavior honors both the culture and your privilege to visit one of the Mediterranean's most extraordinary destinations.</p>
     </section>
 
+    <!-- Interactive Port Map -->
+    <section class="port-section port-map-section" id="port-map-section">
+      <h3>Santorini Port Map</h3>
+      <p class="map-intro">Interactive map showing the tender pier, cable car, villages, and attractions. Click any marker for details and directions.</p>
+      <div id="santorini-port-map" class="port-map-container" role="application" aria-label="Interactive map of Santorini port and points of interest">
+        <noscript>
+          <p style="padding: 2rem; text-align: center; color: #678;">
+            Interactive map requires JavaScript. <a href="https://www.openstreetmap.org/?mlat=36.4167&mlon=25.4333#map=13/36.4/25.43" target="_blank" rel="noopener">View on OpenStreetMap</a>.
+          </p>
+        </noscript>
+      </div>
+      <div class="port-map-actions">
+        <button type="button" class="btn btn-secondary" onclick="document.getElementById('santorini-port-map')._portMap?.fitBounds(document.getElementById('santorini-port-map')._portMap.getBounds())">
+          Reset View
+        </button>
+      </div>
+    </section>
+
     <!-- FAQ Section -->
     <section class="card faq" style="margin-top: 2rem;">
       <h2>Frequently Asked Questions</h2>
@@ -656,6 +678,22 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- Whimsical Distance Units Script -->
   <script src="/assets/js/whimsical-port-units.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Santorini Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'santorini-port-map',
+        portSlug: 'santorini'
+      });
+    }
+  });
+  </script>
 
 </body>
 </html>

--- a/ports/venice.html
+++ b/ports/venice.html
@@ -21,6 +21,11 @@ Soli Deo Gloria
   </script>
 
   <link rel="stylesheet" href="/assets/styles.css"/>
+
+  <!-- Leaflet CSS for interactive maps -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="/assets/css/components/port-map.css"/>
+
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -245,6 +250,24 @@ Soli Deo Gloria
         <p><strong>Q: Can I walk from the cruise port to Venice?</strong><br/>A: Not from Marghera — you'll need the shuttle transfer. Even from the closer San Basilio terminal, a vaporetto is your best option. The People Mover and water bus system exists specifically for this connection.</p>
       </section>
     
+    <!-- Interactive Port Map -->
+    <section class="port-section port-map-section" id="port-map-section">
+      <h3>Venice Port Map</h3>
+      <p class="map-intro">Interactive map showing the cruise terminal areas, major landmarks, and islands. Click any marker for details and directions.</p>
+      <div id="venice-port-map" class="port-map-container" role="application" aria-label="Interactive map of Venice port and points of interest">
+        <noscript>
+          <p style="padding: 2rem; text-align: center; color: #678;">
+            Interactive map requires JavaScript. <a href="https://www.openstreetmap.org/?mlat=45.437&mlon=12.308#map=14/45.437/12.335" target="_blank" rel="noopener">View on OpenStreetMap</a>.
+          </p>
+        </noscript>
+      </div>
+      <div class="port-map-actions">
+        <button type="button" class="btn btn-secondary" onclick="document.getElementById('venice-port-map')._portMap?.fitBounds(document.getElementById('venice-port-map')._portMap.getBounds())">
+          Reset View
+        </button>
+      </div>
+    </section>
+
     <!-- Photo Gallery Section -->
     <section class="port-section photo-gallery">
       <h2>Photo Gallery</h2>
@@ -565,6 +588,22 @@ Soli Deo Gloria
 
   <!-- Whimsical Distance Units Script -->
   <script src="/assets/js/whimsical-port-units.js"></script>
+
+  <!-- Leaflet JS for interactive maps -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="/assets/js/modules/port-map.js"></script>
+
+  <!-- Initialize Venice Port Map -->
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: 'venice-port-map',
+        portSlug: 'venice'
+      });
+    }
+  });
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
- Add map manifests for Barcelona, Civitavecchia (Rome), Venice, Santorini, Dubrovnik
- Add 37 new POI entries to poi-index.json for Mediterranean landmarks
- Integrate Leaflet CSS/JS and map sections into HTML pages
- Include cruise terminals, major attractions, and historic sites