### PR TITLE
Enhance Batch 7: 10 South Pacific & Caribbean ports with richer content

### DIFF
--- a/ports/antigua.html
+++ b/ports/antigua.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Antigua cruise port with tips for Nelson's Dockyard, English Harbour, 365 beaches, and experiencing this historic Caribbean gem."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="ai-summary" content="First-person logbook guide to Antigua cruise port featuring Nelson's Dockyard UNESCO World Heritage Site, 365 beaches, English Harbour's naval history, Shirley Heights, Betty's Hope plantation, and Columbus's 1493 discovery."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Antigua Port Guide — Nelson's Dockyard & 365 Beaches | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Antigua — Nelson's Dockyard UNESCO site, English Harbour history, stunning beaches, and experiencing the warmth of Antiguan hospitality in St. John's."/>
+  <meta name="description" content="First-person logbook guide to Antigua — Nelson's Dockyard UNESCO World Heritage Site, the only working Georgian dockyard in the world, 365 beaches, English Harbour's strategic naval history, and the island Columbus discovered in 1493."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/antigua.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
@@ -46,7 +46,15 @@ Soli Deo Gloria
         "name": "How do I get to Nelson's Dockyard from the cruise port?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Nelson's Dockyard is about 40 minutes from St. John's. Take the #17 bus for about $1.50 USD each way, or arrange a taxi for around $25-30 USD one way."
+          "text": "Nelson's Dockyard is about 40 minutes from St. John's. Take the #17 bus for about $1.50 USD each way, or arrange a taxi for around $25-30 USD one way. It's a UNESCO World Heritage Site and the only continuously working Georgian dockyard in the world."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is special about Nelson's Dockyard?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Nelson's Dockyard is a UNESCO World Heritage Site (since 2016) and the only continuously working Georgian dockyard anywhere in the world. Admiral Horatio Nelson was stationed here from 1784 to 1787, and the restored 18th-century naval buildings still service yachts using equipment that dates back centuries."
         }
       }
     ]
@@ -122,17 +130,21 @@ Soli Deo Gloria
         <h1>Antigua: Where Naval History Meets 365 Beaches</h1>
 
         <div class="logbook-entry clearfix">
-          <p>They say Antigua has a beach for every day of the year. Standing at the ramparts of Shirley Heights, looking down at English Harbour where Georgian naval vessels once sheltered from hurricanes, I could believe it. The coastline below was an impossible jigsaw of coves, bays, and crescents of white sand, each catching the Caribbean light differently.</p>
+          <p>They say Antigua has a beach for every day of the year — 365 of them, to be exact. Standing at the ramparts of Shirley Heights, looking down at English Harbour where Georgian naval vessels once sheltered from hurricanes, I could believe it. The coastline below was an impossible jigsaw of coves, bays, and crescents of white sand, each catching the Caribbean light differently.</p>
 
-          <p>What sets Antigua apart from other Caribbean ports is the sheer weight of maritime history here. In 1723, a hurricane swept thirty-five ships ashore across the Leeward Islands — but two Royal Navy vessels moored in English Harbour survived without a scratch. That storm sealed the harbour's reputation as the safest natural anchorage in the region, and the British spent the next century building what would become their most important naval base in the Western Hemisphere.</p>
+          <p>Christopher Columbus first sighted this island in 1493 during his second voyage to the New World, naming it Santa María de la Antigua after a cathedral in Seville. But it was the English who would leave the deepest mark here, transforming a Spanish colonial footnote into one of the Caribbean's most strategically vital naval strongholds.</p>
+
+          <p>What sets Antigua apart from other Caribbean ports is the sheer weight of maritime history concentrated in these 108 square miles. In 1723, a hurricane swept thirty-five ships ashore across the Leeward Islands — but two Royal Navy vessels moored in English Harbour survived without a scratch. That storm sealed the harbour's reputation as the safest natural anchorage in the region, and the British spent the next century building what would become their most important naval base in the Western Hemisphere.</p>
 
           <div class="poignant-highlight">
-            <strong>The Moment That Stays With Me:</strong> Walking through Nelson's Dockyard, the world's only continuously working Georgian-era dockyard, and realizing that the same capstans used to careen Admiral Nelson's ships in the 1780s still turn today. Not a recreation. Not a museum piece. The actual equipment, still in use after nearly 250 years. History doesn't get more tangible than this.
+            <strong>The Moment That Stays With Me:</strong> Walking through Nelson's Dockyard, the world's only continuously working Georgian-era dockyard, and realizing that the same capstans used to careen Admiral Horatio Nelson's ships in the 1780s still turn today. Not a recreation. Not a museum piece. The actual equipment, still in use after nearly 250 years. History doesn't get more tangible than this.
           </div>
 
-          <p>Nelson himself spent three years here as commander of HMS Boreas in the 1780s, enforcing trade laws and apparently hating every minute of it — he famously called English Harbour "an infernal hellhole." Yet his name now graces the most beautifully preserved naval yard in the Caribbean, restored beginning in 1951 after decades of decay following the Royal Navy's departure in 1889.</p>
+          <p>Admiral Horatio Nelson himself was stationed here from 1784 to 1787 as commander of HMS Boreas, enforcing trade laws and apparently hating every minute of it — he famously called English Harbour "an infernal hellhole." Yet his name now graces what UNESCO recognized in 2016 as a World Heritage Site: the only continuously working Georgian dockyard anywhere in the world. The site was restored beginning in 1951 after decades of decay following the Royal Navy's departure in 1889, a meticulous resurrection of architectural and maritime heritage that few Caribbean ports can match.</p>
 
-          <p>The local bus from St. John's to English Harbour costs about $1.50 and takes 35-45 minutes on a winding road through the island's interior. It's the most popular excursion for cruise passengers, and deservedly so. Pack your patience for the journey, but the destination rewards it tenfold.</p>
+          <p>But Antigua's history runs deeper than naval glory. By 1650, sugar plantations like Betty's Hope were already transforming the island's landscape and economy, creating wealth for European planters while enslaving thousands of Africans to work the cane fields. The twin windmills at Betty's Hope — one of the Caribbean's first sugar estates — still stand today, weathered monuments to an era of prosperity built on profound injustice. It's a history that deserves acknowledgment alongside the romantic tales of admirals and warships.</p>
+
+          <p>The local bus from St. John's — the island's capital and main cruise port — to English Harbour costs about $1.50 and takes 35-45 minutes on a winding road through the island's interior. It's the most popular excursion for cruise passengers, and deservedly so. Pack your patience for the journey, but the destination rewards it tenfold.</p>
         </div>
 
         <section class="port-section">
@@ -154,7 +166,7 @@ Soli Deo Gloria
           <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Nelson's Dockyard National Park</h4>
-          <p>UNESCO World Heritage Site since 2016. The restored Georgian buildings house restaurants, boutiques, and maritime exhibits. The only working dockyard of its era anywhere in the world. Entrance fee around $8. The most historically significant site on the island.</p>
+          <p>UNESCO World Heritage Site since 2016 and the only continuously working Georgian dockyard anywhere in the world — not just in the Caribbean, but globally. The beautifully restored 18th-century naval buildings now house restaurants, boutiques, and maritime exhibits, while the actual dockyard still services yachts using equipment that dates back centuries. Admiral Horatio Nelson was stationed here from 1784 to 1787, and the Royal Navy made this their most strategic Caribbean base for over 150 years. Entrance fee around $8. The most historically significant site on the island.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Shirley Heights Lookout</h4>
           <p>Panoramic views over English Harbour from 18th-century military fortifications. Sunday afternoon barbecue and steel band party is legendary — if your ship timing allows. Even on quiet days, the vista alone justifies the climb.</p>
@@ -170,6 +182,9 @@ Soli Deo Gloria
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Half Moon Bay</h4>
           <p>A more secluded beach on the Atlantic side — stronger waves, fewer crowds, pristine natural setting. About 45 min from port. Bring your own supplies; facilities are minimal.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Betty's Hope</h4>
+          <p>One of the Caribbean's first sugar plantations, established in 1650 and named after the daughter of the original owner. Two partially restored windmills stand as monuments to the island's sugar era and the enslaved laborers who worked these fields. The visitor center offers sobering context about plantation life and Antigua's colonial economy. About 20 minutes from port; small entrance fee.</p>
         </section>
 
         <section class="port-section port-map-section" id="port-map-section">
@@ -199,6 +214,7 @@ Soli Deo Gloria
           <p><strong>Q: Which beach is best near the port?</strong><br/>A: Dickenson Bay is closest and most developed. Half Moon Bay is worth the drive for seclusion.</p>
           <p><strong>Q: Is English Harbour worth the drive?</strong><br/>A: Absolutely. The UNESCO site, restored dockyard, and Shirley Heights views make it the island's premier attraction.</p>
           <p><strong>Q: What's the Shirley Heights Sunday party?</strong><br/>A: Weekly afternoon barbecue with steel band, rum punch, and panoramic views. If your ship timing allows, don't miss it.</p>
+          <p><strong>Q: Should I visit Betty's Hope?</strong><br/>A: If you're interested in colonial history and the Caribbean's sugar plantation era, yes. It's a sobering but important historical site with restored windmills from 1650, offering context about the enslaved people who built Antigua's early economy.</p>
         </section>
 
         <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>

--- a/ports/barbados.html
+++ b/ports/barbados.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Barbados cruise port with tips for Carlisle Bay, Harrison's Cave, rum distilleries, and experiencing authentic Bajan culture."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="ai-summary" content="First-person logbook guide to Barbados cruise port — UNESCO World Heritage Bridgetown, Caribbean's oldest rum distillery (Mount Gay, 1703), St Nicholas Abbey plantation house, Carlisle Bay snorkeling, and George Washington's only foreign port of call."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Barbados Port Guide — Bridgetown & Bajan Beauty | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Barbados — Carlisle Bay beaches, Harrison's Cave, Mount Gay rum, and discovering the warmth of Bajan hospitality in Bridgetown."/>
+  <meta name="description" content="First-person logbook guide to Barbados — UNESCO World Heritage Bridgetown, Mount Gay distillery (1703), St Nicholas Abbey, Carlisle Bay beaches, and the birthplace of rum punch. Experience 360 years of maritime history."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/barbados.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
@@ -38,7 +38,7 @@ Soli Deo Gloria
         "name": "Where do cruise ships dock in Barbados?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Ships dock at the Bridgetown Cruise Terminal in the capital city. The terminal is walking distance to downtown Bridgetown and a short taxi ride to west coast beaches."
+          "text": "Ships dock at the Bridgetown Cruise Terminal in the capital city. The terminal is walking distance to the UNESCO World Heritage downtown area and a short taxi ride to west coast beaches."
         }
       },
       {
@@ -46,7 +46,15 @@ Soli Deo Gloria
         "name": "What is the best beach near the Barbados cruise port?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Carlisle Bay is the closest quality beach, about 10 minutes by taxi. It offers calm turquoise water, excellent snorkeling over shipwrecks, and beach chair rentals."
+          "text": "Carlisle Bay is the closest quality beach, about 10 minutes by taxi. It offers calm turquoise water, excellent snorkeling over shipwrecks, sea turtle sightings, and beach chair rentals."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What makes Barbados historically significant?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Historic Bridgetown and its Garrison are UNESCO World Heritage Sites (designated 2011). Mount Gay distillery (founded 1703) is the Caribbean's oldest rum distillery. George Washington visited in 1751, the only foreign country he ever visited. Barbados was a British colony from 1625-1966, one of the longest continuous colonial relationships in the Caribbean."
         }
       }
     ]
@@ -122,15 +130,21 @@ Soli Deo Gloria
         <h1>Barbados: Where Caribbean Soul Runs Deeper Than the Rum</h1>
 
         <div class="logbook-entry clearfix">
-          <p>Barbados announced itself before we even docked — the scent of salt air mixing with something sweet (was that sugarcane?) as our ship approached the Bridgetown harbor. This easternmost Caribbean island has been welcoming sailors since the 1600s, and you can feel that history in every chattel house, every coral stone church, every raised glass of Mount Gay rum. It's been producing the stuff since 1703, after all.</p>
+          <p>Barbados announced itself before we even docked — the scent of salt air mixing with something sweet (was that sugarcane?) as our ship approached the Bridgetown harbor. This easternmost Caribbean island has been welcoming sailors since 1625, when the British first claimed it, beginning what would become one of the Caribbean's most stable colonial relationships. For 341 years, until independence in 1966, Barbados remained under continuous British rule — longer than almost any other Caribbean territory. You can feel that history in every chattel house, every coral stone church, every raised glass of Mount Gay rum.</p>
 
-          <p>What struck me immediately was how different Barbados feels from the rest of the Caribbean. The British influence runs deep — they drive on the left, cricket is a religion, and afternoon tea is a genuine thing. But underneath that colonial veneer beats an unmistakably Bajan heart: the rhythms of calypso and soca, the fire of pepper sauce on flying fish, the warmth of strangers who call you "love" and actually seem to mean it.</p>
+          <p>Here's something that struck me standing at the port: George Washington once stood on this same island in 1751, at age nineteen. It remains the only foreign country the first American president ever visited. He came for his ailing half-brother's health, stayed two months, and caught smallpox — the immunity from which may have saved his life during the Revolutionary War. History runs deep here, in ways you don't expect.</p>
+
+          <p>What struck me immediately was how different Barbados feels from the rest of the Caribbean. The British influence runs deep — they drive on the left, cricket is a religion, and afternoon tea is a genuine thing. They call it "Little England," and the nickname fits more than you'd think. But underneath that colonial veneer beats an unmistakably Bajan heart: the rhythms of calypso and soca, the fire of pepper sauce on flying fish, the warmth of strangers who call you "love" and actually seem to mean it. It's this blend — 400 years of British formality married to Caribbean soul — that makes Barbados feel unlike anywhere else in the region.</p>
 
           <div class="poignant-highlight">
             <strong>The Moment That Stays With Me:</strong> Floating in the impossibly clear water of Carlisle Bay, snorkeling over the Berwyn shipwreck while sea turtles glided past like they owned the place (they do). I'd paid nothing beyond a taxi ride and mask rental. Sometimes the best Caribbean moments don't require an excursion booking — just a willingness to get in the water and see what shows up.
           </div>
 
           <p>Harrison's Cave exceeded my expectations. I'd braced for a touristy underground train ride through mediocre formations. Instead, we descended into a genuinely spectacular crystallized limestone cavern — waterfalls, pools, stalactites that took millions of years to form. The tram makes it accessible without requiring a spelunking adventure. Worth the drive into the island's interior.</p>
+
+          <p>But let's talk about rum, because you simply cannot understand Barbados without understanding its relationship with the spirit. Mount Gay, founded in 1703, holds the distinction of being the oldest continuously operating rum distillery in the Caribbean — possibly the world. The distillery tour taught me something I'd never known: in 1645, a Royal Navy edict began the tradition of the daily rum ration for sailors, a practice that continued for over 300 years until "Black Tot Day" in 1970. Barbados didn't just produce rum; it fueled the entire British Navy's liquid courage.</p>
+
+          <p>The island is also credited as the birthplace of rum punch — that perfect balance of "one of sour, two of sweet, three of strong, four of weak" that every Caribbean bartender knows. Today, Barbados has over 1,500 rum shops scattered across its 166 square miles. That's roughly one rum shop for every 190 residents. These aren't touristy beach bars; they're corner establishments where locals gather, talk cricket, and pour generous measures. I stopped into one near Speightstown, paid $3 BBD for a rum and coconut water, and left understanding why Bajans take their rum culture seriously.</p>
         </div>
 
         <section class="port-section">
@@ -158,10 +172,13 @@ Soli Deo Gloria
           <p>Spectacular underground cave system with an electric tram tour. Stalactites, waterfalls, pools. About 45 min from port. ~$35 per person. Book ahead in high season.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Mount Gay Rum Distillery</h4>
-          <p>The world's oldest rum brand (since 1703). Tours explain the distillation process and include generous tastings. The signature tour is about $20; premium experiences available. 15 min from port.</p>
+          <p>The Caribbean's oldest rum distillery, documented since 1703. Tours explain the distillation process, the history of the Royal Navy rum ration tradition (begun 1645), and include generous tastings. The signature tour is about $20; premium experiences available. 15 min from port. This is where Caribbean rum culture began.</p>
 
-          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Historic Bridgetown</h4>
-          <p>UNESCO World Heritage Site. Walk through the capital to see Parliament Buildings, the Careenage (inner harbor), and Broad Street shopping. Accessible on foot from the cruise terminal.</p>
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Historic Bridgetown and its Garrison</h4>
+          <p>UNESCO World Heritage Site since 2011. The capital preserves one of the Caribbean's finest examples of British colonial architecture spanning the 17th to 19th centuries. Walk from the cruise terminal to see Parliament Buildings (dating to 1639), the Careenage (inner harbor where wooden sailing ships once careened for repairs), the Garrison Savannah (historic British military complex), and Broad Street shopping. The Garrison area includes a UNESCO-protected collection of historic military buildings, including the Main Guard and the George Washington House where the future president stayed in 1751.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">St Nicholas Abbey</h4>
+          <p>Built in 1658, this Jacobean plantation house is one of only three remaining Jacobean mansions in the entire Western Hemisphere. The coral stone great house has been meticulously preserved, complete with Dutch gables and mullioned windows. Tours include the working rum distillery (they still make rum using traditional methods), heritage railway rides through the cane fields, and screenings of 1930s home movies shot by the Warren family. About 45 min from port. ~$30 per person. An architectural and historical treasure.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">West Coast Beaches</h4>
           <p>Mullins Beach and Paynes Bay offer calmer water and upscale beach bars. Further from port (30-45 min) but worth it for a premium beach day.</p>
@@ -181,22 +198,23 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Local Food & Drink</h3>
           <ul>
-            <li><strong>Flying Fish:</strong> The national dish — breaded, fried, often served with cou-cou (polenta-like cornmeal)</li>
-            <li><strong>Cutter:</strong> Local sandwich on salt bread with fish, ham, or cheese</li>
-            <li><strong>Macaroni Pie:</strong> Bajan mac and cheese — a side dish staple</li>
+            <li><strong>Flying Fish:</strong> The national dish — breaded, fried, often served with cou-cou (polenta-like cornmeal and okra)</li>
+            <li><strong>Cutter:</strong> Local sandwich on salt bread with fish, ham, or cheese — the Bajan fast food</li>
+            <li><strong>Macaroni Pie:</strong> Bajan mac and cheese — a side dish staple at every meal</li>
             <li><strong>Banks Beer:</strong> The local lager, best ice-cold on the beach</li>
-            <li><strong>Rum Punch:</strong> Every bar has their own recipe; Mount Gay is the gold standard</li>
-            <li><strong>Pepper Sauce:</strong> Bajan pepper sauce is HOT — taste cautiously</li>
+            <li><strong>Rum Punch:</strong> Barbados claims to be the birthplace of rum punch. The traditional recipe: "one of sour, two of sweet, three of strong, four of weak." Every bar has their own take; Mount Gay rum is the gold standard base. Over 1,500 rum shops across the island serve it.</li>
+            <li><strong>Pepper Sauce:</strong> Bajan pepper sauce is HOT — taste cautiously before dousing</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Frequently Asked Questions</h3>
-          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Bridgetown Cruise Terminal, walking distance to downtown.</p>
-          <p><strong>Q: What's the best beach near the port?</strong><br/>A: Carlisle Bay — 10 min by taxi, excellent snorkeling, sea turtles.</p>
-          <p><strong>Q: Do I need a taxi?</strong><br/>A: Downtown Bridgetown is walkable; beaches and attractions require taxis or excursions.</p>
-          <p><strong>Q: Is Barbados expensive?</strong><br/>A: Mid-range for the Caribbean. Taxis are pricey but can be shared. Street food and rum are affordable.</p>
-          <p><strong>Q: Can I swim with sea turtles?</strong><br/>A: Yes! Carlisle Bay and west coast beaches frequently have turtle sightings. No touching — just observe.</p>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Bridgetown Cruise Terminal, walking distance to the UNESCO World Heritage downtown area.</p>
+          <p><strong>Q: What's the best beach near the port?</strong><br/>A: Carlisle Bay — 10 min by taxi, excellent snorkeling over shipwrecks, sea turtles.</p>
+          <p><strong>Q: Do I need a taxi?</strong><br/>A: Downtown Bridgetown is walkable; beaches and attractions like St Nicholas Abbey, Harrison's Cave, and west coast beaches require taxis or excursions.</p>
+          <p><strong>Q: Is Barbados expensive?</strong><br/>A: Mid-range for the Caribbean. Taxis are pricey but can be shared. Street food and rum are affordable. Local rum shops offer authentic drinks at local prices ($3-5 BBD).</p>
+          <p><strong>Q: Can I swim with sea turtles?</strong><br/>A: Yes! Carlisle Bay and west coast beaches (especially Paynes Bay) frequently have turtle sightings. No touching — just observe respectfully.</p>
+          <p><strong>Q: What makes Barbados historically significant?</strong><br/>A: Historic Bridgetown and its Garrison are UNESCO World Heritage Sites (2011). Mount Gay distillery (1703) is the Caribbean's oldest. George Washington visited in 1751 — the only foreign country he ever visited. The island was a British colony from 1625-1966, one of the longest continuous colonial relationships in the Caribbean.</p>
         </section>
 
         <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>

--- a/ports/bora-bora.html
+++ b/ports/bora-bora.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Bora Bora cruise port — French Polynesia's most iconic lagoon with Mount Otemanu, tender to Vaitape, and ultimate tropical paradise."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="ai-summary" content="First-person logbook guide to Bora Bora — the Pearl of the Pacific with sacred Mount Otemanu volcano, tender port in turquoise lagoon, Matira Beach, Lagoonarium snorkeling, WWII history, and 10,000 residents on French Polynesia's most legendary island."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Bora Bora Port Guide — The Pearl of the Pacific | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Bora Bora — the legendary lagoon, Mount Otemanu backdrop, tender to Vaitape village, and French Polynesia's most iconic paradise."/>
+  <meta name="description" content="First-person logbook guide to Bora Bora — the Pearl of the Pacific. Sacred Mount Otemanu, tender to Vaitape, Lagoonarium, Matira Beach, WWII remnants, and lagoon paradise on French Polynesia's legendary island."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/bora-bora.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>
@@ -95,9 +95,9 @@ Soli Deo Gloria
       <h1>Bora Bora: The Island That Photographs Don't Do Justice</h1>
 
       <div class="logbook-entry clearfix">
-        <p>The ship anchored in Pofai Bay and Mount Otemanu filled the frame – a volcanic spire rising 727 meters from a lagoon so impossibly turquoise it looked digitally enhanced. I'd seen thousands of photos of Bora Bora. None prepared me. The colors exist on a spectrum that cameras simply can't capture: blues that shift from aquamarine to sapphire to emerald depending on depth and light, greens so vivid they hurt.</p>
+        <p>The ship anchored in Pofai Bay and Mount Otemanu filled the frame – an extinct volcanic spire rising 2,385 feet (727 meters) from a lagoon so impossibly turquoise it looked digitally enhanced. I'd seen thousands of photos of Bora Bora. None prepared me. The colors exist on a spectrum that cameras simply can't capture: blues that shift from aquamarine to sapphire to emerald depending on depth and light, greens so vivid they hurt. They call this place the "Pearl of the Pacific," and standing on deck watching that sacred peak pierce the morning sky, surrounded by a barrier reef that glows like liquid gemstone, I understood why.</p>
 
-        <p>Polynesians have called this island home for thousands of years, naming it Pora Pora ("first born") in their navigation mythology. Europeans arrived in 1722 and mispronounced the name; the error stuck. During World War II, the Americans built a supply base here – the relics at Faanui Bay stand as surprising reminders that this paradise once bristled with guns and airstrips. Today, only beauty remains.</p>
+        <p>Polynesians have called this island home for thousands of years, naming it Pora Pora ("firstborn") in their navigation mythology – the sacred first child of their ancestral homeland. Europeans arrived in 1722 and mispronounced the name; the error stuck. During World War II, the Americans transformed paradise into fortress: 5,000 GIs stationed here, building airstrips, fuel depots, and coastal defenses to protect the South Pacific supply lines. The relics at Faanui Bay still stand – cannons rusting in the jungle, concrete bunkers reclaimed by vines – surprising reminders that this paradise once bristled with military purpose. Today, only beauty remains, and the island's population of roughly 10,000 permanent residents shares it graciously with those of us who arrive by ship.</p>
 
         <div class="poignant-highlight">
           <strong>The Moment The World Stopped:</strong> Floating face-down in the coral garden, watching a black-tip reef shark glide beneath me – close enough to touch, utterly disinterested in my presence. Manta rays swept past like underwater birds. Schools of tropical fish parted around me like I was invisible. The silence underwater was profound, and I forgot I was a tourist. I was simply... there.
@@ -106,15 +106,16 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h2>The Lagoon Experience</h2>
-        <p>Bora Bora isn't a port – it's an anchorage. Your ship stops in the lagoon, and tender boats ferry passengers the 5-10 minutes to Vaitape village on the island's western shore. The tender ride itself is stunning, Mount Otemanu growing larger as you approach, the water beneath shifting through a dozen shades of blue.</p>
-        <p>The lagoon is the attraction. Every excursion worth taking involves getting into or onto it: snorkeling among reef sharks and rays at designated feeding sites, kayaking through water so clear you feel suspended in air, jet skiing around the motus (small islands) that ring the lagoon, or swimming with rays and sharks at protected shallow sites.</p>
-        <p>Glass-bottom boat tours offer non-swimmers views of the underwater world. Many tours include a motu beach stop where fresh fruit and coconuts appear seemingly from nowhere. The water is bathwater warm year-round – snorkeling gear is all you need.</p>
+        <p>Bora Bora isn't a port – it's an anchorage. There is no dock here; the barrier reef and shallow lagoon make direct berthing impossible. Your ship stops in the protected waters, and tender boats ferry passengers the 5-10 minutes to Vaitape village on the island's western shore. The tender ride itself is stunning, Mount Otemanu's sacred peak growing larger as you approach, the water beneath shifting through a dozen shades of blue, so clear you can watch the coral gardens pass thirty feet below.</p>
+        <p>The lagoon is the attraction. Every excursion worth taking involves getting into or onto it: snorkeling among reef sharks and rays at designated feeding sites, kayaking through water so clear you feel suspended in air, jet skiing around the motus (small islands) that ring the lagoon, or swimming with rays and sharks at protected shallow sites. The Lagoonarium – a natural aquarium sectioned by nets in the lagoon itself – offers one of the most reliable encounters: eagle rays, blacktip reef sharks, sea turtles, and tropical fish swirl around you in water so warm and clear it feels like swimming through liquid light.</p>
+        <p>Glass-bottom boat tours offer non-swimmers views of the underwater world. Many tours include a motu beach stop where fresh fruit and coconuts appear seemingly from nowhere, served on white sand that squeaks underfoot. The water is bathwater warm year-round – snorkeling gear is all you need, though reef-safe sunscreen is essential. The sun here is equatorial and unforgiving.</p>
       </section>
 
       <section class="port-section">
         <h2>Vaitape & Island Exploration</h2>
         <p>Vaitape is Bora Bora's main village – perhaps 4,000 residents, a handful of shops, a post office (popular for stamps), and tour operators lining the waterfront. It's charming in a low-key way; this isn't a destination for shopping or nightlife. An ATM, internet cafe, and car rental are available near the tender pier.</p>
-        <p>A ring road circles the island – 32 kilometers that pass through villages, past WWII relics at Faanui Bay, and along beaches that remain surprisingly undeveloped despite Bora Bora's fame. Renting a car or joining a 4x4 island tour reveals a side of Bora Bora most visitors miss. Hiking trails lead to viewpoints, though the summit of Otemanu itself is a technical climb for experts only.</p>
+        <p>A ring road circles the island – 32 kilometers that pass through villages, past WWII relics at Faanui Bay (look for the overgrown coastal gun emplacements and concrete bunkers from the 1942-46 American presence), and along beaches that remain surprisingly undeveloped despite Bora Bora's fame. The southern tip of the island curves into Matira Beach, consistently rated one of the world's finest beaches – a crescent of powdery white sand where the lagoon turns impossibly shallow and warm, perfect for wading out fifty yards with water barely reaching your knees. Public access exists, though the best facilities belong to the hotels lining the shore.</p>
+        <p>Renting a car or joining a 4x4 island tour reveals a side of Bora Bora most visitors miss: family gardens bursting with hibiscus and frangipani, roadside fruit stands selling papayas the size of footballs, and viewpoints where Mount Otemanu frames itself against lagoon and sky. Hiking trails lead to panoramic overlooks, though the summit of Otemanu itself is a technical climb for experts only – the sacred peak remains largely untouched, its vertical basalt walls reserved for the skilled and reverent.</p>
         <p>Most of the famous overwater bungalows cluster on the eastern side of the lagoon, inaccessible without resort reservations. However, some resorts offer day passes including lunch, pool access, and beach time – worth investigating if ultimate luxury appeals.</p>
       </section>
 
@@ -133,7 +134,9 @@ Soli Deo Gloria
 
       <section class="port-section faq-section">
         <h2>Frequently Asked Questions</h2>
-        <details class="faq-item"><summary>Do ships dock at Bora Bora?</summary><p>No – ships anchor in the lagoon and tender passengers to Vaitape village. The tender ride (5-10 minutes) offers gorgeous views of Mount Otemanu as you approach.</p></details>
+        <details class="faq-item"><summary>Do ships dock at Bora Bora?</summary><p>No – there is no dock at Bora Bora. The barrier reef and shallow lagoon make direct berthing impossible. Ships anchor in the protected lagoon waters and tender passengers to Vaitape village. The tender ride (5-10 minutes) offers gorgeous views of sacred Mount Otemanu as you approach.</p></details>
+        <details class="faq-item"><summary>What is the Lagoonarium?</summary><p>The Lagoonarium is a natural aquarium in the lagoon itself – a netted section where you can snorkel safely with eagle rays, blacktip reef sharks, sea turtles, and tropical fish. It's one of the most reliable ways to encounter marine life up close in crystal-clear water.</p></details>
+        <details class="faq-item"><summary>Can I visit Matira Beach?</summary><p>Yes – Matira Beach on the southern tip is publicly accessible and consistently rated one of the world's best beaches. The water is incredibly shallow and warm, perfect for wading. Hotels line the shore with better facilities, but the beach itself is open to all.</p></details>
         <details class="faq-item"><summary>Is snorkeling with sharks safe?</summary><p>Yes – the black-tip reef sharks and lemon sharks at Bora Bora's feeding sites are not aggressive toward humans. Guides supervise all encounters. It's exhilarating rather than frightening.</p></details>
         <details class="faq-item"><summary>Can I visit an overwater bungalow resort?</summary><p>Some resorts offer day passes including lunch, pool, and beach access. Contact resorts directly or through shore excursions. Expect to pay $200+ per person for this luxury experience.</p></details>
         <details class="faq-item"><summary>How expensive is Bora Bora really?</summary><p>Very. Budget $40-50 for lunch, $150+ for excursions, $10+ for a beer. The CFP franc is the currency. Many visitors book ship excursions to control costs.</p></details>
@@ -143,7 +146,7 @@ Soli Deo Gloria
     <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
       <section class="card quick-answer">
         <h2>Quick Answer</h2>
-        <p><strong>Bora Bora</strong> is French Polynesia's crown jewel – an ancient volcanic island surrounded by a lagoon so beautiful it defies photography. Ships anchor in the lagoon and tender to Vaitape village. The experience is all about the water: snorkeling, swimming with sharks and rays, kayaking through impossible blues. Expensive but genuinely once-in-a-lifetime.</p>
+        <p><strong>Bora Bora</strong> – the "Pearl of the Pacific" – is French Polynesia's crown jewel. An extinct volcanic island with sacred Mount Otemanu (2,385 ft) rising from a lagoon so beautiful it defies photography. Ships anchor in the barrier reef-protected waters and tender to Vaitape village (no dock exists). The experience is all about the water: Lagoonarium snorkeling, Matira Beach, swimming with sharks and rays, kayaking through impossible blues. Home to 10,000 residents and WWII history. Expensive but genuinely once-in-a-lifetime.</p>
       </section>
       <section class="card best-for">
         <h2>Best For</h2>
@@ -159,11 +162,15 @@ Soli Deo Gloria
         <dl>
           <dt>Territory</dt><dd>French Polynesia (France)</dd>
           <dt>Island Group</dt><dd>Society Islands (Leeward)</dd>
-          <dt>Port Type</dt><dd>Anchorage (tender to Vaitape)</dd>
-          <dt>Tender Time</dt><dd>5-10 minutes</dd>
+          <dt>Original Name</dt><dd>Pora Pora ("firstborn")</dd>
+          <dt>Population</dt><dd>~10,000 residents</dd>
+          <dt>Port Type</dt><dd>Anchorage (no dock - tender only)</dd>
+          <dt>Tender Time</dt><dd>5-10 minutes to Vaitape</dd>
           <dt>Currency</dt><dd>CFP Franc (USD sometimes)</dd>
           <dt>Language</dt><dd>French, Tahitian</dd>
-          <dt>Mount Otemanu</dt><dd>727 meters</dd>
+          <dt>Mount Otemanu</dt><dd>2,385 ft (727m) - extinct volcano, sacred</dd>
+          <dt>Nickname</dt><dd>"Pearl of the Pacific"</dd>
+          <dt>WWII History</dt><dd>5,000 US GIs (1942-46)</dd>
           <dt>Expect</dt><dd>Expensive, extraordinarily beautiful</dd>
         </dl>
       </section>
@@ -189,7 +196,9 @@ Soli Deo Gloria
     "@context": "https://schema.org",
     "@type": "FAQPage",
     "mainEntity": [
-      {"@type": "Question", "name": "Do ships dock at Bora Bora?", "acceptedAnswer": {"@type": "Answer", "text": "No – ships anchor in the lagoon and tender passengers to Vaitape village, a 5-10 minute ride."}},
+      {"@type": "Question", "name": "Do ships dock at Bora Bora?", "acceptedAnswer": {"@type": "Answer", "text": "No – there is no dock at Bora Bora. Ships anchor in the lagoon and tender passengers to Vaitape village, a 5-10 minute ride with views of sacred Mount Otemanu."}},
+      {"@type": "Question", "name": "What is the Lagoonarium?", "acceptedAnswer": {"@type": "Answer", "text": "The Lagoonarium is a natural aquarium in the lagoon – a netted section where you can snorkel with eagle rays, blacktip reef sharks, sea turtles, and tropical fish in crystal-clear water."}},
+      {"@type": "Question", "name": "Can I visit Matira Beach?", "acceptedAnswer": {"@type": "Answer", "text": "Yes – Matira Beach is publicly accessible and consistently rated one of the world's best beaches. The water is incredibly shallow and warm, perfect for wading."}},
       {"@type": "Question", "name": "Is snorkeling with sharks safe?", "acceptedAnswer": {"@type": "Answer", "text": "Yes – the reef sharks at feeding sites are not aggressive. Guides supervise all encounters."}},
       {"@type": "Question", "name": "Can I visit an overwater bungalow resort?", "acceptedAnswer": {"@type": "Answer", "text": "Some resorts offer day passes ($200+). Contact resorts directly or through shore excursions."}},
       {"@type": "Question", "name": "How expensive is Bora Bora really?", "acceptedAnswer": {"@type": "Answer", "text": "Very. Budget $40-50 for lunch, $150+ for excursions. Many book ship excursions to control costs."}}

--- a/ports/cairns.html
+++ b/ports/cairns.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Cairns cruise port — gateway to the Great Barrier Reef, Daintree Rainforest, and tropical North Queensland adventures."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="ai-summary" content="First-person logbook guide to Cairns cruise port — founded 1876, gateway to TWO UNESCO World Heritage Sites where the Great Barrier Reef meets the world's oldest rainforest."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Cairns Port Guide — Gateway to the Great Barrier Reef | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Cairns — Great Barrier Reef day trips, ancient Daintree Rainforest, Kuranda Scenic Railway, and Australia's tropical adventure capital."/>
+  <meta name="description" content="First-person logbook guide to Cairns — 1876 gold port, gateway to the 2,300km Great Barrier Reef and 180-million-year-old Daintree Rainforest, where two UNESCO sites meet at Cape Tribulation."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/cairns.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>
@@ -95,12 +95,12 @@ Soli Deo Gloria
       <h1>Cairns: Where Two World Heritage Sites Collide</h1>
 
       <div class="logbook-entry clearfix">
-        <p>The Great Barrier Reef stretches offshore. The Daintree Rainforest – the oldest on Earth – presses in from the west. Cairns sits at the improbable intersection of two World Heritage Sites, a small city punching far above its weight as a gateway to natural wonders that defy description. This isn't a place you visit casually; this is a place that changes your understanding of what nature can be.</p>
+        <p>The Great Barrier Reef stretches offshore – 2,300 kilometers long, visible from space, the world's largest living structure. The Daintree Rainforest – 180 million years old, the world's oldest continuously surviving tropical rainforest – presses in from the west. Cairns sits at the improbable intersection of two UNESCO World Heritage Sites, the only place on Earth where they meet. This small city, founded in 1876 as an export port for gold and minerals from the inland, now punches far above its weight as gateway to natural wonders that defy description.</p>
 
-        <p>Australia's fourth-busiest cruise port surprises with its intimacy – the award-winning terminal sits downtown, walkable to shops and the famous Esplanade. But nobody comes to Cairns to walk the city streets. They come to float over coral gardens, to zip-line through rainforest canopy, to encounter wildlife found nowhere else on the planet. Book your tours early – cruise ship days see tremendous demand.</p>
+        <p>Named after Sir William Wellington Cairns, Governor of Queensland, this tropical outpost transformed from rough mining port to Australia's fourth-busiest cruise terminal. The award-winning port sits downtown, walkable to shops and the famous Esplanade. But nobody comes to Cairns to walk city streets. They come to float over coral gardens, to zip-line through rainforest canopy, to encounter wildlife found nowhere else on the planet. At Cape Tribulation, two hours north, rainforest meets reef in the only place on Earth where two World Heritage Sites physically collide – ancient trees descending to white sand, beyond which the reef begins. Book your tours early; cruise ship days see tremendous demand.</p>
 
         <div class="poignant-highlight">
-          <strong>The Moment I Understood:</strong> Floating face-down over the outer reef, the coral city spreading below me in impossible colors – brain coral, staghorn forests, giant clams with electric-blue lips. A sea turtle glided past, unimpressed by my presence, ancient and unhurried. I was a guest in a world 500 million years in the making.
+          <strong>The Moment I Understood:</strong> Floating face-down over the outer reef, the coral city spreading below me in impossible colors – brain coral, staghorn forests, giant clams with electric-blue lips. A sea turtle glided past, unimpressed by my presence, ancient and unhurried. I was a guest in a world 500 million years in the making. Then, standing days later where rainforest meets reef at Cape Tribulation, the full scope hit me: Cairns isn't just near these wonders. It's the doorway to the meeting place of the Earth's most ancient forest and its largest living organism.
         </div>
       </div>
 
@@ -113,16 +113,17 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h2>The Daintree Rainforest</h2>
-        <p>Two hours north of Cairns lies the Daintree – 180 million years old, surviving since dinosaurs walked Australia, the oldest continuously surviving rainforest on Earth. The diversity here is staggering: 30% of Australia's frog species, 65% of its butterfly species, 20% of its bird species, all compressed into this ancient green laboratory. Where else does rainforest meet reef?</p>
-        <p>Day trips from Cairns cross the Daintree River by ferry (crocodile sightings nearly guaranteed on river cruises), wind through Cape Tribulation where rainforest meets beach, and offer guided walks through forest primeval. Indigenous-led tours add cultural depth – the land has been home to Aboriginal peoples for 50,000 years.</p>
-        <p>Mossman Gorge, closer to Cairns, offers an accessible introduction to the rainforest with shorter walks and a cultural center. The Skyrail Rainforest Cableway and Kuranda Scenic Railway provide elevated perspectives through the canopy – combining both for a one-way journey is a classic Cairns experience.</p>
+        <p>Two hours north of Cairns lies the Daintree – 180 million years old, surviving since dinosaurs walked Australia, the world's oldest continuously surviving tropical rainforest. This UNESCO World Heritage Site existed before Australia separated from Gondwana; flowering plants evolved here. The diversity is staggering: 30% of Australia's frog species, 65% of its butterfly species, 20% of its bird species, all compressed into this ancient green laboratory that makes the Amazon look young.</p>
+        <p>Day trips from Cairns cross the Daintree River by cable ferry – saltwater crocodile territory, and the warning signs everywhere aren't decoration. These prehistoric reptiles share the waterways; river cruises almost guarantee sightings. Beyond the crossing, the road winds through Cape Tribulation, the singular place on Earth where two UNESCO World Heritage Sites physically meet. Rainforest descends to white sand beach; beyond the surf lies the reef. Captain Cook named it after running aground on the reef here in 1770 – "the tribulation of our escape."</p>
+        <p>Indigenous-led tours add essential cultural depth. The Eastern Kuku Yalanji people have called this land home for over 50,000 years. The Tjapukai Aboriginal Cultural Park near Cairns showcases more than 40,000 years of Indigenous culture through ceremony, story, and art. This isn't just ancient forest – it's ancient homeland, still occupied by its original custodians.</p>
+        <p>Mossman Gorge, closer to Cairns, offers an accessible introduction with shorter walks and a cultural center. The Skyrail Rainforest Cableway and historic Kuranda Scenic Railway (opened 1891, a marvel of engineering through the Barron Gorge) provide elevated perspectives through the canopy – combining both for a one-way journey remains the classic Cairns rainforest experience.</p>
       </section>
 
       <section class="port-section">
         <h2>Kuranda & Adventure</h2>
-        <p>The village of Kuranda sits in the rainforest above Cairns, reached by the historic Kuranda Scenic Railway (1891) that winds through gorges and past waterfalls, or the Skyrail cableway that floats above the canopy. The village itself offers markets, wildlife parks, and the chance to hold a koala – touristy but genuinely enjoyable.</p>
-        <p>For adrenaline seekers, Cairns delivers: bungee jumping, skydiving over the reef, white-water rafting on the Tully River, zip-lining through rainforest. The adventure tourism infrastructure here rivals anywhere in Australia – if you want to throw yourself off or out of something, Cairns will accommodate.</p>
-        <p>The Cairns Esplanade lagoon offers free swimming in a man-made saltwater pool (the sea itself has marine stingers seasonally). The waterfront development is pleasant for strolling, with restaurants and bars overlooking the marina.</p>
+        <p>The village of Kuranda sits in the rainforest above Cairns, reached by the historic Kuranda Scenic Railway – opened 1891 after five years of dangerous construction through the Barron Gorge. The narrow-gauge train winds through hand-carved tunnels, past Stoney Creek Falls and the Barron Falls, a journey as rewarding as the destination. Alternatively, the modern Skyrail cableway floats above the canopy, offering bird's-eye perspectives. The village itself offers markets, wildlife parks, and the chance to hold a koala – unabashedly touristy but genuinely enjoyable.</p>
+        <p>For adrenaline seekers, Cairns delivers in abundance: bungee jumping from platforms above rainforest, skydiving over the reef (falling toward turquoise water is disconcerting), white-water rafting on the Tully River, zip-lining through canopy. The adventure tourism infrastructure here rivals anywhere in Australia – if you want to throw yourself off or out of something, Cairns will accommodate with professional enthusiasm.</p>
+        <p>The Cairns Esplanade lagoon offers free swimming in a man-made saltwater pool – the sea itself hosts marine stingers seasonally, and those crocodile warning signs appear for good reason. The waterfront development is pleasant for strolling, with restaurants and bars overlooking Trinity Bay. But lingering in town feels like missing the point. The wonders are out there, waiting.</p>
       </section>
 
       <section class="port-section">
@@ -143,7 +144,7 @@ Soli Deo Gloria
     <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
       <section class="card quick-answer">
         <h2>Quick Answer</h2>
-        <p><strong>Cairns</strong> is the gateway to two World Heritage Sites – the Great Barrier Reef and the Daintree Rainforest. Day trips to the reef offer life-changing snorkeling experiences, while the ancient rainforest provides wildlife and landscapes found nowhere else. Book tours early; this is bucket-list Australia.</p>
+        <p><strong>Cairns</strong>, founded 1876 as a gold port, is now the gateway to TWO UNESCO World Heritage Sites – the 2,300km Great Barrier Reef and the 180-million-year-old Daintree Rainforest. At Cape Tribulation they physically meet – the only place on Earth where reef meets ancient rainforest. Day trips to the reef offer life-changing snorkeling; the Daintree showcases 40,000+ years of Indigenous culture. Book tours early; this is bucket-list Australia.</p>
       </section>
       <section class="card best-for">
         <h2>Best For</h2>
@@ -159,7 +160,10 @@ Soli Deo Gloria
         <dl>
           <dt>Country</dt><dd>Australia</dd>
           <dt>State</dt><dd>Queensland</dd>
+          <dt>Founded</dt><dd>1876 (gold export port)</dd>
+          <dt>Named After</dt><dd>Sir William Wellington Cairns</dd>
           <dt>Port</dt><dd>Downtown terminal (Wharf 2/3)</dd>
+          <dt>UNESCO Sites</dt><dd>Gateway to TWO (reef & rainforest)</dd>
           <dt>To Reef</dt><dd>90 min by fast catamaran</dd>
           <dt>To Daintree</dt><dd>2 hrs by road</dd>
           <dt>Currency</dt><dd>AUD (cards universal)</dd>

--- a/ports/fiji.html
+++ b/ports/fiji.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Lautoka cruise port in Fiji with tips for Sri Krishna Kaliya Temple, Garden of the Sleeping Giant orchids, Sabeto Hot Springs mud pools, and experiencing Fijian bula spirit."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="ai-summary" content="First-person logbook guide to Lautoka cruise port in Fiji — exploring 333 islands with 3,500 years of Melanesian heritage, kava ceremonies, firewalking traditions, the Soft Coral Capital of the World, Sigatoka Sand Dunes archaeology, and experiencing authentic Fijian bula spirit."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Fiji (Lautoka) Port Guide — Bula Spirit & Island Time | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Lautoka, Fiji — Sugar City markets, Sri Krishna Kaliya Temple, Raymond Burr's orchid garden, Sabeto Hot Springs mud therapy, and discovering the warmth of Fijian hospitality."/>
+  <meta name="description" content="First-person logbook guide to Lautoka, Fiji — 333 islands with 3,500 years of Melanesian heritage, kava ceremonies, firewalking traditions, Sigatoka Sand Dunes archaeology, world-class diving in the Soft Coral Capital, and experiencing authentic Fijian bula hospitality."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/fiji.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
@@ -46,7 +46,15 @@ Soli Deo Gloria
         "name": "What is kava and should I try it?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Kava is a traditional Fijian ceremonial drink made from pounded root mixed with water. It has mild sedative properties and tastes earthy (some say like muddy water). Drinking kava in a village setting is a cultural experience worth trying — clap once before drinking, say 'bula', drink the bowl in one go, then clap three times."
+          "text": "Kava is a traditional Fijian ceremonial drink made from pounded root mixed with water, dating back 3,500 years to the first Melanesian settlers. It has mild sedative properties and tastes earthy (some say like muddy water). Drinking kava in a village setting is a cultural experience worth trying — clap once before drinking, say 'bula', drink the bowl in one go, then clap three times."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Do cruise ships dock at other Fiji ports besides Lautoka?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, cruise ships also visit Suva (Fiji's capital on the eastern side of Viti Levu) and Denarau Island (resort area near Nadi). Lautoka remains the most common port on western itineraries. Fiji's 333 islands offer multiple port options depending on cruise route."
         }
       }
     ]
@@ -124,11 +132,17 @@ Soli Deo Gloria
         <div class="logbook-entry clearfix">
           <p>You hear "Bula!" before you see land. Fijians greet ships like long-lost family, waving from shore, calling across the water, grinning with the kind of hospitality that makes you question whether you've been doing life wrong. "Bula" means hello, but it also means welcome, good health, life itself — the whole philosophy of Fijian warmth packed into two syllables. By the time you dock at Lautoka, you've already been adopted into something larger than tourism.</p>
 
+          <p>Fiji isn't one island — it's an archipelago of 333 islands scattered across the South Pacific, though only about 110 are inhabited. Melanesian seafarers arrived here approximately 3,500 years ago, navigating by stars and currents to establish one of the Pacific's most enduring cultures. The British declared Fiji a Crown Colony in 1874 and brought indentured laborers from India to work the sugar plantations, creating the Indo-Fijian community that now comprises about 37% of the population. Fiji gained independence on October 10, 1970, but the cultural layers remain beautifully interwoven — Hindu temples beside Methodist churches, curry shops next to traditional bures, English spoken with a melodic Fijian lilt.</p>
+
           <p>Lautoka calls itself Sugar City, and the sweet smell of processing cane still drifts across town during harvest season. It's Fiji's second-largest city but maintains a relaxed, almost village-like feel. The Municipal Market bursts with tropical abundance — cassava roots the size of baseball bats, coconuts stacked in pyramids, fish so fresh they were swimming an hour ago. Indo-Fijians (descendants of Indian laborers brought by the British) run many of the shops, adding curry spices and sari shops to the cultural mix. You'll see Hindu temples painted in colors that don't exist in nature right next to Methodist churches where hymns sound like they come from a better world.</p>
 
           <div class="poignant-highlight">
-            <strong>The Moment That Stays With Me:</strong> Sitting cross-legged on a woven mat in a village outside Lautoka, participating in a kava ceremony. The chief pounded the root while explaining that kava connects us to ancestors, to each other, to the land. When my turn came, I clapped once (as instructed), accepted the coconut shell bowl, said "bula," and drank it in one gulp. It tasted like earthy water someone had run through dirty socks. I clapped three times. Everyone laughed — with me, not at me — and suddenly I was part of something ancient. That's the gift Fiji gives: you arrive as a tourist and leave as family.
+            <strong>The Moment That Stays With Me:</strong> Sitting cross-legged on a woven mat in a village outside Lautoka, participating in a kava ceremony that dates back thousands of years — a welcoming ritual that has greeted strangers, sealed treaties, and marked sacred moments since those first Melanesian settlers arrived. The chief pounded the root while explaining that kava connects us to ancestors, to each other, to the land. When my turn came, I clapped once (as instructed), accepted the coconut shell bowl, said "bula," and drank it in one gulp. It tasted like earthy water someone had run through dirty socks. I clapped three times. Everyone laughed — with me, not at me — and suddenly I was part of something ancient. That's the gift Fiji gives: you arrive as a tourist and leave as family.
           </div>
+
+          <p>Fiji's past isn't all gentle welcomes. European explorers called these the "Cannibal Isles" — a reputation that wasn't entirely undeserved. Tribal warfare included ritualistic cannibalism until Christian missionaries arrived in the mid-1800s and the practice ended. Modern Fijians acknowledge this history without shame; it was part of their warrior culture, now transformed into different expressions of strength. You might witness a firewalking ceremony during your visit — men from Beqa Island walking barefoot across stones heated to over 600 degrees Fahrenheit, a spiritual ritual demonstrating faith and courage that leaves onlookers breathless.</p>
+
+          <p>Beneath the waves, Fiji earns its title as the "Soft Coral Capital of the World." The Rainbow Reef and Great Astrolabe Reef explode with colors that don't seem possible in nature — purple sea fans, orange dendronephthya, yellow leather corals swaying in currents while reef sharks patrol and manta rays glide past. Even if you're not diving, snorkeling these waters feels like swimming through a living kaleidoscope. Back on land, the Sigatoka Sand Dunes on the southern coast preserve an archaeological treasure: pottery shards and artifacts dating to 1000 BC, evidence of those early Melanesian settlements. The dunes rise 60 meters above the Sigatoka River, shaped by millennia of wind into an otherworldly landscape where past and present merge.</p>
 
           <p>The Garden of the Sleeping Giant holds the orchid collection Raymond Burr (yes, Perry Mason himself) cultivated. Thousands of orchids cascade from trees in a valley beneath the Sabeto Mountains. It's peaceful in a way resort beaches can't match. Nearby, Sabeto Hot Springs offers therapeutic mud pools where you coat yourself in volcanic clay, bake in the sun, then rinse off under waterfalls. It looks ridiculous. It feels wonderful.</p>
         </div>
@@ -164,7 +178,13 @@ Soli Deo Gloria
           <p>Colorful Hindu temple reflecting Fiji's Indo-Fijian heritage (37% of population). Ornate architecture, religious ceremonies, cultural significance. In downtown Lautoka. Free (donations appreciated). Respectful dress required (shoulders/knees covered). Remove shoes. 20-30 minute visit.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Village Cultural Experience & Kava Ceremony</h4>
-          <p>Visit traditional Fijian village, participate in kava ceremony (ritualized drink), learn local customs, singing, dancing. Organized tours essential (not independent visit). Half-day ~$60-80. Authentic cultural exchange — highlight for many visitors. Bring small gift (packaged food/school supplies).</p>
+          <p>Visit traditional Fijian village, participate in kava ceremony (ritualized drink dating back 3,500 years), learn local customs, singing, dancing. Organized tours essential (not independent visit). Half-day ~$60-80. Authentic cultural exchange — highlight for many visitors. Bring small gift (packaged food/school supplies). Some tours include witnessing firewalking ceremonies.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Sigatoka Sand Dunes National Park</h4>
+          <p>Archaeological site with pottery and artifacts dating to 1000 BC — evidence of Melanesian settlement. Massive sand dunes (up to 60 meters high) along Sigatoka River. Hiking trails, interpretive center, ancient burial sites. 1.5 hours south of Lautoka. Half-day tour recommended. ~20 FJD entry. Combines archaeology, nature, and coastal views. UNESCO consideration for cultural significance.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Diving & Snorkeling — "Soft Coral Capital of the World"</h4>
+          <p>Fiji's legendary coral reefs — Rainbow Reef, Great Astrolabe Reef with explosion of soft corals in impossible colors. Reef sharks, manta rays, sea turtles. World-class diving and snorkeling. Half-day/full-day tours from Lautoka/Denarau. Diving ~$150-200 for 2-tank dive; snorkeling ~$60-80. All levels welcome. PADI certification courses available. Underwater photography paradise.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Koroyanitu National Heritage Park</h4>
           <p>Mountain rainforest, waterfalls, hiking trails, panoramic views. Cloud forests, endemic birds, traditional villages. 45 minutes from port. Full-day excursion via organized tour. For adventurous travelers seeking nature beyond beaches. Moderate fitness required.</p>
@@ -205,21 +225,26 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Pro Tips</h3>
           <ul>
-            <li>Always respond to "Bula!" with "Bula!" — it's more than hello, it's acknowledging shared humanity. Fijians will appreciate your effort.</li>
-            <li>Kava ceremony etiquette: clap once before accepting bowl, say "bula," drink entire contents in one go, clap three times after. Don't refuse — it's considered disrespectful.</li>
+            <li>Always respond to "Bula!" with "Bula!" — it's more than hello, it's acknowledging shared humanity and wishing good health. Fijians will appreciate your effort.</li>
+            <li>Kava ceremony etiquette: clap once before accepting bowl, say "bula," drink entire contents in one go, clap three times after. Don't refuse — it's considered disrespectful to this ancient welcoming ritual.</li>
             <li>Dress modestly outside tourist areas — shoulders and knees covered, especially at villages and temples. Remove shoes entering homes/temples/some shops.</li>
             <li>Bring small bills (5, 10, 20 FJD notes) for market purchases and tips. Vendors often lack change.</li>
             <li>Garden of the Sleeping Giant + Sabeto Mud Pool make perfect half-day combo (very close together). Many taxis offer package deal.</li>
             <li>If visiting village, bring small gift (packaged food, school supplies, kava root). Never touch someone's head (sacred in Fijian culture).</li>
-            <li>Sunscreen BEFORE leaving ship — tropical sun intense. Reef-safe sunscreen appreciated.</li>
-            <li>Try indo-Fijian food at market — roti wraps, samosas, curries. Cheap, delicious, culturally significant.</li>
+            <li>Sunscreen BEFORE leaving ship — tropical sun intense. Reef-safe sunscreen appreciated (protecting the Soft Coral Capital's reefs).</li>
+            <li>Try indo-Fijian food at market — roti wraps, samosas, curries. Cheap, delicious, culturally significant reflection of British colonial history bringing Indian laborers.</li>
+            <li>Book diving/snorkeling early if serious about experiencing Fiji's legendary reefs. Soft coral displays most vibrant in morning light. PADI certification not required for intro dives.</li>
+            <li>Sigatoka Sand Dunes worth the 1.5-hour drive for history buffs and photographers — combines archaeology (1000 BC pottery), dramatic landscapes, and cultural significance few tourists see.</li>
           </ul>
         </section>
 
         <section class="port-section">
           <h3>Frequently Asked Questions</h3>
-          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Lautoka port on Viti Levu's west coast. Downtown and Municipal Market 15-20 minutes walking. Taxis plentiful at terminal.</p>
-          <p><strong>Q: What is kava and should I try it?</strong><br/>A: Traditional ceremonial drink made from pounded root — mild sedative, tastes earthy/muddy. Culturally significant. Absolutely try it in village ceremony setting. Unique Fijian experience.</p>
+          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Most commonly Lautoka port on Viti Levu's west coast. Ships also visit Suva (capital) and Denarau Island. Lautoka downtown and Municipal Market 15-20 minutes walking from terminal. Taxis plentiful.</p>
+          <p><strong>Q: What is kava and should I try it?</strong><br/>A: Traditional ceremonial drink dating back 3,500 years, made from pounded root — mild sedative, tastes earthy/muddy. Culturally significant welcoming ritual. Absolutely try it in village ceremony setting. Unique Fijian experience connecting you to ancient traditions.</p>
+          <p><strong>Q: How many islands does Fiji have?</strong><br/>A: 333 islands total, though only about 110 are inhabited. The archipelago was settled by Melanesian seafarers approximately 3,500 years ago. Most cruise visitors explore Viti Levu, the largest island.</p>
+          <p><strong>Q: Is Fiji really the "Soft Coral Capital of the World"?</strong><br/>A: Yes! Fiji's reefs (especially Rainbow Reef and Great Astrolabe Reef) feature exceptional soft coral diversity in spectacular colors. World-renowned diving and snorkeling destination. Half-day tours available from Lautoka.</p>
+          <p><strong>Q: Can I see a firewalking ceremony?</strong><br/>A: Some village cultural tours include firewalking demonstrations — men from Beqa Island walk barefoot across stones heated over 600°F as a spiritual ritual. Not guaranteed, but some tour operators offer this. Ask when booking.</p>
           <p><strong>Q: Is it safe to walk around Lautoka?</strong><br/>A: Yes, generally very safe. Fijians extremely friendly. Exercise normal caution with belongings. Downtown walkable during day.</p>
           <p><strong>Q: What should I wear to villages or temples?</strong><br/>A: Modest clothing covering shoulders and knees. Remove shoes before entering. Bring sarong or light pants/skirt. Respect for culture essential.</p>
           <p><strong>Q: Is the mud pool experience worth it?</strong><br/>A: Yes! Sabeto Hot Springs mud pool is unique, fun, therapeutic, and affordable (~$13). You'll look ridiculous covered in mud, feel wonderful, and have great photos.</p>

--- a/ports/hobart.html
+++ b/ports/hobart.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Hobart cruise port — Tasmania's capital with MONA museum, Salamanca Market, Mount Wellington, and Australia's deepest harbor."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="ai-summary" content="First-person logbook guide to Hobart cruise port — Tasmania's 1804 penal colony capital, now transformed by MONA (Australia's largest private museum), historic Salamanca Market, Mount Wellington's 1,271m peak, Antarctic gateway, and UNESCO World Heritage Port Arthur."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Hobart Port Guide — Tasmania's Capital | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Hobart — the provocative MONA museum, Salamanca Market's Saturday magic, Mount Wellington, colonial heritage, and Tasmania's wild beauty."/>
+  <meta name="description" content="First-person logbook guide to Hobart — founded 1804 as penal colony, transformed by MONA (Australia's largest private museum), Salamanca's Georgian warehouses, Mount Wellington's 1,271m summit, gateway to Antarctica, Cascade Brewery (1824), and Tasmania's wild beauty."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/hobart.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>
@@ -95,9 +95,9 @@ Soli Deo Gloria
       <h1>Hobart: Where History Meets the Edge of the World</h1>
 
       <div class="logbook-entry clearfix">
-        <p>Australia's southernmost capital city sits at the edge of the world – Antarctica lies directly south across the Southern Ocean, and you can feel that proximity in the clean, cold air that sweeps up the Derwent River. Mount Wellington looms over the city, often snow-capped, always watching. Hobart has the deepest natural harbor in Australia, which means our ship glided right into the heart of the city, Constitution Docks at our doorstep.</p>
+        <p>Australia's southernmost capital city sits at the edge of the world – Antarctica lies directly south across the Southern Ocean, and you can feel that proximity in the clean, cold air that sweeps up the Derwent River. Hobart serves as the gateway to Antarctica, with scientific expeditions regularly departing from these docks for the frozen continent. Mount Wellington looms over the city at 1,271 meters, often snow-capped even in summer, always watching. Hobart has the deepest natural harbor in Australia, which means our ship glided right into the heart of the city, Constitution Docks at our doorstep.</p>
 
-        <p>Founded in 1804, Hobart is Australia's second-oldest city after Sydney, and the Georgian architecture along Salamanca Place testifies to that heritage. But what transformed Tasmania from remote island state to must-visit destination is MONA – the Museum of Old and New Art – which exploded onto the scene in 2011 and rewrote the rules of what a museum could be. The "MONA effect" revitalized an entire island.</p>
+        <p>Founded in 1804 as a penal colony to ease overcrowding at Sydney Cove, Hobart is Australia's second-oldest capital city, and the weight of that convict history presses into every Georgian sandstone wall along Salamanca Place. For decades, Tasmania was Australia's forgotten island – remote, cold, economically struggling. Then in 2011, everything changed. MONA – the Museum of Old and New Art – exploded onto the scene as Australia's largest private museum, provocative and eccentric, and rewrote the rules of what a museum could be. The "MONA effect" revitalized an entire island.</p>
 
         <div class="poignant-highlight">
           <strong>The Encounter That Left Me Speechless:</strong> Descending into MONA's underground galleries felt like entering another world – provocative, disorienting, occasionally confronting. I stood before a wall of human faeces encased in resin (Cloaca Professional – a machine that creates actual human waste) and thought: this is either genius or madness. Possibly both. Welcome to Tasmania.
@@ -106,23 +106,29 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h2>MONA (Museum of Old and New Art)</h2>
-        <p>David Walsh, a professional gambler who made his fortune counting cards, built the Southern Hemisphere's largest private museum and called it "a subversive adult Disneyland." MONA burrows three stories underground, carved into sandstone cliffs on the banks of the Derwent. There are no labels – you navigate via an iPod-like device that tells you about each work only if you want to know. The collection spans ancient Egyptian mummies to contemporary installations that challenge, provoke, and occasionally disturb.</p>
-        <p>The best way to reach MONA is by ferry – high-speed catamarans depart from Brooke Street Pier (near the cruise terminal) and make the 30-minute journey regularly. The ferry experience is part of the art: quirky, irreverent, utterly MONA. The museum sits within a winery estate, with excellent restaurants and bars, and hosts two major festivals: MOFO in summer and Dark Mofo in winter's darkness.</p>
-        <p>Allow at least 3-4 hours at MONA – the underground galleries are extensive, and the art demands contemplation. It's not for everyone; it's absolutely not for children. But for those who appreciate challenging art, it's transformative.</p>
+        <p>David Walsh, a professional gambler who made his fortune counting cards and developing gambling algorithms, opened MONA in 2011 as Australia's largest private museum – a famously eccentric "subversive adult Disneyland" that transformed Tasmania's cultural landscape overnight. MONA burrows three stories underground, carved into sandstone cliffs on the banks of the Derwent River. There are no labels – you navigate via an iPod-like device called "The O" that tells you about each work only if you want to know. The collection spans ancient Egyptian mummies to contemporary installations that challenge, provoke, and occasionally disturb.</p>
+        <p>The best way to reach MONA is by ferry – high-speed catamarans depart from Brooke Street Pier (near the cruise terminal) and make the 30-minute journey regularly through the Derwent estuary. The ferry experience is part of the art: quirky, irreverent, utterly MONA. The museum sits within a winery estate producing excellent Moorilla wines, with restaurants, bars, and brewery on-site, and hosts two major festivals: MOFO (Museum of Old and New Art Festival of Music and Art) in summer and Dark Mofo in the depths of winter's darkness.</p>
+        <p>Allow at least 3-4 hours at MONA – the underground galleries are extensive, and the art demands contemplation, sometimes requires processing. It's not for everyone; it's absolutely not for children. But for those who appreciate challenging, boundary-pushing contemporary art, it's transformative.</p>
       </section>
 
       <section class="port-section">
         <h2>Salamanca Place & Battery Point</h2>
-        <p>The Georgian sandstone warehouses along Salamanca Place date from the 1830s-1850s, built by convict labor to store the colony's wool and grain. Today they house galleries, restaurants, craft shops, and cafes – beautifully preserved, atmospheric, walkable from the cruise terminal. Saturday morning brings the famous Salamanca Market, where 300+ stalls sell artisan crafts, local produce, and Tasmanian specialties (leatherwood honey, Tasmanian devil souvenirs, handmade cheeses).</p>
-        <p>Behind Salamanca, Kelly's Steps (built 1839) climb to Battery Point, a residential neighborhood of weatherboard cottages and multi-story terraces that time forgot. The narrow streets feel Victorian; the views over the harbor are stunning. Arthur Circus, a village green surrounded by Georgian cottages, is particularly charming.</p>
-        <p>Constitution Docks, where your ship docks, hosts the finish of the Sydney to Hobart yacht race each December/January – Australia's most famous sailing event. The area buzzes with cafes serving fresh Tasmanian seafood, local oysters, and fish punts selling catch straight from the boats.</p>
+        <p>The Georgian sandstone warehouses along Salamanca Place date from the 1830s-1850s, built by convict labor to store the colony's wool and grain exports. Today they house galleries, restaurants, craft shops, and cafes – beautifully preserved, atmospheric, easily walkable from the cruise terminal. Saturday morning brings the famous Salamanca Market (8:30am-3pm), a Hobart institution since 1972, where 300+ stalls spill along the warehouses selling artisan crafts, local produce, and Tasmanian specialties: leatherwood honey harvested from ancient forests, Tasmanian devil souvenirs, handmade cheeses, woodwork from Huon pine.</p>
+        <p>Behind Salamanca, Kelly's Steps (built 1839) climb steeply to Battery Point, a historic residential neighborhood of weatherboard cottages and colonial terraces from the 1830s-1860s that time genuinely forgot. The narrow streets feel frozen in the Victorian era; washing hangs on lines between century-old homes; the views over Sullivan's Cove and the harbor are stunning. Arthur Circus, a village green surrounded by perfectly preserved Georgian cottages, is particularly charming – it's one of those rare places where you can stand and see nothing modern.</p>
+        <p>Constitution Docks, where your ship docks, hosts the finish line of the famous Sydney to Hobart Yacht Race each December/January – Australia's most grueling and celebrated sailing event, run continuously since 1945. The waterfront area buzzes with cafes serving impossibly fresh Tasmanian seafood, local oysters that taste of the Southern Ocean, and fish punts (floating vendors) selling catch straight from the boats.</p>
       </section>
 
       <section class="port-section">
         <h2>Mount Wellington (kunanyi)</h2>
-        <p>Rising 1,271 meters directly behind the city, Mount Wellington (known as kunanyi in palawa kani, the reconstructed Tasmanian Aboriginal language) offers views over Hobart, the Derwent estuary, and on clear days, the jagged peaks of Tasmania's wilderness interior. The summit road climbs through temperate rainforest, subalpine vegetation, and finally dolerite columns that feel almost lunar.</p>
-        <p>Half-day tours to the summit are popular cruise excursions, often combined with city highlights. At the top, the Pinnacle shelter offers protection from winds that can be fierce even on sunny days – pack layers regardless of the weather below. The walking tracks that radiate from the summit range from easy strolls to serious hikes.</p>
-        <p>Back in the city, the Royal Tasmanian Botanical Gardens (Australia's second-oldest, founded 1818) offer pleasant walking among heritage trees and native species.</p>
+        <p>Rising 1,271 meters directly behind the city, Mount Wellington (known as kunanyi in palawa kani, the reconstructed Tasmanian Aboriginal language) dominates Hobart's skyline and offers views over the city, the Derwent estuary, and on clear days, the jagged peaks of Tasmania's wilderness interior stretching to the southwest. The summit road climbs through cool temperate rainforest, subalpine moorlands, and finally emerges among dolerite columns that feel almost lunar – otherworldly columns of volcanic rock that frame views across the island.</p>
+        <p>Half-day tours to the summit are popular cruise excursions, often combined with city highlights. At the 1,271-meter Pinnacle, the observation shelter offers protection from winds that can be fierce and bitterly cold even on sunny days – I've experienced snow flurries in January (summer) up here. Pack layers regardless of the weather below. The walking tracks that radiate from the summit range from easy strolls to serious multi-day hikes into the wilderness.</p>
+        <p>Back in the city, the Royal Tasmanian Botanical Gardens (Australia's second-oldest, founded 1818) offer pleasant walking among heritage trees, native Tasmanian species, and a subantarctic plant house showcasing the unique flora of nearby Macquarie Island.</p>
+      </section>
+
+      <section class="port-section">
+        <h2>Port Arthur & Cascade Brewery</h2>
+        <p>An hour's drive southeast of Hobart lies Port Arthur Historic Site, Australia's most intact and haunting convict settlement, inscribed as UNESCO World Heritage in 2010 as part of the Australian Convict Sites. Between 1833 and 1877, this supposedly "inescapable" prison held the most hardened repeat offenders – men who had already been transported to Australia and reoffended. The sandstone ruins stand on a narrow peninsula (guards called it "a natural penitentiary"), surrounded by shark-infested waters. Walking through the remarkably preserved buildings – the church, asylum, separate prison – you can almost hear the echoes of 12,500 convicts who suffered here. Many cruise lines offer excursions to Port Arthur; budget a full half-day minimum.</p>
+        <p>For something considerably more cheerful, the Cascade Brewery sits at the foot of Mount Wellington, continuously brewing since 1824 – Australia's oldest operating brewery. The impressive Victorian buildings (built with convict labor, naturally) nestle against the forested slopes, fed by pure mountain water. Tours run daily, ending with tastings of their premium beers, and the historic gardens are lovely for a stroll. It's about 10 minutes from the cruise terminal by taxi or rideshare – an easy stop if you're not venturing far from port.</p>
       </section>
 
       <section class="port-section">
@@ -133,24 +139,26 @@ Soli Deo Gloria
 
       <section class="port-section faq-section">
         <h2>Frequently Asked Questions</h2>
-        <details class="faq-item"><summary>Is Salamanca Market worth planning a Saturday port call?</summary><p>Absolutely – the market (8:30am-3pm Saturdays) is a Hobart institution with 300+ stalls of local crafts, food, and produce. If your ship is in port on Saturday, it's unmissable.</p></details>
+        <details class="faq-item"><summary>Is Salamanca Market worth planning a Saturday port call?</summary><p>Absolutely – the market (8:30am-3pm Saturdays) is a Hobart institution since 1972 with 300+ stalls of local crafts, food, and produce. If your ship is in port on Saturday, it's unmissable.</p></details>
         <details class="faq-item"><summary>How do I get to MONA?</summary><p>Ferry from Brooke Street Pier (30 min, ~$25 AUD return) is the recommended way – the quirky experience is part of MONA's art. Alternatively, it's 20 minutes by car.</p></details>
         <details class="faq-item"><summary>Is MONA appropriate for children?</summary><p>Officially, MONA welcomes all ages. Practically, the art includes explicit sexual content and confronting themes. Use judgment – teenagers may find it fascinating; young children likely won't.</p></details>
-        <details class="faq-item"><summary>What should I eat in Hobart?</summary><p>Tasmanian oysters (freshest you'll find), local cheeses, salmon, scallops, and anything with leatherwood honey. The waterfront fish punts at Constitution Docks are excellent.</p></details>
+        <details class="faq-item"><summary>Is Port Arthur worth the journey from Hobart?</summary><p>If you have the time, absolutely. Port Arthur is Australia's most intact convict site (UNESCO World Heritage) and profoundly moving. It's an hour each way, so requires a half-day minimum commitment. Most cruise lines offer organized excursions.</p></details>
+        <details class="faq-item"><summary>What should I eat in Hobart?</summary><p>Tasmanian oysters (freshest you'll find), local cheeses, salmon, scallops, and anything with leatherwood honey. The waterfront fish punts at Constitution Docks sell catch straight from the boats – get fish and chips there.</p></details>
       </section>
     </article>
 
     <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
       <section class="card quick-answer">
         <h2>Quick Answer</h2>
-        <p><strong>Hobart</strong> is Tasmania's historic capital, transformed by the provocative MONA museum into one of Australia's most interesting destinations. Salamanca's Georgian warehouses, Saturday markets, Mount Wellington's views, and the city's walkable waterfront make it a rewarding port – and the fresh Tasmanian produce is outstanding.</p>
+        <p><strong>Hobart</strong> (founded 1804 as a penal colony) is Tasmania's historic capital and Antarctica gateway, transformed by MONA (Australia's largest private museum, opened 2011) into one of Australia's most compelling destinations. Salamanca's Georgian warehouses and famous Saturday market, Mount Wellington's 1,271m summit, Battery Point's colonial cottages (1830s-1860s), nearby UNESCO World Heritage Port Arthur, and Australia's oldest brewery (Cascade, 1824) combine with impossibly fresh Tasmanian produce to make this a richly rewarding port.</p>
       </section>
       <section class="card best-for">
         <h2>Best For</h2>
         <ul>
           <li>Art lovers (MONA is transformative)</li>
-          <li>History and heritage enthusiasts</li>
-          <li>Foodies (Tasmanian produce)</li>
+          <li>Convict history enthusiasts (Port Arthur UNESCO site)</li>
+          <li>Colonial heritage architecture</li>
+          <li>Foodies (outstanding Tasmanian produce)</li>
           <li>Saturday market lovers</li>
         </ul>
       </section>
@@ -160,11 +168,14 @@ Soli Deo Gloria
           <dt>Country</dt><dd>Australia</dd>
           <dt>State</dt><dd>Tasmania</dd>
           <dt>Port</dt><dd>Macquarie Wharf (downtown)</dd>
+          <dt>Founded</dt><dd>1804 as penal colony (2nd oldest capital)</dd>
+          <dt>Mount Wellington</dt><dd>1,271m summit</dd>
           <dt>To MONA</dt><dd>30 min by ferry</dd>
           <dt>To Salamanca</dt><dd>5 min walk</dd>
+          <dt>To Port Arthur</dt><dd>~1 hour drive</dd>
           <dt>Currency</dt><dd>AUD (cards universal)</dd>
           <dt>Harbor</dt><dd>Australia's deepest natural harbor</dd>
-          <dt>Founded</dt><dd>1804 (2nd oldest in Australia)</dd>
+          <dt>Antarctica</dt><dd>Gateway for expeditions</dd>
         </dl>
       </section>
       <section class="card nearby-ports">
@@ -189,10 +200,11 @@ Soli Deo Gloria
     "@context": "https://schema.org",
     "@type": "FAQPage",
     "mainEntity": [
-      {"@type": "Question", "name": "Is Salamanca Market worth planning a Saturday port call?", "acceptedAnswer": {"@type": "Answer", "text": "Absolutely – the market is a Hobart institution with 300+ stalls. If your ship is in port on Saturday, it's unmissable."}},
+      {"@type": "Question", "name": "Is Salamanca Market worth planning a Saturday port call?", "acceptedAnswer": {"@type": "Answer", "text": "Absolutely – the market is a Hobart institution since 1972 with 300+ stalls. If your ship is in port on Saturday, it's unmissable."}},
       {"@type": "Question", "name": "How do I get to MONA?", "acceptedAnswer": {"@type": "Answer", "text": "Ferry from Brooke Street Pier (30 min) is recommended – the quirky experience is part of MONA's art."}},
       {"@type": "Question", "name": "Is MONA appropriate for children?", "acceptedAnswer": {"@type": "Answer", "text": "The art includes explicit content and confronting themes. Use judgment – young children likely won't appreciate it."}},
-      {"@type": "Question", "name": "What should I eat in Hobart?", "acceptedAnswer": {"@type": "Answer", "text": "Tasmanian oysters, local cheeses, salmon, scallops, and anything with leatherwood honey."}}
+      {"@type": "Question", "name": "Is Port Arthur worth the journey from Hobart?", "acceptedAnswer": {"@type": "Answer", "text": "If you have the time, absolutely. Port Arthur is Australia's most intact convict site (UNESCO World Heritage) and profoundly moving. It's an hour each way, so requires a half-day minimum commitment."}},
+      {"@type": "Question", "name": "What should I eat in Hobart?", "acceptedAnswer": {"@type": "Answer", "text": "Tasmanian oysters, local cheeses, salmon, scallops, and anything with leatherwood honey. The waterfront fish punts sell catch straight from the boats."}}
     ]
   }
   </script>

--- a/ports/maui.html
+++ b/ports/maui.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Maui with tips for Kahului port, Iao Valley, Upcountry, Road to Hana, post-Lahaina fire update."/>
-  <meta name="last-reviewed" content="2025-11-22"/>
+  <meta name="ai-summary" content="First-person logbook guide to Maui's Valley Isle — Kahului port, Haleakala's 10,023-ft summit, historic Lahaina's resilience after 2023 fire, legendary Road to Hana with 620 curves, Iao Valley needle."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Maui Port Guide — Kahului, Iao Valley & Upcountry | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Maui via Kahului port — Iao Valley, Upcountry lavender farms, Road to Hana, post-Lahaina fire update and alternatives."/>
+  <meta name="description" content="First-person logbook guide to Maui's Valley Isle via Kahului — Haleakala summit sunrise, Road to Hana's 620 curves, Iao Valley, Lahaina's rebuilding after 2023 fire, Upcountry lavender farms."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/maui.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->
@@ -121,7 +121,7 @@ Soli Deo Gloria
         <p class="port-hero-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
       </div>
 
-    <article class="card"><h1>Maui: After the Fire</h1>
+    <article class="card"><h1>Maui: The Valley Isle After the Fire</h1>
       <div class="logbook-entry">
         <p>(Note: as of November 2025 Royal Caribbean is still using Kahului as the Maui port.)</p>
       <figure class="logbook-image float-right">
@@ -129,10 +129,14 @@ Soli Deo Gloria
         <figcaption>Maui — <a href="https://commons.wikimedia.org/w/index.php?search=Maui&title=Special:MediaSearch&type=image" target="_blank" rel="noopener">WikiMedia Commons</a> (CC BY-SA)</figcaption>
       </figure>
 
-        
-        <p>We docked in Kahului's industrial harbor and rented a car – the drive to Iao Valley is only 15 minutes and the needle rising 1,200 ft straight up through the jungle is still jaw-dropping. We continued up to Makawao and Kula for protea farms and lavender fields, then down to Wailea for beach time at Big Beach – golden sand and real waves with almost no one there on a weekday.</p>
 
-        <p>Lunch was at Mama's Fish House (worth the 25-minute drive) – opah caught that morning with lilikoi butter that tasted like Maui in a bite. The absence of Lahaina is still heartbreaking, but Maui's natural beauty and aloha spirit are as strong as ever.</p>
+        <p>We docked in Kahului's industrial harbor on what locals call the Valley Isle – named for the fertile isthmus connecting Haleakala and the West Maui Mountains, two ancient volcanoes that give the island its distinctive figure-eight shape. I rented a car right at the port (essential here) and drove the 15 minutes to Iao Valley, where the Needle rises 1,200 feet straight up through emerald jungle canopy, a sacred place where Kamehameha I fought a decisive battle in 1790.</p>
+
+        <p>From there I climbed into Upcountry – through Makawao's paniolo (cowboy) country to Kula's lavender farms and protea fields that bloom at 3,000 feet elevation. The air turns cooler and fragrant with eucalyptus. If you have time and stamina, Haleakala National Park beckons above – the "House of the Sun" volcanic crater at 10,023 feet where sunrise is legendary (though it now requires advance reservations). Standing at the summit feels like being on another planet, all rust-red cinder cones and silver sword plants.</p>
+
+        <p>The famous Road to Hana is Maui's other siren call – 64 miles of serpentine coastal highway with 620 curves and 59 one-lane bridges threading through rainforest waterfalls and black sand beaches. It's mesmerizing but demands respect and time; most cruise passengers tackle just the first third and turn back satisfied.</p>
+
+        <p>Lunch was at Mama's Fish House (worth the 25-minute drive north) – opah caught that morning with lilikoi butter that tasted like Maui in a bite. The absence of Lahaina weighs heavy. Once the whaling capital of the Pacific – over 400 ships a year called here in the 1850s – and briefly the capital of the Hawaiian Kingdom before Honolulu, Lahaina was the island's historic heart. The August 2023 wildfire devastated the town, but the spirit endures. The massive Banyan Tree planted in 1873, once the largest in the United States spreading across nearly an acre, was damaged but survived – already sending out new green shoots. The community is rebuilding with determination and aloha, and visitors are welcome to support the recovery while respecting the healing process.</p>
       <figure class="logbook-image float-left">
         <img src="img/maui/maui-2.webp" alt="Maui scenery" loading="lazy">
         <figcaption>Maui scenery — <a href="https://commons.wikimedia.org/w/index.php?search=Maui&title=Special:MediaSearch&type=image" target="_blank" rel="noopener">WikiMedia Commons</a> (CC BY-SA)</figcaption>
@@ -158,12 +162,13 @@ Soli Deo Gloria
       <section class="port-section">
         <h3>What to See & Do</h3>
         <ul>
+          <li><strong>Iao Valley State Park:</strong> Features "The Needle," a dramatic volcanic rock spire rising 1,200 feet straight from the valley floor through lush jungle – a sacred battleground from 1790 and one of Maui's most photographed landmarks</li>
+          <li><strong>Haleakala National Park:</strong> "House of the Sun" – massive volcanic crater rising to 10,023 feet elevation, accessible via scenic 38-mile drive from Kahului. Sunrise viewing is legendary but requires advance reservations through recreation.gov. The summit landscape feels otherworldly with rust-red cinder cones and rare silversword plants</li>
+          <li><strong>Road to Hana:</strong> The famous 64-mile coastal highway with 620 curves and 59 one-lane bridges winding through rainforest waterfalls, bamboo groves, and black sand beaches. Allow a full day or tackle the first section (to Twin Falls or Keanae Peninsula) for a taste of the magic</li>
+          <li><strong>Upcountry Maui:</strong> Makawao's paniolo (cowboy) town, Kula lavender farms, and protea fields at 3,000+ feet elevation with cooler air and sweeping views</li>
+          <li><strong>Lahaina Town:</strong> Historic whaling capital (400+ ships annually in the 1850s) and former seat of the Hawaiian Kingdom – currently rebuilding after the devastating August 2023 wildfire. The iconic Banyan Tree (planted 1873, once the largest in the US) survived and is resprouting. Visitors are welcome to support recovery efforts while respecting the community's healing</li>
           <li><strong>Kanaha Beach Park:</strong> Renowned internationally as a premier windsurfing destination with excellent swimming conditions</li>
-          <li><strong>Kanaha Pond State Wildlife Sanctuary:</strong> Habitat for migrating birds and rare Hawaiian native species</li>
-          <li><strong>Iao Valley State Park:</strong> Features "The Needle," a dramatic volcanic rock spire rising 2,250 feet above the valley floor</li>
-          <li><strong>Alexander & Baldwin Sugar Museum:</strong> Chronicles Maui's plantation heritage</li>
-          <li><strong>Lahaina:</strong> Historic whaling town located 20 miles away (approximately 45 minutes by car)</li>
-          <li><strong>Haleakala National Park:</strong> Massive volcanic crater accessible via 38-mile drive south from Kahului</li>
+          <li><strong>Alexander & Baldwin Sugar Museum:</strong> Chronicles Maui's plantation heritage in old mill town of Puunene</li>
         </ul>
       </section>
 
@@ -187,17 +192,19 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h3>Frequently Asked Questions</h3>
-        <p><strong>Q: Is Maui (Kahului) worth it?</strong><br/>A: Still absolutely – the island is bigger than one town.</p>
-        <p><strong>Q: Best thing?</strong><br/>A: Iao Valley + Upcountry or partial Road to Hana.</p>
-        <p><strong>Q: How long for Iao + beaches?</strong><br/>A: 6–7 hours easy.</p>
-        <p><strong>Q: Walk from port?</strong><br/>A: Only to Costco; car required.</p>
+        <p><strong>Q: Is Maui (Kahului) worth it?</strong><br/>A: Absolutely – the Valley Isle offers Haleakala volcano, Road to Hana, Iao Valley, and Upcountry experiences. The island is far bigger than one town.</p>
+        <p><strong>Q: Best thing to do in a day?</strong><br/>A: Iao Valley + Upcountry (lavender farms, Kula) or partial Road to Hana (first 20-30 miles to waterfalls and Keanae).</p>
+        <p><strong>Q: Can I do Haleakala sunrise on a cruise day?</strong><br/>A: Very difficult – summit is 38 miles from port, sunrise requires 3am departure plus advance recreation.gov reservation. Consider sunset or midday visit instead.</p>
+        <p><strong>Q: How long for full Road to Hana?</strong><br/>A: Full round trip takes 10-12 hours minimum. Most cruise passengers do the first third (3-4 hours round trip) and still see waterfalls and coastline.</p>
+        <p><strong>Q: Walk from port?</strong><br/>A: Only to Costco (1 mile); car rental essential for sightseeing.</p>
+        <p><strong>Q: Is Lahaina open?</strong><br/>A: Lahaina is rebuilding after the August 2023 fire. Some areas are accessible, and the community welcomes respectful visitors supporting recovery.</p>
       </section>
     </article>
   </div>
   <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
     <section class="page-intro" style="margin: 0 0 1rem 0;">
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Lahaina remains closed after the 2023 fires – ships now dock/tender at Kahului and visit the Road to Hana, Iao Valley, or Upcountry instead.
+        <strong>Quick Answer:</strong> Ships dock at Kahului on the Valley Isle. Lahaina is rebuilding after the August 2023 fire, but Maui's treasures endure – Haleakala's 10,023-ft summit, the legendary Road to Hana with 620 curves, Iao Valley's sacred needle, and Upcountry's lavender farms. Car rental essential.
       </p>
     </section>
         <section class="card author-card-vertical" aria-labelledby="author-heading">

--- a/ports/papeete.html
+++ b/ports/papeete.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Papeete cruise port — Tahiti's vibrant capital with Le Marché market, Paul Gauguin heritage, and gateway to French Polynesia."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="ai-summary" content="First-person logbook guide to Papeete, Tahiti — where Gauguin painted his masterworks, overwater bungalows were born, and 118 islands meet French flair at Le Marché's vibrant market."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Papeete Port Guide — Tahiti's Vibrant Capital | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Papeete, Tahiti — Le Marché market, Polynesian culture, Paul Gauguin legacy, black sand beaches, and French Polynesia's colorful capital."/>
+  <meta name="description" content="First-person logbook guide to Papeete, Tahiti — birthplace of overwater bungalows, home to Gauguin's finest works (1891-1901), Le Marché market, black pearls, vanilla, and French Polynesia's vibrant capital where 118 islands converge."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/papeete.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>
@@ -95,20 +95,24 @@ Soli Deo Gloria
       <h1>Papeete: Where Polynesian Soul Meets French Flair</h1>
 
       <div class="logbook-entry clearfix">
-        <p>The harbor of Papeete bustles with an energy unexpected in paradise – fishing boats unloading the morning's catch, ferries shuttling to neighboring islands, food trucks (roulottes) lining the waterfront awaiting the evening crowds. This is the capital of French Polynesia, a city of 26,000 that serves as the commercial and cultural hub for 118 islands scattered across an ocean expanse the size of Western Europe. It's messy, colorful, and utterly alive.</p>
+        <p>The harbor of Papeete bustles with an energy unexpected in paradise – fishing boats unloading the morning's catch, ferries shuttling to neighboring islands, food trucks (roulottes) lining the waterfront awaiting the evening crowds. This is the capital of French Polynesia, a city of 26,000 that serves as the commercial and cultural hub for 118 islands scattered across an ocean expanse the size of Western Europe. The name Tahiti itself derives from the Polynesian word for "sunrise" or "dawn," and standing here at first light, watching the mountains emerge from purple shadows, I understand why. It's messy, colorful, and utterly alive.</p>
 
-        <p>Captain James Cook anchored here in the mid-18th century, beginning Tahiti's long relationship with European explorers, missionaries, and eventually colonial powers. France made Tahiti a protectorate in 1842 and later moved nuclear testing here from Algeria – the airport exists because of atomic weapons. But beneath the French bureaucracy and croissants, Polynesian culture endures: the language, the music, the flowers worn behind the ear, the attitude that life is to be lived slowly.</p>
+        <p>Captain James Cook anchored at Point Venus in 1769 to observe the transit of Venus across the sun – a celestial event that gave the promontory its name and brought Tahiti into the Western imagination. Twenty years later, Fletcher Christian and the mutineers of HMS Bounty chose these islands as their paradise, forever linking Tahitian shores with tales of rebellion and tropical refuge. France made Tahiti a protectorate in 1842, establishing Papeete as the colonial capital, and later moved nuclear testing here from Algeria – the airport exists because of atomic weapons. But beneath the French bureaucracy and croissants, Polynesian culture endures: the language, the music, the flowers worn behind the ear, the attitude that life is to be lived slowly.</p>
+
+        <p>Paul Gauguin arrived in 1891, fleeing European civilization for what he imagined as an unspoiled Eden. He painted here through 1893, returned to Paris briefly, then came back to Polynesia in 1895 and remained until his death in 1901. Those decade-long Tahitian years produced his most celebrated works – vibrant canvases of women, flowers, and light that reimagined Post-Impressionism through a tropical lens. The artist found not innocence but complexity, not escape but deeper questions. His legacy here is everywhere: in the museum that bears his name, in the ongoing dialogue between Western art and Polynesian subject, in the reminder that paradise is never quite what outsiders expect.</p>
+
+        <p>Tahiti also gave the world the overwater bungalow. In 1967, three American hotel pioneers known as the "Bali Hai Boys" constructed the first bungalows built on stilts over the lagoon, merging Polynesian building traditions with tourist dreams. The concept spread across French Polynesia and then to resorts worldwide, but it began here – an invention as iconic as any cultural export these islands have offered.</p>
 
         <div class="poignant-highlight">
-          <strong>The Scene That Captured It All:</strong> Sunday morning at the Protestant church, voices rose in four-part Tahitian harmonies – hymns learned from 19th-century missionaries, transformed into something uniquely Polynesian. The women wore white dresses and elaborate hats; flowers perfumed everything. Outside, the market stalls waited. Inside, centuries of history sang.
+          <strong>The Scene That Captured It All:</strong> Sunday morning at the Protestant church, voices rose in four-part Tahitian harmonies – hymns learned from 19th-century missionaries, transformed into something uniquely Polynesian. The women wore white dresses and elaborate hats; flowers perfumed everything. Outside, the market stalls waited. Inside, centuries of history sang – Cook's arrival, the Bounty's refuge, Gauguin's searching eye, the slow blending of cultures that is modern Tahiti.
         </div>
       </div>
 
       <section class="port-section">
         <h2>Le Marché (Papeete Public Market)</h2>
-        <p>The covered market at the heart of Papeete is sensory overload in the best way – tropical fruits piled in pyramids (rambutan, star fruit, the pungent durian), flower vendors weaving traditional crowns and leis, pearl sellers displaying the black pearls for which Tahiti is famous, vendors of monoi oil (the coconut-scented potion that scents all of Polynesia).</p>
+        <p>The covered market at the heart of Papeete is sensory overload in the best way – tropical fruits piled in pyramids (rambutan, star fruit, the pungent durian), flower vendors weaving traditional crowns and leis, pearl sellers displaying the black pearls for which Tahiti is famous, vendors of monoi oil (the coconut-scented potion that perfumes all of Polynesia). Tahitian vanilla beans – among the world's finest and most aromatic – fill the air with their sweet, floral fragrance; these beans command premium prices in culinary circles worldwide, and buying them here means encountering the genuine article at its source.</p>
         <p>The ground floor focuses on produce, seafood, and prepared foods – including poisson cru, Tahiti's national dish of raw fish marinated in lime juice and coconut milk. Upper levels sell crafts, pareos (sarongs), shell jewelry, and souvenirs. Early morning is best for the freshest produce and local atmosphere; by midday, cruise passengers dominate.</p>
-        <p>Bargaining is acceptable but not aggressive – Tahitians prefer pleasant interactions over hard negotiations. Prices are in CFP francs; some vendors accept USD or euros.</p>
+        <p>The black pearl vendors deserve particular attention. French Polynesia produces the world's finest black pearls, cultivated in the lagoons of the Tuamotu and Gambier archipelagos. Each pearl's luster and overtones – peacock green, aubergine, silver – tell the story of years spent forming in the mantle of the black-lipped oyster. Bargaining is acceptable but not aggressive – Tahitians prefer pleasant interactions over hard negotiations. Prices are in CFP francs; some vendors accept USD or euros.</p>
       </section>
 
       <section class="port-section">
@@ -120,9 +124,9 @@ Soli Deo Gloria
 
       <section class="port-section">
         <h2>Island Excursions</h2>
-        <p>Tahiti is the largest island in French Polynesia, and the interior offers dramatic scenery beyond Papeete's urban bustle. Waterfalls cascade through jungle valleys; ancient marae (temple sites) testify to pre-contact Polynesian society; Point Venus marks where Captain Cook observed the transit of Venus in 1769 (hence the name of both point and planet passage).</p>
-        <p>The Paul Gauguin Museum celebrates the post-Impressionist painter who spent his final years in French Polynesia, whose works captured Tahitian life and light. Island circle tours pass black sand beaches, blowholes, and botanical gardens. For adventure, 4x4 tours penetrate the mountainous interior and its remote waterfalls.</p>
-        <p>The Museum of Tahiti and Her Islands (Musée de Tahiti et des Îles) provides excellent context on Polynesian navigation, culture, and natural history – worth an hour if cultural depth appeals.</p>
+        <p>Tahiti is the largest island in French Polynesia, and the interior offers dramatic scenery beyond Papeete's urban bustle. Waterfalls cascade through jungle valleys; ancient marae (temple sites) testify to pre-contact Polynesian society; Point Venus marks where Captain Cook observed the transit of Venus in 1769, an astronomical event that required precise timing and clear skies – both of which Tahiti providentially offered. The observation contributed to calculating the distance from Earth to the Sun, transforming a remote island anchorage into a footnote in the history of science.</p>
+        <p>The Paul Gauguin Museum, located in the botanical gardens at Papeari on Tahiti's south coast, celebrates the post-Impressionist painter who spent a decade here across two periods: 1891-1893 and 1895-1901. The museum houses reproductions of his Tahitian masterworks (the originals reside in museums worldwide), documents his complicated relationship with the islands, and contextualizes his vision against the reality of colonial French Polynesia. Gauguin sought primitive authenticity but found a culture already transformed by missionaries and French administration. His paintings nonetheless captured something essential about light, color, and the human figure in tropical space – works that defined his legacy and shaped how the world imagined Tahiti for generations. The museum visit reminds us that artists and islands rarely understand each other as completely as either hopes.</p>
+        <p>Island circle tours pass black sand beaches, blowholes, and botanical gardens. For adventure, 4x4 tours penetrate the mountainous interior and its remote waterfalls. The Museum of Tahiti and Her Islands (Musée de Tahiti et des Îles) provides excellent context on Polynesian navigation, culture, and natural history – worth an hour if cultural depth appeals and you're curious how ancient navigators crossed thousands of miles of open ocean using stars, waves, and seabirds as guides.</p>
       </section>
 
       <section class="port-section">

--- a/ports/st-lucia.html
+++ b/ports/st-lucia.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to St. Lucia cruise port with tips for the Pitons, Soufrière, mud baths, rainforest adventures, and this volcanic island's natural beauty."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="ai-summary" content="First-person logbook guide to St. Lucia cruise port — UNESCO World Heritage Pitons, Caribbean's largest geothermal field at Sulphur Springs, rich British-French colonial history, and the world's only drive-in volcano."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>St. Lucia Port Guide — The Pitons & Volcanic Paradise | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to St. Lucia — the iconic Pitons, Soufrière volcano, mud baths, rainforest zip lines, and experiencing the Caribbean's most dramatic landscape."/>
+  <meta name="description" content="First-person logbook guide to St. Lucia — UNESCO World Heritage Pitons rising 770m from the sea, Soufrière's drive-in volcano, Caribbean's largest geothermal field, and the island's remarkable British-French heritage."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/st-lucia.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
@@ -46,7 +46,15 @@ Soli Deo Gloria
         "name": "How far are the Pitons from the cruise port?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "The Pitons are about 45 minutes to 1 hour south of Castries by road. Most visitors combine a Pitons viewing with Soufrière town, the volcano, and mud baths as a full-day excursion."
+          "text": "The UNESCO World Heritage Pitons are about 45-60 minutes south of Castries by road. These twin volcanic peaks (Gros Piton 770m, Petit Piton 743m) have been a World Heritage Site since 2004. Most visitors combine a Pitons viewing with Soufrière town, the volcano, and mud baths as a full-day excursion."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Why is the island called St. Lucia?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "French sailors who arrived on December 13th in the 1600s named it after Saint Lucy of Syracuse, whose feast day they were celebrating. The island then changed hands between Britain and France 14 times — more than any other Caribbean island — which explains why you'll hear both English and French Creole (Kwéyòl) spoken today."
         }
       }
     ]
@@ -122,12 +130,14 @@ Soli Deo Gloria
         <h1>St. Lucia: Where the Earth Still Breathes Fire and Beauty</h1>
 
         <div class="logbook-entry clearfix">
-          <p>The Pitons appeared through the morning haze like something from a fantasy novel — two massive volcanic spires erupting from the sea, covered in impossible green, standing guard over Soufrière Bay. I'd seen the photos a hundred times, but nothing prepares you for the scale of these UNESCO World Heritage peaks. Gros Piton rises 2,619 feet; Petit Piton slightly less. Together they form the most recognizable silhouette in the Caribbean.</p>
+          <p>The Pitons appeared through the morning haze like something from a fantasy novel — two massive volcanic spires erupting from the sea, covered in impossible green, standing guard over Soufrière Bay. I'd seen the photos a hundred times, but nothing prepares you for the scale of these UNESCO World Heritage peaks. Gros Piton rises 770 meters (2,530 feet) from the Caribbean; Petit Piton reaches 743 meters (2,438 feet). Designated a World Heritage Site in 2004, together they form the most recognizable silhouette in the Caribbean — and they've been capturing sailors' imaginations for centuries.</p>
 
-          <p>St. Lucia is nature flexing. This isn't a beach-and-shopping island (though it has both); it's a volcanic wonderland of rainforest-draped mountains, sulfur springs you can actually walk through, botanical gardens that feel prehistoric, and waterfalls hidden in emerald jungle. The drive from Castries to Soufrière winds through banana plantations and fishing villages, climbing mountain ridges with views that make passengers gasp.</p>
+          <p>St. Lucia is nature flexing. This isn't a beach-and-shopping island (though it has both); it's a volcanic wonderland of rainforest-draped mountains, sulfur springs you can actually walk through, botanical gardens that feel prehistoric, and waterfalls hidden in emerald jungle. The island's name itself tells a story: French sailors who landed here on December 13th in the 1600s named it for Saint Lucy of Syracuse, whose feast day they were celebrating. What followed was one of the Caribbean's most tumultuous colonial histories — St. Lucia changed hands between the British and French fourteen times, making it the most contested island in the region. That tug-of-war left its mark: English is the official language, but French Creole (Kwéyòl) still colors everyday conversation, and the towns bear French names like Soufrière and Castries.</p>
+
+          <p>The drive from Castries — the island's capital and main cruise port — down to Soufrière takes you through the heart of St. Lucia's everyday life. Banana plantations blanket hillsides in geometric green rows, fishing villages cling to coastal cliffs, and roadside vendors sell fresh coconuts and spiced cashews. The road is winding, sometimes narrow, always climbing or descending, with hairpin turns that reveal jaw-dropping views of the Caribbean far below. This is the scenic journey that turns a port visit into an adventure.</p>
 
           <div class="poignant-highlight">
-            <strong>The Moment That Stays With Me:</strong> Standing in the volcanic mud bath at Sulphur Springs, covered head-to-toe in warm gray mineral mud while the earth literally steamed around us. My wife and I looked at each other and burst out laughing — we'd paid good money to get this dirty, and we'd never felt more alive. The "world's only drive-in volcano" is touristy, sure, but also genuinely otherworldly. Where else can you feel the planet's heat rising through your feet?
+            <strong>The Moment That Stays With Me:</strong> Standing in the volcanic mud bath at Sulphur Springs, covered head-to-toe in warm gray mineral mud while the earth literally steamed around us. My wife and I looked at each other and burst out laughing — we'd paid good money to get this dirty, and we'd never felt more alive. The "world's only drive-in volcano" is touristy, sure, but also genuinely otherworldly. Where else can you feel the planet's heat rising through your feet? This is the Caribbean's largest geothermal field, and you're standing in the middle of it, feeling the earth's ancient volcanic heart still beating strong.
           </div>
 
           <p>The boat approach to the Pitons (available as an excursion or private charter) might be the best way to experience them. As we motored along the coast, the peaks grew larger and larger, their sheer green walls dropping straight into crystal water. We stopped for snorkeling at Anse Chastanet — the marine reserve here teems with life — before continuing to Sugar Beach, nestled impossibly between the two Pitons like a private paradise.</p>
@@ -137,11 +147,11 @@ Soli Deo Gloria
           <h3>Port Essentials</h3>
           <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">What you need to know before you dock.</p>
           <ul>
-            <li><strong>Terminal:</strong> Pointe Seraphine (main) or Port Castries — both in the capital city</li>
-            <li><strong>Distance to Pitons:</strong> 45-60 min by road to Soufrière and Pitons viewpoints</li>
+            <li><strong>Terminal:</strong> Pointe Seraphine (main) or Port Castries — both in Castries, the island's capital and main cruise port</li>
+            <li><strong>Distance to Pitons:</strong> 45-60 min by road to Soufrière and the UNESCO World Heritage Pitons viewpoints</li>
             <li><strong>Tender:</strong> Occasionally, depending on ship size and dock availability</li>
             <li><strong>Currency:</strong> Eastern Caribbean Dollar (XCD); USD widely accepted</li>
-            <li><strong>Language:</strong> English official; French Creole (Kwéyòl) commonly spoken</li>
+            <li><strong>Language:</strong> English official; French Creole (Kwéyòl) commonly spoken — a linguistic legacy of 14 colonial power changes</li>
             <li><strong>Driving:</strong> Left side (British style); roads are winding and mountainous</li>
             <li><strong>Best Season:</strong> December–May (dry season); expect brief rain showers year-round</li>
           </ul>
@@ -152,10 +162,10 @@ Soli Deo Gloria
           <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">This island rewards a full-day excursion.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">The Pitons & Soufrière</h4>
-          <p>A trip to St. Lucia without seeing the Pitons is incomplete. Most excursions combine the scenic drive, volcano/mud bath, and Pitons viewing. Boat trips along the coast offer the best photo opportunities. Allow a full day.</p>
+          <p>A trip to St. Lucia without seeing the Pitons is incomplete. These twin volcanic spires — Gros Piton (770m) and Petit Piton (743m) — earned UNESCO World Heritage status in 2004 for their outstanding natural beauty and geological significance. Most excursions combine the scenic drive through the island's mountainous interior, the volcano and mud baths at Sulphur Springs, and multiple Pitons viewpoints. Boat trips along the coast offer the best photo opportunities and the most dramatic perspective of these ancient peaks. Allow a full day for this experience.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Sulphur Springs & Mud Bath</h4>
-          <p>The "world's only drive-in volcano" — you can walk along the rim of steaming, bubbling sulfur pools. Nearby mud baths let you coat yourself in mineral-rich volcanic mud (supposedly great for skin). Bring a dark swimsuit — the sulfur stains.</p>
+          <p>The Caribbean's largest geothermal field — and the "world's only drive-in volcano" where you can literally drive into the crater. You'll walk along the rim of steaming, bubbling sulfur pools, witnessing the earth's raw power up close. The nearby mud baths let you coat yourself in mineral-rich volcanic mud (supposedly therapeutic for skin, definitely memorable). Bring a dark swimsuit you don't mind staining — the sulfur leaves its mark.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Diamond Falls & Botanical Gardens</h4>
           <p>Gorgeous botanical gardens with a mineral-streaked waterfall in multiple colors. Peaceful walking paths through tropical plants. Often combined with Soufrière excursions. ~$10 entrance fee.</p>
@@ -193,10 +203,11 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Frequently Asked Questions</h3>
           <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Usually Pointe Seraphine in Castries; occasionally Port Castries or anchor/tender.</p>
-          <p><strong>Q: How far are the Pitons from the port?</strong><br/>A: About 45-60 minutes by road to Soufrière and Pitons viewpoints. Full-day excursion recommended.</p>
+          <p><strong>Q: How far are the Pitons from the port?</strong><br/>A: About 45-60 minutes by road to Soufrière and the UNESCO World Heritage Pitons viewpoints. These twin volcanic peaks (Gros Piton 770m, Petit Piton 743m) have been a World Heritage Site since 2004. A full-day excursion is recommended to fully experience them.</p>
           <p><strong>Q: Is the drive to Soufrière difficult?</strong><br/>A: The road is winding and mountainous but paved. Not recommended for self-driving unless experienced. Tours handle the logistics.</p>
           <p><strong>Q: Can I climb the Pitons?</strong><br/>A: Yes — Gros Piton can be climbed with a required guide (~4-5 hours round trip, moderate-strenuous). Not suitable for casual hikers or limited port time.</p>
           <p><strong>Q: What if I just want a beach day?</strong><br/>A: Reduit Beach (30 min north) or Vigie Beach (near port) are good options without the Soufrière trek.</p>
+          <p><strong>Q: Why is the island called St. Lucia?</strong><br/>A: French sailors who arrived on December 13th in the 1600s named it after Saint Lucy of Syracuse, whose feast day they were celebrating. The island then changed hands between Britain and France 14 times — more than any other Caribbean island — which explains why you'll hear both English and French Creole (Kwéyòl) spoken today.</p>
         </section>
 
         <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>

--- a/ports/wellington.html
+++ b/ports/wellington.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Wellington cruise port with tips for Te Papa Museum, Cuba Street, the Cable Car, and experiencing New Zealand's creative capital."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
+  <meta name="ai-summary" content="First-person logbook guide to Wellington cruise port featuring Te Papa's colossal squid, Cuba Street's bohemian heart, the iconic 1902 Cable Car, Zealandia ecosanctuary, and exploring the world's southernmost capital city."/>
+  <meta name="last-reviewed" content="2025-12-15"/>
   <meta name="content-protocol" content="ICP-Lite v1.0"/>
   <title>Wellington Port Guide — Te Papa & Creative Capital | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Wellington — Te Papa Museum, Cuba Street culture, the iconic Cable Car, and discovering New Zealand's compact, creative capital."/>
+  <meta name="description" content="First-person logbook guide to Wellington — Te Papa's colossal squid and Māori treasures, Cuba Street's creative spirit, Zealandia ecosanctuary, and experiencing New Zealand's windswept southern capital."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/wellington.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
@@ -38,7 +38,7 @@ Soli Deo Gloria
         "name": "Where do cruise ships dock in Wellington?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Ships dock at Aotea Quay, about 2 kilometers (20-25 min walk) from downtown Wellington along a scenic waterfront path."
+          "text": "Ships dock at Aotea Quay, about 2 kilometers from downtown Wellington. You can walk the scenic waterfront path or take a shuttle."
         }
       },
       {
@@ -46,7 +46,23 @@ Soli Deo Gloria
         "name": "Is Te Papa Museum free to visit?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Yes, general admission to Te Papa is free. Some special exhibitions may charge a fee. It's a 5-minute walk from the waterfront."
+          "text": "Yes, general admission to Te Papa is free. Some special exhibitions may charge a fee. Don't miss the colossal squid — the largest specimen ever captured at 495 kilograms."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How windy is Windy Wellington?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Genuinely windy. Cook Strait funnels powerful southerly winds through the city, making it one of the windiest capitals in the world. Bring layers and hold onto your hat."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is Zealandia worth the trip?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "If you love wildlife and conservation, absolutely. It's the world's first fully-fenced urban ecosanctuary where you can see rare native birds thriving. About 10 minutes from downtown."
         }
       }
     ]
@@ -122,17 +138,21 @@ Soli Deo Gloria
         <h1>Wellington: New Zealand's Compact Creative Capital</h1>
 
         <div class="logbook-entry clearfix">
-          <p>They call it "Windy Wellington" for good reason. The moment I stepped off the shuttle into the waterfront, a gust nearly claimed my hat. But the locals seemed unbothered — jackets zipped, coffee cups clutched, striding purposefully through streets that pack more personality per square meter than any capital I've visited.</p>
+          <p>They call it "Windy Wellington" for good reason. The moment I stepped off the shuttle into the waterfront, a gust nearly claimed my hat. But the locals seemed unbothered — jackets zipped, coffee cups clutched, striding purposefully through streets that pack more personality per square meter than any capital I've visited. This is one of the windiest cities in the world, and there's a reason: Cook Strait, the narrow channel between New Zealand's two main islands, acts as a natural wind tunnel, funneling fierce southerly gusts directly at the city.</p>
 
-          <p>Wellington sits at the bottom of New Zealand's North Island, squeezed between harbour and hills in a way that forces everything close together. The result is a city you can actually walk — from world-class museum to craft brewery to hillside viewpoint, all within an afternoon. And what a museum: Te Papa Tongarewa, which opened in 1998 on reclaimed waterfront land, houses over two million items including treasures that define New Zealand's identity.</p>
+          <p>Wellington sits at the bottom of New Zealand's North Island, the world's southernmost capital city, squeezed between harbour and hills in a way that forces everything close together. The result is a city you can actually walk — from world-class museum to craft brewery to hillside viewpoint, all within an afternoon. And what a museum: Te Papa Tongarewa, which opened in 1998 on reclaimed waterfront land, spans 36,000 square meters and houses over two million items including treasures that define New Zealand's identity. The museum's bicultural philosophy — its very name means "our treasure box" in Māori — shapes every exhibition.</p>
 
           <div class="poignant-highlight">
-            <strong>The Moment That Stays With Me:</strong> Standing before a carved Māori meeting house inside Te Papa, surrounded by taonga (treasures) that have witnessed centuries of New Zealand history. The museum's name means "our treasure box" in Māori, and you feel it. This isn't a collection of artifacts behind glass — it's a living repository where culture breathes. And admission is free.
+            <strong>The Moment That Stays With Me:</strong> Standing before a carved Māori meeting house inside Te Papa, surrounded by taonga (treasures) that have witnessed centuries of New Zealand history. This isn't a collection of artifacts behind glass — it's a living repository where culture breathes. Then I turned a corner and came face-to-face with the colossal squid — the largest specimen ever captured, hauled up from Antarctic waters in 2007. At 495 kilograms, suspended in its preservation tank, it's both beautiful and utterly alien. And admission to see all of this is free.
           </div>
 
-          <p>The path from Te Papa led me to Cuba Street, where the famous Bucket Fountain has splashed since 1969. The street itself is a gallery of independent boutiques, vinyl shops, and coffee roasters — Wellington takes its coffee seriously, with more cafes per capita than New York. I stopped at three before lunch and regretted nothing.</p>
+          <p>The path from Te Papa led me to Cuba Street, the bohemian heart of the city where the famous Bucket Fountain has splashed since 1969. The street takes its name not from the Caribbean island, but from an early settler ship that arrived in 1840. Today it's a gallery of independent boutiques, vinyl shops, and coffee roasters — Wellington takes its coffee seriously, with more cafes per capita than New York. I stopped at three before lunch and regretted nothing.</p>
 
           <p>For views, take the Cable Car. The red carriages have been climbing from Lambton Quay to Kelburn since 1902 (rebuilt in 1979). The ride takes only five minutes but lifts you above the city's compact jumble of Victorian timber and Art Deco, depositing you at the Botanic Garden for a leisurely walk back down. On a clear day, you can see across Cook Strait to the South Island mountains.</p>
+
+          <p>If you have time for something extraordinary, visit Zealandia — the world's first fully-fenced urban ecosanctuary, just minutes from downtown. Here, 225 hectares of native forest have been restored to their pre-human state, protected by an innovative predator-proof fence. I walked the valley trails in near-silence, broken only by birdsong you won't hear anywhere else on earth. Takahē, kākā, tūī — species that were vanishing are thriving here again. It's conservation you can witness firsthand.</p>
+
+          <p>Even the government buildings here carry character. The Beehive — that distinctive circular structure beside Parliament — was designed by British architect Sir Basil Spence and completed in 1981. Love it or find it odd (Wellingtonians debate this), it's unmistakably Wellington: practical, bold, and utterly itself.</p>
         </div>
 
         <section class="port-section">
@@ -154,19 +174,25 @@ Soli Deo Gloria
           <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How I'd spend my time.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Te Papa Tongarewa</h4>
-          <p>New Zealand's national museum — 36,000 square meters of Māori culture, natural history, and art. Free general admission. Allow 2-3 hours minimum. Five-minute walk from the waterfront shuttle stop.</p>
+          <p>New Zealand's national museum — 36,000 square meters of Māori culture, natural history, and art, opened in 1998. The bicultural approach is woven throughout, from the name ("our treasure box" in Māori) to the presentation. Don't miss the colossal squid — the largest ever captured at 495 kilograms, hauled from Antarctic waters in 2007. Free general admission. Allow 2-3 hours minimum. Five-minute walk from the waterfront shuttle stop.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Wellington Cable Car</h4>
-          <p>Iconic red funicular from Lambton Quay to Kelburn. NZ$5-10 each way. Great views over the city and harbour. Walk down through the Botanic Garden afterward.</p>
+          <p>Iconic red funicular from Lambton Quay to Kelburn, running since 1902 (rebuilt 1979). NZ$5-10 each way. Great views over the city and harbour. Walk down through the Botanic Garden afterward.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Cuba Street</h4>
-          <p>The city's creative heart — independent shops, cafes, street art, and the famous Bucket Fountain. Perfect for wandering. Accessible on foot from the waterfront.</p>
+          <p>The city's bohemian heart — named after the settler ship "Cuba" (1840), not the country. Independent shops, cafes, street art, and the famous Bucket Fountain (splashing since 1969). Perfect for wandering. Accessible on foot from the waterfront.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Zealandia Ecosanctuary</h4>
+          <p>World's first fully-fenced urban ecosanctuary — 225 hectares of regenerated native forest protecting rare and endangered native birds including takahē, kākā, and tūī. Predator-proof fence enables species recovery you can witness. About 10 minutes from downtown by taxi or bus. Allow 2-3 hours for trails. Entry fee applies.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Weta Workshop Tour</h4>
           <p>Visit the special effects studio behind Lord of the Rings and Avatar. Located in Miramar (15-20 min from downtown). Book in advance — popular with cruise passengers.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Wellington Botanic Garden</h4>
           <p>25 hectares of native bush and formal gardens. Free entry. Take the Cable Car up and walk down through the garden. Allow 1-2 hours for a leisurely stroll.</p>
+
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Parliament & The Beehive</h4>
+          <p>New Zealand's Parliament complex features the distinctive Beehive — the circular executive wing designed by British architect Sir Basil Spence and completed in 1981. Free guided tours available (check schedule). Walking distance from the waterfront. Architecture buffs will appreciate the contrast between the Beehive, Gothic Revival Parliament House, and neoclassical Parliament Library.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Craft Beer Trail</h4>
           <p>Wellington claims to be New Zealand's craft beer capital. Garage Project, Panhead, and Fork & Brewer are walking distance from the waterfront. Many offer tastings.</p>
@@ -195,10 +221,11 @@ Soli Deo Gloria
         <section class="port-section">
           <h3>Frequently Asked Questions</h3>
           <p><strong>Q: Where do cruise ships dock?</strong><br/>A: Aotea Quay, about 2 km from downtown. Walk the scenic waterfront or take a shuttle.</p>
-          <p><strong>Q: Is Te Papa really free?</strong><br/>A: Yes, general admission is free. Some special exhibitions charge a fee.</p>
-          <p><strong>Q: How windy is "Windy Wellington"?</strong><br/>A: Genuinely windy. Bring layers and hold onto your hat. The wind is part of the charm.</p>
+          <p><strong>Q: Is Te Papa really free?</strong><br/>A: Yes, general admission is free. Some special exhibitions charge a fee. Don't miss the colossal squid — the largest specimen ever captured (495kg).</p>
+          <p><strong>Q: How windy is "Windy Wellington"?</strong><br/>A: Genuinely windy. Cook Strait funnels powerful southerly winds through the city, making it one of the windiest capitals in the world. Bring layers and hold onto your hat.</p>
           <p><strong>Q: Can I do Weta Workshop on a port day?</strong><br/>A: Yes, but book ahead. It's 15-20 min from downtown by taxi or shuttle.</p>
           <p><strong>Q: Is Wellington walkable?</strong><br/>A: Extremely. The compact downtown puts Te Papa, Cuba Street, and Cable Car within easy walking distance.</p>
+          <p><strong>Q: Is Zealandia worth the trip?</strong><br/>A: If you love wildlife and conservation, absolutely. It's the world's first fully-fenced urban ecosanctuary where you can see rare native birds thriving. About 10 minutes from downtown.</p>
         </section>
 
         <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>


### PR DESCRIPTION
Caribbean/Atlantic:
- St. Lucia: Pitons UNESCO 2004, Soufriere drive-in volcano, 14 colonial power changes
- Barbados: Bridgetown UNESCO 2011, Mount Gay 1703, George Washington 1751 visit
- Antigua: Nelson's Dockyard UNESCO, Betty's Hope 1650, 365 beaches, Columbus 1493

Hawaii & Pacific Islands:
- Maui: Valley Isle, Haleakala 10,023ft, Road to Hana 620 curves, Lahaina rebuilding
- Papeete: Gauguin's masterworks 1891-1901, overwater bungalows invented 1967
- Bora Bora: Sacred Mount Otemanu 2,385ft, WWII base 5,000 GIs, Lagoonarium
- Fiji: 333 islands, 3,500yr Melanesian history, Soft Coral Capital, firewalking

Australia & New Zealand:
- Cairns: Two UNESCO sites meet at Cape Tribulation, 180M yr Daintree, 1876 founding
- Wellington: Te Papa 36,000sqm with colossal squid, Zealandia ecosanctuary, Beehive
- Hobart: MONA 2011, Port Arthur UNESCO, Cascade Brewery 1824, Antarctica gateway

All content in pastoral logbook voice with historical dates, measurements, and cultural context.