### PR TITLE
Bring Vancouver into full template compliance + add POIs

### DIFF
--- a/assets/data/maps/poi-index.json
+++ b/assets/data/maps/poi-index.json
@@ -114,8 +114,105 @@
       "holyhead": 6,
       "kirkwall": 6,
       "lerwick": 6,
-      "waterford": 6
+      "waterford": 6,
+      "vancouver": 8
     }
+  },
+
+  "canada-place": {
+    "id": "canada-place",
+    "name": "Canada Place Cruise Terminal",
+    "aliases": ["cruise terminal", "cruise port", "vancouver cruise terminal"],
+    "lat": 49.2888,
+    "lon": -123.1117,
+    "type": "port",
+    "geometry": "point",
+    "notes": "Iconic sail-roofed terminal and convention center. FlyOver Canada ride located here.",
+    "port": "vancouver"
+  },
+
+  "stanley-park": {
+    "id": "stanley-park",
+    "name": "Stanley Park",
+    "aliases": ["Stanley Park seawall", "totem poles"],
+    "lat": 49.3017,
+    "lon": -123.1417,
+    "type": "park",
+    "geometry": "polygon",
+    "notes": "1,000-acre urban park with seawall, totem poles, aquarium, and Lost Lagoon.",
+    "port": "vancouver"
+  },
+
+  "gastown": {
+    "id": "gastown",
+    "name": "Gastown",
+    "aliases": ["Gastown Vancouver", "steam clock"],
+    "lat": 49.2838,
+    "lon": -123.1088,
+    "type": "district",
+    "geometry": "polygon",
+    "notes": "Vancouver's oldest neighborhood with cobblestone streets, steam clock, and boutiques.",
+    "port": "vancouver"
+  },
+
+  "granville-island": {
+    "id": "granville-island",
+    "name": "Granville Island",
+    "aliases": ["Granville Island Market", "public market"],
+    "lat": 49.2712,
+    "lon": -123.1340,
+    "type": "attraction",
+    "geometry": "polygon",
+    "notes": "Public market with local produce, artisan shops, restaurants, and buskers.",
+    "port": "vancouver"
+  },
+
+  "capilano-suspension-bridge": {
+    "id": "capilano-suspension-bridge",
+    "name": "Capilano Suspension Bridge",
+    "aliases": ["Capilano Bridge", "suspension bridge"],
+    "lat": 49.3429,
+    "lon": -123.1149,
+    "type": "attraction",
+    "geometry": "point",
+    "notes": "230-foot-high swaying bridge over canyon with cliff walk and treetop adventure.",
+    "port": "vancouver"
+  },
+
+  "grouse-mountain": {
+    "id": "grouse-mountain",
+    "name": "Grouse Mountain",
+    "aliases": ["Grouse Gondola", "Skyride"],
+    "lat": 49.3801,
+    "lon": -123.0819,
+    "type": "nature",
+    "geometry": "point",
+    "notes": "Peak of Vancouver with Skyride gondola, grizzly bear sanctuary, and city views.",
+    "port": "vancouver"
+  },
+
+  "vancouver-aquarium": {
+    "id": "vancouver-aquarium",
+    "name": "Vancouver Aquarium",
+    "aliases": ["aquarium", "Stanley Park Aquarium"],
+    "lat": 49.3008,
+    "lon": -123.1307,
+    "type": "attraction",
+    "geometry": "point",
+    "notes": "Canada's largest aquarium, located in Stanley Park with marine exhibits.",
+    "port": "vancouver"
+  },
+
+  "chinatown": {
+    "id": "chinatown",
+    "name": "Chinatown",
+    "aliases": ["Vancouver Chinatown", "Dr. Sun Yat-Sen Garden"],
+    "lat": 49.2797,
+    "lon": -123.1000,
+    "type": "district",
+    "geometry": "polygon",
+    "notes": "One of North America's largest Chinatowns. Dr. Sun Yat-Sen Classical Chinese Garden is a must-see.",
+    "port": "vancouver"
   },
 
   "aruba-cruise-terminal": {

--- a/ports/vancouver.html
+++ b/ports/vancouver.html
@@ -182,6 +182,10 @@ Soli Deo Gloria
       <p style="font-size: 0.95rem; color: #456; margin-bottom: 0;">
         <strong>Region:</strong> Pacific Northwest &nbsp;|&nbsp; <strong>Season:</strong> April – October &nbsp;|&nbsp; <strong>Terminal:</strong> Canada Place
       </p>
+
+      <p class="answer-line" style="margin: 1rem 0 0; padding: 0.75rem 1rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
+        <strong>Quick Answer:</strong> Vancouver is the premier Alaska cruise gateway — Canada Place terminal sits beneath five iconic white sails, with Stanley Park, Granville Island, and world-class Asian cuisine making extra pre-cruise days essential.
+      </p>
     </article>
 
     <!-- First-Person Logbook Entry -->
@@ -208,7 +212,7 @@ Soli Deo Gloria
         <ul>
           <li><strong>Terminal:</strong> Canada Place, 999 Canada Place, Vancouver</li>
           <li><strong>From YVR Airport:</strong> 25-35 minutes via Canada Line SkyTrain ($9.35 CAD adult fare)</li>
-          <li><strong>SkyTrain:</strong> Direct to Waterfront Station — short walk to terminal</li>
+          <li><strong>SkyTrain:</strong> Direct to Waterfront Station — short walk to terminal <span class="distance-fun">approximately 4 football fields, 14 blue whales end-to-end, or 310 emperor penguins stacked skyward</span></li>
           <li><strong>Taxi/Uber:</strong> $35-45 CAD from airport; Uber and Lyft both operate in Vancouver</li>
           <li><strong>From Seattle:</strong> 3-4 hours via I-5 North (bring passport — required for border crossing)</li>
         </ul>
@@ -220,7 +224,7 @@ Soli Deo Gloria
           <li><strong>SkyTrain:</strong> Three lines serve metro Vancouver — Canada Line (airport/Richmond), Expo Line (east), Millennium Line (east/north)</li>
           <li><strong>SeaBus:</strong> 12-minute ferry across Burrard Inlet to North Vancouver from Waterfront Station</li>
           <li><strong>Aquabus & False Creek Ferries:</strong> Small ferries connecting Granville Island, Yaletown, Science World — $4-7 CAD per hop</li>
-          <li><strong>On Foot:</strong> Downtown core is compact and walkable; Stanley Park seawall is 10 km of waterfront walking</li>
+          <li><strong>On Foot:</strong> Downtown core is compact and walkable; Stanley Park seawall is 10 km of waterfront walking <span class="distance-fun">roughly 91 football fields, 333 blue whales nose-to-tail, or 7,246 emperor penguins in an improbable queue</span></li>
           <li><strong>Bike Rentals:</strong> Mobi bike-share stations throughout downtown</li>
         </ul>
       </section>
@@ -280,28 +284,20 @@ Soli Deo Gloria
     </section>
 
     <!-- FAQ Section -->
-    <section class="card faq">
-      <h2>Frequently Asked Questions</h2>
+    <section class="card port-section">
+      <h3>Frequently Asked Questions</h3>
 
-      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
-        <summary style="cursor: pointer; font-weight: 600;">Do I need a passport for Vancouver?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Yes — US citizens need a valid passport to enter Canada and for the Alaska cruise. Make sure it's valid for the duration of your trip.</p>
-      </details>
+      <p><strong>Q: Do I need a passport for Vancouver?</strong><br/>
+      A: Yes — US citizens need a valid passport to enter Canada and for the Alaska cruise. Make sure it's valid for the duration of your trip.</p>
 
-      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
-        <summary style="cursor: pointer; font-weight: 600;">Vancouver or Seattle for Alaska cruises?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Both are great homeports. One-way cruises between the two see more of the Inside Passage without backtracking. Vancouver is worth extra time to explore — it's a world-class destination in its own right.</p>
-      </details>
+      <p><strong>Q: Vancouver or Seattle for Alaska cruises?</strong><br/>
+      A: Both are great homeports. One-way cruises between the two see more of the Inside Passage without backtracking. Vancouver is worth extra time to explore — it's a world-class destination in its own right.</p>
 
-      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
-        <summary style="cursor: pointer; font-weight: 600;">What's the best way from the airport?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">The Canada Line SkyTrain is efficient, affordable ($9.35 CAD), and drops you right at Waterfront Station, a short walk to Canada Place.</p>
-      </details>
+      <p><strong>Q: What's the best way from the airport?</strong><br/>
+      A: The Canada Line SkyTrain is efficient, affordable ($9.35 CAD), and drops you right at Waterfront Station, a short walk to Canada Place.</p>
 
-      <details style="margin: 0.75rem 0; padding: 0.5rem 0;">
-        <summary style="cursor: pointer; font-weight: 600;">How many days should I spend in Vancouver?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">At minimum, arrive the day before your cruise. Ideally, plan 2-3 extra days to explore Stanley Park, Granville Island, Gastown, and enjoy the dining scene. You won't regret the extra time.</p>
-      </details>
+      <p><strong>Q: How many days should I spend in Vancouver?</strong><br/>
+      A: At minimum, arrive the day before your cruise. Ideally, plan 2-3 extra days to explore Stanley Park, Granville Island, Gastown, and enjoy the dining scene. You won't regret the extra time.</p>
     </section>
 
     <!-- Back to Ports -->


### PR DESCRIPTION
POI Index:
- Add 8 Vancouver POIs (canada-place, stanley-park, gastown, granville-island, capilano-suspension-bridge, grouse-mountain, vancouver-aquarium, chinatown)

Vancouver page fixes:
- Add Quick Answer line after title
- Add distance-fun spans to transport sections
- Change FAQ from details/summary to Q&A paragraph format
- Map markers now visible with real POI data