### PR TITLE
Convert CocoCay gallery to Swiper carousel

### DIFF
--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -257,6 +257,43 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </p>
     </article>
 
+    <!-- Island Photo Gallery (Swiper) -->
+    <section class="card" aria-labelledby="gallery-heading">
+      <h2 id="gallery-heading">CocoCay in Pictures</h2>
+      <p class="tiny" style="margin-bottom: 1rem; color: #678;">Swipe through scenes from Perfect Day at CocoCay.</p>
+      <div class="swiper cococay-gallery" aria-roledescription="carousel">
+        <div class="swiper-wrapper">
+          <div class="swiper-slide">
+            <figure>
+              <img src="/ports/img/cococay/cococay-1.webp" alt="Perfect Day at CocoCay aerial view showing turquoise waters and white sand beaches" loading="eager" decoding="async" class="firstlook-img"/>
+              <figcaption class="tiny">Perfect Day at CocoCay — Photo: Wikimedia Commons (CC BY-SA 4.0)</figcaption>
+            </figure>
+          </div>
+          <div class="swiper-slide">
+            <figure>
+              <img src="/ports/img/cococay/cococay-2.webp" alt="CocoCay beach with pristine white sand" loading="lazy" decoding="async" class="firstlook-img"/>
+              <figcaption class="tiny">CocoCay beach — Photo: Wikimedia Commons (CC BY-SA 3.0)</figcaption>
+            </figure>
+          </div>
+          <div class="swiper-slide">
+            <figure>
+              <img src="/ports/img/cococay/cococay-3.webp" alt="CocoCay shops and colorful buildings" loading="lazy" decoding="async" class="firstlook-img"/>
+              <figcaption class="tiny">CocoCay shops — Photo: Wikimedia Commons (CC BY-SA 3.0)</figcaption>
+            </figure>
+          </div>
+          <div class="swiper-slide">
+            <figure>
+              <img src="/ports/img/cococay/cococay-4.webp" alt="CocoCay welcome sign" loading="lazy" decoding="async" class="firstlook-img"/>
+              <figcaption class="tiny">CocoCay welcome sign — Photo: Wikimedia Commons (CC BY-SA 3.0)</figcaption>
+            </figure>
+          </div>
+        </div>
+        <div class="swiper-pagination" aria-hidden="true"></div>
+        <div class="swiper-button-prev" aria-label="Previous image"></div>
+        <div class="swiper-button-next" aria-label="Next image"></div>
+      </div>
+    </section>
+
     <!-- First-Person Logbook Entry -->
     <article class="card logbook-entry">
       <h2>My CocoCay Logbook</h2>
@@ -485,40 +522,6 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     </section>
     </article>
 
-    <!-- Photo Gallery -->
-    <section class="port-section" style="background: transparent; border: none; padding: 0;">
-      <h3>CocoCay Gallery</h3>
-      <div class="gallery-grid">
-        <figure class="gallery-item">
-          <img src="/ports/img/cococay/cococay-1.webp" alt="Perfect Day at CocoCay" loading="lazy"/>
-          <figcaption>
-            Perfect Day at CocoCay
-            <div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</div>
-          </figcaption>
-        </figure>
-        <figure class="gallery-item">
-          <img src="/ports/img/cococay/cococay-2.webp" alt="CocoCay beach" loading="lazy"/>
-          <figcaption>
-            CocoCay beach
-            <div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 3.0)</div>
-          </figcaption>
-        </figure>
-        <figure class="gallery-item">
-          <img src="/ports/img/cococay/cococay-3.webp" alt="CocoCay shops" loading="lazy"/>
-          <figcaption>
-            CocoCay shops
-            <div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 3.0)</div>
-          </figcaption>
-        </figure>
-        <figure class="gallery-item">
-          <img src="/ports/img/cococay/cococay-4.webp" alt="CocoCay welcome sign" loading="lazy"/>
-          <figcaption>
-            CocoCay welcome sign
-            <div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 3.0)</div>
-          </figcaption>
-        </figure>
-      </div>
-    </section>
     <!-- Interactive Port Map -->
 <section class="port-section port-map-section" id="port-map-section">
   <h3>CocoCay Island Map</h3>
@@ -739,6 +742,25 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 });
+</script>
+
+<!-- Initialize CocoCay Gallery Swiper -->
+<script>
+(function initCococaySwiper(){
+  function when(cb){ if(window.Swiper) cb(); else setTimeout(()=>when(cb), 100); }
+  when(function(){
+    try {
+      new Swiper('.swiper.cococay-gallery', {
+        loop: true,
+        lazy: true,
+        watchOverflow: true,
+        pagination: { el: '.swiper.cococay-gallery .swiper-pagination', clickable: true },
+        navigation: { nextEl: '.swiper.cococay-gallery .swiper-button-next', prevEl: '.swiper.cococay-gallery .swiper-button-prev' },
+        a11y: { enabled: true }
+      });
+    } catch(e) { console.log('Swiper init failed:', e); }
+  });
+})();
 </script>
 
 </body>


### PR DESCRIPTION
- Move stacked images from bottom to Swiper near top of content
- Place after intro section, before personal logbook narrative
- Add Swiper initialization script
- Remove old gallery-grid section