### PR TITLE
Add inline images throughout CocoCay article

### DIFF
--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -310,9 +310,16 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <article class="card logbook-entry">
       <h2>My CocoCay Logbook</h2>
 
+      <img class="inline-image" src="/ports/img/cococay/cococay-1.webp" alt="Perfect Day at CocoCay aerial view showing turquoise waters and white sand beaches" loading="lazy"/>
+
       <p>I've lost count of how many times I've visited Perfect Day at CocoCay now — six? seven? — but I remember the first time with crystal clarity. It was 2019, just months after Royal Caribbean's $250 million transformation was complete, and I was sailing on <a href="/ships/rcl/mariner-of-the-seas.html">Mariner of the Seas</a> out of Miami. The moment we rounded the island and I saw those impossibly turquoise waters and the towering waterslides of Thrill Waterpark rising against the sky, I felt like a kid on Christmas morning. I'd been to plenty of private islands before, but nothing prepared me for this.</p>
 
       <p>The ship docked directly at the pier — no tenders, no waiting, just walk off and you're there. That alone sets CocoCay apart from most Caribbean ports. Within minutes I had my toes in the sand at Chill Island, a complimentary Coco Loco in hand (the frozen drinks here are dangerously good), staring at water so clear I could see fish swimming twenty feet out. The beaches are immaculate — raked daily, with free loungers and umbrellas scattered across multiple zones so you never feel crowded even on two-ship days.</p>
+
+      <figure class="logbook-image float-right">
+        <img src="/ports/img/cococay/cococay-2.webp" alt="CocoCay beach with pristine white sand and turquoise water" loading="lazy"/>
+        <figcaption class="tiny">The pristine beaches of CocoCay<br/><span style="font-size: 0.8rem;">Photo: Wikimedia Commons (CC BY-SA)</span></figcaption>
+      </figure>
 
       <p>But let me tell you about Thrill Waterpark, because it's the headline attraction for good reason. I'm not normally a waterpark person, but when you're standing at the top of Daredevil's Peak — 135 feet up, the tallest waterslide in North America — looking out over the entire island with your heart pounding, you realize Royal Caribbean wasn't messing around with this investment. The drop slide is pure adrenaline, but my personal favorite is the Dueling Demons mat racers where you and three friends can compete side by side. The wave pool is massive and legitimate (none of that gentle ripple nonsense), and kids under a certain age have entire aqua playgrounds to themselves. We spent four hours in Thrill Waterpark on my last visit and still didn't do everything.</p>
 
@@ -320,9 +327,16 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <strong>The Moment That Stays With Me:</strong> It was late afternoon on my third visit, floating in Oasis Lagoon with my wife, swim-up bar cocktails in hand, watching the sun start to paint the sky orange behind our ship docked at the pier. A steel drum band was playing somewhere in the distance. Neither of us said anything for the longest time — we didn't need to. That's when I understood what Royal Caribbean was really selling here: not just a private island, but the closest thing to perfection a single day can hold. The water was exactly body temperature. The drink was exactly sweet enough. The music was exactly far enough away to be ambient. I've chased that feeling on every visit since.
       </div>
 
+      <img class="inline-image" src="/ports/img/cococay/cococay-5.webp" alt="Perfect Day at CocoCay aerial showing the island layout and beaches" loading="lazy"/>
+
       <p>Oasis Lagoon deserves its own paragraph because it's genuinely incredible — the largest freshwater pool in the Caribbean, they claim, and I believe it. It's massive. There's a swim-up bar, floating loungers, a DJ playing poolside, and multiple depth zones so families can share the space safely. I've spent entire port days just here without touching the beach, and that says something. The Coco Beach Club infinity pool is even more luxurious if you book that experience — overwater cabanas, dedicated servers, upscale lunch included — but Oasis Lagoon is free and fantastic.</p>
 
       <p>The food situation has improved dramatically since the early days. Skipper's Grill serves legitimately good BBQ (the ribs disappear fast at lunch — go early), and Chill Grill covers burgers, hot dogs, and all the sides you'd expect. It's all complimentary. Snack Shack has pizza and chicken tenders for picky eaters. If you upgrade to Coco Beach Club, the dining there is a significant step up — think resort-quality with table service. I've done both, and honestly, the free BBQ with a beach view is pretty hard to beat for value.</p>
+
+      <figure class="logbook-image float-left">
+        <img src="/ports/img/cococay/cococay-3.webp" alt="CocoCay shops and colorful buildings" loading="lazy"/>
+        <figcaption class="tiny">Colorful shops at the Arrival Plaza<br/><span style="font-size: 0.8rem;">Photo: Wikimedia Commons (CC BY-SA)</span></figcaption>
+      </figure>
 
       <p>The newer additions have only made things better. Hideaway Beach opened as an adults-only area with its own pool, quieter vibe, and dedicated bar — perfect if you're cruising without kids and want guaranteed peace. Up, Up and Away, the helium balloon that takes you 450 feet above the island, offers the most incredible photos and a completely unique perspective on the whole operation. The zip line across the island is solid fun (1,600 feet), though not as insane as the one at <a href="/ports/labadee.html">Labadee</a>.</p>
 
@@ -339,6 +353,11 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="port-section">
       <h3>From Little Stirrup Cay to Perfect Day: The Island's Journey</h3>
       <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">How an uninhabited Bahamian cay became the world's most visited private island.</p>
+
+      <figure class="logbook-image float-right">
+        <img src="/ports/img/cococay/cococay-4.webp" alt="CocoCay welcome sign at the Arrival Plaza" loading="lazy"/>
+        <figcaption class="tiny">Welcome to Perfect Day at CocoCay<br/><span style="font-size: 0.8rem;">Photo: Wikimedia Commons (CC BY-SA)</span></figcaption>
+      </figure>
 
       <p>Long before cruise ships found these waters, the Lucayan people — the indigenous inhabitants of the Bahamas — knew these islands. Little Stirrup Cay, as it was originally named, sits in the Berry Islands chain about 55 miles northwest of Nassau. For centuries it remained largely untouched, a pristine slice of Caribbean paradise waiting for its moment.</p>
 
@@ -408,6 +427,8 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <section class="port-section">
       <h3>Island Areas: Your Complete Guide</h3>
       <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">Every zone has its own personality — here's what to expect.</p>
+
+      <img class="inline-image" src="/ports/img/cococay/cococay-6.webp" alt="CocoCay tropical beach scene with palm trees and turquoise water" loading="lazy"/>
 
       <h4 style="margin-top: 1.25rem; color: var(--ink, #1a2a3a);">Beaches (All Included)</h4>
       <ul>


### PR DESCRIPTION
CocoCay was missing inline images - only had a gallery at the top. Now has 6 inline images woven into the article content matching the pattern used in Nassau and other port pages:

- Logbook section: 4 images (aerial, beach, another aerial, shops)
- History section: 1 image (welcome sign)
- Island Areas section: 1 image (tropical beach scene)

With ~5,300 words and 6 inline images = ~880 words per image. Plus the 6-image Swiper gallery at the top.