### PR TITLE
Update ITC standard to v1.1 with POI manifest system and fix Nassau/R…

### DIFF
--- a/admin/PORT-PAGE-STANDARD.md
+++ b/admin/PORT-PAGE-STANDARD.md
@@ -1,4 +1,4 @@
-# Port Page Standard - ITC v1.0 (In the Wake Content Standard)
+# Port Page Standard - ITC v1.1 (In the Wake Content Standard)
 **Soli Deo Gloria**
 
 This document defines the enforceable standard for all port pages on In the Wake. Every port page MUST comply with these requirements.
@@ -176,6 +176,216 @@ if('serviceWorker' in navigator){
 - **BLOCKING**: Swiper initialization must check for `window.__swiperReady` flag
 - **WARNING**: Service worker registration should be present for PWA support
 - **WARNING**: Canonical link should point to production URL
+
+---
+
+## II-A. POI MANIFEST SYSTEM (BLOCKING)
+
+Every port page MUST have a corresponding POI (Points of Interest) manifest file that defines all map markers, locations, transit routes, and featured experiences.
+
+### Manifest File Location (BLOCKING)
+
+```
+/assets/data/maps/[port-slug].map.json
+```
+
+**Example**: For `/ports/nassau.html`, the manifest is `/assets/data/maps/nassau.map.json`
+
+### Minimum POI Requirement (BLOCKING)
+
+**Every port MUST have at least 10 POI defined in its manifest.**
+
+POI categories include:
+- Cruise ports/terminals
+- Beaches and waterfront areas
+- Attractions and landmarks
+- Restaurants and cafes
+- Museums and cultural sites
+- Shopping districts
+- Parks and natural areas
+- Transportation hubs (airports, train stations, etc.)
+- Day trip destinations
+- Hotels or accommodations (when relevant)
+
+### Manifest File Structure (BLOCKING)
+
+```json
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "YYYY-MM-DDTHH:MM:SSZ",
+    "source": "Brief description of research sources"
+  },
+
+  "port_slug": "[slug]",
+  "port_name": "[Port Display Name]",
+
+  "port_pin": {
+    "lat": 00.0000,
+    "lon": -00.0000,
+    "label": "[Main cruise terminal name]"
+  },
+
+  "bbox_hint": {
+    "south": 00.00,
+    "west": -00.00,
+    "north": 00.00,
+    "east": -00.00,
+    "note": "Geographic area description"
+  },
+
+  "poi_ids": [
+    "[poi-identifier-1]",
+    "[poi-identifier-2]",
+    "[poi-identifier-3]"
+  ],
+
+  "label_overrides": {
+    "[poi-id]": "Custom marker label with additional context"
+  },
+
+  "approximate_markers": [
+    "[poi-id-with-approximate-coords]"
+  ],
+
+  "transit_routes": [
+    {
+      "id": "[route-id]",
+      "name": "[Route Display Name]",
+      "type": "taxi|bus|train|ferry|walking|trolley|rideshare",
+      "cost": "[Cost in local/USD currency]",
+      "duration": "[Duration description]",
+      "connects": ["[poi-id-1]", "[poi-id-2]"],
+      "note": "[Additional transit details]"
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "[Experience Name]",
+      "type": "tour|attraction|adventure|cultural|relaxation|flightseeing",
+      "duration": "[Duration description]",
+      "highlights": ["[Feature 1]", "[Feature 2]", "[Feature 3]"],
+      "note": "[Helpful context, pricing hints, booking advice]"
+    }
+  ]
+}
+```
+
+### POI ID Format (BLOCKING)
+
+- Use lowercase with hyphens: `nassau-cruise-port`, `queen-stairs`, `atlantis-paradise-island`
+- Be specific and descriptive
+- Consistent naming: `[location]-[type]` when helpful (e.g., `alaska-railroad-depot-anchorage`)
+- Avoid generic IDs like `beach-1` or `restaurant-2`
+
+### Port Map Initialization with PortMap Module (BLOCKING)
+
+Port pages MUST use the `PortMap.init()` pattern to initialize interactive maps:
+
+```html
+<!-- Set current port ID -->
+<script>window.currentPortId = '[port-slug]';</script>
+
+<!-- Load nearby ports module -->
+<script src="/assets/js/nearby-ports.js"></script>
+
+<!-- Leaflet JS -->
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+        crossorigin=""></script>
+
+<!-- Port map module -->
+<script src="/assets/js/modules/port-map.js"></script>
+
+<!-- Initialize map using PortMap module -->
+<script>
+(function() {
+  function initMap() {
+    if (typeof PortMap !== 'undefined' && typeof L !== 'undefined') {
+      PortMap.init({
+        containerId: '[port-slug]-port-map',
+        portSlug: '[port-slug]'
+      });
+    } else {
+      setTimeout(initMap, 100);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initMap);
+  } else {
+    initMap();
+  }
+})();
+</script>
+```
+
+### Map HTML Container (BLOCKING)
+
+```html
+<section class="port-section port-map-section" id="port-map-section">
+  <h3>[Port Name] Area Map</h3>
+  <p class="map-intro">Interactive map showing cruise terminal, attractions, restaurants, and day trip destinations. Click any marker for details.</p>
+
+  <div id="[port-slug]-port-map" class="port-map-container"
+       role="application"
+       aria-label="Interactive map of [Port Name] and points of interest">
+    <noscript>
+      <p style="padding: 2rem; text-align: center; color: #678;">
+        Interactive map requires JavaScript. View our <a href="/assets/data/maps/poi-index.json">POI data</a> for location coordinates.
+      </p>
+    </noscript>
+  </div>
+
+  <div class="port-map-actions">
+    <button type="button" class="btn btn-secondary"
+            onclick="document.getElementById('[port-slug]-port-map')._portMap?.fitBounds(document.getElementById('[port-slug]-port-map')._portMap.getBounds())">
+      Reset View
+    </button>
+  </div>
+</section>
+```
+
+### POI Data Master Index
+
+All POI manifest files are indexed in `/assets/data/maps/poi-index.json` for global POI search and cross-referencing.
+
+### Validation Rules
+
+- **BLOCKING**: POI manifest file must exist at `/assets/data/maps/[port-slug].map.json`
+- **BLOCKING**: Manifest must contain minimum 10 POI in `poi_ids` array
+- **BLOCKING**: All required manifest fields must be present (`port_slug`, `port_name`, `port_pin`, `poi_ids`)
+- **BLOCKING**: `port_slug` in manifest must match filename (e.g., `nassau` for `nassau.map.json`)
+- **BLOCKING**: Page must use `PortMap.init()` pattern, not inline Leaflet initialization
+- **BLOCKING**: `window.currentPortId` must be set before loading nearby-ports.js
+- **WARNING**: `transit_routes` should include at least 2 routes where applicable
+- **WARNING**: `featured_experiences` should include 2-4 curated experiences
+- **WARNING**: Label overrides should be used for POI needing additional context
+
+### POI Selection Guidelines
+
+When selecting POI for a port:
+
+1. **Prioritize cruise relevance**: Focus on locations accessible during typical port days (8-12 hours)
+2. **Mix of categories**: Include terminals, attractions, beaches, dining, cultural sites, transportation
+3. **Geographic distribution**: Cover different areas of the port region
+4. **Accessibility tiers**: Include locations within walking distance, short taxi rides, and full-day excursions
+5. **Include specifics**: Individual restaurants, beaches, museums (not just generic "dining district")
+6. **Day trip destinations**: Include popular day trips mentioned in text (even if 1-2 hours away)
+7. **Transit hubs**: Airports, train stations, ferry terminals when relevant to cruise passengers
+
+**Example - Nassau requires 10+ POI:**
+- Nassau Cruise Port (terminal)
+- Bay Street (shopping district)
+- Atlantis Paradise Island (attraction)
+- Cabbage Beach (beach)
+- Junkanoo Beach (beach)
+- Nassau Straw Market (shopping/cultural)
+- Queen's Staircase (landmark)
+- Pirates of Nassau Museum (cultural)
+- Royal Beach Club Paradise Island (private beach club)
+- Fort Fincastle (landmark)
 
 ---
 
@@ -615,12 +825,22 @@ Some violations require human judgment:
 
 ## XI. VERSIONING
 
-**Current Version**: ITC v1.0.1 (In the Wake Content Standard)
+**Current Version**: ITC v1.1 (In the Wake Content Standard)
 **Based On**: ICP-Lite v1.4, Port Guide Rubric v1.0
 **Last Updated**: 2025-12-26
 **Soli Deo Gloria**
 
 ### Change Log
+- **v1.1** (2025-12-26): Added POI manifest system requirements
+  - Section II-A: POI Manifest System specification
+  - Minimum 10 POI per port requirement (BLOCKING)
+  - POI manifest file structure and validation rules
+  - PortMap.init() pattern for map initialization
+  - window.currentPortId requirement
+  - nearby-ports.js module loading
+  - POI selection guidelines and examples
+  - Updated map initialization from inline Leaflet to PortMap module pattern
+
 - **v1.0.1** (2025-12-26): Added required stylesheets and scripts section
   - Required stylesheet includes (main styles, Leaflet, port map CSS)
   - Swiper CSS/JS fallback pattern specification

--- a/assets/data/maps/nassau.map.json
+++ b/assets/data/maps/nassau.map.json
@@ -24,18 +24,24 @@
   "poi_ids": [
     "nassau-cruise-port",
     "bay-street-nassau",
+    "royal-beach-club-paradise-island",
     "atlantis-paradise-island",
     "cabbage-beach",
     "junkanoo-beach",
     "nassau-straw-market",
     "queen-stairs",
-    "pirates-nassau"
+    "pirates-nassau",
+    "fort-fincastle",
+    "fort-charlotte"
   ],
 
   "label_overrides": {
+    "royal-beach-club-paradise-island": "Royal Beach Club (opened 2025 - private day pass)",
     "atlantis-paradise-island": "Atlantis (waterpark & aquarium)",
     "queen-stairs": "Queen's Staircase (66 historic steps)",
-    "junkanoo-beach": "Junkanoo Beach (closest to port)"
+    "junkanoo-beach": "Junkanoo Beach (closest to port)",
+    "fort-fincastle": "Fort Fincastle (1793 historic fort)",
+    "fort-charlotte": "Fort Charlotte (largest fort in Nassau)"
   },
 
   "approximate_markers": [],
@@ -62,6 +68,13 @@
   ],
 
   "featured_experiences": [
+    {
+      "name": "Royal Beach Club Day Pass",
+      "type": "attraction",
+      "duration": "Full day",
+      "highlights": ["Private beach club opened 2025", "Thrill Waterpark", "All-day dining included", "Complimentary shuttle"],
+      "note": "Day passes $129+. Royal Caribbean's newest Paradise Island destination. Book ahead - limited capacity."
+    },
     {
       "name": "Atlantis Day Pass",
       "type": "attraction",

--- a/assets/data/maps/royal-beach-club-nassau.map.json
+++ b/assets/data/maps/royal-beach-club-nassau.map.json
@@ -1,0 +1,145 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "generated": "2025-12-26T00:00:00Z",
+    "source": "Royal Caribbean official website, Royal Beach Club materials, Paradise Island local guides, Nassau tourism resources"
+  },
+
+  "port_slug": "royal-beach-club-nassau",
+  "port_name": "Royal Beach Club Paradise Island",
+
+  "port_pin": {
+    "lat": 25.0850,
+    "lon": -77.3050,
+    "label": "Royal Beach Club Paradise Island"
+  },
+
+  "bbox_hint": {
+    "south": 25.07,
+    "west": -77.35,
+    "north": 25.10,
+    "east": -77.28,
+    "note": "Covers Royal Beach Club, nearby Paradise Island attractions, and Nassau waterfront"
+  },
+
+  "poi_ids": [
+    "royal-beach-club-main",
+    "thrill-waterpark",
+    "oasis-lagoon-pool",
+    "overwater-cabanas",
+    "barefoot-beach-restaurant",
+    "shoreline-bar",
+    "watersports-pavilion",
+    "cultural-junkanoo-stage",
+    "beach-volleyball-courts",
+    "atlantis-paradise-island",
+    "cabbage-beach",
+    "nassau-cruise-port",
+    "bay-street-nassau",
+    "versailles-gardens-paradise-island"
+  ],
+
+  "label_overrides": {
+    "royal-beach-club-main": "Royal Beach Club (Main Entrance)",
+    "thrill-waterpark": "Thrill Waterpark (slides & splash zones)",
+    "oasis-lagoon-pool": "Oasis Lagoon (main pool complex)",
+    "overwater-cabanas": "Overwater Cabanas (premium upgrade)",
+    "barefoot-beach-restaurant": "Barefoot Beach (buffet & grill)",
+    "atlantis-paradise-island": "Atlantis (nearby waterpark)",
+    "nassau-cruise-port": "Nassau Cruise Port (Prince George Wharf)"
+  },
+
+  "approximate_markers": [],
+
+  "transit_routes": [
+    {
+      "id": "shuttle-from-nassau-port",
+      "name": "Royal Caribbean Shuttle",
+      "type": "bus",
+      "cost": "Included with RBC day pass",
+      "duration": "15-20 minutes",
+      "connects": ["nassau-cruise-port", "royal-beach-club-main"],
+      "note": "Direct shuttle included for all Royal Beach Club guests. Departs from Prince George Wharf."
+    },
+    {
+      "id": "taxi-to-rbc",
+      "name": "Taxi to Royal Beach Club",
+      "type": "taxi",
+      "cost": "USD 25-35",
+      "duration": "15 minutes",
+      "connects": ["nassau-cruise-port", "royal-beach-club-main"],
+      "note": "For independent travelers. Crosses Paradise Island bridge."
+    },
+    {
+      "id": "walk-to-atlantis",
+      "name": "Walk to Atlantis",
+      "type": "walking",
+      "cost": "Free",
+      "duration": "10 minutes",
+      "connects": ["royal-beach-club-main", "atlantis-paradise-island"],
+      "note": "Short walk along Paradise Island coastline to Atlantis entrance."
+    },
+    {
+      "id": "walk-to-cabbage-beach",
+      "name": "Walk to Cabbage Beach",
+      "type": "walking",
+      "cost": "Free",
+      "duration": "5 minutes",
+      "connects": ["royal-beach-club-main", "cabbage-beach"],
+      "note": "Public beach access adjacent to Royal Beach Club."
+    }
+  ],
+
+  "featured_experiences": [
+    {
+      "name": "Royal Beach Club Day Pass",
+      "type": "attraction",
+      "duration": "Full day (8 AM - 5 PM)",
+      "highlights": [
+        "Private white-sand beach access",
+        "Thrill Waterpark with slides",
+        "Oasis Lagoon pool complex",
+        "Barefoot Beach all-day dining",
+        "Complimentary shuttle from cruise port",
+        "Beach chairs, umbrellas, towels included"
+      ],
+      "note": "Day passes $129+ for adults (2025 pricing). Book through Royal Caribbean or independent operators. Limited capacity - advance booking essential."
+    },
+    {
+      "name": "Overwater Cabana Upgrade",
+      "type": "relaxation",
+      "duration": "Full day",
+      "highlights": [
+        "Private overwater bungalow",
+        "Dedicated cabana host service",
+        "Premium seating and shade",
+        "Direct water access"
+      ],
+      "note": "Premium upgrade $300+. Very limited availability. Book well in advance."
+    },
+    {
+      "name": "Thrill Waterpark Adventures",
+      "type": "adventure",
+      "duration": "Half day",
+      "highlights": [
+        "Multiple water slides",
+        "Splash zones for kids",
+        "Lazy river",
+        "Family-friendly attractions"
+      ],
+      "note": "Included with day pass. Life jackets provided. Height restrictions apply for some slides."
+    },
+    {
+      "name": "Cultural Junkanoo Performance",
+      "type": "cultural",
+      "duration": "30-45 minutes",
+      "highlights": [
+        "Live Junkanoo music and dance",
+        "Colorful Bahamian costumes",
+        "Interactive cultural experience",
+        "Photo opportunities"
+      ],
+      "note": "Scheduled performances throughout the day. Check daily schedule upon arrival."
+    }
+  ]
+}

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -7,8 +7,8 @@ Soli Deo Gloria
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="ai-summary" content="First-person logbook guide to Nassau with tips for Atlantis Aquaventure, Cabbage Beach, the Straw Market, and authentic Bahamian conch."/>
-  <meta name="last-reviewed" content="2025-12-16"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="last-reviewed" content="2025-12-26"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Nassau Port Guide — Atlantis & Paradise Island | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Nassau — Atlantis Aquaventure, Cabbage Beach, Queen's Staircase, the Straw Market, and the best cracked conch in the Bahamas."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/nassau.html"/>
@@ -33,6 +33,61 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Nassau", "item": "https://cruisinginthewake.com/ports/nassau.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Nassau Port Guide",
+    "url": "https://cruisinginthewake.com/ports/nassau.html",
+    "description": "First-person logbook guide to Nassau with tips for Atlantis Aquaventure, Cabbage Beach, the Straw Market, and authentic Bahamian conch.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Nassau",
+      "description": "Capital of the Bahamas and popular cruise port with Atlantis, Paradise Island, pristine beaches, and rich maritime history"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is Nassau safe to walk around?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes – stay in the main tourist areas (Bay Street, Paradise Island bridge) during daylight and it's totally fine."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can I do Atlantis without staying there?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Absolutely – buy the Aquaventure day pass online the night before to skip lines."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which beach is better, Junkanoo or Cabbage Beach?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Junkanoo is free and closer (15 min walk). Cabbage Beach is prettier and more resort-style but requires water taxi."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Do I need to book excursions in advance?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "For Atlantis day passes and swimming with pigs, yes. Beach days and downtown walking are fine to do independently."
+        }
+      }
     ]
   }
   </script>
@@ -341,6 +396,8 @@ Soli Deo Gloria
         <p><strong>Junkanoo Beach:</strong> Just a 15-minute walk from the cruise terminal (about the time it takes to apply sunscreen properly, or roughly the length of three Jimmy Buffett songs), Junkanoo Beach is the people's beach – free, convenient, and wonderfully local. You'll share the sand with Bahamian families on weekends, which somehow makes it more authentic than the resort beaches. The water is that impossible turquoise that looks Photoshopped but isn't, and you can see your ship from the beach (always reassuring for nervous first-time cruisers).</p>
 
         <p><strong>Cabbage Beach on Paradise Island:</strong> About 20 minutes from port (roughly the time it takes to finish a frozen piña colada, or about 1,200 seconds of anticipation) — water taxi plus a walk through Atlantis or around it — Cabbage Beach delivers that postcard-perfect Caribbean experience with powdery white sand and water in about seventeen shades of blue. Fair warning: the surf can get surprisingly rough here depending on conditions, so check the flags and don't let small children wander too deep. The tradeoff for those occasional rough waters? Some of the most stunning beach views in the entire Bahamas.</p>
+
+        <p><strong><a href="/ports/royal-beach-club-nassau.html">Royal Beach Club Paradise Island</a>:</strong> Royal Caribbean's newest destination opened in 2025 — a private beach club investment that transformed 13 acres of Paradise Island coastline into an all-inclusive beach experience. Day passes ($129+ for adults, roughly the price of three frozen cocktails at Atlantis, or approximately 129 US dollars that include all-day dining, waterpark access, and shuttle from the cruise port) include the Thrill Waterpark, Oasis Lagoon pool complex, Barefoot Beach restaurant, and pristine white-sand beach access. The overwater cabanas are next-level luxury if you want to splurge (premium upgrade $300+). Shuttle from Prince George Wharf included for all guests — Royal invested heavily in this, and it shows. Limited capacity means advance booking is essential, but reviewers consistently rate it as the best beach club experience in Nassau.</p>
       </section>
 
       <section class="port-section">


### PR DESCRIPTION
…BC integration

**ITC Standard v1.1 Updates:**
- Add Section II-A: POI Manifest System (BLOCKING)
- Require minimum 10 POI per port in /assets/data/maps/[slug].map.json
- Specify POI manifest file structure with examples
- Define PortMap.init() pattern for map initialization
- Add window.currentPortId requirement
- Include POI selection guidelines and validation rules
- Update versioning to v1.1 with detailed changelog

**POI Manifests:**
- Create royal-beach-club-nassau.map.json with 14 POI
  * Beach club facilities (main entrance, waterpark, pools, cabanas)
  * Dining and entertainment venues
  * Nearby attractions (Atlantis, Cabbage Beach)
  * Transit routes with shuttle and taxi details
  * Featured experiences with pricing and booking notes

- Update nassau.map.json from 8 to 11 POI (meets 10+ minimum)
  * Add royal-beach-club-paradise-island POI
  * Add fort-fincastle POI
  * Add fort-charlotte POI
  * Add label overrides for new POI with context
  * Add Royal Beach Club featured experience

**Nassau Port Page:**
- Upgrade to ICP-Lite v1.4 protocol
- Add WebPage JSON-LD with mainEntity (Place schema)
- Add FAQPage JSON-LD with 4 questions
- Update last-reviewed date to 2025-12-26
- Add Royal Beach Club mention in Beach Guide section
- Include opening year (2025), Royal Caribbean investment context
- Provide pricing ($129+ day passes, $300+ cabana upgrades)
- Cross-link to /ports/royal-beach-club-nassau.html
- Maintain whimsical units style consistent with site voice

Addresses user feedback about missing POI for Royal Beach Club and Nassau. Resolves ICP-Lite v1.4 validation errors.