### PR TITLE
Batch 2: Upgrade 5 ports to ITC v1.1 (ICP-Lite v1.4 + author disclaim…

### DIFF
--- a/ports/barcelona.html
+++ b/ports/barcelona.html
@@ -11,14 +11,14 @@ All work on this project is offered as a gift to God.
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="referrer" content="no-referrer-when-downgrade"/>
 
-  <!-- ICP-Lite v1.0 -->
-  <meta name="ai-summary" content="First-person logbook guide to Barcelona with tips for visiting Gaudí's Sagrada Familia, Park Güell, Gothic Quarter's Roman ruins, La Rambla, La Boqueria market, and experiencing 2,000 years of Catalan history and culture."/>
-  <meta name="last-reviewed" content="2025-12-14"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <!-- ICP-Lite v1.4 -->
+  <meta name="ai-summary" content="Barcelona features La Sagrada Familia, Park Güell, Gothic Quarter with Roman ruins, La Rambla, and La Boqueria market. Experience Gaudí and Catalan culture."/>
+  <meta name="last-reviewed" content="2025-12-26"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- SEO -->
   <title>Barcelona Port Guide — Gaudí & Gothic Quarter | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Barcelona — Gaudí's Sagrada Familia, Park Güell, Gothic Quarter with Roman ruins, La Rambla, and La Boqueria market. Essential cruise port tips from a 2,000-year-old city."/>
+  <meta name="description" content="Barcelona features La Sagrada Familia, Park Güell, Gothic Quarter with Roman ruins, La Rambla, and La Boqueria market. Experience Gaudí and Catalan culture."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/barcelona.html"/>
 
   <!-- OpenGraph -->
@@ -66,7 +66,13 @@ All work on this project is offered as a gift to God.
     "@type": "WebPage",
     "name": "Barcelona Port Guide",
     "url": "https://cruisinginthewake.com/ports/barcelona.html",
-    "description": "First-person logbook guide to Barcelona with tips for visiting Gaudí's Sagrada Familia, Park Güell, Gothic Quarter's Roman ruins, La Rambla, La Boqueria market, and exploring 2,000 years of Catalan culture."
+    "description": "Barcelona features La Sagrada Familia, Park Güell, Gothic Quarter with Roman ruins, La Rambla, and La Boqueria market. Experience Gaudí and Catalan culture.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Barcelona",
+      "description": "Mediterranean cruise destination known for Gaudí's Sagrada Familia, Park Güell, Gothic Quarter, and Catalan culture"
+    }
   }
   </script>
 
@@ -480,6 +486,14 @@ All work on this project is offered as a gift to God.
         <strong>Quick Answer:</strong> Barcelona is a major embarkation port and port of call. La Sagrada Familia and Park Güell are must-sees (book tickets in advance). La Rambla, Gothic Quarter, and La Boqueria market are walkable from port. Ships dock at terminals near the bottom of La Rambla.
       </p>
     </section>
+
+    <!-- Author's Note -->
+    <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;">
+      <h3>Author's Note</h3>
+      <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+        Until I have sailed this port myself, these notes are soundings in another's wake; carefully curated and edited to meet our standards. We believe they are helpful for planning, and marked for revision once I've logged my own steps ashore.
+      </p>
+    </aside>
 
         <section class="card author-card-vertical" aria-labelledby="author-heading">
       <h3 id="author-heading">About the Author</h3>

--- a/ports/cabo-san-lucas.html
+++ b/ports/cabo-san-lucas.html
@@ -6,11 +6,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Cabo San Lucas, Mexico — Land's End rock formations, Medano Beach, whale watching, and where the Sea of Cortez meets the Pacific."/>
-  <meta name="last-reviewed" content="2025-12-17"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="ai-summary" content="Cabo San Lucas features Land's End arch, Medano Beach, whale watching, and where Sea of Cortez meets Pacific. Tender port with dramatic scenery."/>
+  <meta name="last-reviewed" content="2025-12-26"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Cabo San Lucas Port Guide — Land's End & Medano Beach | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Cabo San Lucas — Land's End arch, Medano Beach, whale watching, and the dramatic meeting of Sea of Cortez and Pacific Ocean."/>
+  <meta name="description" content="Cabo San Lucas features Land's End arch, Medano Beach, whale watching, and where Sea of Cortez meets Pacific. Tender port with dramatic scenery."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/cabo-san-lucas.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <script>
@@ -29,6 +29,23 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Cabo San Lucas", "item": "https://cruisinginthewake.com/ports/cabo-san-lucas.html"}
     ]
+  }
+  </script>
+
+  <!-- JSON-LD: WebPage -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Cabo San Lucas Port Guide",
+    "url": "https://cruisinginthewake.com/ports/cabo-san-lucas.html",
+    "description": "Cabo San Lucas features Land's End arch, Medano Beach, whale watching, and where Sea of Cortez meets Pacific. Tender port with dramatic scenery.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Cabo San Lucas",
+      "description": "Tender port where the Pacific Ocean meets the Sea of Cortez, featuring Land's End arch and world-class whale watching"
+    }
   }
   </script>
 </head>
@@ -169,6 +186,15 @@ Soli Deo Gloria
         <h2>Quick Answer</h2>
         <p><strong>Cabo San Lucas</strong> is where desert meets sea at Land's End – the famous 30-million-year-old arch marking where the Pacific collides with the Sea of Cortez, one of Earth's most biologically diverse bodies of water. Tender to the marina, water taxi to Lover's Beach, hang out at Medano, and watch for whales (December-April). It's dramatic, fun, and thoroughly Mexican Riviera.</p>
       </section>
+
+      <!-- Author's Note -->
+      <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;">
+        <h3>Author's Note</h3>
+        <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+          Until I have sailed this port myself, these notes are soundings in another's wake; carefully curated and edited to meet our standards. We believe they are helpful for planning, and marked for revision once I've logged my own steps ashore.
+        </p>
+      </aside>
+
       <section class="card best-for">
         <h2>Best For</h2>
         <ul>

--- a/ports/jamaica.html
+++ b/ports/jamaica.html
@@ -29,9 +29,9 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="referrer" content="no-referrer-when-downgrade"/>
-  <meta name="ai-summary" content="First-person logbook guide to Jamaica with tips for Dunn's River Falls, Blue Hole, and Scotchies jerk chicken. Falmouth, founded 1769 by Thomas Reid and named after Falmouth, Cornwall, was the first city in the Western Hemisphere with piped water (1799) and hosts Jamaica's largest collection of Georgian architecture. Modern cruise port opened 2011 for Royal Caribbean's Oasis-class ships.">
-  <meta name="last-reviewed" content="2025-12-18">
-  <meta name="content-protocol" content="ICP-Lite v1.0">
+  <meta name="ai-summary" content="Jamaica features Dunn's River Falls climbing, Blue Hole cliff jumping, and Scotchies jerk chicken. Falmouth cruise port with waterfalls and reggae vibes.">
+  <meta name="last-reviewed" content="2025-12-26">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
 
   <!-- SEO: Robots & Crawling -->
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"/>
@@ -46,7 +46,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <!-- Title & SEO -->
   <title>Jamaica (Falmouth) Port Guide — Dunn's River Falls & Blue Hole | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/jamaica.html"/>
-  <meta name="description" content="First-person logbook guide to Jamaica — Dunn's River Falls climbing, Blue Hole cliff jumping, Scotchies jerk chicken, and reggae vibes in Falmouth and Ocho Rios."/>
+  <meta name="description" content="Jamaica features Dunn's River Falls climbing, Blue Hole cliff jumping, and Scotchies jerk chicken. Falmouth cruise port with waterfalls and reggae vibes."/>
 
   <!-- OpenGraph -->
   <meta property="og:type" content="article"/>
@@ -99,7 +99,13 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     "@type": "WebPage",
     "name": "Jamaica (Falmouth) Port Guide",
     "url": "https://cruisinginthewake.com/ports/jamaica.html",
-    "description": "First-person logbook guide to Jamaica — Dunn's River Falls, Blue Hole, and Scotchies jerk chicken."
+    "description": "Jamaica features Dunn's River Falls climbing, Blue Hole cliff jumping, and Scotchies jerk chicken. Falmouth cruise port with waterfalls and reggae vibes.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Jamaica (Falmouth)",
+      "description": "Caribbean cruise port featuring Dunn's River Falls, Blue Hole, and authentic Jamaican jerk chicken"
+    }
   }
   </script>
 
@@ -123,6 +129,22 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Scotchies has locations in both Montego Bay and Ocho Rios — it's the gold standard. The jerk is slow-smoked over pimento wood with authentic spices. Don't skip the festival (fried dumplings)."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is a private driver worth it in Jamaica?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Absolutely. For groups of 4-6, private drivers cost around $150-180 total for the day, split among everyone. You get flexibility, local insights, and can combine multiple stops like Dunn's River Falls, Blue Hole, and Scotchies."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How far is Dunn's River Falls from Falmouth cruise port?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "About 1 hour by taxi or private driver to Ocho Rios area. The drive takes you along Jamaica's scenic north coast. Book early excursions or private drivers to maximize your time at the falls."
         }
       }
     ]
@@ -502,6 +524,14 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <p class="answer-line">
           <strong>Quick Answer:</strong> Jamaica is all about Dunn's River Falls climbing, Blue Hole cliff jumping, and the best jerk chicken you'll ever eat at Scotchies. Hire a private driver for the day (surprisingly affordable for groups) for maximum flexibility and authentic local insights.</p>
       </section>
+
+    <!-- Author's Note -->
+    <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;">
+      <h3>Author's Note</h3>
+      <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+        Until I have sailed this port myself, these notes are soundings in another's wake; carefully curated and edited to meet our standards. We believe they are helpful for planning, and marked for revision once I've logged my own steps ashore.
+      </p>
+    </aside>
 
     <!-- Author Card (collapsible) -->
     <section class="card author-card-vertical" aria-labelledby="author-heading">

--- a/ports/ketchikan.html
+++ b/ports/ketchikan.html
@@ -14,11 +14,11 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Ketchikan with tips for totem poles, Creek Street, and Misty Fjords."/>
-  <meta name="last-reviewed" content="2025-12-12"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="ai-summary" content="Ketchikan features totem poles, Creek Street, and Misty Fjords. Alaska's Salmon Capital with world-class flightseeing."/>
+  <meta name="last-reviewed" content="2025-12-26"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Ketchikan Port Guide — Totem Poles & Misty Fjords | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Ketchikan, Alaska — one of the world's largest totem pole collections, historic Creek Street, Misty Fjords flightseeing, and the Salmon Capital of the World."/>
+  <meta name="description" content="Ketchikan features totem poles, Creek Street, and Misty Fjords. Alaska's Salmon Capital with world-class flightseeing."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/ketchikan.html"/>
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->
@@ -41,6 +41,61 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Ketchikan", "item": "https://cruisinginthewake.com/ports/ketchikan.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Ketchikan Port Guide",
+    "url": "https://cruisinginthewake.com/ports/ketchikan.html",
+    "description": "Ketchikan features totem poles, Creek Street, and Misty Fjords. Alaska's Salmon Capital with world-class flightseeing.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Ketchikan",
+      "description": "Alaska's Salmon Capital known for totem poles, Creek Street historic boardwalk, and Misty Fjords flightseeing"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is Ketchikan worth visiting on an Alaska cruise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Absolutely. Ketchikan offers the world's largest collection of standing totem poles, historic Creek Street, and access to Misty Fjords—one of Alaska's most dramatic landscapes. It's the most accessible Alaska port for experiencing authentic Native culture and rainforest scenery."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the best excursion in Ketchikan?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Misty Fjords flightseeing is the bucket-list experience. The floatplane tour over glacial valleys, waterfalls, and fjords is unforgettable. For a more budget-friendly option, the Saxman Village totem park and cultural center offers excellent value."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can you walk to town from the Ketchikan cruise port?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes! Downtown Ketchikan and Creek Street are an easy 5-10 minute walk from most cruise berths. The compact waterfront makes it one of Alaska's most walkable ports."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does it always rain in Ketchikan?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ketchikan averages 150+ inches of rain annually and earned its nickname 'Rain Capital of Alaska.' Pack waterproof layers regardless of forecast. That said, rain creates the lush temperate rainforest scenery that makes Ketchikan magical."
+        }
+      }
     ]
   }
   </script>
@@ -301,6 +356,14 @@ Soli Deo Gloria
         <strong>Quick Answer:</strong> Ketchikan drips with rain, character, and color — Creek Street's crooked boardwalks, world-class totem poles, lumberjack shows, and Misty Fjords flightseeing that makes you believe in God.
       </p>
     </section>
+
+    <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;">
+      <h3>Author's Note</h3>
+      <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+        Until I have sailed this port myself, these notes are soundings in another's wake; carefully curated and edited to meet our standards. We believe they are helpful for planning, and marked for revision once I've logged my own steps ashore.
+      </p>
+    </aside>
+
         <section class="card author-card-vertical" aria-labelledby="author-heading">
       <h3 id="author-heading">About the Author</h3>
       <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">

--- a/ports/royal-beach-club-nassau.html
+++ b/ports/royal-beach-club-nassau.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
                width="1200"
                height="600"/>
           <div class="port-hero-overlay">
-            <h1 class="port-hero-title">Royal Beach Club Paradise Island</h1>
+            <h1 class="port-hero-title">Royal Beach Club:<br>Paradise Island</h1>
           </div>
         </div>
         <p class="port-hero-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>

--- a/ports/sydney.html
+++ b/ports/sydney.html
@@ -10,13 +10,13 @@ All work on this project is offered as a gift to God.
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- ICP-Lite v1.0 Meta Tags -->
-  <meta name="ai-summary" content="First-person guide to Sydney cruise port: Opera House's UNESCO heritage at Bennelong Point, The Coathanger bridge, The Rocks historic village, and the Eora Nation's 30,000-year legacy in Australia's highest-rated port." />
-  <meta name="last-reviewed" content="2025-12-15" />
-  <meta name="content-protocol" content="ICP-Lite v1.0" />
+  <!-- ICP-Lite v1.4 Meta Tags -->
+  <meta name="ai-summary" content="Sydney features Opera House, Harbour Bridge, Bondi Beach, and spectacular harbour entrance. Australia's highest-rated cruise port with world-class attractions." />
+  <meta name="last-reviewed" content="2025-12-26" />
+  <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Sydney Cruise Port Guide – In the Wake</title>
-  <meta name="description" content="First-person guide to Sydney cruise port: Opera House's UNESCO heritage at Bennelong Point, The Coathanger bridge, The Rocks historic village, and the Eora Nation's 30,000-year legacy in Australia's highest-rated port." />
+  <meta name="description" content="Sydney features Opera House, Harbour Bridge, Bondi Beach, and spectacular harbour entrance. Australia's highest-rated cruise port with world-class attractions." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->
   <script>
@@ -40,6 +40,65 @@ All work on this project is offered as a gift to God.
       { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://inthewake.io/" },
       { "@type": "ListItem", "position": 2, "name": "Ports", "item": "https://inthewake.io/ports.html" },
       { "@type": "ListItem", "position": 3, "name": "Sydney" }
+    ]
+  }
+  </script>
+
+  <!-- JSON-LD: WebPage -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Sydney Cruise Port Guide",
+    "url": "https://cruisinginthewake.com/ports/sydney.html",
+    "description": "Sydney features Opera House, Harbour Bridge, Bondi Beach, and spectacular harbour entrance. Australia's highest-rated cruise port with world-class attractions.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Sydney",
+      "description": "Australia's premier cruise port featuring Sydney Opera House, Harbour Bridge, and iconic harbour entrance"
+    }
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Should I book the Opera House tour in advance?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, definitely book ahead – tours fill up quickly on cruise ship days. The guided tour is worth it to see backstage and learn the incredible construction story."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is the Harbour Bridge climb worth it?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "If you're not afraid of heights and have the budget ($150–300+), it's unforgettable. The views are spectacular and you get a great photo at the top."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do I get to Bondi Beach from the cruise terminal?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "From Circular Quay, take a bus (30–40 minutes) or taxi/Uber ($30–40). The Bondi to Bronte coastal walk is free and absolutely stunning."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What's the best way to see Sydney Harbour?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The Manly Ferry from Circular Quay offers stunning harbour views and is an experience itself. The 30-minute crossing passes under the Bridge and by the Opera House."
+        }
+      }
     ]
   }
   </script>
@@ -280,6 +339,14 @@ All work on this project is offered as a gift to God.
     
   
   <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">
+    <!-- Author's Note -->
+    <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;">
+      <h3>Author's Note</h3>
+      <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+        Until I have sailed this port myself, these notes are soundings in another's wake; carefully curated and edited to meet our standards. We believe they are helpful for planning, and marked for revision once I've logged my own steps ashore.
+      </p>
+    </aside>
+
     <section class="card author-card-vertical" aria-labelledby="author-heading">
       <h3 id="author-heading">About the Author</h3>
       <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">


### PR DESCRIPTION
…ers)

Upgraded Ketchikan, Barcelona, Cabo San Lucas, Sydney, and Jamaica to full ITC v1.1 compliance:

Metadata upgrades (all 5 ports):
- ICP-Lite v1.0 → v1.4
- Trimmed ai-summary to ≤155 chars (dual-cap rule)
- Updated last-reviewed to 2025-12-26
- Synced description meta tags with ai-summary

JSON-LD enhancements (all 5 ports):
- Added WebPage mainEntity with Place type
- Added/updated dateModified to 2025-12-26
- Ensured FAQPage has 4+ questions (Jamaica: 2→4, Sydney: 3→4)

Author experience disclaimers (all 5 ports):
- Added Level 1 "Author's Note" disclaimer cards
- Positioned between Quick Answer/At a Glance and About the Author
- Used standard styling: #fffbf0 background, #d4a574 border

Also fixed:
- Royal Beach Club hero title: split to two lines ("Royal Beach Club:<br>Paradise Island")

POI manifests already compliant (≥10 POI):
- Barcelona: 10 POI
- Cabo San Lucas: 10 POI
- Jamaica: 10 POI
- Sydney: 12 POI
- Ketchikan: uses existing manifest

All ports now meet ITC v1.1 standard requirements.