### PR TITLE
Upgrade bergen, bilbao, boston, bangkok, buenos-aires to ITC v1.1

### DIFF
--- a/ports/bangkok.html
+++ b/ports/bangkok.html
@@ -12,8 +12,8 @@ All work on this project is offered as a gift to God.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- ICP-Lite v1.0 Meta Tags -->
   <meta name="ai-summary" content="First-person guide to Bangkok cruise port via Laem Chabang: Grand Palace's 1782 royal heritage, Wat Phra Kaew's Emerald Buddha, Wat Arun's porcelain tower, Wat Pho's Reclining Buddha, Chinatown street food, and rooftop bars." />
-  <meta name="last-reviewed" content="2025-12-15" />
-  <meta name="content-protocol" content="ICP-Lite v1.0" />
+  <meta name="last-reviewed" content="2025-12-26" />
+  <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Bangkok / Laem Chabang Cruise Port Guide – In the Wake</title>
   <meta name="description" content="First-person Bangkok cruise guide: Grand Palace's royal history, Temple of the Emerald Buddha, Wat Arun's porcelain-encrusted tower, Wat Pho's golden Reclining Buddha, street food crawls, and sunset rooftop bars." />
@@ -40,6 +40,64 @@ All work on this project is offered as a gift to God.
       { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://inthewake.io/" },
       { "@type": "ListItem", "position": 2, "name": "Ports", "item": "https://inthewake.io/ports.html" },
       { "@type": "ListItem", "position": 3, "name": "Bangkok / Laem Chabang" }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Bangkok / Laem Chabang Cruise Port Guide",
+    "description": "First-person guide to Bangkok cruise port via Laem Chabang: Grand Palace's 1782 royal heritage, Wat Phra Kaew's Emerald Buddha, Wat Arun's porcelain tower, Wat Pho's Reclining Buddha, Chinatown street food, and rooftop bars.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Bangkok",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 13.7563,
+        "longitude": 100.5018
+      }
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Should I book a private van or use the ship shuttle from Laem Chabang?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Private vans are much faster and more flexible — book through Klook or your hotel. Ship shuttles are cheaper but slower and limit your time in Bangkok. The port is 120 kilometers from Bangkok (2-hour drive), so maximizing time matters."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What should I wear to the Grand Palace in Bangkok?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Strict dress code: cover shoulders and knees — no tank tops, shorts, or short skirts. Guards will turn you away. They sell cover-ups at the entrance but it's easier to dress appropriately from the start."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is Bangkok street food safe to eat?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes — look for busy stalls with high turnover, which means the food is fresh. Chinatown's Yaowarat Road is legendary. Start with pad thai, mango sticky rice, and boat noodles. The heat and spice are intense but authentic."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How long does it take to get from Laem Chabang port to Bangkok?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "About 2 hours by car when traffic cooperates, though Bangkok's notorious congestion can stretch that considerably. The port is 120 kilometers (75 miles) southeast of Bangkok. Most cruisers book ship excursions or private vans rather than attempting public transport."
+        }
+      }
     ]
   }
   </script>
@@ -250,6 +308,14 @@ All work on this project is offered as a gift to God.
       </ul>
       <p><em>Images sourced from WikiMedia Commons under Creative Commons licenses.</em></p>
     </section>
+
+    <!-- Author's Note -->
+    <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;margin-top:2rem;">
+      <h3>Author's Note</h3>
+      <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+        Until I have sailed this port myself, these notes are soundings in another's wake — a chart drawn from research, fellow travelers' accounts, and nautical publications. I've tried to be accurate and honest, but second-hand knowledge has limits. When I finally dock here and walk these shores, I'll update this guide with my own bearings. Trust it as a starting point, but verify details with your cruise line and local sources before you go ashore.
+      </p>
+    </aside>
 
     <!-- Interactive Port Map -->
     <section class="port-section">

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -7,8 +7,8 @@ Soli Deo Gloria
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="ai-summary" content="First-person logbook guide to Bergen (founded 1070) with UNESCO-listed Bryggen wharf, Hanseatic heritage from ~1350, Fløibanen funicular (1901), and gateway to Norwegian fjords."/>
-  <meta name="last-reviewed" content="2025-12-17"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="last-reviewed" content="2025-12-26"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Bergen Port Guide — Hanseatic Wharf & Gateway to Fjords | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Bergen, Norway — UNESCO World Heritage Bryggen wharf, Hanseatic League history from 1350, colorful wooden buildings, Mount Fløyen funicular, and gateway to the Norwegian fjords."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/bergen.html"/>
@@ -34,6 +34,64 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Bergen", "item": "https://cruisinginthewake.com/ports/bergen.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Bergen Port Guide",
+    "description": "First-person logbook guide to Bergen (founded 1070) with UNESCO-listed Bryggen wharf, Hanseatic heritage from ~1350, Fløibanen funicular (1901), and gateway to Norwegian fjords.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Bergen",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 60.3913,
+        "longitude": 5.3221
+      }
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is Bergen worth it?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Bergen is the prettiest city in Norway, full stop. The combination of UNESCO-listed Bryggen wharf, the Fløibanen funicular offering panoramic views of fjords and mountains, and the authentic maritime heritage makes Bergen one of the most rewarding cruise ports in Scandinavia."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the best thing to do in Bergen?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The Fløibanen funicular combined with wandering through Bryggen's medieval wooden buildings. The funicular takes you 320 meters up Mount Fløyen for spectacular views over the city, harbor, and surrounding fjords. Then explore Bryggen's narrow passages and colorful gabled houses dating back to Hanseatic League days."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How long should I spend on Mount Fløyen?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Plan for 2-3 hours including the funicular ride and time at the summit. The funicular itself takes 6 minutes each way. At the top, you can enjoy the viewpoint, have coffee at the café, or take a short hike on well-marked trails through the forest."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can you walk from the cruise port to Bergen attractions?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes! The cruise terminal is only a 5-minute walk from the fish market and Bryggen wharf. Bergen is exceptionally walkable for cruise passengers - everything is compact and accessible on foot or via the funicular."
+        }
+      }
     ]
   }
   </script>
@@ -305,6 +363,14 @@ Soli Deo Gloria
       </ul>
       <p><em>Images sourced from WikiMedia Commons under Creative Commons licenses.</em></p>
     </section>
+
+    <!-- Author's Note -->
+    <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;margin-top:2rem;">
+      <h3>Author's Note</h3>
+      <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+        Until I have sailed this port myself, these notes are soundings in another's wake — a chart drawn from research, fellow travelers' accounts, and nautical publications. I've tried to be accurate and honest, but second-hand knowledge has limits. When I finally dock here and walk these shores, I'll update this guide with my own bearings. Trust it as a starting point, but verify details with your cruise line and local sources before you go ashore.
+      </p>
+    </aside>
 </article>
   </div>
   <aside class="rail" style="grid-column: 2; grid-row: 1; align-self: start;">

--- a/ports/bilbao.html
+++ b/ports/bilbao.html
@@ -6,9 +6,9 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook exploring Bilbao's transformation through the Guggenheim Effect — Frank Gehry's titanium masterpiece, Casco Viejo's medieval charm, Basque pintxos culture, and the artistic renaissance that turned industrial decay into Europe's boldest cultural destination."/>
-  <meta name="last-reviewed" content="2025-12-17"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="ai-summary" content="Bilbao's Guggenheim Effect — Frank Gehry's titanium masterpiece (1997), Casco Viejo medieval charm, Basque pintxos culture, artistic renaissance turning industrial decay into Europe's boldest cultural destination."/>
+  <meta name="last-reviewed" content="2025-12-26"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Bilbao Port Guide — Guggenheim Effect & Basque Pintxos | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Bilbao's renaissance — Frank Gehry's Guggenheim opened 1997, Koons' Puppy, Serra's steel spirals, medieval Casco Viejo, and the Bilbao Effect that transformed a city."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/bilbao.html"/>
@@ -34,6 +34,64 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Bilbao", "item": "https://cruisinginthewake.com/ports/bilbao.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Bilbao Port Guide",
+    "description": "Bilbao's Guggenheim Effect — Frank Gehry's titanium masterpiece (1997), Casco Viejo medieval charm, Basque pintxos culture, artistic renaissance turning industrial decay into Europe's boldest cultural destination.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Bilbao",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 43.2627,
+        "longitude": -2.9253
+      }
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is Bilbao really worth visiting on a cruise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Absolutely. This is the single best example of urban transformation in modern Europe — a city that bet everything on culture and won. Even if you're not typically an 'art museum person,' the Guggenheim is worth experiencing simply as architecture, and the combination of cutting-edge design with medieval Basque culture is genuinely unique. You won't find this anywhere else."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What's the one thing I absolutely shouldn't miss in Bilbao?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The Guggenheim itself, experienced from outside and in. Walk completely around the building first — it's a different sculpture from every angle. Then venture inside to Serra's 'The Matter of Time.' Those massive steel spirals aren't just art you look at; they're art you walk through, and the experience is physically disorienting in the most wonderful way."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How long should I budget for the Guggenheim?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Three to four hours minimum if you want to do it justice. That includes time to photograph Puppy (Koons' 12-meter topiary dog), circumnavigate the building's exterior, explore the permanent collection, and sit with whatever temporary exhibitions are showing. If you're an art lover, you could easily spend an entire day. If you're museum-averse, even ninety minutes will give you the highlights and a sense of why this building changed everything."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can I walk from the cruise port to Bilbao city center?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Not practically — the port at Getxo is fifteen kilometers from the city center. But the tram system is excellent, affordable, and scenic. You'll ride alongside the river watching the landscape shift from industrial port to contemporary art district. Think of the tram as part of the experience, not an inconvenience."
+        }
+      }
     ]
   }
   </script>
@@ -267,6 +325,14 @@ Soli Deo Gloria
       </ul>
       <p><em>Images sourced from WikiMedia Commons under Creative Commons licenses.</em></p>
     </section>
+
+    <!-- Author's Note -->
+    <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;margin-top:2rem;">
+      <h3>Author's Note</h3>
+      <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+        Until I have sailed this port myself, these notes are soundings in another's wake — a chart drawn from research, fellow travelers' accounts, and nautical publications. I've tried to be accurate and honest, but second-hand knowledge has limits. When I finally dock here and walk these shores, I'll update this guide with my own bearings. Trust it as a starting point, but verify details with your cruise line and local sources before you go ashore.
+      </p>
+    </aside>
 
   </article>
   </div>

--- a/ports/boston.html
+++ b/ports/boston.html
@@ -7,8 +7,8 @@ Soli Deo Gloria
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="ai-summary" content="First-person logbook guide to Boston with tips for Freedom Trail, Fenway Park, and North End cannoli."/>
-  <meta name="last-reviewed" content="2025-12-17"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="last-reviewed" content="2025-12-26"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Boston Port Guide — Freedom Trail & Fenway | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Boston — Freedom Trail history, Fenway Park, North End Italian food, Mike's Pastry cannoli, and Revolutionary War sites."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/boston.html"/>
@@ -34,6 +34,64 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Boston", "item": "https://cruisinginthewake.com/ports/boston.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Boston Port Guide",
+    "description": "First-person logbook guide to Boston with tips for Freedom Trail, Fenway Park, and North End cannoli.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Boston",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 42.3601,
+        "longitude": -71.0589
+      }
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is Boston worth it for a short port call?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Absolutely. Even with just six hours, the Freedom Trail gives you a concentrated dose of American history, and downtown is close enough to maximize time ashore. You won't see everything, but you'll see enough to understand why people love this city."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What's the single best thing to do in Boston?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Walk the Freedom Trail. It's free, it's iconic, and it connects more 'I learned about this in school' moments than any other experience in Boston. If you can only do one thing, make it that. The 2.5-mile red-brick path connects sixteen Revolutionary War sites from Boston Common to USS Constitution."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How long does the Freedom Trail take?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "If you just walk without stopping, maybe 90 minutes. If you actually tour the sites, read markers, and take photos, budget four to five hours. Most people land somewhere in between at three hours. The trail includes Paul Revere's House, Old North Church, USS Constitution, and burial sites for Samuel Adams and John Hancock."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can you walk from the cruise terminal to downtown Boston?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Technically yes — it's about two miles — but it's through an industrial port area with limited sidewalks and zero charm. Take the free shuttle, a taxi, or the Silver Line. Save your walking energy for the Freedom Trail and historic sites."
+        }
+      }
     ]
   }
   </script>
@@ -298,6 +356,14 @@ Soli Deo Gloria
       </ul>
       <p><em>Images sourced from WikiMedia Commons under Creative Commons licenses.</em></p>
     </section>
+
+    <!-- Author's Note -->
+    <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;margin-top:2rem;">
+      <h3>Author's Note</h3>
+      <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+        Until I have sailed this port myself, these notes are soundings in another's wake — a chart drawn from research, fellow travelers' accounts, and nautical publications. I've tried to be accurate and honest, but second-hand knowledge has limits. When I finally dock here and walk these shores, I'll update this guide with my own bearings. Trust it as a starting point, but verify details with your cruise line and local sources before you go ashore.
+      </p>
+    </aside>
 
   </article>
   </div>

--- a/ports/buenos-aires.html
+++ b/ports/buenos-aires.html
@@ -6,9 +6,9 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Buenos Aires cruise port with tips for La Boca's colorful streets, Teatro Colón opera house, tango shows, San Telmo markets, and experiencing Argentina's passionate capital."/>
-  <meta name="last-reviewed" content="2025-12-13"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="ai-summary" content="Buenos Aires cruise guide: La Boca's colorful streets, Teatro Colón opera house, tango shows in milongas, San Telmo Sunday markets, Recoleta Cemetery where Evita rests, and Argentina's passionate capital."/>
+  <meta name="last-reviewed" content="2025-12-26"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Buenos Aires Port Guide — Tango, Steak & the Paris of South America | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Buenos Aires — La Boca's colorful shipyard houses painted with leftover ship paint, Recoleta Cemetery where flowers always cover Evita's tomb, passionate tango born in immigrant milongas, and 13 million Porteños who made the Paris of South America distinctly Argentine."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/buenos-aires.html"/>
@@ -31,6 +31,24 @@ Soli Deo Gloria
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Buenos Aires Port Guide",
+    "description": "Buenos Aires cruise guide: La Boca's colorful streets, Teatro Colón opera house, tango shows in milongas, San Telmo Sunday markets, Recoleta Cemetery where Evita rests, and Argentina's passionate capital.",
+    "dateModified": "2025-12-26",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Buenos Aires",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": -34.6037,
+        "longitude": -58.3816
+      }
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
     "@type": "FAQPage",
     "mainEntity": [
       {
@@ -47,6 +65,22 @@ Soli Deo Gloria
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Absolutely. Buenos Aires is the birthplace of tango, and seeing a professional show is essential. Book in advance. Dinner shows in San Telmo or La Boca offer the full experience. For authenticity, visit a milonga (tango dance hall) where locals dance."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is Buenos Aires safe for cruise passengers?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Tourist areas are generally safe during daytime. Watch for pickpockets on crowded subways. Avoid La Boca outside the main tourist zone (Caminito). Use official taxis or Uber after dark. Puerto Madero, Recoleta, and San Telmo are well-policed and walkable."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What currency should I bring to Buenos Aires?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Bring US dollars in pristine condition (no tears or marks). Exchange at official exchange houses (casas de cambio) for better rates. ATMs work but have daily limits. Many restaurants and shops accept USD due to Argentina's currency instability."
         }
       }
     ]
@@ -232,6 +266,14 @@ Soli Deo Gloria
           <p><strong>Q: Can I do a same-day trip to Iguazu Falls?</strong><br/>A: No — Iguazu is 1,000+ km away (18+ hours by bus, 2 hours by flight). You'd need at least 2 days. Save it for a longer Argentina visit.</p>
           <p><strong>Q: What's the deal with blue dollar vs. official rate?</strong><br/>A: Argentina has parallel exchange rates due to currency controls. As a tourist, use ATMs or exchange houses. Avoid street money changers — it's illegal and risky.</p>
         </section>
+
+        <!-- Author's Note -->
+        <aside class="card" style="background:#fffbf0;border-left:4px solid #d4a574;margin-top:2rem;">
+          <h3>Author's Note</h3>
+          <p class="tiny" style="line-height:1.6;color:#5a4a3a;">
+            Until I have sailed this port myself, these notes are soundings in another's wake — a chart drawn from research, fellow travelers' accounts, and nautical publications. I've tried to be accurate and honest, but second-hand knowledge has limits. When I finally dock here and walk these shores, I'll update this guide with my own bearings. Trust it as a starting point, but verify details with your cruise line and local sources before you go ashore.
+          </p>
+        </aside>
 
         <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
       </article>


### PR DESCRIPTION
- Updated meta tags to ICP-Lite v1.4
- Shortened ai-summary for bilbao (278→215 chars) & buenos-aires (291→197 chars)
- Added WebPage JSON-LD with mainEntity Place & geo coordinates
- Added/expanded FAQPage JSON-LD (4+ questions each)
- Added Level 1 disclaimer to all ports
- Updated last-reviewed to 2025-12-26

All ports validated successfully (0 blocking errors).