### PR TITLE
Codify viewport, tracker, and Swiper fixes in validator and standards

### DIFF
--- a/admin/validate-ship-page.js
+++ b/admin/validate-ship-page.js
@@ -588,7 +588,24 @@ function validateJavaScript(html) {
     warnings.push({ section: 'javascript', rule: 'missing_dropdown', message: 'Missing dropdown.js', severity: 'WARNING' });
   }
 
-  return { valid: errors.length === 0, errors, warnings, data: { loadArticlesCount, hasDropdown } };
+  // Check Swiper configurations for rewind:false
+  const swiperInits = html.match(/new Swiper\([^)]+\{[^}]+\}/g) || [];
+  let swiperMissingRewind = 0;
+  swiperInits.forEach(init => {
+    if (!init.includes('rewind:false') && !init.includes('rewind: false')) {
+      swiperMissingRewind++;
+    }
+  });
+  if (swiperMissingRewind > 0) {
+    errors.push({
+      section: 'javascript',
+      rule: 'swiper_missing_rewind',
+      message: `${swiperMissingRewind} Swiper carousels missing rewind:false (causes infinite scroll bug)`,
+      severity: 'BLOCKING'
+    });
+  }
+
+  return { valid: errors.length === 0, errors, warnings, data: { loadArticlesCount, hasDropdown, swiperMissingRewind } };
 }
 
 /**

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -81,8 +81,11 @@ h3 { font-size: 1.25rem; line-height: 1.4; }
 .mb-1 { margin-bottom: 1rem; }
 
 /* Grid Column Helpers (600+ uses) */
-.col-1 { grid-column: 1; }
-.col-2 { grid-column: 2; }
+.col-1 { grid-column: 1; min-width: 0; max-width: 100%; }
+.col-2 { grid-column: 2; min-width: 0; max-width: 100%; }
+@media (max-width: 979.98px) {
+  .col-1, .col-2 { grid-column: 1; }
+}
 .col-full { grid-column: 1 / -1; }
 
 /* Multi-column list layout */

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -1030,25 +1030,25 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   })();
   </script>
 
-  <!-- ===== Live tracker (MarineTraffic iframe: auto-centers on ship by IMO) ===== -->
+  <!-- ===== Live tracker (VesselFinder iframe: auto-centers on ship by IMO) ===== -->
   <script>
   (function initLiveTracker(){
     const card=document.querySelector('.card.itinerary[data-imo]');
     if(!card) return;
     const imo=card.getAttribute('data-imo');
     const container=document.getElementById('vf-tracker-container');
-    if(!imo||!container) return;
+    if(!imo||!container||imo==='TBD') return;
 
     // Create wrapper div
     const wrapper = document.createElement('div');
     wrapper.style.cssText = 'width:100%;height:500px;position:relative;background:#f0f4f8;border-radius:8px;overflow:hidden;';
 
-    // MarineTraffic iframe embed using IMO
+    // VesselFinder iframe embed using IMO (more reliable than MarineTraffic)
     const iframe = document.createElement('iframe');
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.marinetraffic.com/en/ais/embed/zoom:10/maptype:0/shownames:true/mmsi:0/shipid:0/imo:' + imo + '/showmenu:false/remember:false';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/standards/SHIP_PAGE_STANDARD.md
+++ b/standards/SHIP_PAGE_STANDARD.md
@@ -432,9 +432,9 @@ Stories must cover diverse perspectives. Each ship should have **at least one st
 
 ## Ship Tracker Requirements
 
-### MarineTraffic Integration (REQUIRED)
+### VesselFinder Integration (REQUIRED)
 
-Each active ship page must have a working live tracker:
+Each active ship page must have a working live tracker using VesselFinder:
 
 ```html
 <section class="card itinerary" aria-labelledby="liveTrackHeading" data-imo="9195195" data-name="RADIANCE-OF-THE-SEAS">
@@ -444,10 +444,16 @@ Each active ship page must have a working live tracker:
 </section>
 ```
 
+**Tracker JavaScript (Required):**
+```javascript
+// VesselFinder embed (more reliable than MarineTraffic)
+iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+```
+
 **IMO Number Validation:**
 - Must be valid 7-digit IMO number
-- Must match ship (verify via MarineTraffic)
-- TBN ships use `data-imo="TBD"`
+- Must match ship (verify via VesselFinder)
+- TBN ships use `data-imo="TBD"` and skip tracker init
 
 **Known IMO Numbers (RCL):**
 
@@ -565,8 +571,24 @@ Must include all standard elements:
 | Video Loader | Video carousel | After content | Yes |
 | Stats Loader | Ship specs | After content | Yes |
 | Dining Loader | Venues | After content | Yes |
-| Tracker Init | MarineTraffic | After content | Yes |
+| Tracker Init | VesselFinder | After content | Yes |
 | Articles Loader | Recent Stories | After content | Yes |
+
+### Swiper Configuration (REQUIRED)
+
+All Swiper carousels must include `rewind:false` to prevent infinite scroll bug:
+
+```javascript
+new Swiper('.swiper.firstlook',{
+  loop:false,
+  rewind:false,  // REQUIRED - prevents infinite scroll
+  lazy:true,
+  watchOverflow:true,
+  pagination:{el:'.swiper.firstlook .swiper-pagination',clickable:true},
+  navigation:{nextEl:'.swiper.firstlook .swiper-button-next',prevEl:'.swiper.firstlook .swiper-button-prev'},
+  a11y:{enabled:true}
+});
+```
 
 ### Script Duplication Rules (BLOCKING)
 
@@ -621,6 +643,9 @@ Must include all standard elements:
 17. Fewer than 10 videos (8 required categories)
 18. Duplicate author names across ships
 19. Duplicate story content across ships
+20. **HTML Structure:** Mismatched section/div tags (causes layout overflow)
+21. **Viewport:** Missing viewport meta tag or cards with fixed widths >400px
+22. **Swiper:** Missing `rewind:false` in carousel configuration
 
 ### Warnings (Should Fix)
 
@@ -631,6 +656,8 @@ Must include all standard elements:
 5. Missing video category coverage
 6. Logbook stories under 300 words
 7. Missing accessibility persona in logbook
+8. Grid-2 sections without mobile-responsive CSS
+9. Large images without max-width constraints
 
 ---
 


### PR DESCRIPTION
Validator updates:
- Add Swiper rewind:false validation (BLOCKING error if missing)
- Swiper regex matches both "rewind:false" and "rewind: false"

CSS fixes (viewport overflow on iPhone Pro Max):
- Add min-width:0 and max-width:100% to .col-1 and .col-2
- Force grid-column:1 on mobile for both column helpers
- Prevents cards from extending beyond viewport

Ship tracker fix:
- Switch from MarineTraffic to VesselFinder (more reliable embed)
- VesselFinder URL: https://www.vesselfinder.com/aismap?imo={IMO}
- Skip tracker init for TBN ships (data-imo="TBD")

Standards documentation (SHIP_PAGE_STANDARD.md v2.0):
- Update tracker section: MarineTraffic → VesselFinder
- Add Swiper configuration section with rewind:false requirement
- Add blocking errors #20-22: HTML structure, viewport, Swiper
- Add warnings #8-9: grid responsive, image max-width