### PR TITLE
Capitalize 'In the Wake' as proper noun site-wide

### DIFF
--- a/index.html
+++ b/index.html
@@ -540,7 +540,7 @@
         </p>
 
         <p class="content-text">
-          <strong>Best For:</strong> Cruisers researching cruising in the wake, comparing options, and gathering information for trip planning.
+          <strong>Best For:</strong> Cruisers researching cruising In the Wake, comparing options, and gathering information for trip planning.
         </p>
 
         <div class="callout-box">

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -430,7 +430,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -360,7 +360,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -328,7 +328,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -353,7 +353,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -265,7 +265,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> A first-person account captured “in the wake,” edited to our venue standards for clarity. Sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> A first-person account captured “In the Wake,” edited to our venue standards for clarity. Sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/chops.html
+++ b/restaurants/chops.html
@@ -328,7 +328,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> This is a first-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> This is a first-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -274,7 +274,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Experiences vary by ship and sailing.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Experiences vary by ship and sailing.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -331,7 +331,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Experiences vary by ship and sailing.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Experiences vary by ship and sailing.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -383,7 +383,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -349,7 +349,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -425,7 +425,7 @@ All work on this project is offered as a gift to God.
     <img src="/assets/watermark.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
-      <p class="pill"><strong>Depth Sounding:</strong> First-person account captured “in the wake,” standardized to our venue template. Experiences vary by ship/sailing.</p>
+      <p class="pill"><strong>Depth Sounding:</strong> First-person account captured “In the Wake,” standardized to our venue template. Experiences vary by ship/sailing.</p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">
         <span class="badge" style="font-size:.85rem;border:1px solid #d9b382;border-radius:999px;padding:.15rem .55rem;background:#fff;">

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -438,7 +438,7 @@ All work on this project is offered as a gift to God.
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
-      <p class="pill"><strong>Depth Sounding:</strong> This is a first-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.</p>
+      <p class="pill"><strong>Depth Sounding:</strong> This is a first-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.</p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">
         <span class="badge" style="font-size:.85rem;border:1px solid #d9b382;border-radius:999px;padding:.15rem .55rem;background:#fff;">4 ★ out of 5</span>

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -386,7 +386,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <!-- Review meta header -->

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -343,7 +343,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/room-service.html
+++ b/restaurants/room-service.html
@@ -338,7 +338,7 @@ All work on this project is offered as a gift to God.
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
-      <p class="pill"><strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited for clarity. Experiences vary by ship and      itinerary.</p>
+      <p class="pill"><strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited for clarity. Experiences vary by ship and      itinerary.</p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">
         <span class="badge" style="font-size:.85rem;border:1px solid #d9b382;border-radius:999px;padding:.15rem .55rem;background:#fff;">

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> A first-person account captured “in the wake,” edited to our venue standards for clarity. Sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> A first-person account captured “In the Wake,” edited to our venue standards for clarity. Sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -257,7 +257,7 @@ All work on this project is offered as a gift to God.
   <div class="card__content prose">
     <h2>The Logbook — Real Guest Soundings</h2>
 
-    <p class="pill"><strong>Depth Sounding:</strong> First-person account captured “in the wake.” Experiences vary by ship and crew.</p>
+    <p class="pill"><strong>Depth Sounding:</strong> First-person account captured “In the Wake.” Experiences vary by ship and crew.</p>
 
     <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">
       <span class="badge" style="font-size:.85rem;border:1px solid #d9b382;border-radius:999px;padding:.15rem .55rem;background:#fff;">4.2 ★ out of 5</span>

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -398,7 +398,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -381,7 +381,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -328,7 +328,7 @@ All work on this project is offered as a gift to God.
       <h2>The Logbook — Real Guest Soundings</h2>
 
       <p class="pill">
-        <strong>Depth Sounding:</strong> First-person account captured “in the wake,” standardized to our venue template. Experiences vary by ship/sailing.
+        <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” standardized to our venue template. Experiences vary by ship/sailing.
       </p>
 
       <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -311,7 +311,7 @@ All work on this project is offered as a gift to God.
     <h2>The Logbook — Real Guest Soundings</h2>
 
     <p class="pill">
-      <strong>Depth Sounding:</strong> First-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+      <strong>Depth Sounding:</strong> First-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
     </p>
 
     <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -465,7 +465,7 @@ All work on this project is offered as a gift to God.
     <h2>The Logbook — Real Guest Soundings</h2>
 
     <p class="pill">
-      <strong>Depth Sounding:</strong> This is a first-person account captured “in the wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+      <strong>Depth Sounding:</strong> This is a first-person account captured “In the Wake,” edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
     </p>
 
     <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">


### PR DESCRIPTION
- Fix 22 restaurant pages: 'captured "in the wake,"' → 'captured "In the Wake,"'
- Fix index.html: 'cruising in the wake' → 'cruising In the Wake'
- Nautical phrases like 'in the wake of' correctly remain lowercase