### PR TITLE
Fix hero positioning in port pages and add validator checks

### DIFF
--- a/admin/validate-port-page.js
+++ b/admin/validate-port-page.js
@@ -257,6 +257,75 @@ function validateSectionOrder($) {
   const warnings = [];
   const detectedSections = [];
 
+  // Check hero box requirements - must be inside main content with image, port name overlay, and proper credits
+  const heroSection = $('section.port-hero, #hero, .port-hero');
+  if (heroSection.length > 0) {
+    // Check if hero is first child of body (wrong) vs inside main/article (correct)
+    const heroInMain = heroSection.closest('main, article, .card');
+    const heroIsFirstBodyChild = heroSection.parent().is('body') ||
+      (heroSection.prevAll('header, main, nav').length === 0 && heroSection.parent().is('body'));
+
+    if (!heroInMain.length || heroIsFirstBodyChild) {
+      errors.push({
+        section: 'hero',
+        rule: 'hero_wrong_position',
+        message: 'Hero section must be inside main content area (article/card), not at top of body before header',
+        severity: 'BLOCKING'
+      });
+    }
+
+    // Check for hero image
+    const heroImg = heroSection.find('img').first();
+    if (!heroImg.length) {
+      errors.push({
+        section: 'hero',
+        rule: 'hero_missing_image',
+        message: 'Hero box must contain an image',
+        severity: 'BLOCKING'
+      });
+    } else {
+      // Check image is webp format
+      const imgSrc = heroImg.attr('src') || '';
+      if (!imgSrc.endsWith('.webp')) {
+        errors.push({
+          section: 'hero',
+          rule: 'hero_not_webp',
+          message: 'Hero image must be in webp format',
+          severity: 'BLOCKING'
+        });
+      }
+    }
+
+    // Check for port name overlay
+    const portNameOverlay = heroSection.find('.port-hero-overlay, .port-name-overlay, h1');
+    if (!portNameOverlay.length) {
+      errors.push({
+        section: 'hero',
+        rule: 'hero_missing_overlay',
+        message: 'Hero box must contain port name overlay (h1 or .port-hero-overlay)',
+        severity: 'BLOCKING'
+      });
+    }
+
+    // Check for Wikimedia Commons credit link
+    const creditLink = heroSection.find('a[href*="commons.wikimedia.org"], a[href*="wikimedia"]');
+    if (!creditLink.length) {
+      errors.push({
+        section: 'hero',
+        rule: 'hero_missing_wikimedia_credit',
+        message: 'Hero image must include Wikimedia Commons credit link',
+        severity: 'BLOCKING'
+      });
+    }
+  } else {
+    errors.push({
+      section: 'hero',
+      rule: 'hero_missing',
+      message: 'Page must have a hero box section with class "port-hero"',
+      severity: 'BLOCKING'
+    });
+  }
+
   // Detect sections by scanning headings and IDs
   $('h2, h3, section, div[id], div[class*="section"]').each((i, elem) => {
     const $elem = $(elem);

--- a/ports/athens.html
+++ b/ports/athens.html
@@ -93,17 +93,6 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Athens cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/athens/acropolis-parthenon.webp" alt="The Parthenon temple atop the Acropolis hill glowing golden at sunset over Athens" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Athens</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
-  </section>
-
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
   <span role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></span>
@@ -166,6 +155,17 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Athens cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/athens/acropolis-parthenon.webp" alt="The Parthenon temple atop the Acropolis hill glowing golden at sunset over Athens" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;"/>
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Athens</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Acropolis_of_Athens_01361.JPG" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
         <h1>Athens: Where Western Civilization Found Its Voice</h1>
 
         <section id="logbook">

--- a/ports/auckland.html
+++ b/ports/auckland.html
@@ -93,17 +93,6 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Auckland cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/auckland/skyline-harbor.webp" alt="Auckland skyline with Sky Tower rising above Waitemata Harbour filled with sailboats" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Auckland</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
-  </section>
-
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
   <span role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></span>
@@ -166,6 +155,17 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Auckland cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/auckland/skyline-harbor.webp" alt="Auckland skyline with Sky Tower rising above Waitemata Harbour filled with sailboats" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;"/>
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Auckland</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
         <h1>Auckland: New Zealand's City of Sails</h1>
 
         <section id="logbook">

--- a/ports/bali.html
+++ b/ports/bali.html
@@ -93,17 +93,6 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Bali cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/bali/uluwatu-temple-sunset.webp" alt="Uluwatu Temple perched on dramatic sea cliffs at sunset with Indian Ocean below" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Bali</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
-  </section>
-
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
   <span role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></span>
@@ -166,6 +155,17 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Bali cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/bali/uluwatu-temple-sunset.webp" alt="Uluwatu Temple perched on dramatic sea cliffs at sunset with Indian Ocean below" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;"/>
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Bali</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
         <h1>Bali: Indonesia's Island of the Gods</h1>
 
         <section id="logbook">

--- a/ports/falkland-islands.html
+++ b/ports/falkland-islands.html
@@ -92,17 +92,6 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Falkland Islands cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/falkland-islands/falkland-islands-hero.webp" alt="Aerial view of Port Stanley harbor and colorful houses along the waterfront in the Falkland Islands" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Falkland Islands</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org/wiki/File:Aerial_photo_Port_Stanley.jpg" target="_blank" rel="noopener">Hohum / Wikimedia Commons</a> (Public Domain)</p>
-  </section>
-
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
   <span role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></span>
@@ -165,6 +154,17 @@ Soli Deo Gloria
 
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Falkland Islands cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/falkland-islands/falkland-islands-hero.webp" alt="Aerial view of Port Stanley harbor and colorful houses along the waterfront in the Falkland Islands" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;"/>
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Falkland Islands</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Aerial_photo_Port_Stanley.jpg" target="_blank" rel="noopener">Hohum / Wikimedia Commons</a> (Public Domain)</p>
+        </section>
+
         <h1>Falkland Islands: Penguins at the Edge of the World</h1>
 
         <section id="logbook">


### PR DESCRIPTION
- Move hero section inside article card (not at top of body) for: athens.html, auckland.html, bali.html, falkland-islands.html
- Add BLOCKING validation rules for hero requirements:
  - Hero must be inside main/article/card, not at body top
  - Hero must contain image in webp format
  - Hero must have port name overlay
  - Hero must include Wikimedia Commons credit link