### PR TITLE
Fix text overlap on stateroom-check.html

### DIFF
--- a/stateroom-check.html
+++ b/stateroom-check.html
@@ -303,7 +303,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     <!-- Introduction -->
     <section class="intro-section">
       <h1>Stateroom Sanity Check</h1>
-      <p class="tagline">Gentle guidance for your cabin choice—know before you sail.</p>
+      <p class="subtitle" style="font-size: 1.1rem; color: #5a7a8a; margin-top: -0.5rem; margin-bottom: 1rem;">Gentle guidance for your cabin choice—know before you sail.</p>
       <p>Enter your cabin number below and we'll help you understand what makes your stateroom special. Most rooms are wonderful choices—and if there's anything to know, we'll share it gently.</p>
     </section>
 


### PR DESCRIPTION
Change subtitle from .tagline class (hero positioning) to .subtitle with inline styles to prevent overlap with other content.