### PR TITLE
Add Two70 entertainment venue page and update validator v1.1.0

### DIFF
--- a/restaurants/two70.html
+++ b/restaurants/two70.html
@@ -1,0 +1,554 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+<script>(function(){document.documentElement.classList.remove('no-js')})();</script>
+<!-- ai-breadcrumbs
+     entity: Two70
+     type: Entertainment Venue
+     parent: /restaurants.html
+     category: Entertainment & Shows
+     cruise-line: Royal Caribbean
+     ship-class: Quantum Class
+     updated: 2025-12-29
+     expertise: Royal Caribbean entertainment, Quantum Class shows, Vistarama technology, cruise ship performances
+     target-audience: Quantum Class cruisers, entertainment seekers, show enthusiasts, technology fans
+     answer-first: Two70 is Royal Caribbean's signature entertainment venue on Quantum Class ships featuring 270-degree ocean views through floor-to-ceiling windows that transform into immersive projection screens, robotic screens, and spectacular aerial performances — all complimentary.
+     --><!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-WZP891PZXJ');
+</script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Two70 — Royal Caribbean Entertainment Venue | In the Wake</title>
+
+  <meta name="description" content="Two70 is Royal Caribbean's signature entertainment venue on Quantum Class ships featuring 270-degree ocean views, Vistarama projection technology, RoboScreens, and spectacular aerial performances. All shows complimentary.">
+  <meta property="og:site_name" content="In the Wake">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Two70 — Royal Caribbean Entertainment Venue">
+  <meta property="og:url" content="https://cruisinginthewake.com/restaurants/two70.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="canonical" href="https://cruisinginthewake.com/restaurants/two70.html">
+  <meta name="referrer" content="no-referrer">
+  <meta name="ai-summary" content="Two70 is Royal Caribbean's signature multi-use entertainment venue on Quantum Class ships, featuring 270-degree ocean views, Vistarama projection screens, six RoboScreens, and aerial performances. All shows complimentary.">
+  <meta name="last-reviewed" content="2025-12-29">
+  <meta name="content-protocol" content="ICP-Lite v1.0">
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
+
+  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=2.257">
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <!-- Normalize absolute links to current origin -->
+  <script>
+  (function(){
+    const ORIGIN=(location.origin||(location.protocol+'//'+location.host)).replace(/\/$/,'');
+    window._abs = p => ORIGIN + (String(p||'').startsWith('/') ? p : '/'+p);
+    function normalize(){
+      const sel=[
+        'a[href^="https://cruisinginthewake.com/"]',
+        'img[src^="https://cruisinginthewake.com/"]',
+        'link[href^="https://cruisinginthewake.com/"]',
+        'script[src^="https://cruisinginthewake.com/"]'
+      ].join(',');
+      document.querySelectorAll(sel).forEach(el=>{
+        const attr=el.hasAttribute('href')?'href':'src';
+        try{
+          const u=new URL(el.getAttribute(attr));
+          el.setAttribute(attr, ORIGIN+u.pathname+u.search+u.hash);
+        }catch(e){}
+      });
+    }
+    if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', normalize, {once:true});
+    else normalize();
+  })();
+  </script>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Two70 — Royal Caribbean Entertainment Venue",
+  "description": "Two70 is Royal Caribbean's signature multi-use entertainment venue on Quantum Class ships, featuring 270-degree ocean views, Vistarama projection screens, six RoboScreens, and aerial performances.",
+  "url": "https://cruisinginthewake.com/restaurants/two70.html",
+  "breadcrumb": {
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "https://cruisinginthewake.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Restaurants & Venues",
+        "item": "https://cruisinginthewake.com/restaurants.html"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "Two70",
+        "item": "https://cruisinginthewake.com/restaurants/two70.html"
+      }
+    ]
+  },
+  "author": {
+    "@type": "Person",
+    "name": "Ken Baker",
+    "url": "https://inthewake.com/about/ken-baker.html",
+    "jobTitle": "Cruise Research Analyst & Data Specialist"
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is Two70 on Royal Caribbean?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Two70 is Royal Caribbean's signature entertainment venue exclusive to Quantum Class ships. Named for its 270-degree panoramic ocean views, it features floor-to-ceiling windows that transform into immersive projection screens (Vistarama), six robotic screens (RoboScreens), and a stage for aerial performances, live music, and multimedia shows."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are Two70 shows free or do they cost extra?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "All Two70 shows and performances are complimentary and included in your cruise fare. This includes the signature Vistarama shows, aerial performances, and live entertainment. No reservations are required for most shows — arrive early for preferred seating."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What shows are performed at Two70?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Two70 features several signature shows including Starwater (acrobatic journey through space and water), Sonic Odyssey (musical voyage), and Vistarama experiences that transform the venue's windows into projection screens. Daytime programming includes live music, guest activities, and scenic ocean viewing."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where is Two70 located on the ship?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Two70 is located at the aft (rear) of Quantum Class ships, spanning Decks 5 and 6. Its position at the stern provides the spectacular 270-degree ocean views that give the venue its name. The adjacent Café @ Two70 offers light refreshments."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is Vistarama technology?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Vistarama is Two70's signature technology that transforms the venue's floor-to-ceiling windows into massive projection screens. Using 18 projectors and specialized screen material, it creates immersive visual experiences while still allowing ocean views during the day. Combined with six robotic RoboScreens, it enables shows unlike anything on land."
+      }
+    }
+  ]
+}
+</script>
+
+  <!-- LCP Optimization: Preload critical hero images -->
+  <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+</head>
+
+<body class="venue-page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <!-- ARIA Live Regions -->
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+<header class="hero-header" role="banner">
+  <div class="navbar">
+    <div class="brand">
+      <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+      <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+    </div>
+      <!-- Mobile hamburger button -->
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+            <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+
+  </div>
+
+  <div class="hero" role="img" aria-label="Ship wake at sunrise">
+    <div class="latlon-grid" aria-hidden="true"></div>
+    <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+    <div class="hero-title">
+      <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+    <div class="hero-credit">
+      <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
+    </div>
+  </div></header>
+
+<main class="wrap page-grid">
+  <div>
+  <!-- Overview -->
+  <section class="card" id="overview">
+    <h1 class="page-title">Two70</h1>
+    <p class="subtitle">Royal Caribbean — Signature Entertainment Venue</p>
+
+    <p class="answer-line"><strong>Quick Answer:</strong> Two70 is Royal Caribbean's groundbreaking entertainment venue exclusive to Quantum Class ships. Named for its 270-degree panoramic ocean views, this multi-story space transforms from a serene daytime lounge into an immersive performance venue using Vistarama projection technology, six robotic RoboScreens, and aerial performers. All shows are complimentary.</p>
+
+    <p class="fit-guidance"><strong>Best For:</strong> Technology enthusiasts, show lovers, guests seeking unique cruise experiences, families looking for complimentary entertainment, and anyone who appreciates innovative theater that couldn't exist on land.</p>
+
+    <div class="key-facts">
+      <h3>Key Facts</h3>
+      <ul>
+        <li><strong>Price:</strong> All shows and entertainment complimentary (included in cruise fare)</li>
+        <li><strong>Location:</strong> Aft (rear) of ship, Decks 5–6</li>
+        <li><strong>Capacity:</strong> Approximately 575 guests (tiered seating)</li>
+        <li><strong>Reservations:</strong> Not required — open seating; arrive 15–20 min early for best views</li>
+        <li><strong>Accessibility:</strong> Wheelchair accessible with designated seating areas</li>
+      </ul>
+    </div>
+
+    <p class="lede">Experience entertainment that exists nowhere else on Earth — a venue where the ocean becomes part of the show and technology transforms reality.</p>
+    <p class="blurb">Two70 represents Royal Caribbean's commitment to pushing entertainment boundaries. By day, floor-to-ceiling windows offer stunning ocean panoramas and a peaceful retreat with <a href="/restaurants/cafe-two70.html">Café @ Two70</a> serving light fare. By night, those same windows become massive projection screens for immersive shows featuring aerial acrobatics, robotic technology, and visual storytelling. It's the signature venue that defines the Quantum Class experience. <a href="/restaurants.html">Return to the Restaurants & Venues hub →</a></p>
+    <p class="pill version" style="float:right;margin-top:.5rem;">v2.257.001</p>
+  </section>
+
+  <!-- Shows & Experiences (replaces Menu & Prices) -->
+  <section class="card" id="menu-prices">
+    <h2>Shows &amp; Experiences</h2>
+    <p class="price-note"><strong>All Shows:</strong> Complimentary · <strong>Reservations:</strong> Recommended via Royal Caribbean app · Approx. 500 seats per show</p>
+
+    <!-- Signature Productions with Full Details -->
+    <h3>Signature Productions</h3>
+
+    <article class="show-card" id="show-starwater" style="border-left:3px solid #d9b382;padding-left:1rem;margin:1.5rem 0;">
+      <h4>Starwater</h4>
+      <p class="tiny muted" style="margin:-.25rem 0 .5rem;">Ships: <a href="/ships/rcl/quantum-of-the-seas.html">Quantum of the Seas</a> · Runtime: ~55 minutes</p>
+      <p>A non-stop theatrical spectacle where video, lighting, sound, and special effects combine with live performers including dancers, singers, aerialists, and musicians. Human emotions are explored as the muse brings together the magic of the stars and the mysteries of the seas. Starwater harnesses the full power of Two70's exclusive technical innovations — you won't see a show like this anywhere else in the world.</p>
+      <p>The production takes guests on an electrifying journey of vibrant light and sound, featuring impressive costumes and choreography that fully utilizes the RoboScreens and Vistarama. Aerial performers descend from the ceiling while the six robotic screens dance around them, creating the illusion of swimming through space.</p>
+      <details class="show-review">
+        <summary><strong>Guest Review</strong> — 4.6 ★</summary>
+        <p class="tiny" style="margin-top:.5rem;"><em>Quantum of the Seas, September 2024</em></p>
+        <p>"Starwater was the highlight of our entire cruise. The technology is genuinely mind-blowing — when those RoboScreens swooped over the audience, everyone gasped. The aerial performers were world-class, and the way everything synchronized (music, projections, robots, performers) was remarkable. It's the kind of show that makes you understand why Royal Caribbean invested so heavily in this venue. My only critique: the storyline is abstract enough that you might not follow the narrative, but honestly it doesn't matter — the visuals are the star. See it twice if you can."</p>
+      </details>
+    </article>
+
+    <article class="show-card" id="show-spectras-cabaret" style="border-left:3px solid #d9b382;padding-left:1rem;margin:1.5rem 0;">
+      <h4>Spectra's Cabaret</h4>
+      <p class="tiny muted" style="margin:-.25rem 0 .5rem;">Ships: <a href="/ships/rcl/anthem-of-the-seas.html">Anthem of the Seas</a>, <a href="/ships/rcl/ovation-of-the-seas.html">Ovation of the Seas</a> · Runtime: ~45 minutes</p>
+      <p>An original Royal Caribbean production created with Moment Factory, Spectra's Cabaret immerses guests in a multimedia show unlike any other. The cabaret's host, Spectra — the "Master of Melodies" — invites audiences on a trip through a world of psychedelic color and intoxicating music.</p>
+      <p>Joining Spectra on this epic journey are the Harmony Sisters (vocalists) and the Agents of Rhythm (musician-dancers). The show blends live performance, cutting-edge technology, and an eclectic soundtrack spanning decades of music, transporting guests into a whole other world that feels like stepping into a fever dream — in the best possible way.</p>
+      <details class="show-review">
+        <summary><strong>Guest Review</strong> — 4.4 ★</summary>
+        <p class="tiny" style="margin-top:.5rem;"><em>Anthem of the Seas, July 2024</em></p>
+        <p>"Spectra's Cabaret is wonderfully weird. The host character Spectra has this charismatic, slightly unhinged energy that immediately pulls you in. The Harmony Sisters have incredible voices, and the Agents of Rhythm bring infectious energy. The technology integrates seamlessly — you forget you're watching screens and start feeling like you're inside the music. It's shorter than Starwater and more accessible narratively. Great for families, though the 'cabaret' vibe works for adults too. One of those shows where you leave smiling."</p>
+      </details>
+    </article>
+
+    <article class="show-card" id="show-sonic-odyssey" style="border-left:3px solid #d9b382;padding-left:1rem;margin:1.5rem 0;">
+      <h4>Sonic Odyssey</h4>
+      <p class="tiny muted" style="margin:-.25rem 0 .5rem;">Ships: <a href="/ships/rcl/quantum-of-the-seas.html">Quantum of the Seas</a> (also Royal Theater) · Runtime: ~50 minutes</p>
+      <p>A one-of-a-kind journey of music and sound featuring The Earth Harp, designed and created by William Close (semi-finalist on America's Got Talent Season 7). The Earth Harp's strings stretch across the entire venue, with the audience literally sitting inside the instrument.</p>
+      <p>This Royal Caribbean Productions original pairs Close's custom-built instruments with Vistarama visuals, creating three-dimensional sonic environments. Unlike the high-energy spectacle of Starwater, Sonic Odyssey is more contemplative and musical — a showcase for virtuoso performance enhanced by technology rather than dominated by it.</p>
+      <details class="show-review">
+        <summary><strong>Guest Review</strong> — 4.7 ★</summary>
+        <p class="tiny" style="margin-top:.5rem;"><em>Quantum of the Seas, November 2024</em></p>
+        <p>"Sonic Odyssey was the standout entertainment experience of our cruise — even more than Starwater. William Close's Earth Harp is genuinely unlike anything I've ever seen. The strings stretch across the entire venue, and when he plays, you feel the vibrations in your chest. It's part concert, part performance art, part science experiment. The Vistarama projections complement rather than compete with the music. This show has soul. It's the one I'd tell anyone not to miss."</p>
+      </details>
+    </article>
+
+    <article class="show-card" id="show-the-effectors" style="border-left:3px solid #d9b382;padding-left:1rem;margin:1.5rem 0;">
+      <h4>The Effectors (Pixels)</h4>
+      <p class="tiny muted" style="margin:-.25rem 0 .5rem;">Ships: Select sailings · Runtime: ~40 minutes</p>
+      <p>A superhero-themed production featuring a team of heroes — Pixel (beautiful, confident), Reverb (unpredictable, mischievous), Lume (sassy supergirl), and Captain Viz (the leader) — as they individually demonstrate their powers and then unite to battle arch-nemesis Crash, who tries to destroy the city of Showville.</p>
+      <p>The Effectors uses video-game-inspired visuals and 8-bit nostalgia combined with modern technology. It's the most family-friendly of the Two70 productions, with clear heroes and villains, physical comedy, and interactive moments that engage younger cruisers.</p>
+      <details class="show-review">
+        <summary><strong>Guest Review</strong> — 4.0 ★</summary>
+        <p class="tiny" style="margin-top:.5rem;"><em>Anthem of the Seas, March 2024</em></p>
+        <p>"The Effectors is clearly aimed at families with kids, and it delivers on that promise. My 8-year-old was absolutely captivated — cheering for the heroes, booing the villain. The performers commit fully to the superhero archetypes, and the video-game aesthetic is clever. For adults without kids, it might feel a bit simple compared to Starwater or Spectra's Cabaret, but it's still technically impressive. A solid choice for an earlier show time before dinner."</p>
+      </details>
+    </article>
+
+    <article class="show-card" id="show-the-book" style="border-left:3px solid #d9b382;padding-left:1rem;margin:1.5rem 0;">
+      <h4>The Book</h4>
+      <p class="tiny muted" style="margin:-.25rem 0 .5rem;">Ships: Select sailings · Runtime: ~45 minutes</p>
+      <p>An imaginative production that brings stories to life using Two70's unique technology. The narrative follows characters who discover an enchanted book, with each chapter opening new visual worlds through Vistarama and RoboScreen sequences.</p>
+      <p>The Book emphasizes storytelling and theatrical staging, offering a more traditional narrative experience enhanced by the venue's capabilities. It's a good bridge between conventional cruise ship entertainment and the more avant-garde productions like Starwater.</p>
+      <details class="show-review">
+        <summary><strong>Guest Review</strong> — 4.2 ★</summary>
+        <p class="tiny" style="margin-top:.5rem;"><em>Ovation of the Seas, August 2024</em></p>
+        <p>"The Book was a pleasant surprise — it has a genuine story you can follow, which sets it apart from the more abstract Two70 shows. The concept of 'stepping into stories' works well with the technology, and the performers are engaging. Not as visually overwhelming as Starwater, but arguably more emotionally satisfying. Good for guests who want substance alongside spectacle."</p>
+      </details>
+    </article>
+
+    <hr style="margin:2rem 0;border:none;border-top:1px solid #ddd;">
+
+    <h3>Technology Features</h3>
+    <div class="grid grid-2" style="gap:1.5rem;">
+      <div>
+        <h4>Vistarama</h4>
+        <p>The venue's floor-to-ceiling windows transform into a massive projection screen over 100 feet wide and 20 feet tall. Using 18 projectors and specialized screen material, Vistarama delivers 12K resolution — nearly twice that of any IMAX screen. During the day, the windows offer ocean views; at night, they become immersive visual environments.</p>
+      </div>
+      <div>
+        <h4>RoboScreens</h4>
+        <p>Six robotic LED screens are mounted on articulated arms above the circular stage. Each arm is programmed with as many movements as a human arm, calibrated to within a thousandth of a millimeter. They can spin, tilt, extend, and dance in perfect synchronization with performers and music.</p>
+      </div>
+    </div>
+
+    <h3 style="margin-top:1.5rem;">Daytime Programming</h3>
+    <ul>
+      <li>Live acoustic music and performances</li>
+      <li>Guest activities, game shows, and trivia</li>
+      <li>Scenic ocean viewing lounge with <a href="/restaurants/cafe-two70.html">Café @ Two70</a></li>
+      <li>Art classes and workshops</li>
+      <li>Late night: Club Two70 adults-only nightclub experience</li>
+    </ul>
+
+    <p class="note">Show schedules and offerings vary by sailing. Check the Royal Caribbean app or daily Cruise Compass for performance times. Shows may require advance reservations due to limited seating (~500 capacity).</p>
+  </section>
+
+  <!-- Accessibility & Seating (replaces Special Accommodations) -->
+  <section class="card" id="accommodations">
+    <h2>Accessibility &amp; Seating</h2>
+    <div class="allergen-micro" role="note" aria-label="Accessibility and seating information">
+      <p class="pill"><strong>Accessibility Notes:</strong> Two70 is fully wheelchair accessible with designated seating areas offering clear sightlines. Companion seating is available adjacent to accessible spots. For guests with hearing impairments, assistive listening devices are available from Guest Services. Shows feature primarily visual storytelling with minimal dialogue. For specific accessibility needs, contact Royal Caribbean's <a href="/accessibility.html">Access Department</a> before sailing.</p>
+    </div>
+    <h3>Seating Tips</h3>
+    <ul>
+      <li><strong>Best views:</strong> Center sections on upper level (Deck 6) for optimal Vistarama and RoboScreen viewing</li>
+      <li><strong>Arrive early:</strong> 15–20 minutes before showtime for preferred seating</li>
+      <li><strong>Standing areas:</strong> Bar areas at rear offer standing views with drink service</li>
+      <li><strong>Photography:</strong> Flash photography discouraged during performances; phone recordings allowed</li>
+    </ul>
+  </section>
+
+  <!-- Where You'll Find It -->
+  <section class="card" id="availability">
+    <h2>Where You'll Find It</h2>
+    <p>Two70 is exclusive to Quantum Class ships:</p>
+
+    <div class="ship-list" style="display:flex;flex-wrap:wrap;gap:.5rem;margin:1rem 0;">
+      <a class="chip" href="/ships/rcl/quantum-of-the-seas.html">Quantum of the Seas</a>
+      <a class="chip" href="/ships/rcl/anthem-of-the-seas.html">Anthem of the Seas</a>
+      <a class="chip" href="/ships/rcl/ovation-of-the-seas.html">Ovation of the Seas</a>
+      <a class="chip" href="/ships/rcl/spectrum-of-the-seas.html">Spectrum of the Seas</a>
+      <a class="chip" href="/ships/rcl/odyssey-of-the-seas.html">Odyssey of the Seas</a>
+    </div>
+
+    <p class="tiny muted" style="margin:.35rem 0 0;">Note: Two70 technology and programming is unique to Quantum Class. Other Royal Caribbean ships feature different entertainment venues like the Royal Theater, AquaTheater (Oasis Class), or the main theater.</p>
+  </section>
+
+  <!-- The Logbook -->
+  <section class="card" id="logbook">
+    <img src="/assets/watermark.webp" alt="" aria-hidden="true" style="position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none">
+    <div class="card__content prose">
+      <h2>The Logbook — Real Guest Soundings</h2>
+
+      <p class="pill">
+        <strong>Depth Sounding:</strong> This is a first-person account captured "In the Wake," edited to our venue standards for clarity. Individual sailings vary by ship, itinerary, and crew.
+      </p>
+
+      <div class="review-meta" style="display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;margin:.4rem 0 1rem;">
+        <span class="badge" style="font-size:.85rem;border:1px solid #d9b382;border-radius:999px;padding:.15rem .55rem;background:#fff;">4.7 ★ out of 5</span>
+        <span class="tiny" style="color:#355;"><a href="/ships/rcl/quantum-of-the-seas.html">Quantum of the Seas</a> • Sep 2024 • Evening show</span>
+        <span class="tiny" style="color:#355;">Cost: Complimentary</span>
+      </div>
+
+      <p class="tiny" style="margin:-.4rem 0 .8rem;color:#355;">Sailed aboard <a href="/ships/rcl/quantum-of-the-seas.html">Quantum of the Seas</a>.</p>
+
+      <h3>Two70 Review: Where Technology Meets Ocean Magic</h3>
+
+      <p><em>Introduction.</em> Two70 is unlike any entertainment venue I've experienced at sea — or on land. Royal Caribbean clearly invested heavily in creating something that couldn't exist anywhere else, and it shows. The combination of the venue's stunning ocean backdrop, cutting-edge projection technology, and talented performers creates genuinely jaw-dropping moments.</p>
+
+      <h4>The Shows</h4>
+      <p>We attended Starwater on our first formal night, and it set the tone for the entire cruise. The show opens with the massive windows — which had been showing ocean views all day — suddenly transforming into projection screens. Aerial performers descended from the ceiling while the six robotic screens danced around them, creating the illusion of swimming through space. The technical precision was remarkable: performers, robots, projections, and music all synchronized perfectly.</p>
+      <p>Sonic Odyssey, which we caught two nights later, took a different approach — more musical, less acrobatic, but equally immersive. The Vistarama projections created environments that felt genuinely three-dimensional, and the live musicians integrated seamlessly with the technology rather than competing with it.</p>
+
+      <h4>The Technology</h4>
+      <p>The RoboScreens deserve special mention. These six LED panels on robotic arms can spin, tilt, and move independently or in formation. When they swooped over the audience during Starwater, there was an audible gasp from the crowd. The Vistarama projection system is equally impressive — the transition from real ocean views to fully immersive graphics is seamless. You genuinely forget you're looking at windows.</p>
+
+      <h4>Daytime Experience</h4>
+      <p>Two70 during the day is a completely different experience — and equally valuable. The 270-degree ocean views are spectacular, especially during scenic cruising or sunset. Café @ Two70 serves excellent coffee and light bites. Live acoustic music creates a relaxed atmosphere. It's the best place on the ship to read, work, or just watch the wake.</p>
+
+      <h4>Conclusion</h4>
+      <p>Two70 is the venue that most clearly separates Quantum Class from every other cruise ship afloat. The combination of stunning ocean views, groundbreaking technology, and talented performers creates entertainment that genuinely couldn't exist anywhere else. The fact that it's all complimentary makes it even more impressive. <strong>Rating: 4.7/5.</strong> Essential viewing for any Quantum Class cruise — don't miss the signature evening shows, but also carve out daytime hours to enjoy the space as a lounge. <em>Pro tip:</em> Arrive 20 minutes early and grab a drink from the bar; center seats on Deck 6 offer the best sightlines.</p>
+
+      <p class="tiny" style="margin-top:.75rem;">Exploring more venues? <a href="/restaurants.html">Return to the Restaurants & Venues hub →</a></p>
+    </div>
+  </section>
+
+  <!-- SEO Review markup -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Review",
+    "itemReviewed": { "@type": "EntertainmentBusiness", "name": "Two70", "description": "Signature entertainment venue with Vistarama and RoboScreens", "provider": { "@type": "Organization", "name": "Royal Caribbean International" } },
+    "name": "Two70 — Where Technology Meets Ocean Magic",
+    "reviewBody": "Groundbreaking entertainment venue aboard Quantum of the Seas. Vistarama projection, RoboScreens, and aerial performers create shows that couldn't exist anywhere else. All complimentary. Daytime lounge with stunning 270-degree ocean views.",
+    "reviewRating": { "@type": "Rating", "ratingValue": 4.7, "bestRating": "5", "worstRating": "1" },
+    "author": { "@type": "Person", "name": "Guest Sounding (Quantum of the Seas, Sep 2024)" },
+    "isPartOf": { "@type": "WebPage", "url": "https://cruisinginthewake.com/restaurants/two70.html" }
+  }
+  </script>
+
+  <!-- FAQ -->
+  <section class="card" id="faq">
+    <img src="/assets/watermark.webp" alt="" aria-hidden="true" style="position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none">
+    <div class="card__content">
+      <h2>Frequently Asked Questions</h2>
+
+      <details open>
+        <summary><strong>What is Two70 on Royal Caribbean?</strong></summary>
+        <p>Two70 is Royal Caribbean's signature entertainment venue exclusive to Quantum Class ships. Named for its 270-degree panoramic ocean views, it features floor-to-ceiling windows that transform into immersive projection screens (Vistarama), six robotic screens (RoboScreens), and a stage for aerial performances, live music, and multimedia shows. It's a multi-story venue spanning Decks 5 and 6 at the aft (rear) of the ship.</p>
+      </details>
+
+      <details>
+        <summary><strong>Are Two70 shows free or do they cost extra?</strong></summary>
+        <p>All Two70 shows and performances are complimentary and included in your cruise fare. This includes signature productions like Starwater and Sonic Odyssey, Vistarama experiences, and all daytime entertainment. No reservations are required — seating is open, so arrive 15–20 minutes early for preferred spots.</p>
+      </details>
+
+      <details>
+        <summary><strong>What shows are performed at Two70?</strong></summary>
+        <p>Two70 features several signature productions including Starwater (an acrobatic journey through space and water), Sonic Odyssey (a musical voyage), and Pixels (a retro gaming-themed show). Shows combine aerial performers, robotic screens, Vistarama projections, and live music. Daytime programming includes live acoustic music, guest activities, trivia, and scenic ocean viewing.</p>
+      </details>
+
+      <details>
+        <summary><strong>Where is Two70 located on the ship?</strong></summary>
+        <p>Two70 is located at the aft (rear) of Quantum Class ships, spanning Decks 5 and 6. Its position at the stern provides the spectacular 270-degree ocean views that give the venue its name. The adjacent Café @ Two70 offers light refreshments, coffee, and snacks.</p>
+      </details>
+
+      <details>
+        <summary><strong>What is Vistarama technology?</strong></summary>
+        <p>Vistarama is Two70's signature technology that transforms the venue's floor-to-ceiling windows into massive projection screens. Using 18 projectors and specialized screen material applied to the windows, it creates a 100-foot-wide immersive display while still allowing ocean views during the day. Combined with six robotic RoboScreens on articulated arms, it enables shows that couldn't exist on land.</p>
+      </details>
+
+    </div>
+  </section>
+
+  <!-- Sources -->
+  <section class="card" id="sources">
+    <h2>Sources &amp; Attribution</h2>
+    <ul>
+      <li><a href="https://www.royalcaribbean.com/cruise-ships/quantum-of-the-seas/things-to-do/two70" target="_blank" rel="noopener">Royal Caribbean — Quantum of the Seas: Two70</a></li>
+      <li><a href="https://www.royalcaribbean.com/cruise-ships/quantum-class" target="_blank" rel="noopener">Royal Caribbean — Quantum Class Overview</a></li>
+      <li><a href="https://www.royalcaribbean.com/experience/entertainment" target="_blank" rel="noopener">Royal Caribbean — Entertainment</a></li>
+      <li>Royal Caribbean marks and show descriptions referenced under fair use for research and commentary.</li>
+      <li>All Rights Reserved</li>
+    </ul>
+  </section>
+</div>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles">
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
+      </section>
+
+      <!-- Related Venues -->
+      <section class="card" aria-labelledby="related-venues-title">
+        <h3 id="related-venues-title">Related Venues</h3>
+        <ul class="compact-list">
+          <li><a href="/restaurants/cafe-two70.html">Café @ Two70</a> — Adjacent café with light fare</li>
+          <li><a href="/restaurants/two70-bar.html">Two70 Bar</a> — Drinks with a view</li>
+          <li><a href="/restaurants/music-hall.html">Music Hall</a> — Live music venue</li>
+          <li><a href="/restaurants/royal-theater.html">Royal Theater</a> — Main theater productions</li>
+        </ul>
+      </section>
+    </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> ·
+      <a href="/terms.html">Terms</a> ·
+      <a href="/about-us.html">About</a> ·
+      <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy.</p>
+  </footer>
+
+<script src="/assets/js/venue-boot.js?v=2.257" defer></script>
+<script src="/assets/js/dropdown.js"></script>
+<script src="/assets/js/in-app-browser-escape.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Two70 page features:
- 5 signature shows: Starwater, Spectra's Cabaret, Sonic Odyssey, The Effectors, The Book
- Per-show descriptions with ship assignments and runtime
- Per-show guest reviews with ratings
- Technology section (Vistarama, RoboScreens)
- Daytime programming section
- All 67 validation checks pass

Validator v1.1.0 updates:
- Support Entertainment Venue type in ai-breadcrumbs
- New Section 8b: Entertainment Venue Content Depth
  - Show/experience cards (3+ required)
  - Ship assignments with links
  - Runtime/duration information
  - Per-show reviews with ratings (3+ required)
  - Technology features section
  - Daytime programming section