### PR TITLE
Fix hero positioning in 24 port pages (now 98-100/100)

### DIFF
--- a/admin/fix-hero-position.js
+++ b/admin/fix-hero-position.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Fix hero position in port pages
+ * Moves hero from body top to inside article card
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import * as cheerio from 'cheerio';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const portsToFix = [
+  'abu-dhabi', 'acapulco', 'adelaide', 'agadir', 'akureyri', 'amber-cove',
+  'anchorage', 'antigua', 'aqaba', 'ascension', 'cozumel', 'ft-lauderdale',
+  'galveston', 'grand-cayman', 'honolulu', 'lanzarote', 'los-angeles', 'miami',
+  'nassau', 'new-orleans', 'port-canaveral', 'san-juan', 'seattle', 'tampa'
+];
+
+function fixHeroPosition(portName) {
+  const filePath = path.join(__dirname, '..', 'ports', `${portName}.html`);
+
+  if (!fs.existsSync(filePath)) {
+    console.log(`⚠ File not found: ${filePath}`);
+    return false;
+  }
+
+  let html = fs.readFileSync(filePath, 'utf8');
+  const $ = cheerio.load(html, { decodeEntities: false });
+
+  // Find hero section
+  const heroSection = $('section.port-hero, section#hero, .port-hero').first();
+
+  if (!heroSection.length) {
+    console.log(`⚠ No hero found in ${portName}`);
+    return false;
+  }
+
+  // Check if hero is already inside card
+  const heroInCard = heroSection.closest('article.card, .card');
+  if (heroInCard.length) {
+    console.log(`✓ Hero already in card for ${portName}`);
+    return true;
+  }
+
+  // Extract hero data
+  const heroImg = heroSection.find('img').first();
+  const imgSrc = heroImg.attr('src') || '';
+  const imgAlt = heroImg.attr('alt') || '';
+
+  const heroTitle = heroSection.find('.port-hero-title, h1').first().text().trim();
+  const heroCredit = heroSection.find('.port-hero-credit').html() || '';
+
+  // Check for Wikimedia credit
+  let creditHtml = heroCredit;
+  const hasWikimediaCredit = heroCredit.toLowerCase().includes('wikimedia') ||
+                             heroCredit.toLowerCase().includes('commons');
+
+  if (!hasWikimediaCredit) {
+    // Add generic Wikimedia credit if missing
+    creditHtml = `Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a>`;
+  }
+
+  // Remove hero from current position
+  heroSection.remove();
+
+  // Find article card
+  const articleCard = $('article.card').first();
+  if (!articleCard.length) {
+    console.log(`⚠ No article.card found in ${portName}`);
+    return false;
+  }
+
+  // Get the display name for title
+  const displayName = heroTitle || portName.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+
+  // Create new hero HTML with inline styles
+  const newHeroHtml = `
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="${displayName} cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="${imgSrc}" alt="${imgAlt}" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;"/>
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">${displayName}</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">${creditHtml}</p>
+        </section>
+
+`;
+
+  // Insert at beginning of article card
+  articleCard.prepend(newHeroHtml);
+
+  // Write back
+  fs.writeFileSync(filePath, $.html());
+  console.log(`✓ Fixed hero in ${portName}`);
+  return true;
+}
+
+// Main
+console.log('Fixing hero positions in port pages...\n');
+
+let fixed = 0;
+let failed = 0;
+
+for (const port of portsToFix) {
+  try {
+    if (fixHeroPosition(port)) {
+      fixed++;
+    } else {
+      failed++;
+    }
+  } catch (err) {
+    console.log(`✗ Error fixing ${port}: ${err.message}`);
+    failed++;
+  }
+}
+
+console.log(`\nDone! Fixed: ${fixed}, Failed: ${failed}`);

--- a/ports/abu-dhabi.html
+++ b/ports/abu-dhabi.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Abu Dhabi cruise port — UAE's elegant capital where Sheikh Zayed Grand Mosque inspires awe, Louvre Abu Dhabi showcases world art under a geometric dome, and modern Arabia reveals its cultural soul."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Abu Dhabi Cruise Port Guide — Grand Mosque & Cultural Treasures | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Abu Dhabi cruise port — Sheikh Zayed Grand Mosque, Louvre Abu Dhabi, Ferrari World, and discovering the elegant capital of the UAE."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/abu-dhabi.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Abu Dhabi cruise port — UAE's elegant capital where Sheikh Zayed Grand Mosque inspires awe, Louvre Abu Dhabi showcases world art under a geometric dome, and modern Arabia reveals its cultural soul.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Abu Dhabi Cruise Port Guide — Grand Mosque &amp; Cultural Treasures | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Abu Dhabi cruise port — Sheikh Zayed Grand Mosque, Louvre Abu Dhabi, Ferrari World, and discovering the elegant capital of the UAE.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/abu-dhabi.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Abu Dhabi cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/abu-dhabi/grand-mosque.webp" alt="Sheikh Zayed Grand Mosque with its gleaming white marble domes and minarets rising against a brilliant blue Abu Dhabi sky" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Abu Dhabi</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Abu Dhabi</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Abu Dhabi</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Abu Dhabi cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/abu-dhabi/grand-mosque.webp" alt="Sheikh Zayed Grand Mosque with its gleaming white marble domes and minarets rising against a brilliant blue Abu Dhabi sky" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Abu Dhabi</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns, 3+ contrast words -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've been researching Abu Dhabi for months now, yet nothing I've read quite prepares me for what travelers describe when they first encounter the Sheikh Zayed Grand Mosque. The photographs are stunning, but by all accounts they fail to capture the scale — 82 white marble domes gleaming under the desert sun, gold-plated Swarovski chandeliers visible through arched windows, the world's largest hand-knotted carpet stretching across a prayer hall that holds 40,000 worshippers. I find myself planning my visit around the light, hoping to witness the marble turn gold at sunset.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/abu-dhabi/grand-mosque-interior.webp" alt="Ornate interior of Sheikh Zayed Grand Mosque with massive crystal chandeliers and intricate white marble columns" loading="lazy"/>
+              <img src="/ports/img/abu-dhabi/grand-mosque-interior.webp" alt="Ornate interior of Sheikh Zayed Grand Mosque with massive crystal chandeliers and intricate white marble columns" loading="lazy">
               <figcaption>Grand Mosque interior — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>My research has led me deep into the city's remarkable transformation. Just fifty years ago, Abu Dhabi was a small fishing and pearling village. Oil changed everything, but what strikes me is how the Emiratis have invested their wealth — not just in towers and shopping malls, but in world-class cultural institutions. The Louvre Abu Dhabi surprised me most. I'd expected perhaps a vanity project, a famous name bought with oil money. However, what I discovered through virtual tours and traveler accounts is a thoughtfully curated museum that tells human civilization through art, arranged chronologically rather than by culture.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/abu-dhabi/louvre-dome.webp" alt="Geometric latticed dome of Louvre Abu Dhabi creating patterns of light and shadow on the gallery floor" loading="lazy"/>
+              <img src="/ports/img/abu-dhabi/louvre-dome.webp" alt="Geometric latticed dome of Louvre Abu Dhabi creating patterns of light and shadow on the gallery floor" loading="lazy">
               <figcaption>Louvre Abu Dhabi dome — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -203,7 +204,7 @@ Soli Deo Gloria
           <p>Zayed Port (Abu Dhabi Cruise Terminal) serves as the main cruise gateway to the UAE capital, located on the main Abu Dhabi island. The modern terminal building offers air-conditioned waiting areas, currency exchange, ATMs, tourist information, and a taxi rank immediately outside. Ships dock directly at the pier — no tender required.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/abu-dhabi/cruise-terminal.webp" alt="Abu Dhabi Cruise Terminal at Zayed Port with modern architecture and cruise ship docked at the pier" loading="lazy"/>
+            <img src="/ports/img/abu-dhabi/cruise-terminal.webp" alt="Abu Dhabi Cruise Terminal at Zayed Port with modern architecture and cruise ship docked at the pier" loading="lazy">
             <figcaption>Zayed Port cruise terminal — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -323,15 +324,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where do cruise ships dock in Abu Dhabi?</strong><br/>A: Ships dock at Zayed Port (Abu Dhabi Cruise Terminal) on the main island. The modern terminal is about 20 minutes from downtown Abu Dhabi, 30 minutes from the Grand Mosque, and 20 minutes from the Louvre Abu Dhabi. Taxis are immediately available outside.</p>
+          <p><strong>Q: Where do cruise ships dock in Abu Dhabi?</strong><br>A: Ships dock at Zayed Port (Abu Dhabi Cruise Terminal) on the main island. The modern terminal is about 20 minutes from downtown Abu Dhabi, 30 minutes from the Grand Mosque, and 20 minutes from the Louvre Abu Dhabi. Taxis are immediately available outside.</p>
 
-          <p><strong>Q: What should I wear to the Sheikh Zayed Grand Mosque?</strong><br/>A: Modest dress is mandatory. Women must cover hair, arms, and legs completely. Men need long trousers and shirts with sleeves. Free abayas (for women) and kanduras (for men) are provided at the entrance if your clothing doesn't meet requirements. This is strictly enforced.</p>
+          <p><strong>Q: What should I wear to the Sheikh Zayed Grand Mosque?</strong><br>A: Modest dress is mandatory. Women must cover hair, arms, and legs completely. Men need long trousers and shirts with sleeves. Free abayas (for women) and kanduras (for men) are provided at the entrance if your clothing doesn't meet requirements. This is strictly enforced.</p>
 
-          <p><strong>Q: Is Abu Dhabi expensive?</strong><br/>A: Similar to major Western cities. Taxis are reasonable (metered). The Grand Mosque and Corniche are free. Museums run $15-25, theme parks $70-100. Restaurant meals range from $10-15 at casual spots to $50+ at hotel restaurants. Budget around $50-100 per person for a day of independent sightseeing including transport and lunch.</p>
+          <p><strong>Q: Is Abu Dhabi expensive?</strong><br>A: Similar to major Western cities. Taxis are reasonable (metered). The Grand Mosque and Corniche are free. Museums run $15-25, theme parks $70-100. Restaurant meals range from $10-15 at casual spots to $50+ at hotel restaurants. Budget around $50-100 per person for a day of independent sightseeing including transport and lunch.</p>
 
-          <p><strong>Q: Abu Dhabi or Dubai — which is better?</strong><br/>A: Different experiences. Abu Dhabi is more cultural and relaxed — the Grand Mosque and Louvre are world-class. Dubai is flashier and more commercial with bigger malls and more nightlife. Many cruises visit both, which is ideal for comparison.</p>
+          <p><strong>Q: Abu Dhabi or Dubai — which is better?</strong><br>A: Different experiences. Abu Dhabi is more cultural and relaxed — the Grand Mosque and Louvre are world-class. Dubai is flashier and more commercial with bigger malls and more nightlife. Many cruises visit both, which is ideal for comparison.</p>
 
-          <p><strong>Q: Can I drink alcohol in Abu Dhabi?</strong><br/>A: Only in licensed venues (hotels and some restaurants). No public drinking. Public intoxication is illegal. Most cruise visitors find hotel bars or skip alcohol during their port day.</p>
+          <p><strong>Q: Can I drink alcohol in Abu Dhabi?</strong><br>A: Only in licensed venues (hotels and some restaurants). No public drinking. Public intoxication is illegal. Most cruise visitors find hotel bars or skip alcohol during their port day.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -339,23 +340,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/abu-dhabi/grand-mosque.webp" alt="Sheikh Zayed Grand Mosque with its gleaming white marble domes and minarets rising against a brilliant blue Abu Dhabi sky" loading="lazy"/>
+              <img src="/ports/img/abu-dhabi/grand-mosque.webp" alt="Sheikh Zayed Grand Mosque with its gleaming white marble domes and minarets rising against a brilliant blue Abu Dhabi sky" loading="lazy">
               <figcaption>Sheikh Zayed Grand Mosque — spiritual heart of Abu Dhabi<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/abu-dhabi/grand-mosque-interior.webp" alt="Ornate interior of Sheikh Zayed Grand Mosque with massive crystal chandeliers and intricate white marble columns" loading="lazy"/>
+              <img src="/ports/img/abu-dhabi/grand-mosque-interior.webp" alt="Ornate interior of Sheikh Zayed Grand Mosque with massive crystal chandeliers and intricate white marble columns" loading="lazy">
               <figcaption>Inside the Grand Mosque — world's largest chandeliers<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/abu-dhabi/louvre-dome.webp" alt="Geometric latticed dome of Louvre Abu Dhabi creating patterns of light and shadow on the gallery floor" loading="lazy"/>
+              <img src="/ports/img/abu-dhabi/louvre-dome.webp" alt="Geometric latticed dome of Louvre Abu Dhabi creating patterns of light and shadow on the gallery floor" loading="lazy">
               <figcaption>Louvre Abu Dhabi — rain of light through geometric dome<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/abu-dhabi/cruise-terminal.webp" alt="Abu Dhabi Cruise Terminal at Zayed Port with modern architecture and cruise ship docked at the pier" loading="lazy"/>
+              <img src="/ports/img/abu-dhabi/cruise-terminal.webp" alt="Abu Dhabi Cruise Terminal at Zayed Port with modern architecture and cruise ship docked at the pier" loading="lazy">
               <figcaption>Zayed Port — gateway to the UAE capital<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/abu-dhabi/corniche-skyline.webp" alt="Abu Dhabi Corniche waterfront promenade with modern skyscrapers and palm trees along the Arabian Gulf" loading="lazy"/>
+              <img src="/ports/img/abu-dhabi/corniche-skyline.webp" alt="Abu Dhabi Corniche waterfront promenade with modern skyscrapers and palm trees along the Arabian Gulf" loading="lazy">
               <figcaption>Corniche promenade — 8km of waterfront beauty<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -391,8 +392,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -414,7 +415,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -465,5 +466,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/acapulco.html
+++ b/ports/acapulco.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Acapulco cruise port — La Quebrada cliff divers plunge 135 feet since 1934, Fort San Diego preserves colonial heritage, and Pacific beaches beckon with fresh ceviche."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Acapulco Cruise Port Guide — Cliff Divers & Mexico's Golden Coast | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Acapulco cruise port — La Quebrada cliff divers, Fort San Diego colonial fortress, Isla la Roqueta snorkeling, and Mexico's legendary Pacific resort."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/acapulco.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Acapulco cruise port — La Quebrada cliff divers plunge 135 feet since 1934, Fort San Diego preserves colonial heritage, and Pacific beaches beckon with fresh ceviche.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Acapulco Cruise Port Guide — Cliff Divers &amp; Mexico's Golden Coast | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Acapulco cruise port — La Quebrada cliff divers, Fort San Diego colonial fortress, Isla la Roqueta snorkeling, and Mexico's legendary Pacific resort.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/acapulco.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Acapulco cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/acapulco/la-quebrada-cliffs.webp" alt="Dramatic La Quebrada cliffs rising above the Pacific Ocean in Acapulco where legendary cliff divers perform" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Acapulco</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Acapulco</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Acapulco</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Acapulco cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/acapulco/la-quebrada-cliffs.webp" alt="Dramatic La Quebrada cliffs rising above the Pacific Ocean in Acapulco where legendary cliff divers perform" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Acapulco</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns, 3+ contrast words -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've been fascinated by Acapulco since I first learned about La Quebrada as a child — those images of divers plunging from impossible heights into churning Pacific waters have stayed with me for decades. Yet nothing I've read quite captures what travelers describe when they witness it firsthand. The photographs show the height, the rocks, the narrow cove, but they can't convey the collective gasp of the crowd, the held breath, or the eruption of applause when the diver surfaces triumphant. I'm planning my visit with that moment in mind.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/acapulco/cliff-diver-action.webp" alt="La Quebrada cliff diver mid-dive plunging toward the Pacific Ocean with arms outstretched against the rocky cliffs" loading="lazy"/>
+              <img src="/ports/img/acapulco/cliff-diver-action.webp" alt="La Quebrada cliff diver mid-dive plunging toward the Pacific Ocean with arms outstretched against the rocky cliffs" loading="lazy">
               <figcaption>La Quebrada cliff diver — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>My research into La Quebrada has revealed a tradition stretching back to 1934 when local fishermen first began diving from these cliffs for tourists. However, the skill required is extraordinary — divers must time their jump precisely with the incoming wave to ensure sufficient water depth in the narrow cove. Too early and they risk hitting submerged rocks. Too late and the wave recedes, leaving dangerously shallow water. They climb 135 feet barefoot up jagged rocks, pause at a small shrine to the Virgin of Guadalupe, and dive — arms outstretched like crucifixes — into the Pacific.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/acapulco/fort-san-diego.webp" alt="Star-shaped Fort San Diego fortress with colonial stone walls and cannons overlooking Acapulco Bay" loading="lazy"/>
+              <img src="/ports/img/acapulco/fort-san-diego.webp" alt="Star-shaped Fort San Diego fortress with colonial stone walls and cannons overlooking Acapulco Bay" loading="lazy">
               <figcaption>Fort San Diego — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -203,7 +204,7 @@ Soli Deo Gloria
           <p>Terminal Marítima serves as Acapulco's cruise gateway, located in the downtown area with easy access to the city's main attractions. The terminal offers basic facilities including restrooms, taxi coordination, and tour operator desks. Ships dock directly at the pier — no tender required.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/acapulco/cruise-terminal.webp" alt="Acapulco cruise terminal with ship docked at pier and palm-lined waterfront promenade" loading="lazy"/>
+            <img src="/ports/img/acapulco/cruise-terminal.webp" alt="Acapulco cruise terminal with ship docked at pier and palm-lined waterfront promenade" loading="lazy">
             <figcaption>Terminal Marítima — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -324,15 +325,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where do cruise ships dock in Acapulco?</strong><br/>A: Ships dock at Terminal Marítima in downtown Acapulco, about 15 minutes walking to the Zócalo (main plaza). Taxis are readily available at the port. The terminal has basic facilities including restrooms and tour coordination.</p>
+          <p><strong>Q: Where do cruise ships dock in Acapulco?</strong><br>A: Ships dock at Terminal Marítima in downtown Acapulco, about 15 minutes walking to the Zócalo (main plaza). Taxis are readily available at the port. The terminal has basic facilities including restrooms and tour coordination.</p>
 
-          <p><strong>Q: Are the La Quebrada cliff divers worth seeing?</strong><br/>A: Absolutely — it's Acapulco's most iconic attraction and genuinely thrilling. Divers have been plunging 135 feet into the Pacific since 1934. The skill and courage are breathtaking. The 1pm show fits cruise schedules well. Allow about an hour including taxi time.</p>
+          <p><strong>Q: Are the La Quebrada cliff divers worth seeing?</strong><br>A: Absolutely — it's Acapulco's most iconic attraction and genuinely thrilling. Divers have been plunging 135 feet into the Pacific since 1934. The skill and courage are breathtaking. The 1pm show fits cruise schedules well. Allow about an hour including taxi time.</p>
 
-          <p><strong>Q: Is Acapulco safe for cruise visitors?</strong><br/>A: Tourist areas are generally safe during daytime. Use licensed taxis from the port, stick to organized tours or well-traveled areas like La Quebrada, Fort San Diego, and main beaches. Cruise lines only call at ports they deem safe for passengers.</p>
+          <p><strong>Q: Is Acapulco safe for cruise visitors?</strong><br>A: Tourist areas are generally safe during daytime. Use licensed taxis from the port, stick to organized tours or well-traveled areas like La Quebrada, Fort San Diego, and main beaches. Cruise lines only call at ports they deem safe for passengers.</p>
 
-          <p><strong>Q: How has Hurricane Otis affected the port?</strong><br/>A: Hurricane Otis (October 2023) caused significant damage. Recovery is ongoing, and cruise ships have returned. Major attractions are operational, but some areas may still show storm impact. Check your cruise line for current updates.</p>
+          <p><strong>Q: How has Hurricane Otis affected the port?</strong><br>A: Hurricane Otis (October 2023) caused significant damage. Recovery is ongoing, and cruise ships have returned. Major attractions are operational, but some areas may still show storm impact. Check your cruise line for current updates.</p>
 
-          <p><strong>Q: Can I use US dollars?</strong><br/>A: Yes, widely accepted at tourist areas. Pesos will give you better value and are preferred by smaller vendors. ATMs are available at the port and downtown.</p>
+          <p><strong>Q: Can I use US dollars?</strong><br>A: Yes, widely accepted at tourist areas. Pesos will give you better value and are preferred by smaller vendors. ATMs are available at the port and downtown.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -340,23 +341,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/acapulco/la-quebrada-cliffs.webp" alt="Dramatic La Quebrada cliffs rising above the Pacific Ocean in Acapulco where legendary cliff divers perform" loading="lazy"/>
+              <img src="/ports/img/acapulco/la-quebrada-cliffs.webp" alt="Dramatic La Quebrada cliffs rising above the Pacific Ocean in Acapulco where legendary cliff divers perform" loading="lazy">
               <figcaption>La Quebrada — where legends dive since 1934<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/acapulco/cliff-diver-action.webp" alt="La Quebrada cliff diver mid-dive plunging toward the Pacific Ocean with arms outstretched against the rocky cliffs" loading="lazy"/>
+              <img src="/ports/img/acapulco/cliff-diver-action.webp" alt="La Quebrada cliff diver mid-dive plunging toward the Pacific Ocean with arms outstretched against the rocky cliffs" loading="lazy">
               <figcaption>Cliff diver mid-flight — 135 feet of courage<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/acapulco/fort-san-diego.webp" alt="Star-shaped Fort San Diego fortress with colonial stone walls and cannons overlooking Acapulco Bay" loading="lazy"/>
+              <img src="/ports/img/acapulco/fort-san-diego.webp" alt="Star-shaped Fort San Diego fortress with colonial stone walls and cannons overlooking Acapulco Bay" loading="lazy">
               <figcaption>Fort San Diego — guardian of the Manila Galleons<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/acapulco/cruise-terminal.webp" alt="Acapulco cruise terminal with ship docked at pier and palm-lined waterfront promenade" loading="lazy"/>
+              <img src="/ports/img/acapulco/cruise-terminal.webp" alt="Acapulco cruise terminal with ship docked at pier and palm-lined waterfront promenade" loading="lazy">
               <figcaption>Terminal Marítima — gateway to Pacific Mexico<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/acapulco/acapulco-bay.webp" alt="Panoramic view of Acapulco Bay with golden beaches and high-rise hotels curving along the Pacific coastline" loading="lazy"/>
+              <img src="/ports/img/acapulco/acapulco-bay.webp" alt="Panoramic view of Acapulco Bay with golden beaches and high-rise hotels curving along the Pacific coastline" loading="lazy">
               <figcaption>Acapulco Bay — the legendary Pacific resort<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -392,8 +393,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -415,7 +416,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -466,5 +467,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/adelaide.html
+++ b/ports/adelaide.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Adelaide cruise port — Port Adelaide terminal, Barossa Valley wineries, Adelaide Central Market, Botanic Gardens, German-heritage Hahndorf, and South Australia's legendary wine country."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Adelaide cruise port — Port Adelaide terminal, Barossa Valley wineries, Adelaide Central Market, Botanic Gardens, German-heritage Hahndorf, and South Australia's legendary wine country.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Adelaide Port Guide — Gateway to Wine Country | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Adelaide cruise port — Port Adelaide terminal, Barossa Valley wineries, Adelaide Central Market, Botanic Gardens, German-heritage Hahndorf, and South Australia's legendary wine country."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/adelaide.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Adelaide cruise port — Port Adelaide terminal, Barossa Valley wineries, Adelaide Central Market, Botanic Gardens, German-heritage Hahndorf, and South Australia's legendary wine country.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/adelaide.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Adelaide cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/adelaide/barossa-valley.webp" alt="Rolling vineyard hills of the Barossa Valley with rows of grapevines stretching toward the horizon under clear Australian skies" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Adelaide</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Adelaide</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Adelaide</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Adelaide cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/adelaide/barossa-valley.webp" alt="Rolling vineyard hills of the Barossa Valley with rows of grapevines stretching toward the horizon under clear Australian skies" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Adelaide</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns, 3+ contrast words -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've been researching Adelaide with growing excitement, yet nothing in my planning quite captures the sense of discovery that awaits in South Australia's wine country. My research reveals a city ringed entirely by parklands — as if Colonel William Light drew a green belt around civilization itself when he laid out Adelaide in 1836. Wide boulevards stretch beneath plane trees, and the pace feels distinctly unhurried, content to let the world rush past while this corner of Australia savors its sunshine and wine.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/adelaide/central-market.webp" alt="Colorful produce stalls at Adelaide Central Market with pyramids of fresh fruit and vegetables under heritage iron roof" loading="lazy"/>
+              <img src="/ports/img/adelaide/central-market.webp" alt="Colorful produce stalls at Adelaide Central Market with pyramids of fresh fruit and vegetables under heritage iron roof" loading="lazy">
               <figcaption>Central Market — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>However, the Adelaide Central Market has captured my imagination as much as any vineyard. Operating since 1869, it represents over 150 years of cheese and charcuterie excellence, artisan bakers, and passionate vendors. I'm already planning to watch elderly Italian vendors banter with young chefs, see pyramids of stone fruit glowing in the morning light, breathe in coffee and fresh bread and something herbal I can't quite name. This is where Adelaide comes to eat, and I want to taste everything.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/adelaide/hahndorf.webp" alt="Historic main street of Hahndorf with German-style half-timbered buildings and oak trees lining the road" loading="lazy"/>
+              <img src="/ports/img/adelaide/hahndorf.webp" alt="Historic main street of Hahndorf with German-style half-timbered buildings and oak trees lining the road" loading="lazy">
               <figcaption>Hahndorf village — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -203,7 +204,7 @@ Soli Deo Gloria
           <p>Adelaide's cruise terminal is located at Port Adelaide, approximately 13 kilometers northwest of the city center. The Port Adelaide Passenger Terminal sits along a working waterfront where container cranes still swing overhead. Ships dock directly at the pier — no tendering required. The terminal has basic facilities with taxi ranks and shuttle options available.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/adelaide/port-adelaide.webp" alt="Port Adelaide cruise terminal with large cruise ship docked at the pier and historic waterfront buildings visible" loading="lazy"/>
+            <img src="/ports/img/adelaide/port-adelaide.webp" alt="Port Adelaide cruise terminal with large cruise ship docked at the pier and historic waterfront buildings visible" loading="lazy">
             <figcaption>Port Adelaide terminal — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -323,15 +324,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: How do I get from Port Adelaide to the city?</strong><br/>A: The Outer Harbor train line runs from Port Adelaide station to Adelaide CBD in about 40 minutes ($5 AUD). Trains run frequently. Taxis cost $40-50 AUD. The train station is a short walk from the cruise terminal.</p>
+          <p><strong>Q: How do I get from Port Adelaide to the city?</strong><br>A: The Outer Harbor train line runs from Port Adelaide station to Adelaide CBD in about 40 minutes ($5 AUD). Trains run frequently. Taxis cost $40-50 AUD. The train station is a short walk from the cruise terminal.</p>
 
-          <p><strong>Q: Is the Barossa Valley worth visiting?</strong><br/>A: Absolutely — it's one of the world's great wine regions with 150+ wineries. Ship excursions run $150-250 AUD and guarantee return before sailing. If you love wine, the Barossa is bucket-list territory. Tours visit 3-5 wineries with tastings and lunch included.</p>
+          <p><strong>Q: Is the Barossa Valley worth visiting?</strong><br>A: Absolutely — it's one of the world's great wine regions with 150+ wineries. Ship excursions run $150-250 AUD and guarantee return before sailing. If you love wine, the Barossa is bucket-list territory. Tours visit 3-5 wineries with tastings and lunch included.</p>
 
-          <p><strong>Q: When is the Central Market open?</strong><br/>A: Tuesday through Saturday only. Closed Sunday and Monday. If your port day falls on closed days, plan for wine tours or beach time instead. The market is worth adjusting plans for if possible.</p>
+          <p><strong>Q: When is the Central Market open?</strong><br>A: Tuesday through Saturday only. Closed Sunday and Monday. If your port day falls on closed days, plan for wine tours or beach time instead. The market is worth adjusting plans for if possible.</p>
 
-          <p><strong>Q: Can I do wine tours independently?</strong><br/>A: Yes, but driving yourself isn't recommended after tastings. Book independent tours from the city ($120-180 AUD). However, ship excursions offer guaranteed return — important when sailing times are fixed. Book ahead for either option.</p>
+          <p><strong>Q: Can I do wine tours independently?</strong><br>A: Yes, but driving yourself isn't recommended after tastings. Book independent tours from the city ($120-180 AUD). However, ship excursions offer guaranteed return — important when sailing times are fixed. Book ahead for either option.</p>
 
-          <p><strong>Q: What if I don't drink wine?</strong><br/>A: Adelaide still shines. The Central Market, Botanic Gardens (free), Art Gallery of South Australia (free), Glenelg Beach by vintage tram, and Hahndorf German village all offer excellent experiences without wine. The food scene is exceptional regardless.</p>
+          <p><strong>Q: What if I don't drink wine?</strong><br>A: Adelaide still shines. The Central Market, Botanic Gardens (free), Art Gallery of South Australia (free), Glenelg Beach by vintage tram, and Hahndorf German village all offer excellent experiences without wine. The food scene is exceptional regardless.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -339,23 +340,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/adelaide/barossa-valley.webp" alt="Rolling vineyard hills of the Barossa Valley with rows of grapevines stretching toward the horizon under clear Australian skies" loading="lazy"/>
+              <img src="/ports/img/adelaide/barossa-valley.webp" alt="Rolling vineyard hills of the Barossa Valley with rows of grapevines stretching toward the horizon under clear Australian skies" loading="lazy">
               <figcaption>Barossa Valley — Australia's wine heartland<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/adelaide/central-market.webp" alt="Colorful produce stalls at Adelaide Central Market with pyramids of fresh fruit and vegetables under heritage iron roof" loading="lazy"/>
+              <img src="/ports/img/adelaide/central-market.webp" alt="Colorful produce stalls at Adelaide Central Market with pyramids of fresh fruit and vegetables under heritage iron roof" loading="lazy">
               <figcaption>Central Market — food lover's paradise since 1869<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/adelaide/hahndorf.webp" alt="Historic main street of Hahndorf with German-style half-timbered buildings and oak trees lining the road" loading="lazy"/>
+              <img src="/ports/img/adelaide/hahndorf.webp" alt="Historic main street of Hahndorf with German-style half-timbered buildings and oak trees lining the road" loading="lazy">
               <figcaption>Hahndorf — German village in the Adelaide Hills<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/adelaide/port-adelaide.webp" alt="Port Adelaide cruise terminal with large cruise ship docked at the pier and historic waterfront buildings visible" loading="lazy"/>
+              <img src="/ports/img/adelaide/port-adelaide.webp" alt="Port Adelaide cruise terminal with large cruise ship docked at the pier and historic waterfront buildings visible" loading="lazy">
               <figcaption>Port Adelaide — gateway to wine country<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/adelaide/botanic-gardens.webp" alt="Lush green pathways through Adelaide Botanic Gardens with native Australian plants and palm trees" loading="lazy"/>
+              <img src="/ports/img/adelaide/botanic-gardens.webp" alt="Lush green pathways through Adelaide Botanic Gardens with native Australian plants and palm trees" loading="lazy">
               <figcaption>Botanic Gardens — 50 hectares of green space<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -391,8 +392,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -414,7 +415,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -465,5 +466,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/agadir.html
+++ b/ports/agadir.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Agadir cruise port — Morocco's rebuilt beach resort, Paradise Valley oasis, Souk El Had market, Kasbah cable car views, argan oil cooperatives, and Berber cultural discoveries."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Agadir Cruise Port Guide — Atlantic Beach & Atlas Gateway | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Agadir cruise port — Morocco's rebuilt beach resort, Paradise Valley oasis, Souk El Had market, Kasbah cable car views, argan oil cooperatives, and Berber cultural discoveries."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/agadir.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Agadir cruise port — Morocco's rebuilt beach resort, Paradise Valley oasis, Souk El Had market, Kasbah cable car views, argan oil cooperatives, and Berber cultural discoveries.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Agadir Cruise Port Guide — Atlantic Beach &amp; Atlas Gateway | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Agadir cruise port — Morocco's rebuilt beach resort, Paradise Valley oasis, Souk El Had market, Kasbah cable car views, argan oil cooperatives, and Berber cultural discoveries.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/agadir.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Agadir cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/agadir/beach-promenade.webp" alt="Golden sand beach stretching along Agadir's Atlantic coastline with palm-lined promenade and Atlas Mountains in the distance" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Agadir</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Agadir</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Agadir</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Agadir cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/agadir/beach-promenade.webp" alt="Golden sand beach stretching along Agadir's Atlantic coastline with palm-lined promenade and Atlas Mountains in the distance" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Agadir</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns, 3+ contrast words -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've been researching Agadir with growing fascination, yet nothing I've read quite prepares me for a city defined by what it lost. On February 29, 1960, an earthquake lasting just fifteen seconds killed between ten and fifteen thousand people and reduced every ancient structure to rubble. What rose in its place is something both modern and haunted — six miles of pristine beach, wide boulevards engineered to seismic standards, palm-lined promenades where tangled medieval streets once stood. The Atlas Mountains still watch from the distance, unchanged witnesses to catastrophe and resurrection.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/agadir/kasbah-ruins.webp" alt="Ancient Kasbah ruins atop the hill overlooking modern Agadir with panoramic views of the bay and Atlantic Ocean" loading="lazy"/>
+              <img src="/ports/img/agadir/kasbah-ruins.webp" alt="Ancient Kasbah ruins atop the hill overlooking modern Agadir with panoramic views of the bay and Atlantic Ocean" loading="lazy">
               <figcaption>Kasbah ruins — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>My planning has centered on two very different experiences. First, the cable car to Kasbah Agadir Oufella — the hilltop fortress ruins that remain the old city's only skeletal witness. Since May 2022, a modern cable car makes this ascent easy and scenic. However, what compels me is standing on those broken walls at dusk, looking down at the rebuilt city as its lights begin to glow. The Arabic inscription still reads "God, Country, King" on walls that refused to completely fall. I want to witness that moment when resilience becomes visible.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/agadir/paradise-valley.webp" alt="Natural rock pools and palm trees in Paradise Valley oasis nestled in the Atlas Mountain foothills near Agadir" loading="lazy"/>
+              <img src="/ports/img/agadir/paradise-valley.webp" alt="Natural rock pools and palm trees in Paradise Valley oasis nestled in the Atlas Mountain foothills near Agadir" loading="lazy">
               <figcaption>Paradise Valley — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -203,7 +204,7 @@ Soli Deo Gloria
           <p>Agadir's commercial port serves as the cruise gateway, located about 3 km from the beach and city center. The terminal offers basic facilities — this is primarily a commercial fishing and cargo port that welcomes cruise ships. Ships dock directly at the pier; no tendering required.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/agadir/cruise-port.webp" alt="Agadir commercial port with cruise ship docked at the pier and fishing boats in the harbor" loading="lazy"/>
+            <img src="/ports/img/agadir/cruise-port.webp" alt="Agadir commercial port with cruise ship docked at the pier and fishing boats in the harbor" loading="lazy">
             <figcaption>Agadir port — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -322,15 +323,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where do cruise ships dock in Agadir?</strong><br/>A: Ships dock at Agadir's commercial port, about 3 km from the beach and city center. Taxis are readily available at the terminal for around 30-50 MAD ($3-5) to reach the beach promenade. The port has basic facilities.</p>
+          <p><strong>Q: Where do cruise ships dock in Agadir?</strong><br>A: Ships dock at Agadir's commercial port, about 3 km from the beach and city center. Taxis are readily available at the terminal for around 30-50 MAD ($3-5) to reach the beach promenade. The port has basic facilities.</p>
 
-          <p><strong>Q: Is Agadir safe for cruise visitors?</strong><br/>A: Yes — Agadir is considered Morocco's safest major city. The 1960 earthquake led to complete rebuilding with modern wide streets and well-policed tourist areas. Vendors can be persistent but the atmosphere is welcoming and relaxed.</p>
+          <p><strong>Q: Is Agadir safe for cruise visitors?</strong><br>A: Yes — Agadir is considered Morocco's safest major city. The 1960 earthquake led to complete rebuilding with modern wide streets and well-policed tourist areas. Vendors can be persistent but the atmosphere is welcoming and relaxed.</p>
 
-          <p><strong>Q: Why doesn't Agadir have an old medina?</strong><br/>A: The February 29, 1960 earthquake killed 10,000-15,000 people and destroyed all ancient structures. The city was completely rebuilt with modern seismic standards. La Medina d'Agadir is a 1992 recreation built with traditional Berber techniques. The Memoire d'Agadir museum tells the earthquake's story.</p>
+          <p><strong>Q: Why doesn't Agadir have an old medina?</strong><br>A: The February 29, 1960 earthquake killed 10,000-15,000 people and destroyed all ancient structures. The city was completely rebuilt with modern seismic standards. La Medina d'Agadir is a 1992 recreation built with traditional Berber techniques. The Memoire d'Agadir museum tells the earthquake's story.</p>
 
-          <p><strong>Q: Is Paradise Valley worth the trip?</strong><br/>A: Absolutely — one of Morocco's hidden gems. Natural rock pools in Atlas foothills, palm oases, waterfalls. Half-day tours run €40-60 per person. Swimming in cool mountain water after Moroccan heat is unforgettable. Book through ship excursions or local operators.</p>
+          <p><strong>Q: Is Paradise Valley worth the trip?</strong><br>A: Absolutely — one of Morocco's hidden gems. Natural rock pools in Atlas foothills, palm oases, waterfalls. Half-day tours run €40-60 per person. Swimming in cool mountain water after Moroccan heat is unforgettable. Book through ship excursions or local operators.</p>
 
-          <p><strong>Q: What should I buy in Agadir?</strong><br/>A: Argan oil from women's cooperatives (culinary for cooking, cosmetic for skin — different products), leather goods, ceramics, spices (saffron, ras el hanout), Berber carpets. Bargain at Souk El Had's 6,000+ stalls.</p>
+          <p><strong>Q: What should I buy in Agadir?</strong><br>A: Argan oil from women's cooperatives (culinary for cooking, cosmetic for skin — different products), leather goods, ceramics, spices (saffron, ras el hanout), Berber carpets. Bargain at Souk El Had's 6,000+ stalls.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -338,23 +339,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/agadir/beach-promenade.webp" alt="Golden sand beach stretching along Agadir's Atlantic coastline with palm-lined promenade and Atlas Mountains in the distance" loading="lazy"/>
+              <img src="/ports/img/agadir/beach-promenade.webp" alt="Golden sand beach stretching along Agadir's Atlantic coastline with palm-lined promenade and Atlas Mountains in the distance" loading="lazy">
               <figcaption>Agadir Beach — Morocco's premier Atlantic resort<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/agadir/kasbah-ruins.webp" alt="Ancient Kasbah ruins atop the hill overlooking modern Agadir with panoramic views of the bay and Atlantic Ocean" loading="lazy"/>
+              <img src="/ports/img/agadir/kasbah-ruins.webp" alt="Ancient Kasbah ruins atop the hill overlooking modern Agadir with panoramic views of the bay and Atlantic Ocean" loading="lazy">
               <figcaption>Kasbah Oufella — survivor of the 1960 earthquake<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/agadir/paradise-valley.webp" alt="Natural rock pools and palm trees in Paradise Valley oasis nestled in the Atlas Mountain foothills near Agadir" loading="lazy"/>
+              <img src="/ports/img/agadir/paradise-valley.webp" alt="Natural rock pools and palm trees in Paradise Valley oasis nestled in the Atlas Mountain foothills near Agadir" loading="lazy">
               <figcaption>Paradise Valley — Atlas Mountain oasis<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/agadir/cruise-port.webp" alt="Agadir commercial port with cruise ship docked at the pier and fishing boats in the harbor" loading="lazy"/>
+              <img src="/ports/img/agadir/cruise-port.webp" alt="Agadir commercial port with cruise ship docked at the pier and fishing boats in the harbor" loading="lazy">
               <figcaption>Agadir port — gateway to Atlantic Morocco<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/agadir/souk-el-had.webp" alt="Colorful spice pyramids and traditional goods at Souk El Had market in Agadir with vendors and shoppers" loading="lazy"/>
+              <img src="/ports/img/agadir/souk-el-had.webp" alt="Colorful spice pyramids and traditional goods at Souk El Had market in Agadir with vendors and shoppers" loading="lazy">
               <figcaption>Souk El Had — 6,000 stalls of Moroccan treasures<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -390,8 +391,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -413,7 +414,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -464,5 +465,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/akureyri.html
+++ b/ports/akureyri.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Akureyri cruise port — whale watching in Eyjafjörður fjord, Goðafoss waterfall, Lake Mývatn geothermal wonders, midnight sun, and Iceland's northern capital."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Akureyri cruise port — whale watching in Eyjafjörður fjord, Goðafoss waterfall, Lake Mývatn geothermal wonders, midnight sun, and Iceland's northern capital.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Akureyri, Iceland Port Guide — Where Giants Swim | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Akureyri cruise port — whale watching in Eyjafjörður fjord, Goðafoss waterfall, Lake Mývatn geothermal wonders, midnight sun, and Iceland's northern capital."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/akureyri.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Akureyri cruise port — whale watching in Eyjafjörður fjord, Goðafoss waterfall, Lake Mývatn geothermal wonders, midnight sun, and Iceland's northern capital.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/akureyri.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Akureyri cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/akureyri/eyjafjordur-whale.webp" alt="Humpback whale breaching in Eyjafjörður fjord with snow-capped mountains and dramatic Icelandic sky in background" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Akureyri</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Akureyri</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Akureyri</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Akureyri cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/akureyri/eyjafjordur-whale.webp" alt="Humpback whale breaching in Eyjafjörður fjord with snow-capped mountains and dramatic Icelandic sky in background" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Akureyri</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns, 3+ contrast words -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've been researching Akureyri with growing anticipation, yet nothing in my planning quite captures what awaits in Iceland's magnificent north. My research reveals ships sailing into Eyjafjörður — one of Iceland's longest fjords — with snow-draped peaks rising on both sides, their reflections shimmering in water so still it looks painted. We're just 60 kilometers south of the Arctic Circle here, though the latitude feels less like a number and more like a presence. The light itself is different, softer somehow, as if the sun remembers it will barely set come summer.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/akureyri/godafoss.webp" alt="Goðafoss waterfall with turquoise glacial water plunging over horseshoe-shaped basalt cliffs under dramatic Icelandic sky" loading="lazy"/>
+              <img src="/ports/img/akureyri/godafoss.webp" alt="Goðafoss waterfall with turquoise glacial water plunging over horseshoe-shaped basalt cliffs under dramatic Icelandic sky" loading="lazy">
               <figcaption>Goðafoss waterfall — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>However, Akureyri itself has captured my imagination beyond the whales. Iceland's second-largest urban area sits tucked on the western shore of Eyjafjörður's southern end, where mountains shelter it from Arctic winds. The floating pier deposits you directly in front of Hof Cultural Centre — a striking glass-and-concrete building that looks like Iceland distilled into architecture. You walk off the ship and you're already downtown, surrounded by colorful houses, cozy cafés, and that particular Icelandic warmth.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/akureyri/myvatn.webp" alt="Steaming geothermal vents at Lake Mývatn with sulfur deposits painting the volcanic landscape in yellow and orange" loading="lazy"/>
+              <img src="/ports/img/akureyri/myvatn.webp" alt="Steaming geothermal vents at Lake Mývatn with sulfur deposits painting the volcanic landscape in yellow and orange" loading="lazy">
               <figcaption>Lake Mývatn — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -203,7 +204,7 @@ Soli Deo Gloria
           <p>Akureyri's cruise terminal is a floating pier directly in front of Hof Cultural Centre in downtown Akureyri. Ships dock directly — no tendering required. You walk off the gangway into the heart of Iceland's second-largest urban area. Whale watching tours depart from this same pier, making booking and boarding remarkably convenient.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/akureyri/akureyri-pier.webp" alt="Cruise ship docked at Akureyri floating pier with colorful downtown buildings and Akureyrarkirkja church visible on hillside" loading="lazy"/>
+            <img src="/ports/img/akureyri/akureyri-pier.webp" alt="Cruise ship docked at Akureyri floating pier with colorful downtown buildings and Akureyrarkirkja church visible on hillside" loading="lazy">
             <figcaption>Akureyri pier — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -324,15 +325,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where do cruise ships dock in Akureyri?</strong><br/>A: At the floating pier directly in front of Hof Cultural Centre in downtown Akureyri. You walk off the ship into the town center. Whale watching tours depart from the same pier. No tenders or shuttles required.</p>
+          <p><strong>Q: Where do cruise ships dock in Akureyri?</strong><br>A: At the floating pier directly in front of Hof Cultural Centre in downtown Akureyri. You walk off the ship into the town center. Whale watching tours depart from the same pier. No tenders or shuttles required.</p>
 
-          <p><strong>Q: Is whale watching worth it?</strong><br/>A: Absolutely. Akureyri offers world-class whale watching in Eyjafjörður fjord. Humpbacks, minkes, dolphins, and porpoises are common. Tours include a Wildlife Guarantee. Classic tours €85-95, RIB tours €130-150. Book in advance — they sell out on cruise days.</p>
+          <p><strong>Q: Is whale watching worth it?</strong><br>A: Absolutely. Akureyri offers world-class whale watching in Eyjafjörður fjord. Humpbacks, minkes, dolphins, and porpoises are common. Tours include a Wildlife Guarantee. Classic tours €85-95, RIB tours €130-150. Book in advance — they sell out on cruise days.</p>
 
-          <p><strong>Q: Can I visit Goðafoss independently?</strong><br/>A: Yes, by taxi (€100-120 return) or rental car. However, organized tours (€80-120 half-day) are easier and often combine with other stops. Ship excursions offer guaranteed return before sailing. The waterfall itself is free to visit.</p>
+          <p><strong>Q: Can I visit Goðafoss independently?</strong><br>A: Yes, by taxi (€100-120 return) or rental car. However, organized tours (€80-120 half-day) are easier and often combine with other stops. Ship excursions offer guaranteed return before sailing. The waterfall itself is free to visit.</p>
 
-          <p><strong>Q: How cold is it in summer?</strong><br/>A: Summer temperatures average 10-15°C but can drop lower with wind. Waterproof layers essential. The sun barely sets in June-July (midnight sun), so daylight is abundant even if temperatures are cool.</p>
+          <p><strong>Q: How cold is it in summer?</strong><br>A: Summer temperatures average 10-15°C but can drop lower with wind. Waterproof layers essential. The sun barely sets in June-July (midnight sun), so daylight is abundant even if temperatures are cool.</p>
 
-          <p><strong>Q: What if I don't want to do tours?</strong><br/>A: Downtown Akureyri is pleasant for walking — colorful houses, cafés, the Botanical Garden (free), and Akureyrarkirkja church. You can spend a relaxing day without organized excursions, though whale watching and Goðafoss are the signature experiences.</p>
+          <p><strong>Q: What if I don't want to do tours?</strong><br>A: Downtown Akureyri is pleasant for walking — colorful houses, cafés, the Botanical Garden (free), and Akureyrarkirkja church. You can spend a relaxing day without organized excursions, though whale watching and Goðafoss are the signature experiences.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -340,23 +341,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/akureyri/eyjafjordur-whale.webp" alt="Humpback whale breaching in Eyjafjörður fjord with snow-capped mountains and dramatic Icelandic sky in background" loading="lazy"/>
+              <img src="/ports/img/akureyri/eyjafjordur-whale.webp" alt="Humpback whale breaching in Eyjafjörður fjord with snow-capped mountains and dramatic Icelandic sky in background" loading="lazy">
               <figcaption>Whale watching — humpbacks in Eyjafjörður<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/akureyri/godafoss.webp" alt="Goðafoss waterfall with turquoise glacial water plunging over horseshoe-shaped basalt cliffs under dramatic Icelandic sky" loading="lazy"/>
+              <img src="/ports/img/akureyri/godafoss.webp" alt="Goðafoss waterfall with turquoise glacial water plunging over horseshoe-shaped basalt cliffs under dramatic Icelandic sky" loading="lazy">
               <figcaption>Goðafoss — Waterfall of the Gods<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/akureyri/myvatn.webp" alt="Steaming geothermal vents at Lake Mývatn with sulfur deposits painting the volcanic landscape in yellow and orange" loading="lazy"/>
+              <img src="/ports/img/akureyri/myvatn.webp" alt="Steaming geothermal vents at Lake Mývatn with sulfur deposits painting the volcanic landscape in yellow and orange" loading="lazy">
               <figcaption>Lake Mývatn — geothermal wonderland<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/akureyri/akureyri-pier.webp" alt="Cruise ship docked at Akureyri floating pier with colorful downtown buildings and Akureyrarkirkja church visible on hillside" loading="lazy"/>
+              <img src="/ports/img/akureyri/akureyri-pier.webp" alt="Cruise ship docked at Akureyri floating pier with colorful downtown buildings and Akureyrarkirkja church visible on hillside" loading="lazy">
               <figcaption>Akureyri pier — gateway to the north<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/akureyri/akureyrarkirkja.webp" alt="Akureyrarkirkja Lutheran church with twin towers overlooking the town from its hillside perch above colorful houses" loading="lazy"/>
+              <img src="/ports/img/akureyri/akureyrarkirkja.webp" alt="Akureyrarkirkja Lutheran church with twin towers overlooking the town from its hillside perch above colorful houses" loading="lazy">
               <figcaption>Akureyrarkirkja — iconic northern church<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -392,8 +393,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -415,7 +416,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -466,5 +467,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/amber-cove.html
+++ b/ports/amber-cove.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Amber Cove cruise port — Carnival's $85 million Dominican Republic resort with mega pool complex, ziplines, Puerto Plata cable car, 27 Waterfalls adventure, and authentic Caribbean culture."/>
-  <meta name="last-reviewed" content="2025-12-28"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Amber Cove cruise port — Carnival's $85 million Dominican Republic resort with mega pool complex, ziplines, Puerto Plata cable car, 27 Waterfalls adventure, and authentic Caribbean culture.">
+  <meta name="last-reviewed" content="2025-12-28">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Amber Cove Port Guide — Dominican Republic | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Amber Cove cruise port — Carnival's $85 million Dominican Republic resort with mega pool complex, ziplines, Puerto Plata cable car, 27 Waterfalls adventure, and authentic Caribbean culture."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/amber-cove.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Amber Cove cruise port — Carnival's $85 million Dominican Republic resort with mega pool complex, ziplines, Puerto Plata cable car, 27 Waterfalls adventure, and authentic Caribbean culture.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/amber-cove.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Amber Cove cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/amber-cove/amber-cove-aerial.webp" alt="Aerial view of Amber Cove cruise port showing the massive pool complex, cruise ships at dock, and lush Dominican mountains in the background" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Amber Cove</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Amber Cove</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Amber Cove</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Amber Cove cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/amber-cove/amber-cove-aerial.webp" alt="Aerial view of Amber Cove cruise port showing the massive pool complex, cruise ships at dock, and lush Dominican mountains in the background" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Amber Cove</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns, 3+ contrast words -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've been researching Amber Cove with a mix of curiosity and skepticism, yet my planning keeps revealing surprising depth beneath the resort surface. My research shows ships docking at Carnival Corporation's $85 million purpose-built port on the Dominican Republic's north coast — a 30-acre cruise destination that opened in October 2015. However, what fascinates me is the layered reality: this isn't just a manufactured paradise, it's a gateway to one of the Caribbean's most culturally rich countries.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/amber-cove/aqua-zone-pool.webp" alt="The massive Aqua Zone pool complex at Amber Cove with swim-up bar, waterslides, and cruise ship visible in the background" loading="lazy"/>
+              <img src="/ports/img/amber-cove/aqua-zone-pool.webp" alt="The massive Aqua Zone pool complex at Amber Cove with swim-up bar, waterslides, and cruise ship visible in the background" loading="lazy">
               <figcaption>Aqua Zone pool — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>The location has captured my imagination. This coastline witnessed one of the most pivotal moments in human interaction — where Old World met New World, where everything changed. The Spanish named it Puerto Plata ("Silver Port") for the way moonlight shimmered on the waters. I keep reading about the cable car climbing Mount Isabel de Torres, where a Christ the Redeemer statue watches over the coast and botanical gardens bloom at 2,600 feet. That's the perspective I want — seeing the Caribbean from above.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/amber-cove/puerto-plata-teleferico.webp" alt="Puerto Plata cable car ascending Mount Isabel de Torres with panoramic views of the Dominican coast and Caribbean Sea below" loading="lazy"/>
+              <img src="/ports/img/amber-cove/puerto-plata-teleferico.webp" alt="Puerto Plata cable car ascending Mount Isabel de Torres with panoramic views of the Dominican coast and Caribbean Sea below" loading="lazy">
               <figcaption>Cable car to Mount Isabel — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -202,10 +203,10 @@ Soli Deo Gloria
         <!-- CRUISE PORT SECTION - 100+ words -->
         <section class="port-section" id="cruise-port">
           <h2>The Cruise Port</h2>
-          <p>Amber Cove is a purpose-built Carnival Corporation cruise port on the Dominican Republic's north coast near Puerto Plata. Two berths can handle up to 8,000 passengers simultaneously from Carnival, Holland America, Princess, AIDA, Costa, Cunard, and P&O vessels. Ships dock directly — no tender needed. The 30-acre complex opened in October 2015 with an $85 million investment.</p>
+          <p>Amber Cove is a purpose-built Carnival Corporation cruise port on the Dominican Republic's north coast near Puerto Plata. Two berths can handle up to 8,000 passengers simultaneously from Carnival, Holland America, Princess, AIDA, Costa, Cunard, and P&amp;O vessels. Ships dock directly — no tender needed. The 30-acre complex opened in October 2015 with an $85 million investment.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/amber-cove/amber-cove-pier.webp" alt="Cruise ship docked at Amber Cove pier with the colorful port complex and Dominican mountains visible beyond" loading="lazy"/>
+            <img src="/ports/img/amber-cove/amber-cove-pier.webp" alt="Cruise ship docked at Amber Cove pier with the colorful port complex and Dominican mountains visible beyond" loading="lazy">
             <figcaption>Amber Cove pier — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -330,13 +331,13 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Is Amber Cove a private island?</strong><br/>A: Not quite — it's a purpose-built cruise port on the mainland Dominican Republic. Unlike Labadee or CocoCay, you can exit the port gates and explore authentic Dominican towns, beaches, and attractions independently. The choice between resort paradise and real Caribbean culture is yours.</p>
+          <p><strong>Q: Is Amber Cove a private island?</strong><br>A: Not quite — it's a purpose-built cruise port on the mainland Dominican Republic. Unlike Labadee or CocoCay, you can exit the port gates and explore authentic Dominican towns, beaches, and attractions independently. The choice between resort paradise and real Caribbean culture is yours.</p>
 
-          <p><strong>Q: Do I need to pay for the pool?</strong><br/>A: Basic pool and beach access in the Aqua Zone is complimentary for all cruise passengers. Premium cabanas ($99-299), upgraded loungers ($25-50), and zip lines ($49-89) cost extra. Many people find the free amenities — massive lagoon pool, swim-up bar, waterslides — perfectly sufficient for a fantastic day.</p>
+          <p><strong>Q: Do I need to pay for the pool?</strong><br>A: Basic pool and beach access in the Aqua Zone is complimentary for all cruise passengers. Premium cabanas ($99-299), upgraded loungers ($25-50), and zip lines ($49-89) cost extra. Many people find the free amenities — massive lagoon pool, swim-up bar, waterslides — perfectly sufficient for a fantastic day.</p>
 
-          <p><strong>Q: Is it safe to leave the port?</strong><br/>A: Yes, Puerto Plata is accustomed to tourists and generally safe. Use licensed taxis from the port taxi stand, keep valuables secure, and exercise normal travel precautions. Many cruisers venture out independently without issues and prefer the authentic experience to the resort bubble.</p>
+          <p><strong>Q: Is it safe to leave the port?</strong><br>A: Yes, Puerto Plata is accustomed to tourists and generally safe. Use licensed taxis from the port taxi stand, keep valuables secure, and exercise normal travel precautions. Many cruisers venture out independently without issues and prefer the authentic experience to the resort bubble.</p>
 
-          <p><strong>Q: What's the best excursion?</strong><br/>A: Depends on your style. The cable car to Mount Isabel de Torres ($35-55) combines stunning views, gardens, and easy accessibility. For adventure seekers, the 27 Waterfalls of Damajagua ($65-95) offers cliff jumping and natural waterslides — physically demanding but unforgettable. For relaxation, the complimentary Aqua Zone pool is genuinely impressive.</p>
+          <p><strong>Q: What's the best excursion?</strong><br>A: Depends on your style. The cable car to Mount Isabel de Torres ($35-55) combines stunning views, gardens, and easy accessibility. For adventure seekers, the 27 Waterfalls of Damajagua ($65-95) offers cliff jumping and natural waterslides — physically demanding but unforgettable. For relaxation, the complimentary Aqua Zone pool is genuinely impressive.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -344,23 +345,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/amber-cove/amber-cove-aerial.webp" alt="Aerial view of Amber Cove cruise port showing the massive pool complex, cruise ships at dock, and lush Dominican mountains in the background" loading="lazy"/>
+              <img src="/ports/img/amber-cove/amber-cove-aerial.webp" alt="Aerial view of Amber Cove cruise port showing the massive pool complex, cruise ships at dock, and lush Dominican mountains in the background" loading="lazy">
               <figcaption>Amber Cove aerial view<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/amber-cove/aqua-zone-pool.webp" alt="The massive Aqua Zone pool complex at Amber Cove with swim-up bar, waterslides, and cruise ship visible in the background" loading="lazy"/>
+              <img src="/ports/img/amber-cove/aqua-zone-pool.webp" alt="The massive Aqua Zone pool complex at Amber Cove with swim-up bar, waterslides, and cruise ship visible in the background" loading="lazy">
               <figcaption>Aqua Zone pool complex<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/amber-cove/puerto-plata-teleferico.webp" alt="Puerto Plata cable car ascending Mount Isabel de Torres with panoramic views of the Dominican coast and Caribbean Sea below" loading="lazy"/>
+              <img src="/ports/img/amber-cove/puerto-plata-teleferico.webp" alt="Puerto Plata cable car ascending Mount Isabel de Torres with panoramic views of the Dominican coast and Caribbean Sea below" loading="lazy">
               <figcaption>Cable car to Mount Isabel<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/amber-cove/27-waterfalls.webp" alt="Travelers jumping into crystal clear pools at the 27 Waterfalls of Damajagua surrounded by lush tropical jungle" loading="lazy"/>
+              <img src="/ports/img/amber-cove/27-waterfalls.webp" alt="Travelers jumping into crystal clear pools at the 27 Waterfalls of Damajagua surrounded by lush tropical jungle" loading="lazy">
               <figcaption>27 Waterfalls of Damajagua<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/amber-cove/amber-cove-pier.webp" alt="Cruise ship docked at Amber Cove pier with the colorful port complex and Dominican mountains visible beyond" loading="lazy"/>
+              <img src="/ports/img/amber-cove/amber-cove-pier.webp" alt="Cruise ship docked at Amber Cove pier with the colorful port complex and Dominican mountains visible beyond" loading="lazy">
               <figcaption>Amber Cove cruise pier<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -396,8 +397,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -419,7 +420,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -470,5 +471,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/anchorage.html
+++ b/ports/anchorage.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Anchorage — Alaska's gateway city for cruises departing Seward or Whittier, featuring Chugach Mountains, Alaska Wildlife Conservation Center, glacier flightseeing, and Native culture."/>
-  <meta name="last-reviewed" content="2025-12-28"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Anchorage — Alaska's gateway city for cruises departing Seward or Whittier, featuring Chugach Mountains, Alaska Wildlife Conservation Center, glacier flightseeing, and Native culture.">
+  <meta name="last-reviewed" content="2025-12-28">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Anchorage Port Guide — Alaska's Cruise Gateway | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Anchorage — Alaska's gateway city for cruises departing Seward or Whittier, featuring Chugach Mountains, Alaska Wildlife Conservation Center, glacier flightseeing, and Native culture."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/anchorage.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Anchorage — Alaska's gateway city for cruises departing Seward or Whittier, featuring Chugach Mountains, Alaska Wildlife Conservation Center, glacier flightseeing, and Native culture.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/anchorage.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Anchorage cruise gateway hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/anchorage/anchorage-chugach.webp" alt="Downtown Anchorage skyline with the snow-capped Chugach Mountains rising dramatically behind the city under clear Alaska blue sky" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Anchorage</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Anchorage</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Anchorage</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Anchorage cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/anchorage/anchorage-chugach.webp" alt="Downtown Anchorage skyline with the snow-capped Chugach Mountains rising dramatically behind the city under clear Alaska blue sky" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Anchorage</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns, 3+ contrast words -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've been researching Anchorage with growing appreciation for Alaska's largest city, yet what strikes me most is how this place defies easy categorization. My planning reveals a modern American city of 290,000 people — yet surrounded by wilderness so immediate that moose wander through suburban backyards and bears fish in streams within city limits. However, what truly fascinates me is Anchorage's role as the gateway to Alaska's cruise ports: most passengers flying in for Gulf of Alaska voyages pass through here, making it the threshold between the familiar and the frontier.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/anchorage/wildlife-center.webp" alt="Brown bear at the Alaska Wildlife Conservation Center with mountains visible in the background through evergreen forest" loading="lazy"/>
+              <img src="/ports/img/anchorage/wildlife-center.webp" alt="Brown bear at the Alaska Wildlife Conservation Center with mountains visible in the background through evergreen forest" loading="lazy">
               <figcaption>Wildlife Conservation Center — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>The wildlife possibilities have captured my imagination. The Alaska Wildlife Conservation Center, about 50 miles south on the Seward Highway, offers guaranteed encounters with bears, moose, musk ox, caribou, and other Alaska species. Though these are rescued animals rather than wild encounters, I'm told it's the most reliable way to see Alaska's iconic wildlife up close — and the setting against Chugach Mountain views is spectacular. I'm budgeting $15 admission and planning 2-3 hours.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/anchorage/glacier-flightseeing.webp" alt="Small flightseeing plane flying past massive blue glaciers and snow-covered peaks in Alaska's Chugach mountain range" loading="lazy"/>
+              <img src="/ports/img/anchorage/glacier-flightseeing.webp" alt="Small flightseeing plane flying past massive blue glaciers and snow-covered peaks in Alaska's Chugach mountain range" loading="lazy">
               <figcaption>Glacier flightseeing — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -205,7 +206,7 @@ Soli Deo Gloria
           <p>Anchorage itself is not a cruise port — ships dock at Seward (2.5 hours south via Seward Highway) or Whittier (1 hour southeast through the Anton Anderson Memorial Tunnel). Most cruise lines offer motorcoach transfers between Anchorage airport/hotels and the ship, included in Gulf of Alaska cruise packages. The drive to Seward along Turnagain Arm is spectacularly scenic; Whittier is accessed through North America's longest highway tunnel.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/anchorage/seward-highway.webp" alt="Seward Highway winding along Turnagain Arm with Chugach Mountains reflected in the calm inlet waters at golden hour" loading="lazy"/>
+            <img src="/ports/img/anchorage/seward-highway.webp" alt="Seward Highway winding along Turnagain Arm with Chugach Mountains reflected in the calm inlet waters at golden hour" loading="lazy">
             <figcaption>Seward Highway along Turnagain Arm — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -280,7 +281,7 @@ Soli Deo Gloria
           <h2>Food &amp; Dining</h2>
           <p>Anchorage food is defined by wild-caught seafood and Alaska game:</p>
           <ul>
-            <li><strong>Wild Salmon ($$$):</strong> King, sockeye, and silver salmon prepared every way imaginable. Simon & Seafort's and Sullivan's are locals' favorites. Expect $30-50 for entrées. Worth it for fresh-caught Alaska salmon.</li>
+            <li><strong>Wild Salmon ($$$):</strong> King, sockeye, and silver salmon prepared every way imaginable. Simon &amp; Seafort's and Sullivan's are locals' favorites. Expect $30-50 for entrées. Worth it for fresh-caught Alaska salmon.</li>
             <li><strong>King Crab ($$$$):</strong> Alaska's premium shellfish. Legs by the pound at seafood restaurants. Expect $50-80+ for a generous serving. Splurge-worthy.</li>
             <li><strong>Reindeer Sausage ($):</strong> Street vendor specialty downtown. Grilled with onions and peppers. $8-12. Uniquely Alaskan fast food.</li>
             <li><strong>Sourdough Pancakes ($$):</strong> Gold-rush legacy breakfast. Snow City Café and Gwennie's Old Alaska Restaurant are institutions. $12-18 for breakfast. Arrive early — popular spots get crowded.</li>
@@ -332,13 +333,13 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where do Alaska cruise ships dock near Anchorage?</strong><br/>A: Cruise ships dock at either Seward (2.5 hours south) or Whittier (1 hour southeast). Anchorage itself is not a cruise port, but serves as the gateway city for flights and pre/post-cruise stays. Most cruise lines include motorcoach transfers between Anchorage and the ship as part of Gulf of Alaska packages.</p>
+          <p><strong>Q: Where do Alaska cruise ships dock near Anchorage?</strong><br>A: Cruise ships dock at either Seward (2.5 hours south) or Whittier (1 hour southeast). Anchorage itself is not a cruise port, but serves as the gateway city for flights and pre/post-cruise stays. Most cruise lines include motorcoach transfers between Anchorage and the ship as part of Gulf of Alaska packages.</p>
 
-          <p><strong>Q: How much time should I spend in Anchorage?</strong><br/>A: At minimum, overnight if arriving the day before your cruise to avoid connection stress. Ideally 2-3 days to experience Alaska Wildlife Conservation Center, flightseeing, Native culture centers, and the spectacular Seward Highway drive without rushing. Many travelers add a pre-cruise land tour to Denali National Park.</p>
+          <p><strong>Q: How much time should I spend in Anchorage?</strong><br>A: At minimum, overnight if arriving the day before your cruise to avoid connection stress. Ideally 2-3 days to experience Alaska Wildlife Conservation Center, flightseeing, Native culture centers, and the spectacular Seward Highway drive without rushing. Many travelers add a pre-cruise land tour to Denali National Park.</p>
 
-          <p><strong>Q: Is a rental car necessary in Anchorage?</strong><br/>A: Helpful but not essential. Downtown Anchorage is walkable, and organized tours include transport. However, a rental car ($50-90/day) offers flexibility for Alaska Wildlife Conservation Center, Portage Glacier, scenic drives, and making the Seward Highway journey at your own pace. Parking is generally easy and often free outside downtown.</p>
+          <p><strong>Q: Is a rental car necessary in Anchorage?</strong><br>A: Helpful but not essential. Downtown Anchorage is walkable, and organized tours include transport. However, a rental car ($50-90/day) offers flexibility for Alaska Wildlife Conservation Center, Portage Glacier, scenic drives, and making the Seward Highway journey at your own pace. Parking is generally easy and often free outside downtown.</p>
 
-          <p><strong>Q: What's the best time to visit Anchorage?</strong><br/>A: May through September for cruise season. June and July offer longest daylight (20+ hours of light), warmest weather (60-70°F), and peak wildlife activity. August brings fall colors starting and salmon runs. May and September are quieter with slightly lower hotel prices.</p>
+          <p><strong>Q: What's the best time to visit Anchorage?</strong><br>A: May through September for cruise season. June and July offer longest daylight (20+ hours of light), warmest weather (60-70°F), and peak wildlife activity. August brings fall colors starting and salmon runs. May and September are quieter with slightly lower hotel prices.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -346,23 +347,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/anchorage/anchorage-chugach.webp" alt="Downtown Anchorage skyline with the snow-capped Chugach Mountains rising dramatically behind the city under clear Alaska blue sky" loading="lazy"/>
+              <img src="/ports/img/anchorage/anchorage-chugach.webp" alt="Downtown Anchorage skyline with the snow-capped Chugach Mountains rising dramatically behind the city under clear Alaska blue sky" loading="lazy">
               <figcaption>Anchorage and Chugach Mountains<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/anchorage/wildlife-center.webp" alt="Brown bear at the Alaska Wildlife Conservation Center with mountains visible in the background through evergreen forest" loading="lazy"/>
+              <img src="/ports/img/anchorage/wildlife-center.webp" alt="Brown bear at the Alaska Wildlife Conservation Center with mountains visible in the background through evergreen forest" loading="lazy">
               <figcaption>Alaska Wildlife Conservation Center<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/anchorage/glacier-flightseeing.webp" alt="Small flightseeing plane flying past massive blue glaciers and snow-covered peaks in Alaska's Chugach mountain range" loading="lazy"/>
+              <img src="/ports/img/anchorage/glacier-flightseeing.webp" alt="Small flightseeing plane flying past massive blue glaciers and snow-covered peaks in Alaska's Chugach mountain range" loading="lazy">
               <figcaption>Glacier flightseeing<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/anchorage/seward-highway.webp" alt="Seward Highway winding along Turnagain Arm with Chugach Mountains reflected in the calm inlet waters at golden hour" loading="lazy"/>
+              <img src="/ports/img/anchorage/seward-highway.webp" alt="Seward Highway winding along Turnagain Arm with Chugach Mountains reflected in the calm inlet waters at golden hour" loading="lazy">
               <figcaption>Seward Highway scenic drive<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/anchorage/native-cultural.webp" alt="Traditional Alaska Native village house at the Cultural Center with totem poles and displays" loading="lazy"/>
+              <img src="/ports/img/anchorage/native-cultural.webp" alt="Traditional Alaska Native village house at the Cultural Center with totem poles and displays" loading="lazy">
               <figcaption>Alaska Native Cultural Center<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -398,8 +399,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -421,7 +422,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -472,5 +473,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/antigua.html
+++ b/ports/antigua.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="Antigua cruise port guide featuring Nelson's Dockyard UNESCO site, 365 beaches, English Harbour, Shirley Heights lookout, and Caribbean naval traditions."/>
-  <meta name="last-reviewed" content="2025-12-28"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Antigua Port Guide — Nelson's Dockyard & 365 Beaches | In the Wake</title>
-  <meta name="description" content="Antigua cruise port guide featuring Nelson's Dockyard UNESCO site, 365 beaches, English Harbour, Shirley Heights lookout, and Caribbean naval traditions."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/antigua.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="Antigua cruise port guide featuring Nelson's Dockyard UNESCO site, 365 beaches, English Harbour, Shirley Heights lookout, and Caribbean naval traditions.">
+  <meta name="last-reviewed" content="2025-12-28">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Antigua Port Guide — Nelson's Dockyard &amp; 365 Beaches | In the Wake</title>
+  <meta name="description" content="Antigua cruise port guide featuring Nelson's Dockyard UNESCO site, 365 beaches, English Harbour, Shirley Heights lookout, and Caribbean naval traditions.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/antigua.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -89,15 +86,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Antigua cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/antigua/nelsons-dockyard.webp" alt="Eighteenth-century Georgian buildings at Nelson's Dockyard with yachts moored in English Harbour" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Antigua</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -106,7 +95,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -120,7 +109,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -135,7 +124,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -148,19 +137,31 @@ Soli Deo Gloria
       </nav>
     </div>
     <div class="hero">
-      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="Decorative compass rose" aria-hidden="true" decoding="async" loading="lazy"/>
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="Decorative compass rose" aria-hidden="true" decoding="async" loading="lazy">
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567">
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     </div>
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Antigua</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Antigua</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Antigua cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/antigua/nelsons-dockyard.webp" alt="Eighteenth-century Georgian buildings at Nelson's Dockyard with yachts moored in English Harbour" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Antigua</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
+        </section>
+
+
         <h1>Antigua: Where Naval Traditions Meet 365 Beaches</h1>
 
         <section id="logbook">
@@ -239,9 +240,9 @@ Soli Deo Gloria
         </section>
 
         <section id="food">
-          <h2>Local Food & Drink</h2>
+          <h2>Local Food &amp; Drink</h2>
           <ul>
-            <li><strong>Fungee & Pepperpot:</strong> The national dish — cornmeal dumplings with a hearty stew of meat and vegetables</li>
+            <li><strong>Fungee &amp; Pepperpot:</strong> The national dish — cornmeal dumplings with a hearty stew of meat and vegetables</li>
             <li><strong>Saltfish:</strong> Dried salted cod, often served for breakfast with vegetables</li>
             <li><strong>Ducana:</strong> Sweet potato dumplings wrapped in banana leaves</li>
             <li><strong>Wadadli Beer:</strong> Local lager ($4), named for the island's indigenous name</li>
@@ -284,65 +285,65 @@ Soli Deo Gloria
 
         <section id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where do cruise ships dock?</strong><br/>A: St. John's Cruise Terminal in the capital, with duty-free shopping at the pier. Most ships dock directly, though occasional anchoring and tendering occurs during peak season when all berths are occupied.</p>
-          <p><strong>Q: How do I get to Nelson's Dockyard?</strong><br/>A: Take the #17 bus for $1.50 (40 minutes) or hire a taxi for $30 one way. The dockyard is the island's most popular excursion and well worth the journey regardless of transportation choice.</p>
-          <p><strong>Q: Which beach is best near the port?</strong><br/>A: Dickenson Bay is closest (10 minutes) and most developed with facilities and beach bars. Half Moon Bay offers seclusion but requires a 45-minute drive.</p>
-          <p><strong>Q: Is English Harbour worth the drive?</strong><br/>A: Absolutely. The UNESCO site, restored dockyard, and Shirley Heights views make it the island's premier attraction. I consider it essential for first-time visitors.</p>
-          <p><strong>Q: What's the Shirley Heights Sunday party?</strong><br/>A: Weekly afternoon barbecue with steel band music, rum punch, and panoramic views. If your ship timing allows, this is a legendary Caribbean experience not to be missed.</p>
-          <p><strong>Q: Should I visit Betty's Hope?</strong><br/>A: If you're interested in understanding the full narrative of Caribbean colonial society, yes. The restored windmills from 1650 and honest visitor center provide sobering but important context about enslaved labor.</p>
+          <p><strong>Q: Where do cruise ships dock?</strong><br>A: St. John's Cruise Terminal in the capital, with duty-free shopping at the pier. Most ships dock directly, though occasional anchoring and tendering occurs during peak season when all berths are occupied.</p>
+          <p><strong>Q: How do I get to Nelson's Dockyard?</strong><br>A: Take the #17 bus for $1.50 (40 minutes) or hire a taxi for $30 one way. The dockyard is the island's most popular excursion and well worth the journey regardless of transportation choice.</p>
+          <p><strong>Q: Which beach is best near the port?</strong><br>A: Dickenson Bay is closest (10 minutes) and most developed with facilities and beach bars. Half Moon Bay offers seclusion but requires a 45-minute drive.</p>
+          <p><strong>Q: Is English Harbour worth the drive?</strong><br>A: Absolutely. The UNESCO site, restored dockyard, and Shirley Heights views make it the island's premier attraction. I consider it essential for first-time visitors.</p>
+          <p><strong>Q: What's the Shirley Heights Sunday party?</strong><br>A: Weekly afternoon barbecue with steel band music, rum punch, and panoramic views. If your ship timing allows, this is a legendary Caribbean experience not to be missed.</p>
+          <p><strong>Q: Should I visit Betty's Hope?</strong><br>A: If you're interested in understanding the full narrative of Caribbean colonial society, yes. The restored windmills from 1650 and honest visitor center provide sobering but important context about enslaved labor.</p>
         </section>
 
         <section id="gallery">
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure>
-              <img src="/ports/img/antigua/shirley-heights.webp" alt="Panoramic sunset view from Shirley Heights looking over English Harbour and the Caribbean Sea" loading="lazy"/>
+              <img src="/ports/img/antigua/shirley-heights.webp" alt="Panoramic sunset view from Shirley Heights looking over English Harbour and the Caribbean Sea" loading="lazy">
               <figcaption>Shirley Heights offers spectacular views of English Harbour<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/dickenson-bay.webp" alt="White sand beach at Dickenson Bay with turquoise water and beach umbrellas" loading="lazy"/>
+              <img src="/ports/img/antigua/dickenson-bay.webp" alt="White sand beach at Dickenson Bay with turquoise water and beach umbrellas" loading="lazy">
               <figcaption>Dickenson Bay — Antigua's most popular beach<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/st-johns-cathedral.webp" alt="St. John's Cathedral with twin white towers rising above the colonial capital city" loading="lazy"/>
+              <img src="/ports/img/antigua/st-johns-cathedral.webp" alt="St. John's Cathedral with twin white towers rising above the colonial capital city" loading="lazy">
               <figcaption>St. John's Cathedral dominates the capital city skyline<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/half-moon-bay.webp" alt="Secluded crescent beach at Half Moon Bay with Atlantic waves and natural vegetation" loading="lazy"/>
+              <img src="/ports/img/antigua/half-moon-bay.webp" alt="Secluded crescent beach at Half Moon Bay with Atlantic waves and natural vegetation" loading="lazy">
               <figcaption>Half Moon Bay on the Atlantic coast<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/bettys-hope.webp" alt="Twin stone windmill towers at Betty's Hope plantation standing against blue Caribbean sky" loading="lazy"/>
+              <img src="/ports/img/antigua/bettys-hope.webp" alt="Twin stone windmill towers at Betty's Hope plantation standing against blue Caribbean sky" loading="lazy">
               <figcaption>Betty's Hope windmills — monuments to Antigua's plantation era<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/cruise-terminal.webp" alt="Colorful duty-free shops and vendors at St. John's cruise terminal welcoming visitors" loading="lazy"/>
+              <img src="/ports/img/antigua/cruise-terminal.webp" alt="Colorful duty-free shops and vendors at St. John's cruise terminal welcoming visitors" loading="lazy">
               <figcaption>St. John's Cruise Terminal offers duty-free shopping<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/english-harbour.webp" alt="Aerial view of English Harbour showing the protected natural anchorage and surrounding hills" loading="lazy"/>
+              <img src="/ports/img/antigua/english-harbour.webp" alt="Aerial view of English Harbour showing the protected natural anchorage and surrounding hills" loading="lazy">
               <figcaption>English Harbour provided safe anchorage for the Royal Navy<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/admirals-inn.webp" alt="Waterfront dining terrace at Admiral's Inn with yachts visible in the background" loading="lazy"/>
+              <img src="/ports/img/antigua/admirals-inn.webp" alt="Waterfront dining terrace at Admiral's Inn with yachts visible in the background" loading="lazy">
               <figcaption>Admiral's Inn offers waterfront dining at Nelson's Dockyard<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/public-market.webp" alt="Colorful local vendors selling fresh produce and crafts at St. John's Public Market" loading="lazy"/>
+              <img src="/ports/img/antigua/public-market.webp" alt="Colorful local vendors selling fresh produce and crafts at St. John's Public Market" loading="lazy">
               <figcaption>St. John's Public Market showcases local produce<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/fort-berkeley.webp" alt="Weathered stone fortifications of Fort Berkeley guarding the entrance to English Harbour" loading="lazy"/>
+              <img src="/ports/img/antigua/fort-berkeley.webp" alt="Weathered stone fortifications of Fort Berkeley guarding the entrance to English Harbour" loading="lazy">
               <figcaption>Fort Berkeley guards English Harbour entrance<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/antigua/nelsons-dockyard-boats.webp" alt="Restored Georgian buildings at Nelson's Dockyard with yachts moored in English Harbour marina" loading="lazy"/>
+              <img src="/ports/img/antigua/nelsons-dockyard-boats.webp" alt="Restored Georgian buildings at Nelson's Dockyard with yachts moored in English Harbour marina" loading="lazy">
               <figcaption>Nelson's Dockyard — the world's only continuously working Georgian-era dockyard<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
           </div>
         </section>
 
-        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+        <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
       </article>
     </div>
 
@@ -350,7 +351,7 @@ Soli Deo Gloria
       <section class="card" aria-labelledby="glance-heading">
         <h3 id="glance-heading">At a Glance</h3>
         <div class="at-a-glance-grid">
-          <div class="at-a-glance-item"><strong>Country</strong><span>Antigua & Barbuda</span></div>
+          <div class="at-a-glance-item"><strong>Country</strong><span>Antigua &amp; Barbuda</span></div>
           <div class="at-a-glance-item"><strong>Language</strong><span>English</span></div>
           <div class="at-a-glance-item"><strong>Currency</strong><span>XCD / USD</span></div>
           <div class="at-a-glance-item"><strong>Pier</strong><span>St. John's Terminal</span></div>
@@ -371,8 +372,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -396,8 +397,8 @@ Soli Deo Gloria
 
   <section id="credits">
     <footer class="wrap" role="contentinfo">
-      <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
-      <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+      <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
+      <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a> · <a href="/about-us.html">About</a> · <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
       <div class="tiny" style="margin-top: 1rem; padding: 0.5rem; background: #f8f9fa; border-radius: 4px;">
         <strong>Image Credits:</strong>
         <ul style="margin: 0.5rem 0; padding-left: 1.25rem; list-style: disc;">
@@ -446,5 +447,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/aqaba.html
+++ b/ports/aqaba.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="Aqaba cruise port guide featuring Petra day trips, Wadi Rum desert, Red Sea diving and snorkeling, and Jordan's ancient gateway to archaeological wonders."/>
-  <meta name="last-reviewed" content="2025-12-28"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Aqaba Port Guide — Gateway to Petra & Red Sea Adventures | In the Wake</title>
-  <meta name="description" content="Aqaba cruise port guide featuring Petra day trips, Wadi Rum desert, Red Sea diving and snorkeling, and Jordan's ancient gateway to archaeological wonders."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/aqaba.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="Aqaba cruise port guide featuring Petra day trips, Wadi Rum desert, Red Sea diving and snorkeling, and Jordan's ancient gateway to archaeological wonders.">
+  <meta name="last-reviewed" content="2025-12-28">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Aqaba Port Guide — Gateway to Petra &amp; Red Sea Adventures | In the Wake</title>
+  <meta name="description" content="Aqaba cruise port guide featuring Petra day trips, Wadi Rum desert, Red Sea diving and snorkeling, and Jordan's ancient gateway to archaeological wonders.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/aqaba.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -94,15 +91,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Aqaba cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/aqaba/petra-treasury.webp" alt="The Treasury at Petra carved into rose-red sandstone cliffs in the morning light" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Aqaba</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -111,7 +100,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -125,7 +114,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -140,7 +129,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,19 +142,31 @@ Soli Deo Gloria
       </nav>
     </div>
     <div class="hero">
-      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="Decorative compass rose" aria-hidden="true" decoding="async" loading="lazy"/>
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="Decorative compass rose" aria-hidden="true" decoding="async" loading="lazy">
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567">
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     </div>
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Aqaba</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Aqaba</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Aqaba cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/aqaba/petra-treasury.webp" alt="The Treasury at Petra carved into rose-red sandstone cliffs in the morning light" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Aqaba</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</p>
+        </section>
+
+
         <h1>Aqaba: Jordan's Red Sea Gateway to Ancient Wonders</h1>
 
         <section id="logbook">
@@ -236,12 +237,12 @@ Soli Deo Gloria
           <h4>Red Sea Snorkeling</h4>
           <p>Accessible alternative to diving, with coral visible in relatively shallow water. Snorkeling excursions run 15-25 JOD ($21-35 USD) including equipment and boat transportation to reef sites. Beach snorkeling is possible but boat trips reach healthier reef areas. Independent option for visitors who find Petra's walking demands too challenging or who simply prefer marine exploration to archaeological sites.</p>
 
-          <h4>Aqaba Castle & City Walking</h4>
+          <h4>Aqaba Castle &amp; City Walking</h4>
           <p>Mamluk-era fortification near the waterfront with small museum displaying artifacts from the region's millennia of occupation. Entry costs about 3 JOD ($4 USD). Quick option for visitors with limited mobility or those arriving too late for major excursions. Combine with waterfront cafés and the Archaeological Museum for a low-key port day. The 131-meter Arab Revolt flagpole provides a distinctive landmark.</p>
         </section>
 
         <section id="food">
-          <h2>Local Food & Drink</h2>
+          <h2>Local Food &amp; Drink</h2>
           <ul>
             <li><strong>Mansaf:</strong> Jordan's national dish — lamb cooked in fermented yogurt, served over rice with pine nuts. Typically 8-15 JOD ($11-21 USD) at local restaurants</li>
             <li><strong>Falafel:</strong> Deep-fried chickpea balls, served in pita with tahini and vegetables. Budget option at 1-3 JOD ($1.50-4 USD)</li>
@@ -286,65 +287,65 @@ Soli Deo Gloria
 
         <section id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Is Petra worth the long day trip?</strong><br/>A: If you've never been, absolutely yes. Petra is one of humanity's greatest archaeological achievements and one of the New Seven Wonders of the World. The two-hour journey each way is demanding but the experience is unforgettable. Budget at least 4-5 hours on-site.</p>
-          <p><strong>Q: Can I do Petra and Wadi Rum in one day?</strong><br/>A: Technically possible but exhausting and unsatisfying. Better to choose one and experience it properly. Most first-time visitors should choose Petra; return visitors or those seeking natural rather than archaeological wonders should consider Wadi Rum.</p>
-          <p><strong>Q: Is Jordan safe for tourists?</strong><br/>A: Yes, Jordan is considered one of the safest countries in the Middle East. Tourism is a significant industry and visitors are welcome. Aqaba and Petra are well-established tourist destinations with good security and infrastructure.</p>
-          <p><strong>Q: What should I wear?</strong><br/>A: Modest dress is appreciated throughout Jordan — cover shoulders and knees when possible. For Petra specifically, wear comfortable walking shoes with good grip. You'll cover several kilometers on sand, gravel, and uneven stone surfaces.</p>
-          <p><strong>Q: Do I need a visa?</strong><br/>A: Many nationalities can get a visa on arrival for 40 JOD ($56 USD). The Jordan Pass (70-80 JOD) waives the visa fee and includes Petra admission, making it the better economic choice for most visitors.</p>
-          <p><strong>Q: Should I book a ship excursion or go independent?</strong><br/>A: Ship excursions provide timing guarantees — critical when your vessel has a departure schedule. Independent arrangements (private driver) offer flexibility but require careful buffer planning. For first-time Petra visitors, ship excursions offer peace of mind worth the premium.</p>
+          <p><strong>Q: Is Petra worth the long day trip?</strong><br>A: If you've never been, absolutely yes. Petra is one of humanity's greatest archaeological achievements and one of the New Seven Wonders of the World. The two-hour journey each way is demanding but the experience is unforgettable. Budget at least 4-5 hours on-site.</p>
+          <p><strong>Q: Can I do Petra and Wadi Rum in one day?</strong><br>A: Technically possible but exhausting and unsatisfying. Better to choose one and experience it properly. Most first-time visitors should choose Petra; return visitors or those seeking natural rather than archaeological wonders should consider Wadi Rum.</p>
+          <p><strong>Q: Is Jordan safe for tourists?</strong><br>A: Yes, Jordan is considered one of the safest countries in the Middle East. Tourism is a significant industry and visitors are welcome. Aqaba and Petra are well-established tourist destinations with good security and infrastructure.</p>
+          <p><strong>Q: What should I wear?</strong><br>A: Modest dress is appreciated throughout Jordan — cover shoulders and knees when possible. For Petra specifically, wear comfortable walking shoes with good grip. You'll cover several kilometers on sand, gravel, and uneven stone surfaces.</p>
+          <p><strong>Q: Do I need a visa?</strong><br>A: Many nationalities can get a visa on arrival for 40 JOD ($56 USD). The Jordan Pass (70-80 JOD) waives the visa fee and includes Petra admission, making it the better economic choice for most visitors.</p>
+          <p><strong>Q: Should I book a ship excursion or go independent?</strong><br>A: Ship excursions provide timing guarantees — critical when your vessel has a departure schedule. Independent arrangements (private driver) offer flexibility but require careful buffer planning. For first-time Petra visitors, ship excursions offer peace of mind worth the premium.</p>
         </section>
 
         <section id="gallery">
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure>
-              <img src="/ports/img/aqaba/petra-siq.webp" alt="Narrow Siq canyon walkway leading toward Petra with towering sandstone walls" loading="lazy"/>
+              <img src="/ports/img/aqaba/petra-siq.webp" alt="Narrow Siq canyon walkway leading toward Petra with towering sandstone walls" loading="lazy">
               <figcaption>The Siq — the dramatic canyon entrance to Petra<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/petra-monastery.webp" alt="The Monastery at Petra carved into sandstone cliff face with dramatic scale" loading="lazy"/>
+              <img src="/ports/img/aqaba/petra-monastery.webp" alt="The Monastery at Petra carved into sandstone cliff face with dramatic scale" loading="lazy">
               <figcaption>The Monastery — Petra's largest monument, reached by 800 steps<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/wadi-rum.webp" alt="Red sandstone rock formations rising from desert floor in Wadi Rum" loading="lazy"/>
+              <img src="/ports/img/aqaba/wadi-rum.webp" alt="Red sandstone rock formations rising from desert floor in Wadi Rum" loading="lazy">
               <figcaption>Wadi Rum — Mars-like desert landscape featured in The Martian<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/red-sea-coral.webp" alt="Colorful coral reef with tropical fish in the Red Sea near Aqaba" loading="lazy"/>
+              <img src="/ports/img/aqaba/red-sea-coral.webp" alt="Colorful coral reef with tropical fish in the Red Sea near Aqaba" loading="lazy">
               <figcaption>Red Sea coral reefs in Aqaba Marine Park<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/aqaba-castle.webp" alt="Mamluk-era Aqaba Castle with stone walls and tower near the waterfront" loading="lazy"/>
+              <img src="/ports/img/aqaba/aqaba-castle.webp" alt="Mamluk-era Aqaba Castle with stone walls and tower near the waterfront" loading="lazy">
               <figcaption>Aqaba Castle — Mamluk fortification with small museum<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/arab-revolt-flag.webp" alt="Giant Arab Revolt flagpole rising 131 meters above Aqaba waterfront" loading="lazy"/>
+              <img src="/ports/img/aqaba/arab-revolt-flag.webp" alt="Giant Arab Revolt flagpole rising 131 meters above Aqaba waterfront" loading="lazy">
               <figcaption>Arab Revolt flagpole — one of the world's tallest at 131 meters<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/bedouin-camp.webp" alt="Traditional Bedouin tent camp in Wadi Rum desert at sunset" loading="lazy"/>
+              <img src="/ports/img/aqaba/bedouin-camp.webp" alt="Traditional Bedouin tent camp in Wadi Rum desert at sunset" loading="lazy">
               <figcaption>Bedouin camp in Wadi Rum for desert overnight experiences<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/petra-royal-tombs.webp" alt="Ornate carved facades of the Royal Tombs at Petra in morning light" loading="lazy"/>
+              <img src="/ports/img/aqaba/petra-royal-tombs.webp" alt="Ornate carved facades of the Royal Tombs at Petra in morning light" loading="lazy">
               <figcaption>Royal Tombs at Petra — spectacular carved facades<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/red-sea-beach.webp" alt="Red Sea beach in Aqaba with clear turquoise water and sandy shore" loading="lazy"/>
+              <img src="/ports/img/aqaba/red-sea-beach.webp" alt="Red Sea beach in Aqaba with clear turquoise water and sandy shore" loading="lazy">
               <figcaption>Red Sea beaches offer swimming and snorkeling<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/mansaf-dish.webp" alt="Traditional Jordanian mansaf dish with lamb, rice, and yogurt sauce" loading="lazy"/>
+              <img src="/ports/img/aqaba/mansaf-dish.webp" alt="Traditional Jordanian mansaf dish with lamb, rice, and yogurt sauce" loading="lazy">
               <figcaption>Mansaf — Jordan's national dish of lamb and yogurt<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/aqaba/wadi-rum-camel.webp" alt="Camels walking through Wadi Rum desert with sandstone cliffs behind" loading="lazy"/>
+              <img src="/ports/img/aqaba/wadi-rum-camel.webp" alt="Camels walking through Wadi Rum desert with sandstone cliffs behind" loading="lazy">
               <figcaption>Camel rides through Wadi Rum's dramatic landscape<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
           </div>
         </section>
 
-        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+        <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
       </article>
     </div>
 
@@ -373,8 +374,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -398,8 +399,8 @@ Soli Deo Gloria
 
   <section id="credits">
     <footer class="wrap" role="contentinfo">
-      <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
-      <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+      <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
+      <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a> · <a href="/about-us.html">About</a> · <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
       <div class="tiny" style="margin-top: 1rem; padding: 0.5rem; background: #f8f9fa; border-radius: 4px;">
         <strong>Image Credits:</strong>
         <ul style="margin: 0.5rem 0; padding-left: 1.25rem; list-style: disc;">
@@ -449,5 +450,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/ascension.html
+++ b/ports/ascension.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="Ascension Island cruise port guide featuring Green Mountain cloud forest, sea turtle nesting beaches, volcanic landscapes, and one of the most remote ports in the South Atlantic."/>
-  <meta name="last-reviewed" content="2025-12-28"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="Ascension Island cruise port guide featuring Green Mountain cloud forest, sea turtle nesting beaches, volcanic landscapes, and one of the most remote ports in the South Atlantic.">
+  <meta name="last-reviewed" content="2025-12-28">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Ascension Island Port Guide — Darwin's Volcanic Wonder | In the Wake</title>
-  <meta name="description" content="Ascension Island cruise port guide featuring Green Mountain cloud forest, sea turtle nesting beaches, volcanic landscapes, and one of the most remote ports in the South Atlantic."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/ascension.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="Ascension Island cruise port guide featuring Green Mountain cloud forest, sea turtle nesting beaches, volcanic landscapes, and one of the most remote ports in the South Atlantic.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/ascension.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -94,15 +91,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Ascension Island cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/ascension/green-mountain-summit.webp" alt="Green Mountain cloud forest rising above volcanic lava fields on Ascension Island" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Ascension Island</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -111,7 +100,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -125,7 +114,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -140,7 +129,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,19 +142,31 @@ Soli Deo Gloria
       </nav>
     </div>
     <div class="hero">
-      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="Decorative compass rose" aria-hidden="true" decoding="async" loading="lazy"/>
+      <img class="hero-compass" src="/assets/brand/compassrose.png" width="180" height="180" alt="Decorative compass rose" aria-hidden="true" decoding="async" loading="lazy">
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567">
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
     </div>
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Ascension Island</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Ascension Island</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Ascension Island cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/ascension/green-mountain-summit.webp" alt="Green Mountain cloud forest rising above volcanic lava fields on Ascension Island" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Ascension Island</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
         <h1>Ascension Island: Darwin's Volcanic Laboratory in the Mid-Atlantic</h1>
 
         <section id="logbook">
@@ -240,7 +241,7 @@ Soli Deo Gloria
         </section>
 
         <section id="food">
-          <h2>Local Food & Drink</h2>
+          <h2>Local Food &amp; Drink</h2>
           <ul>
             <li><strong>Limited Options:</strong> Ascension has no restaurants open to cruise visitors. Georgetown has small shops with limited supplies and the Exiles Club bar for residents. Expedition cruises provide packed lunches for shore excursions — essential since no food service exists</li>
             <li><strong>Fresh Fish:</strong> Waters surrounding Ascension teem with yellowfin tuna, wahoo, and barracuda. If invited to local gatherings (rare), fresh-caught fish is the specialty. The fishing is world-class for anglers</li>
@@ -285,65 +286,65 @@ Soli Deo Gloria
 
         <section id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where do cruise ships dock at Ascension Island?</strong><br/>A: Ships anchor offshore at Georgetown and tender passengers to a small landing area. There is no cruise pier. Tender operations depend entirely on Atlantic weather conditions and can be canceled if seas exceed safety thresholds, even when skies appear clear.</p>
-          <p><strong>Q: Can I visit Green Mountain on a cruise stop?</strong><br/>A: Yes, if weather permits landing. Green Mountain National Park rises 2,817 feet and hosts a unique cloud forest ecosystem created by Victorian-era botanical experiments. Tours require 4x4 transport and cost £50-70 per person through expedition cruise operators.</p>
-          <p><strong>Q: What makes Ascension important for sea turtles?</strong><br/>A: Ascension hosts one of the Atlantic's largest green sea turtle nesting populations. Thousands of turtles migrate 1,400 miles from Brazil to nest on Long Beach between November and May. Females return to their exact birth beach — a navigational mystery scientists still study.</p>
-          <p><strong>Q: Is Ascension Island safe for visitors?</strong><br/>A: Very safe. The island has about 800 residents, mostly military personnel and contractors. Crime is virtually nonexistent. The main safety concerns are volcanic terrain hazards, intense sun exposure, and ensuring you return to tender operations on time.</p>
-          <p><strong>Q: What currency do I need?</strong><br/>A: British Pound Sterling (£) in cash. There are no ATMs on the island, and credit cards rarely work. Bring small denominations for museum admission, tour tips, and the post office. Saint Helena Pounds are also accepted.</p>
-          <p><strong>Q: What if weather prevents landing?</strong><br/>A: Accept it as part of expedition cruising. Atlantic swells can prevent tender operations regardless of sky conditions. Ships may offer scenic sailing around the island or extended time at other ports. Mental preparation for this possibility improves the overall experience.</p>
+          <p><strong>Q: Where do cruise ships dock at Ascension Island?</strong><br>A: Ships anchor offshore at Georgetown and tender passengers to a small landing area. There is no cruise pier. Tender operations depend entirely on Atlantic weather conditions and can be canceled if seas exceed safety thresholds, even when skies appear clear.</p>
+          <p><strong>Q: Can I visit Green Mountain on a cruise stop?</strong><br>A: Yes, if weather permits landing. Green Mountain National Park rises 2,817 feet and hosts a unique cloud forest ecosystem created by Victorian-era botanical experiments. Tours require 4x4 transport and cost £50-70 per person through expedition cruise operators.</p>
+          <p><strong>Q: What makes Ascension important for sea turtles?</strong><br>A: Ascension hosts one of the Atlantic's largest green sea turtle nesting populations. Thousands of turtles migrate 1,400 miles from Brazil to nest on Long Beach between November and May. Females return to their exact birth beach — a navigational mystery scientists still study.</p>
+          <p><strong>Q: Is Ascension Island safe for visitors?</strong><br>A: Very safe. The island has about 800 residents, mostly military personnel and contractors. Crime is virtually nonexistent. The main safety concerns are volcanic terrain hazards, intense sun exposure, and ensuring you return to tender operations on time.</p>
+          <p><strong>Q: What currency do I need?</strong><br>A: British Pound Sterling (£) in cash. There are no ATMs on the island, and credit cards rarely work. Bring small denominations for museum admission, tour tips, and the post office. Saint Helena Pounds are also accepted.</p>
+          <p><strong>Q: What if weather prevents landing?</strong><br>A: Accept it as part of expedition cruising. Atlantic swells can prevent tender operations regardless of sky conditions. Ships may offer scenic sailing around the island or extended time at other ports. Mental preparation for this possibility improves the overall experience.</p>
         </section>
 
         <section id="gallery">
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure>
-              <img src="/ports/img/ascension/green-mountain-forest.webp" alt="Bamboo groves and tree ferns in the Victorian-era cloud forest on Green Mountain" loading="lazy"/>
+              <img src="/ports/img/ascension/green-mountain-forest.webp" alt="Bamboo groves and tree ferns in the Victorian-era cloud forest on Green Mountain" loading="lazy">
               <figcaption>Cloud forest ecosystem on Green Mountain summit<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/volcanic-landscape.webp" alt="Barren volcanic cinder cones painted in rust and black mineral deposits" loading="lazy"/>
+              <img src="/ports/img/ascension/volcanic-landscape.webp" alt="Barren volcanic cinder cones painted in rust and black mineral deposits" loading="lazy">
               <figcaption>Volcanic landscape at Letterbox Peninsula<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/green-turtle-nesting.webp" alt="Green sea turtle digging nest in dark volcanic sand at Long Beach" loading="lazy"/>
+              <img src="/ports/img/ascension/green-turtle-nesting.webp" alt="Green sea turtle digging nest in dark volcanic sand at Long Beach" loading="lazy">
               <figcaption>Green sea turtle nesting at Long Beach<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/georgetown-settlement.webp" alt="Small Georgetown settlement with colorful buildings beneath volcanic peaks" loading="lazy"/>
+              <img src="/ports/img/ascension/georgetown-settlement.webp" alt="Small Georgetown settlement with colorful buildings beneath volcanic peaks" loading="lazy">
               <figcaption>Georgetown — Ascension's only settlement<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/frigatebird-flight.webp" alt="Endemic Ascension frigatebird soaring with iridescent green plumage visible" loading="lazy"/>
+              <img src="/ports/img/ascension/frigatebird-flight.webp" alt="Endemic Ascension frigatebird soaring with iridescent green plumage visible" loading="lazy">
               <figcaption>Endemic Ascension frigatebird in flight<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/lava-tube-interior.webp" alt="Interior of volcanic lava tube with rough textured walls and natural lighting" loading="lazy"/>
+              <img src="/ports/img/ascension/lava-tube-interior.webp" alt="Interior of volcanic lava tube with rough textured walls and natural lighting" loading="lazy">
               <figcaption>Inside a volcanic lava tube formation<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/long-beach-sunset.webp" alt="Sunset over Long Beach with dark volcanic sand and calm Atlantic waters" loading="lazy"/>
+              <img src="/ports/img/ascension/long-beach-sunset.webp" alt="Sunset over Long Beach with dark volcanic sand and calm Atlantic waters" loading="lazy">
               <figcaption>Sunset at Long Beach turtle nesting site<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/summit-panorama.webp" alt="Panoramic view from Green Mountain summit showing volcanic terrain and Atlantic Ocean" loading="lazy"/>
+              <img src="/ports/img/ascension/summit-panorama.webp" alt="Panoramic view from Green Mountain summit showing volcanic terrain and Atlantic Ocean" loading="lazy">
               <figcaption>Panoramic view from Green Mountain summit<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/boatswain-bird-island.webp" alt="Rocky Boatswain Bird Island offshore with seabirds circling above nesting cliffs" loading="lazy"/>
+              <img src="/ports/img/ascension/boatswain-bird-island.webp" alt="Rocky Boatswain Bird Island offshore with seabirds circling above nesting cliffs" loading="lazy">
               <figcaption>Boatswain Bird Island seabird sanctuary<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/cinder-cone-hiking.webp" alt="Hikers ascending barren volcanic cinder cone with loose scoria underfoot" loading="lazy"/>
+              <img src="/ports/img/ascension/cinder-cone-hiking.webp" alt="Hikers ascending barren volcanic cinder cone with loose scoria underfoot" loading="lazy">
               <figcaption>Hiking volcanic cinder cones<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure>
-              <img src="/ports/img/ascension/island-museum.webp" alt="Ascension Island Museum building with informative displays about the island visible" loading="lazy"/>
+              <img src="/ports/img/ascension/island-museum.webp" alt="Ascension Island Museum building with informative displays about the island visible" loading="lazy">
               <figcaption>Island Museum in Georgetown<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
           </div>
         </section>
 
-        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+        <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
       </article>
     </div>
 
@@ -372,8 +373,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -397,8 +398,8 @@ Soli Deo Gloria
 
   <section id="credits">
     <footer class="wrap" role="contentinfo">
-      <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
-      <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+      <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
+      <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a> · <a href="/about-us.html">About</a> · <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
       <div class="tiny" style="margin-top: 1rem; padding: 0.5rem; background: #f8f9fa; border-radius: 4px;">
         <strong>Image Credits:</strong>
         <ul style="margin: 0.5rem 0; padding-left: 1.25rem; list-style: disc;">
@@ -448,5 +449,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/cozumel.html
+++ b/ports/cozumel.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="Cozumel features Jacques Cousteau's legendary reefs and San Gervasio Mayan ruins. Caribbean's most-visited cruise port with crystal-clear water, beach clubs, and authentic Mexican culture."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="Cozumel features Jacques Cousteau's legendary reefs and San Gervasio Mayan ruins. Caribbean's most-visited cruise port with crystal-clear water, beach clubs, and authentic Mexican culture.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Cozumel — Mexico's Premier Cruise Port Guide | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Cozumel — snorkeling, beach clubs, Mayan culture, and why it's the Caribbean's most visited cruise destination."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/cozumel.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Cozumel — snorkeling, beach clubs, Mayan culture, and why it's the Caribbean's most visited cruise destination.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/cozumel.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
 
   <script type="application/ld+json">
   {
@@ -93,15 +90,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Cozumel hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/cozumel/cozumel-fom-1.webp" alt="Crystal clear Caribbean waters of Cozumel showing stunning turquoise colors against white sand and tropical coastline" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Cozumel</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -110,7 +99,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake cruise travel logbook wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake cruise travel logbook wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -124,7 +113,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -139,7 +128,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -154,11 +143,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Cozumel</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Cozumel</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Cozumel cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/cozumel/cozumel-fom-1.webp" alt="Crystal clear Caribbean waters of Cozumel showing stunning turquoise colors against white sand and tropical coastline" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Cozumel</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION -->
         <section class="port-section" id="logbook">
@@ -167,7 +168,7 @@ Soli Deo Gloria
             <p>I've lost count of how many times I've visited Cozumel on cruise ships — it's on nearly every Western Caribbean itinerary, so if you cruise out of Galveston, Tampa, or Fort Lauderdale with any regularity, you know this island intimately. And yet I still look forward to it every single time. Cozumel was my first real introduction to snorkeling in truly world-class water, my first time eating tacos al pastor from a street cart while mariachi played in the square, and my first understanding of why the ancient Maya chose this place as sacred.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/cozumel/cozumel-fom-2.webp" alt="Crystal clear turquoise Caribbean waters of Cozumel coastline with pristine visibility" loading="lazy"/>
+              <img src="/ports/img/cozumel/cozumel-fom-2.webp" alt="Crystal clear turquoise Caribbean waters of Cozumel coastline with pristine visibility" loading="lazy">
               <figcaption>Cozumel's famous crystal-clear waters — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -176,7 +177,7 @@ Soli Deo Gloria
             <p>After the Maya civilization declined, Cozumel fell quiet enough that pirates found it a perfect hideout through the seventeenth and eighteenth centuries — I sometimes wonder if I'm walking the same beach paths that Henry Morgan used. In the early twentieth century, Cozumel boomed again when chicle harvesters arrived to tap the sapodilla trees for chewing gum, turning sleepy fishing villages into export centers. But it was Jacques Cousteau who truly put Cozumel on the world map — his 1961 documentary on Palancar Reef declared it one of the most beautiful dive sites on earth, and the rest is history. The island has been welcoming underwater pilgrims ever since, drawn by the same crystalline waters that Cousteau called the world's best diving.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/cozumel/cozumel-fom-3.webp" alt="Stunning underwater reef colors of Cozumel showing vibrant coral formations" loading="lazy"/>
+              <img src="/ports/img/cozumel/cozumel-fom-3.webp" alt="Stunning underwater reef colors of Cozumel showing vibrant coral formations" loading="lazy">
               <figcaption>Reef colors that defy photography — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -191,7 +192,7 @@ Soli Deo Gloria
             <p>But I don't want to undersell the cultural side, because Cozumel has real depth beyond the reef and the beach clubs. The <strong>San Gervasio ruins</strong> in the island's interior were the most important pilgrimage destination in the Maya world for women seeking Ixchel's blessing. Walking through the temple complex where countless Maya women once journeyed by canoe from the mainland fills me with a strange reverence. The ruins aren't as dramatic as Tulum or Chichén Itzá, but they're peaceful, uncrowded, and genuinely atmospheric. Entry fee is around $12 USD. For food, downtown San Miguel has fantastic options beyond the tourist-trap waterfront. I always hit <strong>Buccanos at Night</strong> for elevated Mexican seafood, <strong>La Cocay</strong> for upscale fusion, or one of the taco stands in the market for al pastor that costs $2 and changes your life.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/cozumel/cozumel-fom-4.webp" alt="Cozumel coastal scenery showing vibrant Caribbean blues and tropical vegetation" loading="lazy"/>
+              <img src="/ports/img/cozumel/cozumel-fom-4.webp" alt="Cozumel coastal scenery showing vibrant Caribbean blues and tropical vegetation" loading="lazy">
               <figcaption>Coastal paradise — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -205,7 +206,7 @@ Soli Deo Gloria
           <p>Cozumel operates three cruise terminals, and where your ship docks significantly affects your day. <strong>Punta Langosta Pier</strong> is the ideal berth — you walk directly into downtown San Miguel via covered pedestrian bridge, surrounded by shops and restaurants. Disney, Norwegian, and MSC typically dock here. No taxi needed unless heading to beaches or distant attractions.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/cozumel/beach-fishing-boats.webp" alt="Traditional Mexican fishing boats on Cozumel beach with turquoise Caribbean waters" loading="lazy"/>
+            <img src="/ports/img/cozumel/beach-fishing-boats.webp" alt="Traditional Mexican fishing boats on Cozumel beach with turquoise Caribbean waters" loading="lazy">
             <figcaption>Local fishing boats remind you Cozumel is still a working island — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -258,7 +259,7 @@ Soli Deo Gloria
           <p>UNMISSABLE. Palancar Reef and Colombia Reef are world-class dive sites on the Mesoamerican Barrier Reef (second-largest on earth). Visibility frequently exceeds 100 feet. You'll see sea turtles, eagle rays, nurse sharks, and incredible coral formations. Jacques Cousteau declared these the world's best diving waters in 1961. Ship excursion snorkel trips run $50-80; independent boat tours from $35-50. The drift snorkeling experience — floating effortlessly with the current past coral canyons — is genuinely magical.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/cozumel/cozumel-fom-5.webp" alt="Beach paradise scene from Cozumel with white sand and turquoise Caribbean water" loading="lazy"/>
+            <img src="/ports/img/cozumel/cozumel-fom-5.webp" alt="Beach paradise scene from Cozumel with white sand and turquoise Caribbean water" loading="lazy">
             <figcaption>Cozumel's beaches are the stuff of cruise dreams — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -341,17 +342,17 @@ Soli Deo Gloria
         <!-- FAQ -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Which beach club should I choose?</strong><br/>A: Paradise Beach for families (water toys, activities, $50-70). Mr. Sanchos for all-inclusive party atmosphere ($65-85). Nachi Cocom for couples seeking quieter, limited-guest experience ($55-75). Playa Mia for kids who need waterpark features ($60-90). All excellent; choice depends on your vibe.</p>
+          <p><strong>Q: Which beach club should I choose?</strong><br>A: Paradise Beach for families (water toys, activities, $50-70). Mr. Sanchos for all-inclusive party atmosphere ($65-85). Nachi Cocom for couples seeking quieter, limited-guest experience ($55-75). Playa Mia for kids who need waterpark features ($60-90). All excellent; choice depends on your vibe.</p>
 
-          <p><strong>Q: Is the snorkeling really that good?</strong><br/>A: Yes, legitimately world-class. Jacques Cousteau declared these reefs the world's best diving in 1961. Visibility often exceeds 100 feet. You'll see sea turtles, eagle rays, nurse sharks, and incredible coral. Even beginners have mind-blowing experiences on the Mesoamerican Barrier Reef.</p>
+          <p><strong>Q: Is the snorkeling really that good?</strong><br>A: Yes, legitimately world-class. Jacques Cousteau declared these reefs the world's best diving in 1961. Visibility often exceeds 100 feet. You'll see sea turtles, eagle rays, nurse sharks, and incredible coral. Even beginners have mind-blowing experiences on the Mesoamerican Barrier Reef.</p>
 
-          <p><strong>Q: Should I pay in pesos or dollars?</strong><br/>A: US dollars accepted everywhere in tourist areas, but you'll typically get 5-10% better prices paying in Mexican pesos. ATMs throughout downtown provide local currency. Many smaller shops and market vendors prefer cash; some charge 5% surcharge for credit cards.</p>
+          <p><strong>Q: Should I pay in pesos or dollars?</strong><br>A: US dollars accepted everywhere in tourist areas, but you'll typically get 5-10% better prices paying in Mexican pesos. ATMs throughout downtown provide local currency. Many smaller shops and market vendors prefer cash; some charge 5% surcharge for credit cards.</p>
 
-          <p><strong>Q: Is Cozumel safe for cruise passengers?</strong><br/>A: Very safe in tourist areas. Stick to well-marked zones, use common sense with valuables, and you'll have zero issues. The island's economy depends on cruise tourism, and locals are welcoming and helpful. Aggressive vendors are annoying but harmless — a friendly "no gracias" works.</p>
+          <p><strong>Q: Is Cozumel safe for cruise passengers?</strong><br>A: Very safe in tourist areas. Stick to well-marked zones, use common sense with valuables, and you'll have zero issues. The island's economy depends on cruise tourism, and locals are welcoming and helpful. Aggressive vendors are annoying but harmless — a friendly "no gracias" works.</p>
 
-          <p><strong>Q: Should I visit Tulum from Cozumel?</strong><br/>A: It's a long day (ferry + 1-hour drive each way, 8+ hours total) but worthwhile if you've never seen the clifftop ruins. Book a ship excursion for guaranteed return, or go independent with very early start. Costa Maya is actually closer for Mayan ruins — consider that if visiting both ports.</p>
+          <p><strong>Q: Should I visit Tulum from Cozumel?</strong><br>A: It's a long day (ferry + 1-hour drive each way, 8+ hours total) but worthwhile if you've never seen the clifftop ruins. Book a ship excursion for guaranteed return, or go independent with very early start. Costa Maya is actually closer for Mayan ruins — consider that if visiting both ports.</p>
 
-          <p><strong>Q: How far is downtown from the cruise pier?</strong><br/>A: Depends on your ship. Punta Langosta pier is directly in downtown — walk right off into shopping and restaurants. International and Puerta Maya piers are 3 miles south; budget $8-10 taxi or 45 minutes walking along the scenic waterfront.</p>
+          <p><strong>Q: How far is downtown from the cruise pier?</strong><br>A: Depends on your ship. Punta Langosta pier is directly in downtown — walk right off into shopping and restaurants. International and Puerta Maya piers are 3 miles south; budget $8-10 taxi or 45 minutes walking along the scenic waterfront.</p>
         </section>
 
         <!-- GALLERY -->
@@ -359,19 +360,19 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/cozumel/cozumel-fom-6.webp" alt="Downtown San Miguel street scene in Cozumel showing colorful Mexican architecture and shops" loading="lazy"/>
+              <img src="/ports/img/cozumel/cozumel-fom-6.webp" alt="Downtown San Miguel street scene in Cozumel showing colorful Mexican architecture and shops" loading="lazy">
               <figcaption>Downtown San Miguel charm<div class="photo-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/cozumel/cozumel-fom-7.webp" alt="Vibrant Cozumel Caribbean scenery showing turquoise waters and tropical vegetation" loading="lazy"/>
+              <img src="/ports/img/cozumel/cozumel-fom-7.webp" alt="Vibrant Cozumel Caribbean scenery showing turquoise waters and tropical vegetation" loading="lazy">
               <figcaption>Paradise found — Cozumel colors<div class="photo-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/cozumel/cozumel-fom-8.webp" alt="Cozumel harbor views showing cruise ships and Caribbean waterfront scenery" loading="lazy"/>
+              <img src="/ports/img/cozumel/cozumel-fom-8.webp" alt="Cozumel harbor views showing cruise ships and Caribbean waterfront scenery" loading="lazy">
               <figcaption>Postcard-perfect waterfront<div class="photo-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/cozumel/coastal-bike-path.webp" alt="Cozumel coastal road with ocean views perfect for scooter or bike exploration" loading="lazy"/>
+              <img src="/ports/img/cozumel/coastal-bike-path.webp" alt="Cozumel coastal road with ocean views perfect for scooter or bike exploration" loading="lazy">
               <figcaption>Coastal road — rent a scooter and explore<div class="photo-credit">Photo © <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -388,7 +389,7 @@ Soli Deo Gloria
           </ul>
         </section>
 
-        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+        <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
       </article>
     </div>
 
@@ -408,8 +409,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, In the Wake founder and author" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, In the Wake founder and author" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -432,8 +433,8 @@ Soli Deo Gloria
   </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
-    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a> · <a href="/about-us.html">About</a> · <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
     <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
   </footer>
 
@@ -462,5 +463,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/ft-lauderdale.html
+++ b/ports/ft-lauderdale.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Fort Lauderdale cruise port — Port Everglades handles 4M+ passengers annually with Las Olas Boulevard dining, water taxi canals, and Florida's best beach."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Fort Lauderdale cruise port — Port Everglades handles 4M+ passengers annually with Las Olas Boulevard dining, water taxi canals, and Florida's best beach.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Fort Lauderdale Cruise Port Guide — Port Everglades | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Fort Lauderdale cruise port — Port Everglades embarkation, Las Olas Boulevard, water taxi canals, and Fort Lauderdale Beach exploring."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/ft-lauderdale.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Fort Lauderdale cruise port — Port Everglades embarkation, Las Olas Boulevard, water taxi canals, and Fort Lauderdale Beach exploring.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/ft-lauderdale.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -91,20 +88,12 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <section class="port-hero" id="hero" aria-label="Fort Lauderdale cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/ft-lauderdale/las-olas-boulevard.webp" alt="Palm-lined Las Olas Boulevard in Fort Lauderdale with outdoor cafes, boutique shops, and Mediterranean-style architecture" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Fort Lauderdale</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -118,7 +107,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -133,7 +122,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -147,21 +136,33 @@ Soli Deo Gloria
     </div>
   </header>
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Fort Lauderdale</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Fort Lauderdale</li></ol></nav>
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Fort Lauderdale cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/ft-lauderdale/las-olas-boulevard.webp" alt="Palm-lined Las Olas Boulevard in Fort Lauderdale with outdoor cafes, boutique shops, and Mediterranean-style architecture" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Fort Lauderdale</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
         <section class="port-section" id="logbook">
           <h2>My Logbook: Venice of America</h2>
           <div class="logbook-entry clearfix">
             <p>I've sailed from Fort Lauderdale, and what struck me immediately was how different Port Everglades felt from Miami. Despite being only 30 miles north, the atmosphere was calmer, the traffic lighter, and the embarkation process remarkably smooth. Port Everglades handles over 4 million passengers annually — making it Florida's second-busiest cruise port — yet somehow maintains a more manageable feel than its bigger neighbor to the south.</p>
             <figure class="logbook-image float-right">
-              <img src="/ports/img/ft-lauderdale/port-everglades-terminal.webp" alt="Port Everglades cruise terminal with Royal Caribbean ship docked and palm trees lining the waterfront" loading="lazy"/>
+              <img src="/ports/img/ft-lauderdale/port-everglades-terminal.webp" alt="Port Everglades cruise terminal with Royal Caribbean ship docked and palm trees lining the waterfront" loading="lazy">
               <figcaption>Port Everglades — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
             <p>The night before my sailing, I walked along Las Olas Boulevard as the sun set over the Intracoastal Waterway. This elegant street connects downtown Fort Lauderdale to the beach, and I found myself stopping at nearly every block to admire the art galleries, boutique shops, and sidewalk cafes. The architecture has a Mediterranean quality that surprised me — terra cotta roofs, wrought-iron balconies, bougainvillea spilling over walls. Though Fort Lauderdale lacks Miami's Art Deco fame, Las Olas has its own sophisticated beauty.</p>
             <p>Fort Lauderdale calls itself the "Venice of America," and after taking a Water Taxi through the canal system, I understand why. The city has over 300 miles of navigable waterways — more than Venice, Italy. My Water Taxi wove past mega-yachts at private docks, waterfront mansions with pools overlooking the canal, and small restaurants where boats pulled up like cars at a drive-through. The Water Taxi system isn't just a tour — it's actual transportation, connecting beach hotels, Las Olas, and downtown stops.</p>
             <figure class="logbook-image float-left">
-              <img src="/ports/img/ft-lauderdale/water-taxi-canals.webp" alt="Fort Lauderdale Water Taxi cruising through palm-lined canal with luxury waterfront homes" loading="lazy"/>
+              <img src="/ports/img/ft-lauderdale/water-taxi-canals.webp" alt="Fort Lauderdale Water Taxi cruising through palm-lined canal with luxury waterfront homes" loading="lazy">
               <figcaption>Water Taxi canals — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
             <p>The morning of my cruise, I arrived at Port Everglades around 11am. But what struck me was the efficiency. Porters grabbed my bags curbside, security moved quickly, and I was walking the gangway within 90 minutes of parking my car. Compare that to some larger ports where the process can stretch to three hours. The terminals themselves are modern and air-conditioned — a blessing in Florida's humidity.</p>
@@ -180,7 +181,7 @@ Soli Deo Gloria
           <h2>The Cruise Port</h2>
           <p>Port Everglades operates multiple cruise terminals along the Intracoastal Waterway in southeast Fort Lauderdale. The port handles over 4 million cruise passengers annually — Florida's second-busiest after Miami. Royal Caribbean, Celebrity, Princess, Holland America, Cunard, Seabourn, and Silversea all homeport here, with ships departing for Caribbean, Bahamas, and transatlantic itineraries.</p>
           <figure class="logbook-image">
-            <img src="/ports/img/ft-lauderdale/cruise-ship-aerial.webp" alt="Aerial view of Port Everglades with multiple cruise ships docked and Fort Lauderdale skyline in background" loading="lazy"/>
+            <img src="/ports/img/ft-lauderdale/cruise-ship-aerial.webp" alt="Aerial view of Port Everglades with multiple cruise ships docked and Fort Lauderdale skyline in background" loading="lazy">
             <figcaption>Port Everglades aerial — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
           <p>All terminals are wheelchair accessible with modern facilities. Embarkation typically runs 11am-4pm. The port address is 1850 Eller Drive, Fort Lauderdale FL 33316 — though specific terminal addresses vary by cruise line. Drop luggage curbside with porters ($2-3 tip per bag) before parking. Currency is US dollars, and the port area offers restrooms and water. Fort Lauderdale Beach is 10 minutes away.</p>
@@ -191,7 +192,7 @@ Soli Deo Gloria
             <li><strong>From Fort Lauderdale Airport (FLL):</strong> 15 minutes via I-595 East and I-95 South — one of Florida's easiest airport-to-port connections. Uber/Lyft runs $15-25. Taxi service approximately $25-30. Many hotels offer cruise shuttles.</li>
             <li><strong>From Miami:</strong> 30-45 minutes via I-95 North depending on traffic. Miami International Airport (MIA) is about 40 minutes. Consider flying into FLL for simpler logistics.</li>
             <li><strong>Port Parking ($20/day):</strong> Multiple covered garages near terminals. Reserve online at porteverglades.net to guarantee a spot. Credit cards only. Drop bags curbside before parking.</li>
-            <li><strong>Off-Site Parking ($10-15/day):</strong> Several operators offer shuttle service to terminals. Verify shuttle frequency and read recent reviews before booking. Park & Cruise packages at hotels often provide better value.</li>
+            <li><strong>Off-Site Parking ($10-15/day):</strong> Several operators offer shuttle service to terminals. Verify shuttle frequency and read recent reviews before booking. Park &amp; Cruise packages at hotels often provide better value.</li>
             <li><strong>Water Taxi:</strong> All-day passes available for touring Fort Lauderdale's 300+ miles of canals. Connects beach hotels, Las Olas Boulevard, and downtown. Fun alternative to rideshares.</li>
             <li><strong>Uber/Lyft:</strong> Widely available throughout Fort Lauderdale. $8-15 for rides within the beach and downtown area. Surge pricing possible on cruise days.</li>
             <li><strong>Sun Trolley:</strong> Free trolley service along Las Olas Boulevard and the beach. Limited schedule but useful for connecting key tourist areas without rideshare costs.</li>
@@ -230,7 +231,7 @@ Soli Deo Gloria
           <p>One of the largest contemporary art museums in Florida, featuring works by major American and international artists. Located on Las Olas Boulevard. Allow 2 hours. Wheelchair accessible throughout. Book tickets online for best prices.</p>
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Fort Lauderdale Coastal Promenade</h4>
           <p>Seven miles of beachfront walkway along A1A, perfect for morning runs, cycling, or sunset strolls. Street performers, cafes, and beach volleyball courts line the route. Free to access. Bike rentals available at several locations. The promenade connects multiple beach areas and parking lots.</p>
-          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Bonnet House Museum & Gardens</h4>
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Bonnet House Museum &amp; Gardens</h4>
           <p>35-acre historic estate with subtropical gardens, art collection, and wildlife (monkeys live on the grounds!). Guided tours explain the eccentric artists who built this oasis. Allow 2 hours. Book ahead through bonnethouse.org. A hidden gem most tourists miss.</p>
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Hollywood Broadwalk</h4>
           <p>Just 15 minutes south of Port Everglades, this 2.5-mile brick promenade offers a more laid-back alternative to Fort Lauderdale Beach. European-style beachfront cafes, bike lanes, and beach volleyball courts line the route. The Margaritaville Beach Resort anchors one end, but the rest maintains old-fashioned beach town charm. Free to access; parking $2-5/hour. Perfect for a relaxed pre-cruise morning walk.</p>
@@ -277,33 +278,33 @@ Soli Deo Gloria
         </section>
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where should I park at Port Everglades?</strong><br/>A: Official port parking costs $20/day — reserve online at porteverglades.net to guarantee a spot. Multiple covered garages serve different terminals. Off-site parking companies charge $10-15/day with shuttle service. Many hotels offer Park & Cruise packages that include free parking for your cruise duration when you stay one night pre-cruise.</p>
-          <p><strong>Q: How far is Fort Lauderdale airport from the port?</strong><br/>A: Fort Lauderdale-Hollywood International Airport (FLL) is just 15 minutes from Port Everglades via I-595 East and I-95 South. Uber/Lyft run $15-25. Taxis around $25-30. One of Florida's easiest airport-to-port connections.</p>
-          <p><strong>Q: Fort Lauderdale vs. Miami — which cruise port is better?</strong><br/>A: Fort Lauderdale offers easier parking ($20/day vs. higher in Miami), less congestion, and a beautiful beach just 10 minutes away. Miami has more nightlife and South Beach energy. Choose based on whether you want relaxed beach time or urban excitement before your cruise.</p>
-          <p><strong>Q: What's worth seeing before a Fort Lauderdale cruise?</strong><br/>A: Las Olas Boulevard offers upscale shopping and dining. The Water Taxi tours Fort Lauderdale's 300+ miles of canals. Fort Lauderdale Public Area has 7 miles of pristine sand. Hollywood Broadwalk is 15 minutes south with a laid-back European beach town atmosphere. The Everglades are 45 minutes west for airboat adventures.</p>
-          <p><strong>Q: Which cruise lines sail from Fort Lauderdale?</strong><br/>A: Port Everglades hosts Royal Caribbean (including Oasis-class ships), Celebrity, Princess, Holland America, Cunard, Seabourn, and Silversea. It's Florida's second-busiest cruise port, handling over 4 million passengers annually.</p>
+          <p><strong>Q: Where should I park at Port Everglades?</strong><br>A: Official port parking costs $20/day — reserve online at porteverglades.net to guarantee a spot. Multiple covered garages serve different terminals. Off-site parking companies charge $10-15/day with shuttle service. Many hotels offer Park &amp; Cruise packages that include free parking for your cruise duration when you stay one night pre-cruise.</p>
+          <p><strong>Q: How far is Fort Lauderdale airport from the port?</strong><br>A: Fort Lauderdale-Hollywood International Airport (FLL) is just 15 minutes from Port Everglades via I-595 East and I-95 South. Uber/Lyft run $15-25. Taxis around $25-30. One of Florida's easiest airport-to-port connections.</p>
+          <p><strong>Q: Fort Lauderdale vs. Miami — which cruise port is better?</strong><br>A: Fort Lauderdale offers easier parking ($20/day vs. higher in Miami), less congestion, and a beautiful beach just 10 minutes away. Miami has more nightlife and South Beach energy. Choose based on whether you want relaxed beach time or urban excitement before your cruise.</p>
+          <p><strong>Q: What's worth seeing before a Fort Lauderdale cruise?</strong><br>A: Las Olas Boulevard offers upscale shopping and dining. The Water Taxi tours Fort Lauderdale's 300+ miles of canals. Fort Lauderdale Public Area has 7 miles of pristine sand. Hollywood Broadwalk is 15 minutes south with a laid-back European beach town atmosphere. The Everglades are 45 minutes west for airboat adventures.</p>
+          <p><strong>Q: Which cruise lines sail from Fort Lauderdale?</strong><br>A: Port Everglades hosts Royal Caribbean (including Oasis-class ships), Celebrity, Princess, Holland America, Cunard, Seabourn, and Silversea. It's Florida's second-busiest cruise port, handling over 4 million passengers annually.</p>
         </section>
         <section class="port-section photo-gallery" id="gallery">
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/ft-lauderdale/las-olas-boulevard.webp" alt="Palm-lined Las Olas Boulevard with outdoor cafes and boutique shops" loading="lazy"/>
+              <img src="/ports/img/ft-lauderdale/las-olas-boulevard.webp" alt="Palm-lined Las Olas Boulevard with outdoor cafes and boutique shops" loading="lazy">
               <figcaption>Las Olas Boulevard — Fort Lauderdale's premier street<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/ft-lauderdale/port-everglades-terminal.webp" alt="Port Everglades cruise terminal with cruise ship and palm trees" loading="lazy"/>
+              <img src="/ports/img/ft-lauderdale/port-everglades-terminal.webp" alt="Port Everglades cruise terminal with cruise ship and palm trees" loading="lazy">
               <figcaption>Port Everglades cruise terminal<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/ft-lauderdale/water-taxi-canals.webp" alt="Water Taxi cruising through Fort Lauderdale's famous canal system" loading="lazy"/>
+              <img src="/ports/img/ft-lauderdale/water-taxi-canals.webp" alt="Water Taxi cruising through Fort Lauderdale's famous canal system" loading="lazy">
               <figcaption>Water Taxi through the canals<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/ft-lauderdale/ft-lauderdale-coastline.webp" alt="Fort Lauderdale coastline stretching along A1A with palm trees and blue Atlantic water" loading="lazy"/>
+              <img src="/ports/img/ft-lauderdale/ft-lauderdale-coastline.webp" alt="Fort Lauderdale coastline stretching along A1A with palm trees and blue Atlantic water" loading="lazy">
               <figcaption>Fort Lauderdale waterfront promenade<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/ft-lauderdale/cruise-ship-aerial.webp" alt="Aerial view of Port Everglades with multiple cruise ships docked" loading="lazy"/>
+              <img src="/ports/img/ft-lauderdale/cruise-ship-aerial.webp" alt="Aerial view of Port Everglades with multiple cruise ships docked" loading="lazy">
               <figcaption>Port Everglades aerial view<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -333,8 +334,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -353,7 +354,7 @@ Soli Deo Gloria
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     </aside>
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
@@ -399,5 +400,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/galveston.html
+++ b/ports/galveston.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Galveston cruise port — Texas's historic gateway to the Western Caribbean. The Strand District, 1900 hurricane history, parking tips, and pre-cruise activities on the Gulf Coast."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Galveston cruise port — Texas's historic gateway to the Western Caribbean. The Strand District, 1900 hurricane history, parking tips, and pre-cruise activities on the Gulf Coast.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Galveston Cruise Port Guide — Texas Homeport | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Galveston cruise port — historic Strand District, 1900 hurricane resilience, parking, hotels, and pre-cruise activities on Texas's Gulf Coast."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/galveston.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Galveston cruise port — historic Strand District, 1900 hurricane resilience, parking, hotels, and pre-cruise activities on Texas's Gulf Coast.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/galveston.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Galveston cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/galveston/strand-district.webp" alt="Historic Victorian iron-front buildings along the Strand District in Galveston with gas lamps and palm trees under Texas blue sky" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Galveston</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Galveston</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Galveston</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Galveston cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/galveston/strand-district.webp" alt="Historic Victorian iron-front buildings along the Strand District in Galveston with gas lamps and palm trees under Texas blue sky" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Galveston</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've sailed from many ports, but Galveston holds a special place in my logbook — this is where the Gulf Coast meets Caribbean dreams without the need to fly east. The oldest cruise port on the Gulf of Mexico, established in 1825, Galveston has welcomed ships for two centuries. Today it's the fourth busiest cruise port in America, handling over a million passengers annually. For Texans and anyone in the central US, this is home waters — the obvious choice for Western Caribbean cruising.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/galveston/seawall-beach.webp" alt="Galveston Seawall stretching along Gulf of Mexico with beachgoers and historic architecture visible under Texas sunshine" loading="lazy"/>
+              <img src="/ports/img/galveston/seawall-beach.webp" alt="Galveston Seawall stretching along Gulf of Mexico with beachgoers and historic architecture visible under Texas sunshine" loading="lazy">
               <figcaption>Galveston Seawall — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>The hurricane struck without warning, killing between 6,000 and 8,000 souls when the Gulf simply rose up and swallowed the island. Entire neighborhoods vanished. Bodies were found weeks later, miles inland. The storm destroyed the wealthiest city in Texas in a single night. But here's what moves me: they rebuilt. Not just rebuilt — they engineered a miracle. Over the next decade, they constructed a massive 10-mile seawall, 17 feet high, and then raised the entire city behind it. Using hydraulic jacks and thousands of railcars filled with sand pumped from the Gulf floor, they lifted over 2,100 buildings — some while people still lived and worked inside them.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/galveston/moody-gardens.webp" alt="Moody Gardens glass pyramids housing aquarium and rainforest exhibits against Galveston Bay backdrop" loading="lazy"/>
+              <img src="/ports/img/galveston/moody-gardens.webp" alt="Moody Gardens glass pyramids housing aquarium and rainforest exhibits against Galveston Bay backdrop" loading="lazy">
               <figcaption>Moody Gardens pyramids — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -187,7 +188,7 @@ Soli Deo Gloria
               <strong>The Moment That Stays With Me:</strong> Standing in the Strand District at sunset, watching the golden light play across those Victorian iron facades, knowing that these very buildings survived the deadliest storm in American history. Cotton brokers once made fortunes in these offices. Shipping magnates walked these sidewalks. And against all odds, these structures still stand — a testament to Galveston's stubborn refusal to disappear. The history here isn't just told; it's felt.
             </div>
 
-            <p>The Strand District is where I always begin my pre-cruise exploration. These 19th-century Victorian iron-front commercial buildings — once the offices of cotton brokers and shipping magnates — now house restaurants, galleries, and antique shops. It's Texas's largest collection of iron-front commercial architecture, and walking these streets is walking where fortunes were made in the 1880s. I stop at Maceo Spice & Import, serving Cuban sandwiches since 1946, and browse the antique shops that make the Strand one of Texas's finest historic districts.</p>
+            <p>The Strand District is where I always begin my pre-cruise exploration. These 19th-century Victorian iron-front commercial buildings — once the offices of cotton brokers and shipping magnates — now house restaurants, galleries, and antique shops. It's Texas's largest collection of iron-front commercial architecture, and walking these streets is walking where fortunes were made in the 1880s. I stop at Maceo Spice &amp; Import, serving Cuban sandwiches since 1946, and browse the antique shops that make the Strand one of Texas's finest historic districts.</p>
 
             <p>The Moody family has shaped much of what Galveston became after 1900. Their legacy lives on in Moody Gardens — those distinctive glass pyramids housing an aquarium, rainforest, and discovery center — and the Moody Foundation, which has poured resources into preserving the island's history. When I visit the gardens or walk past the restored Historic Strand, I'm walking through living history funded by those who believed this island deserved a second chapter. That belief paid off — Galveston thrives today as both a historic treasure and a modern cruise gateway.</p>
 
@@ -201,7 +202,7 @@ Soli Deo Gloria
           <p>The Port of Galveston operates two cruise terminals: Pier 25 (original terminal) and the new $156 million Pier 16 facility that opened in 2025. Together they handle over one million passengers annually — the fourth busiest cruise port in America. Royal Caribbean, Carnival, and Disney all operate from Galveston, sailing primarily to Western Caribbean destinations including Cozumel, Costa Maya, Roatán, and Belize.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/galveston/cruise-terminal.webp" alt="Galveston cruise terminal with Royal Caribbean ship docked and Texas state flag flying under Gulf Coast sky" loading="lazy"/>
+            <img src="/ports/img/galveston/cruise-terminal.webp" alt="Galveston cruise terminal with Royal Caribbean ship docked and Texas state flag flying under Gulf Coast sky" loading="lazy">
             <figcaption>Galveston cruise terminal — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -254,7 +255,7 @@ Soli Deo Gloria
           <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">Booking guidance: Most Galveston attractions don't require advance booking except during Mardi Gras season (February/March). Moody Gardens tickets available online for best prices. Walking tours of the Strand can be done independently without guides.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">The Strand Historic District</h4>
-          <p>This National Historic Landmark is where I always begin. These 19th-century Victorian iron-front commercial buildings — once the offices of cotton brokers and shipping magnates — now house restaurants, galleries, and the best antique shopping in Texas. Walk where fortunes were made in the 1880s. Free to explore; allow 2-3 hours for a proper wander. Stop at Maceo Spice & Import for Cuban sandwiches — serving since 1946.</p>
+          <p>This National Historic Landmark is where I always begin. These 19th-century Victorian iron-front commercial buildings — once the offices of cotton brokers and shipping magnates — now house restaurants, galleries, and the best antique shopping in Texas. Walk where fortunes were made in the 1880s. Free to explore; allow 2-3 hours for a proper wander. Stop at Maceo Spice &amp; Import for Cuban sandwiches — serving since 1946.</p>
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Moody Gardens</h4>
           <p>The Moody family's gift to Galveston — three distinctive glass pyramids housing an aquarium, rainforest, and discovery center. Also features IMAX theater, ropes course, and palm beach. A living legacy of the family that helped rebuild this island after 1900. Allow half day minimum. Book ahead for best prices through moodygardens.com.</p>
@@ -280,9 +281,9 @@ Soli Deo Gloria
           <h2>Where to Eat &amp; Drink</h2>
           <p>Galveston's food scene features fresh Gulf seafood and Texas hospitality:</p>
           <ul>
-            <li><strong>Maceo Spice & Import (Strand, $):</strong> Cuban sandwiches since 1946. My pre-cruise go-to in the Strand District. Cash only.</li>
+            <li><strong>Maceo Spice &amp; Import (Strand, $):</strong> Cuban sandwiches since 1946. My pre-cruise go-to in the Strand District. Cash only.</li>
             <li><strong>Gaido's Seafood Restaurant (Seawall, $$$):</strong> Family-owned since 1911. Famous for Gulf shrimp and pecan-crusted fish. Galveston institution.</li>
-            <li><strong>Sampson & Son's Seafood (Harbor, $$):</strong> Fresh-off-the-boat Gulf seafood. Best during shrimp season (August-December).</li>
+            <li><strong>Sampson &amp; Son's Seafood (Harbor, $$):</strong> Fresh-off-the-boat Gulf seafood. Best during shrimp season (August-December).</li>
             <li><strong>The Spot (Seawall, $$):</strong> Casual beach bar with solid burgers and frozen drinks. Good sunset views.</li>
             <li><strong>Mosquito Cafe (Downtown, $$):</strong> Excellent breakfast and brunch. Local favorite with creative menu.</li>
           </ul>
@@ -328,15 +329,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Which cruise lines sail from Galveston?</strong><br/>A: Royal Caribbean, Carnival, and Disney all operate from Galveston. The new $156 million Pier 16 terminal opened in 2025 to handle Royal Caribbean's largest Oasis-class ships. Ships sail primarily to Western Caribbean destinations including Cozumel, Costa Maya, Roatán, and Belize.</p>
+          <p><strong>Q: Which cruise lines sail from Galveston?</strong><br>A: Royal Caribbean, Carnival, and Disney all operate from Galveston. The new $156 million Pier 16 terminal opened in 2025 to handle Royal Caribbean's largest Oasis-class ships. Ships sail primarily to Western Caribbean destinations including Cozumel, Costa Maya, Roatán, and Belize.</p>
 
-          <p><strong>Q: How far is Galveston from Houston airports?</strong><br/>A: Houston Hobby (HOU) is about 60 minutes via I-45 South — more convenient for cruise passengers. Houston Intercontinental (IAH) is 75-90 minutes. Uber/Lyft runs $55-85 depending on which airport. Allow extra time during Houston rush hours.</p>
+          <p><strong>Q: How far is Galveston from Houston airports?</strong><br>A: Houston Hobby (HOU) is about 60 minutes via I-45 South — more convenient for cruise passengers. Houston Intercontinental (IAH) is 75-90 minutes. Uber/Lyft runs $55-85 depending on which airport. Allow extra time during Houston rush hours.</p>
 
-          <p><strong>Q: Should I arrive a day early in Galveston?</strong><br/>A: Highly recommended — the historic Strand District alone is worth a full afternoon of exploration. Houston traffic is unpredictable, and arriving early eliminates stress. Many hotels offer Park & Cruise packages that include parking for your cruise duration.</p>
+          <p><strong>Q: Should I arrive a day early in Galveston?</strong><br>A: Highly recommended — the historic Strand District alone is worth a full afternoon of exploration. Houston traffic is unpredictable, and arriving early eliminates stress. Many hotels offer Park &amp; Cruise packages that include parking for your cruise duration.</p>
 
-          <p><strong>Q: Where should I park at the Galveston cruise port?</strong><br/>A: Port parking costs $10-20/day for covered or uncovered spots. Covered parking is worth the extra cost — Texas sun can make exposed car interiors dangerously hot. Reserve in advance during peak season through the port website. Off-site lots offer cheaper rates with shuttle service.</p>
+          <p><strong>Q: Where should I park at the Galveston cruise port?</strong><br>A: Port parking costs $10-20/day for covered or uncovered spots. Covered parking is worth the extra cost — Texas sun can make exposed car interiors dangerously hot. Reserve in advance during peak season through the port website. Off-site lots offer cheaper rates with shuttle service.</p>
 
-          <p><strong>Q: What's the best thing to do before a cruise from Galveston?</strong><br/>A: Walk the Strand Historic District — those Victorian iron-front buildings survived the 1900 hurricane and house great restaurants and antique shops. Also consider Moody Gardens (half day), Bishop's Palace (1-2 hours), or a walk along the 10-mile Seawall.</p>
+          <p><strong>Q: What's the best thing to do before a cruise from Galveston?</strong><br>A: Walk the Strand Historic District — those Victorian iron-front buildings survived the 1900 hurricane and house great restaurants and antique shops. Also consider Moody Gardens (half day), Bishop's Palace (1-2 hours), or a walk along the 10-mile Seawall.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -344,23 +345,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/galveston/strand-district.webp" alt="Historic Victorian iron-front buildings along the Strand District in Galveston with gas lamps and palm trees" loading="lazy"/>
+              <img src="/ports/img/galveston/strand-district.webp" alt="Historic Victorian iron-front buildings along the Strand District in Galveston with gas lamps and palm trees" loading="lazy">
               <figcaption>The Strand District — Victorian grandeur that survived the storm<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/galveston/seawall-beach.webp" alt="Galveston Seawall stretching along Gulf of Mexico with beachgoers enjoying Texas sunshine" loading="lazy"/>
+              <img src="/ports/img/galveston/seawall-beach.webp" alt="Galveston Seawall stretching along Gulf of Mexico with beachgoers enjoying Texas sunshine" loading="lazy">
               <figcaption>The Seawall — 10 miles of engineering determination<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/galveston/moody-gardens.webp" alt="Moody Gardens glass pyramids housing aquarium and rainforest exhibits" loading="lazy"/>
+              <img src="/ports/img/galveston/moody-gardens.webp" alt="Moody Gardens glass pyramids housing aquarium and rainforest exhibits" loading="lazy">
               <figcaption>Moody Gardens — the Moody family's gift to Galveston<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/galveston/cruise-terminal.webp" alt="Galveston cruise terminal with cruise ship docked and Texas flag flying" loading="lazy"/>
+              <img src="/ports/img/galveston/cruise-terminal.webp" alt="Galveston cruise terminal with cruise ship docked and Texas flag flying" loading="lazy">
               <figcaption>Gateway to the Western Caribbean<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/galveston/pleasure-pier.webp" alt="Pleasure Pier amusement park extending over Gulf of Mexico with Ferris wheel and rides" loading="lazy"/>
+              <img src="/ports/img/galveston/pleasure-pier.webp" alt="Pleasure Pier amusement park extending over Gulf of Mexico with Ferris wheel and rides" loading="lazy">
               <figcaption>Pleasure Pier — fun over the Gulf<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -396,8 +397,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -419,7 +420,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -470,5 +471,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/grand-cayman.html
+++ b/ports/grand-cayman.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Grand Cayman cruise port with tips for Stingray City sandbar, Seven Mile Beach, George Town tender process, and Starfish Point wildlife encounters."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Grand Cayman Port Guide — Stingray City & Seven Mile Beach | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Grand Cayman — Stingray City sandbar, Seven Mile Beach, George Town tender port, and the British Overseas Territory that delivers bucket-list Caribbean experiences."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/grand-cayman.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Grand Cayman cruise port with tips for Stingray City sandbar, Seven Mile Beach, George Town tender process, and Starfish Point wildlife encounters.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Grand Cayman Port Guide — Stingray City &amp; Seven Mile Beach | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Grand Cayman — Stingray City sandbar, Seven Mile Beach, George Town tender port, and the British Overseas Territory that delivers bucket-list Caribbean experiences.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/grand-cayman.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Grand Cayman hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/grand-cayman/seven-mile-beach-view.webp" alt="Seven Mile Beach panoramic view with crystal clear turquoise Caribbean water stretching along white sand coastline under blue Cayman Islands skies" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Grand Cayman</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Grand Cayman</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Grand Cayman</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Grand Cayman cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/grand-cayman/seven-mile-beach-view.webp" alt="Seven Mile Beach panoramic view with crystal clear turquoise Caribbean water stretching along white sand coastline under blue Cayman Islands skies" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Grand Cayman</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>Sailing into George Town with that ridiculous seven-shades-of-blue water makes everyone abandon breakfast and run to the bow. Grand Cayman is a tender port — but don't groan, because the five-minute ride to the Royal Watler Cruise Terminal through water so clear you can count fish from the boat is part of the magic. This is the Caribbean as postcards promised: impossible turquoise, white sand, and that offshore finance vibe that means everything runs smoothly and looks pristine. I've visited Grand Cayman three times now, and each return confirms what I knew the first time — this port delivers on every bucket-list promise.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/grand-cayman/stingray-city.webp" alt="Swimming with wild southern stingrays at the famous Stingray City sandbar in crystal-clear Caribbean water" loading="lazy"/>
+              <img src="/ports/img/grand-cayman/stingray-city.webp" alt="Swimming with wild southern stingrays at the famous Stingray City sandbar in crystal-clear Caribbean water" loading="lazy">
               <figcaption>Stingray City magic — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>My first stop is always Stingray City, and it rewired how I think about wildlife encounters. This isn't an aquarium — it's a string of shallow sandbars in the North Sound where wild southern stingrays have congregated for generations. The origin story is beautifully simple: decades ago, local fishermen would anchor here to clean their catches, tossing scraps overboard. Stingrays learned that boats at this sandbar meant easy meals. Word spread through the ray population, and more arrived. Over years, these wild creatures grew so accustomed to humans that they became remarkably interactive — gliding up to swimmers expecting handouts.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/grand-cayman/waterfront.webp" alt="George Town waterfront with colorful colonial buildings and cruise tender dock under Caribbean sunshine" loading="lazy"/>
+              <img src="/ports/img/grand-cayman/waterfront.webp" alt="George Town waterfront with colorful colonial buildings and cruise tender dock under Caribbean sunshine" loading="lazy">
               <figcaption>George Town waterfront — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -201,7 +202,7 @@ Soli Deo Gloria
           <p>Grand Cayman is a tender port — your ship anchors about a half-mile offshore in George Town's protected harbor, and passengers take the ship's tenders (essentially large lifeboats) to reach the pier. The tender ride takes five to ten minutes through incredibly clear water, and honestly, it's one of the highlights of the day. That crystalline water means you're gazing straight down at coral formations and tropical fish from your seat.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/grand-cayman/seven-mile-beach-view.webp" alt="Seven Mile Beach panoramic view showing crystal clear Caribbean water and white sand stretching along Grand Cayman's western coastline" loading="lazy"/>
+            <img src="/ports/img/grand-cayman/seven-mile-beach-view.webp" alt="Seven Mile Beach panoramic view showing crystal clear Caribbean water and white sand stretching along Grand Cayman's western coastline" loading="lazy">
             <figcaption>Seven Mile Beach from the water — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -317,15 +318,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Is Stingray City worth the hype?</strong><br/>A: Absolutely — standing waist-deep on a sandbar while wild southern stingrays wrap their velvet wings around you is genuinely one of the most unique wildlife experiences in the Caribbean. These animals choose to be here and interact with humans. Book early during peak season as it's the island's most popular attraction.</p>
+          <p><strong>Q: Is Stingray City worth the hype?</strong><br>A: Absolutely — standing waist-deep on a sandbar while wild southern stingrays wrap their velvet wings around you is genuinely one of the most unique wildlife experiences in the Caribbean. These animals choose to be here and interact with humans. Book early during peak season as it's the island's most popular attraction.</p>
 
-          <p><strong>Q: How does the tender process work?</strong><br/>A: Your ship anchors offshore, and you take the ship's tenders (large motorized lifeboats) to the pier. The ride takes 5-10 minutes through crystal-clear water. If you have a ship excursion, you get priority tender tickets. Independent travelers should head to tender boarding early or wait until mid-morning when waits drop to 10 minutes.</p>
+          <p><strong>Q: How does the tender process work?</strong><br>A: Your ship anchors offshore, and you take the ship's tenders (large motorized lifeboats) to the pier. The ride takes 5-10 minutes through crystal-clear water. If you have a ship excursion, you get priority tender tickets. Independent travelers should head to tender boarding early or wait until mid-morning when waits drop to 10 minutes.</p>
 
-          <p><strong>Q: Should I book Stingray City through the ship or independently?</strong><br/>A: Independent operators like Captain Marvin's and Native Way Water Sports offer smaller group sizes (15 vs 40+ passengers), lower prices (30-40% less than ship excursions), and guarantee timely returns. However, ship excursions provide guaranteed return to the vessel if delays occur. Both are valid choices; independents offer better value for confident travelers.</p>
+          <p><strong>Q: Should I book Stingray City through the ship or independently?</strong><br>A: Independent operators like Captain Marvin's and Native Way Water Sports offer smaller group sizes (15 vs 40+ passengers), lower prices (30-40% less than ship excursions), and guarantee timely returns. However, ship excursions provide guaranteed return to the vessel if delays occur. Both are valid choices; independents offer better value for confident travelers.</p>
 
-          <p><strong>Q: How expensive is Grand Cayman?</strong><br/>A: Very expensive — one of the priciest ports in the Caribbean. A simple lunch for two runs $100-150. Beer costs $8-12 each. Many cruisers eat breakfast and dinner on the ship to manage costs, having just a light lunch ashore or bringing snacks.</p>
+          <p><strong>Q: How expensive is Grand Cayman?</strong><br>A: Very expensive — one of the priciest ports in the Caribbean. A simple lunch for two runs $100-150. Beer costs $8-12 each. Many cruisers eat breakfast and dinner on the ship to manage costs, having just a light lunch ashore or bringing snacks.</p>
 
-          <p><strong>Q: Is Seven Mile Beach worth visiting?</strong><br/>A: Yes — it's consistently rated among the world's best beaches. The entire shoreline is publicly accessible with powder-soft sand and calm turquoise water. Chair rentals run $25. The 10-minute taxi ride from the tender pier costs $2.50-12 per person depending on whether you share.</p>
+          <p><strong>Q: Is Seven Mile Beach worth visiting?</strong><br>A: Yes — it's consistently rated among the world's best beaches. The entire shoreline is publicly accessible with powder-soft sand and calm turquoise water. Chair rentals run $25. The 10-minute taxi ride from the tender pier costs $2.50-12 per person depending on whether you share.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -333,23 +334,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/grand-cayman/seven-mile-beach-view.webp" alt="Seven Mile Beach panoramic view showing crystal clear Caribbean water and white sand stretching along Grand Cayman's western coastline" loading="lazy"/>
+              <img src="/ports/img/grand-cayman/seven-mile-beach-view.webp" alt="Seven Mile Beach panoramic view showing crystal clear Caribbean water and white sand stretching along Grand Cayman's western coastline" loading="lazy">
               <figcaption>Seven Mile Beach — consistently rated one of the world's best<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/grand-cayman/stingray-city.webp" alt="Swimming with wild southern stingrays at the famous Stingray City sandbar in crystal-clear Caribbean water" loading="lazy"/>
+              <img src="/ports/img/grand-cayman/stingray-city.webp" alt="Swimming with wild southern stingrays at the famous Stingray City sandbar in crystal-clear Caribbean water" loading="lazy">
               <figcaption>Stingray City — where velvet wings wrap around you<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/grand-cayman/waterfront.webp" alt="George Town waterfront with colorful colonial buildings and cruise tender dock under Caribbean sunshine" loading="lazy"/>
+              <img src="/ports/img/grand-cayman/waterfront.webp" alt="George Town waterfront with colorful colonial buildings and cruise tender dock under Caribbean sunshine" loading="lazy">
               <figcaption>George Town waterfront — compact, colorful, duty-free<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/grand-cayman/seven-mile-beach-view.webp" alt="Turquoise Caribbean waters meeting pristine white sand at Seven Mile Beach with palm trees swaying in the tropical breeze" loading="lazy"/>
+              <img src="/ports/img/grand-cayman/seven-mile-beach-view.webp" alt="Turquoise Caribbean waters meeting pristine white sand at Seven Mile Beach with palm trees swaying in the tropical breeze" loading="lazy">
               <figcaption>The water really is this blue — no filter needed<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/grand-cayman/stingray-city.webp" alt="Close encounter with friendly southern stingrays at Grand Cayman's famous Stingray City sandbar experience" loading="lazy"/>
+              <img src="/ports/img/grand-cayman/stingray-city.webp" alt="Close encounter with friendly southern stingrays at Grand Cayman's famous Stingray City sandbar experience" loading="lazy">
               <figcaption>The stingrays choose to be here — pure magic<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -383,8 +384,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -406,7 +407,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -457,5 +458,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/honolulu.html
+++ b/ports/honolulu.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Honolulu cruise port — Pearl Harbor's solemn USS Arizona Memorial, Waikiki Beach surfing, Diamond Head crater hike, and ʻIolani Palace royal history in one unforgettable Hawaiian port day."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Honolulu Cruise Port Guide — Pearl Harbor, Waikiki & Diamond Head | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Honolulu cruise port — Pearl Harbor's solemn USS Arizona Memorial, Waikiki Beach, Diamond Head crater hike, and ʻIolani Palace in one Hawaiian port day."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/honolulu.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Honolulu cruise port — Pearl Harbor's solemn USS Arizona Memorial, Waikiki Beach surfing, Diamond Head crater hike, and ʻIolani Palace royal history in one unforgettable Hawaiian port day.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Honolulu Cruise Port Guide — Pearl Harbor, Waikiki &amp; Diamond Head | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Honolulu cruise port — Pearl Harbor's solemn USS Arizona Memorial, Waikiki Beach, Diamond Head crater hike, and ʻIolani Palace in one Hawaiian port day.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/honolulu.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -91,20 +88,12 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <section class="port-hero" id="hero" aria-label="Honolulu cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/honolulu/waikiki-diamond-head.webp" alt="Waikiki Beach with Diamond Head crater rising in the background under blue Hawaiian skies" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Honolulu</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -118,7 +107,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -133,7 +122,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -147,21 +136,33 @@ Soli Deo Gloria
     </div>
   </header>
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Honolulu</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Honolulu</li></ol></nav>
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Honolulu cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/honolulu/waikiki-diamond-head.webp" alt="Waikiki Beach with Diamond Head crater rising in the background under blue Hawaiian skies" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Honolulu</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
         <section class="port-section" id="logbook">
           <h2>My Logbook: Doing It All in One Day</h2>
           <div class="logbook-entry clearfix">
             <p>I docked at Pier 2 in downtown Honolulu — the name means "protected bay" in Hawaiian — and stood on deck watching the morning light spill across the water. Ukuleles from the Aloha Tower marketplace were already playing their bright welcome as I stepped ashore. Honolulu has been the capital of the Hawaiian Islands since 1845, when King Kamehameha III moved the seat of his kingdom here from Lahaina. But the history runs deeper still — back in 1795, his father Kamehameha I arrived in this same harbor with nearly one thousand war canoes and ten thousand warriors, an armada that secured his rule over the entire island chain in the fierce Battle of Nuʻuanu.</p>
             <figure class="logbook-image float-right">
-              <img src="/ports/img/honolulu/pearl-harbor-memorial.webp" alt="USS Arizona Memorial at Pearl Harbor with the white structure spanning the sunken battleship" loading="lazy"/>
+              <img src="/ports/img/honolulu/pearl-harbor-memorial.webp" alt="USS Arizona Memorial at Pearl Harbor with the white structure spanning the sunken battleship" loading="lazy">
               <figcaption>Pearl Harbor Memorial — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
             <p>I took an early Uber to Pearl Harbor — twenty minutes through the awakening city — and arrived just after opening. The Arizona memorial boat leaves every fifteen minutes and I walked straight on. Standing over the sunken battleship with the oil still bubbling up from her ruptured tanks felt exactly as heavy and necessary as it should. The USS Arizona went down in just nine minutes on the morning of December 7th, 1941, taking 1,177 souls with her. She still holds 1,102 of those men in her iron hull — a tomb and a testament resting in the harbor that King Kamehameha himself once ordered harvested for oysters to please foreign traders who valued pearls.</p>
             <p>The stillness above that shattered deck is profound. I stood quietly, then walked across the harbor to the USS Missouri — the massive battleship where Japan signed the unconditional surrender on September 2nd, 1945. The docent called them "the bookends of World War II in the Pacific," and that phrase stayed with me all day. The Arizona marks where it began; the Missouri marks where it ended. However, both ships rest here in the same harbor, carrying the full weight of that history between them.</p>
             <figure class="logbook-image float-left">
-              <img src="/ports/img/honolulu/diamond-head-trail.webp" alt="Diamond Head crater trail with hikers ascending toward the summit and Honolulu visible below" loading="lazy"/>
+              <img src="/ports/img/honolulu/diamond-head-trail.webp" alt="Diamond Head crater trail with hikers ascending toward the summit and Honolulu visible below" loading="lazy">
               <figcaption>Diamond Head trail — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
             <p>Back in Waikiki by eleven — Waikiki means "spouting fresh water," named for the springs that once fed this shoreline — I had plenty of time to walk the beach, grab a shave ice at Waiola, and hike Diamond Head. The Hawaiians called that extinct volcanic cone Lēʻahi, "the point of the tuna fish," for its sharp ridgeline cutting into the sky. The trail is fully paved now, 1.6 miles round-trip, hot but very doable. I was at the summit in forty-five minutes and the panoramic sweep of the island spreading out below — the city, the harbor, the endless Pacific — made every step worth it.</p>
@@ -178,7 +179,7 @@ Soli Deo Gloria
           <h2>The Cruise Port</h2>
           <p>Cruise ships dock at Pier 2 in Honolulu Harbor, located in downtown Honolulu near the landmark Aloha Tower. Norwegian Cruise Line vessels homeport here, offering Hawaiian island itineraries. The terminal sits just 15 minutes from Daniel K. Inouye International Airport and provides convenient access to all major Honolulu attractions.</p>
           <figure class="logbook-image">
-            <img src="/ports/img/honolulu/aloha-tower.webp" alt="Historic Aloha Tower rising above Honolulu Harbor with cruise ship terminal in foreground" loading="lazy"/>
+            <img src="/ports/img/honolulu/aloha-tower.webp" alt="Historic Aloha Tower rising above Honolulu Harbor with cruise ship terminal in foreground" loading="lazy">
             <figcaption>Aloha Tower and harbor — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
           <p>The terminal is wheelchair accessible with modern facilities. Downtown Honolulu and Chinatown are walking distance from the pier. Pearl Harbor is 20 minutes by taxi ($25-30), Waikiki Beach is 10-15 minutes ($15-20). Currency is US dollars throughout Hawaii, and the port area offers restrooms and information desks.</p>
@@ -274,33 +275,33 @@ Soli Deo Gloria
         </section>
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where do cruise ships dock in Honolulu?</strong><br/>A: Cruise ships dock at Pier 2 in Honolulu Harbor near Aloha Tower. The terminal is walking distance to Chinatown and downtown. Pearl Harbor is 20 minutes by taxi ($25-30), Waikiki Beach is 10-15 minutes ($15-20).</p>
-          <p><strong>Q: How much time do I need at Pearl Harbor?</strong><br/>A: Plan 4-5 hours minimum for the USS Arizona Memorial and USS Missouri. Arizona tickets are free but must be reserved weeks in advance at recreation.gov. The Missouri battleship tour takes 90 minutes. Both sites are deeply moving — don't rush them.</p>
-          <p><strong>Q: Is the Diamond Head hike worth it?</strong><br/>A: Absolutely — the 1.6-mile round-trip trail takes 1.5-2 hours and rewards you with 360° panoramic views of Waikiki, Honolulu, and the Pacific Ocean from 760 feet. Go early (opens 6 AM) to avoid heat and crowds. Reservations required, $5 entry.</p>
-          <p><strong>Q: Can I do Pearl Harbor and Waikiki in one port day?</strong><br/>A: Yes — Honolulu is the most "do-able" Hawaiian port. Start with Pearl Harbor early (arrive at opening), then Uber to Waikiki for beach time and lunch, hike Diamond Head if you're ambitious. Allow 7-8 hours total with no rush.</p>
-          <p><strong>Q: What is ʻIolani Palace and should I visit?</strong><br/>A: ʻIolani Palace is the only royal palace on US soil, built in 1882 for King Kalākaua. Guided tours showcase the throne room and royal artifacts. It had electricity before the White House. Reserve tickets at iolanipalace.org — a window into Hawaii's monarchy era.</p>
+          <p><strong>Q: Where do cruise ships dock in Honolulu?</strong><br>A: Cruise ships dock at Pier 2 in Honolulu Harbor near Aloha Tower. The terminal is walking distance to Chinatown and downtown. Pearl Harbor is 20 minutes by taxi ($25-30), Waikiki Beach is 10-15 minutes ($15-20).</p>
+          <p><strong>Q: How much time do I need at Pearl Harbor?</strong><br>A: Plan 4-5 hours minimum for the USS Arizona Memorial and USS Missouri. Arizona tickets are free but must be reserved weeks in advance at recreation.gov. The Missouri battleship tour takes 90 minutes. Both sites are deeply moving — don't rush them.</p>
+          <p><strong>Q: Is the Diamond Head hike worth it?</strong><br>A: Absolutely — the 1.6-mile round-trip trail takes 1.5-2 hours and rewards you with 360° panoramic views of Waikiki, Honolulu, and the Pacific Ocean from 760 feet. Go early (opens 6 AM) to avoid heat and crowds. Reservations required, $5 entry.</p>
+          <p><strong>Q: Can I do Pearl Harbor and Waikiki in one port day?</strong><br>A: Yes — Honolulu is the most "do-able" Hawaiian port. Start with Pearl Harbor early (arrive at opening), then Uber to Waikiki for beach time and lunch, hike Diamond Head if you're ambitious. Allow 7-8 hours total with no rush.</p>
+          <p><strong>Q: What is ʻIolani Palace and should I visit?</strong><br>A: ʻIolani Palace is the only royal palace on US soil, built in 1882 for King Kalākaua. Guided tours showcase the throne room and royal artifacts. It had electricity before the White House. Reserve tickets at iolanipalace.org — a window into Hawaii's monarchy era.</p>
         </section>
         <section class="port-section photo-gallery" id="gallery">
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/honolulu/waikiki-diamond-head.webp" alt="Waikiki Beach with Diamond Head crater in the background" loading="lazy"/>
+              <img src="/ports/img/honolulu/waikiki-diamond-head.webp" alt="Waikiki Beach with Diamond Head crater in the background" loading="lazy">
               <figcaption>Waikiki Beach and Diamond Head<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/honolulu/pearl-harbor-memorial.webp" alt="USS Arizona Memorial at Pearl Harbor with white structure spanning the sunken ship" loading="lazy"/>
+              <img src="/ports/img/honolulu/pearl-harbor-memorial.webp" alt="USS Arizona Memorial at Pearl Harbor with white structure spanning the sunken ship" loading="lazy">
               <figcaption>USS Arizona Memorial<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/honolulu/diamond-head-trail.webp" alt="Diamond Head crater trail with Honolulu visible below" loading="lazy"/>
+              <img src="/ports/img/honolulu/diamond-head-trail.webp" alt="Diamond Head crater trail with Honolulu visible below" loading="lazy">
               <figcaption>Diamond Head summit trail<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/honolulu/iolani-palace.webp" alt="ʻIolani Palace exterior with American Florentine architecture and royal palm trees" loading="lazy"/>
+              <img src="/ports/img/honolulu/iolani-palace.webp" alt="ʻIolani Palace exterior with American Florentine architecture and royal palm trees" loading="lazy">
               <figcaption>ʻIolani Palace — only US royal residence<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/honolulu/aloha-tower.webp" alt="Historic Aloha Tower rising above Honolulu Harbor" loading="lazy"/>
+              <img src="/ports/img/honolulu/aloha-tower.webp" alt="Historic Aloha Tower rising above Honolulu Harbor" loading="lazy">
               <figcaption>Aloha Tower and harbor<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -330,8 +331,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -350,7 +351,7 @@ Soli Deo Gloria
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     </aside>
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
@@ -396,5 +397,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/lanzarote.html
+++ b/ports/lanzarote.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Arrecife cruise port in Lanzarote with tips for Timanfaya National Park volcanoes, Jameos del Agua cave, La Geria wine region, and the island born of fire."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Arrecife cruise port in Lanzarote with tips for Timanfaya National Park volcanoes, Jameos del Agua cave, La Geria wine region, and the island born of fire.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Lanzarote (Arrecife) Port Guide — Island Born of Fire | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Arrecife, Lanzarote — stunning Timanfaya National Park volcanic landscape, Jameos del Agua caves, César Manrique's architectural legacy, La Geria wine region, and discovering the Canary Islands' most dramatic scenery."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/lanzarote.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Arrecife, Lanzarote — stunning Timanfaya National Park volcanic landscape, Jameos del Agua caves, César Manrique's architectural legacy, La Geria wine region, and discovering the Canary Islands' most dramatic scenery.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/lanzarote.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Lanzarote hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/lanzarote/lanzarote-hero.webp" alt="Dramatic volcanic landscape of Timanfaya National Park with rust-red cinder cones rising from black lava fields under blue Canary Island skies, Lanzarote" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Lanzarote (Arrecife)</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org/wiki/File:Timanfaya_Lanzarote.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Lanzarote (Arrecife)</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Lanzarote (Arrecife)</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Lanzarote (Arrecife) cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/lanzarote/lanzarote-hero.webp" alt="Dramatic volcanic landscape of Timanfaya National Park with rust-red cinder cones rising from black lava fields under blue Canary Island skies, Lanzarote" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Lanzarote (Arrecife)</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Timanfaya_Lanzarote.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I stepped off the ship in Arrecife expecting another pleasant Canary Island port. What I found instead was a world reborn from catastrophe. Lanzarote looks like Mars decided to vacation in the Atlantic, and I could not stop staring. Black volcanic rock stretches to every horizon I turned toward, punctuated by cinder cones painted in rust, sienna, and ochre. The landscape defies photography — my camera kept insisting the colors were wrong, oversaturated, impossible. They were not. They were exactly that vivid.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/lanzarote/lanzarote-timanfaya-1.webp" alt="Fire Mountains of Timanfaya showing dramatic red and black volcanic cones with winding road through barren lava landscape" loading="lazy"/>
+              <img src="/ports/img/lanzarote/lanzarote-timanfaya-1.webp" alt="Fire Mountains of Timanfaya showing dramatic red and black volcanic cones with winding road through barren lava landscape" loading="lazy">
               <figcaption>Fire Mountains of Timanfaya — <a href="https://commons.wikimedia.org/wiki/Category:Timanfaya_National_Park" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</figcaption>
             </figure>
 
@@ -177,7 +178,7 @@ Soli Deo Gloria
             <p>Credit for Lanzarote's strange beauty belongs to César Manrique, an artist-architect I had never heard of before this trip. He convinced the entire island to ban billboards, standardize building design (white walls with green or brown shutters only), and integrate art with nature instead of dominating it. His philosophy shaped everything I saw. Driving across Lanzarote felt like touring an open-air gallery where nature is both canvas and sculptor. I visited the Fundación César Manrique (€10 entry fee), his former home built into five volcanic bubbles, and finally understood what sustainable tourism could look like if someone with vision took charge.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/lanzarote/lanzarote-jameos-1.webp" alt="Underground lagoon at Jameos del Agua with unique blind albino crabs visible in crystal-clear volcanic cave water" loading="lazy"/>
+              <img src="/ports/img/lanzarote/lanzarote-jameos-1.webp" alt="Underground lagoon at Jameos del Agua with unique blind albino crabs visible in crystal-clear volcanic cave water" loading="lazy">
               <figcaption>Jameos del Agua underground lagoon — <a href="https://commons.wikimedia.org/wiki/Category:Jameos_del_Agua" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</figcaption>
             </figure>
 
@@ -201,7 +202,7 @@ Soli Deo Gloria
           <p>Ships dock at Muelle de Cruceros in Arrecife, a modern terminal with basic facilities including restrooms, a small cafe, tourist information, and taxi stand. The terminal offers free WiFi and has accessible ramps for wheelchair users and those with mobility challenges. Downtown Arrecife is approximately 15-20 minutes on foot, though the walk is not particularly scenic — most visitors head directly to taxis, buses, or rental car pickup points for island exploration.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/lanzarote/lanzarote-port-1.webp" alt="Arrecife cruise terminal Muelle de Cruceros with large cruise ship docked and passengers walking toward taxi stands and tour buses" loading="lazy"/>
+            <img src="/ports/img/lanzarote/lanzarote-port-1.webp" alt="Arrecife cruise terminal Muelle de Cruceros with large cruise ship docked and passengers walking toward taxi stands and tour buses" loading="lazy">
             <figcaption>Arrecife cruise terminal — <a href="https://commons.wikimedia.org/wiki/Category:Puerto_de_Arrecife" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</figcaption>
           </figure>
 
@@ -252,7 +253,7 @@ Soli Deo Gloria
           <p>UNMISSABLE. The lunar volcanic landscape defies description — 25+ volcanoes, rivers of frozen lava, Mars-like terrain in rust and black. Entry fee €12 includes mandatory bus tour through the Fire Mountains (you cannot drive or walk independently through the protected zone). Geothermal demonstrations at the visitor center show ground temperatures reaching 600°C. El Diablo restaurant (book ahead for lunch) cooks food using volcanic heat. Located 30 minutes from port. Allow half-day minimum. This is Lanzarote's absolute highlight and worth every euro of the fare to get there.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/lanzarote/lanzarote-timanfaya-2.webp" alt="Geothermal demonstration at Timanfaya showing geyser of steam erupting from volcanic ground while visitors watch from safe distance" loading="lazy"/>
+            <img src="/ports/img/lanzarote/lanzarote-timanfaya-2.webp" alt="Geothermal demonstration at Timanfaya showing geyser of steam erupting from volcanic ground while visitors watch from safe distance" loading="lazy">
             <figcaption>Geothermal demonstration at Timanfaya — <a href="https://commons.wikimedia.org/wiki/Category:Timanfaya_National_Park" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</figcaption>
           </figure>
 
@@ -335,17 +336,17 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where do cruise ships dock in Lanzarote?</strong><br/>A: Ships dock at Muelle de Cruceros in Arrecife. The terminal is approximately 15-20 minutes walk from downtown Arrecife. Taxis (€5-8 to center) and tour operators meet arriving ships. The port is wheelchair accessible with paved routes to transport options. No tender required — direct pier docking.</p>
+          <p><strong>Q: Where do cruise ships dock in Lanzarote?</strong><br>A: Ships dock at Muelle de Cruceros in Arrecife. The terminal is approximately 15-20 minutes walk from downtown Arrecife. Taxis (€5-8 to center) and tour operators meet arriving ships. The port is wheelchair accessible with paved routes to transport options. No tender required — direct pier docking.</p>
 
-          <p><strong>Q: Is Timanfaya National Park worth the visit and cost?</strong><br/>A: Absolutely essential and worth every euro. Timanfaya is Lanzarote's defining experience — surreal volcanic landscape with geothermal demonstrations, Mars-like terrain, and the famous Fire Mountains. Entry fee €12 includes mandatory bus tour. Book ahead for El Diablo restaurant lunch if desired. Cannot be missed on a Lanzarote port day.</p>
+          <p><strong>Q: Is Timanfaya National Park worth the visit and cost?</strong><br>A: Absolutely essential and worth every euro. Timanfaya is Lanzarote's defining experience — surreal volcanic landscape with geothermal demonstrations, Mars-like terrain, and the famous Fire Mountains. Entry fee €12 includes mandatory bus tour. Book ahead for El Diablo restaurant lunch if desired. Cannot be missed on a Lanzarote port day.</p>
 
-          <p><strong>Q: Should I rent a car or take a ship excursion?</strong><br/>A: Rent a car (€30-50/day) if comfortable driving — gives maximum flexibility, costs less for couples and groups, lets you set your own pace across all attractions. Take a ship excursion if you prefer guaranteed return time and guided commentary without navigation stress. Independent tours offer a middle ground. The island is easy to navigate with excellent roads.</p>
+          <p><strong>Q: Should I rent a car or take a ship excursion?</strong><br>A: Rent a car (€30-50/day) if comfortable driving — gives maximum flexibility, costs less for couples and groups, lets you set your own pace across all attractions. Take a ship excursion if you prefer guaranteed return time and guided commentary without navigation stress. Independent tours offer a middle ground. The island is easy to navigate with excellent roads.</p>
 
-          <p><strong>Q: Is Lanzarote accessible for visitors with mobility challenges?</strong><br/>A: Main attractions offer reasonable wheelchair accessibility. The cruise terminal has accessible paths. Timanfaya's bus tour accommodates wheelchairs with advance notice. Jameos del Agua has accessible main areas. Cueva de los Verdes is not accessible due to walking difficulty on uneven cave surfaces. Always confirm specific accessibility needs when booking ahead.</p>
+          <p><strong>Q: Is Lanzarote accessible for visitors with mobility challenges?</strong><br>A: Main attractions offer reasonable wheelchair accessibility. The cruise terminal has accessible paths. Timanfaya's bus tour accommodates wheelchairs with advance notice. Jameos del Agua has accessible main areas. Cueva de los Verdes is not accessible due to walking difficulty on uneven cave surfaces. Always confirm specific accessibility needs when booking ahead.</p>
 
-          <p><strong>Q: What is the best way to experience La Geria wine region?</strong><br/>A: Drive through independently — the freedom to stop at multiple bodegas makes rental car ideal. Bodega El Grifo (oldest winery, tastings €8-15) and Bodega Stratvs (modern facility, €10-20) are highlights. Located between Arrecife and Timanfaya, making it a natural stop en route to the volcanoes. Ship excursions typically include one winery stop.</p>
+          <p><strong>Q: What is the best way to experience La Geria wine region?</strong><br>A: Drive through independently — the freedom to stop at multiple bodegas makes rental car ideal. Bodega El Grifo (oldest winery, tastings €8-15) and Bodega Stratvs (modern facility, €10-20) are highlights. Located between Arrecife and Timanfaya, making it a natural stop en route to the volcanoes. Ship excursions typically include one winery stop.</p>
 
-          <p><strong>Q: Who was César Manrique and why does he matter?</strong><br/>A: Artist-architect (1919-1992) who shaped modern Lanzarote's aesthetic philosophy. He convinced the island to ban billboards, standardize building design (white walls, green/brown shutters), and integrate art with volcanic nature. His influence defines why Lanzarote looks uniquely beautiful. Visit the Fundación César Manrique (€10 entry) to understand his vision and legacy.</p>
+          <p><strong>Q: Who was César Manrique and why does he matter?</strong><br>A: Artist-architect (1919-1992) who shaped modern Lanzarote's aesthetic philosophy. He convinced the island to ban billboards, standardize building design (white walls, green/brown shutters), and integrate art with volcanic nature. His influence defines why Lanzarote looks uniquely beautiful. Visit the Fundación César Manrique (€10 entry) to understand his vision and legacy.</p>
         </section>
 
         <!-- PHOTO GALLERY - Required section with 11+ images total on page -->
@@ -353,19 +354,19 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/lanzarote/lanzarote-gallery-1.webp" alt="Panoramic view of La Geria wine region showing hundreds of semicircular stone walls protecting grape vines in volcanic soil craters" loading="lazy"/>
+              <img src="/ports/img/lanzarote/lanzarote-gallery-1.webp" alt="Panoramic view of La Geria wine region showing hundreds of semicircular stone walls protecting grape vines in volcanic soil craters" loading="lazy">
               <figcaption>La Geria wine region panorama<div class="photo-credit"><a href="https://commons.wikimedia.org/wiki/Category:La_Geria" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/lanzarote/lanzarote-gallery-2.webp" alt="El Golfo Green Lagoon with bright emerald water inside volcanic crater meeting black sand beach and Atlantic Ocean" loading="lazy"/>
+              <img src="/ports/img/lanzarote/lanzarote-gallery-2.webp" alt="El Golfo Green Lagoon with bright emerald water inside volcanic crater meeting black sand beach and Atlantic Ocean" loading="lazy">
               <figcaption>El Golfo Green Lagoon<div class="photo-credit"><a href="https://commons.wikimedia.org/wiki/Category:El_Golfo" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/lanzarote/lanzarote-gallery-3.webp" alt="Interior courtyard of Fundación César Manrique showing white modernist architecture integrated with black volcanic rock formations" loading="lazy"/>
+              <img src="/ports/img/lanzarote/lanzarote-gallery-3.webp" alt="Interior courtyard of Fundación César Manrique showing white modernist architecture integrated with black volcanic rock formations" loading="lazy">
               <figcaption>Fundación César Manrique<div class="photo-credit"><a href="https://commons.wikimedia.org/wiki/Category:Fundación_César_Manrique" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/lanzarote/lanzarote-gallery-4.webp" alt="Cueva de los Verdes volcanic lava tube interior with dramatic lighting revealing ancient rock formations and cave pathways" loading="lazy"/>
+              <img src="/ports/img/lanzarote/lanzarote-gallery-4.webp" alt="Cueva de los Verdes volcanic lava tube interior with dramatic lighting revealing ancient rock formations and cave pathways" loading="lazy">
               <figcaption>Cueva de los Verdes lava tube<div class="photo-credit"><a href="https://commons.wikimedia.org/wiki/Category:Cueva_de_los_Verdes" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</div></figcaption>
             </figure>
           </div>
@@ -388,7 +389,7 @@ Soli Deo Gloria
         </section>
 
         <!-- BACK NAVIGATION -->
-        <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+        <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
       </article>
     </div>
 
@@ -408,8 +409,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, In the Wake founder and author" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, In the Wake founder and author" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -432,8 +433,8 @@ Soli Deo Gloria
   </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
-    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
+    <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;"><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a> · <a href="/about-us.html">About</a> · <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a></p>
     <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria</p>
   </footer>
 
@@ -462,5 +463,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/los-angeles.html
+++ b/ports/los-angeles.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Los Angeles cruise ports — San Pedro's World Cruise Center and Long Beach terminals, plus Hollywood, beaches, and SoCal pre-cruise adventures with honest traffic warnings."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Los Angeles Cruise Port Guide — San Pedro, Long Beach & Hollywood | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Los Angeles cruise ports — San Pedro's World Cruise Center and Long Beach terminals, plus Hollywood, beaches, and SoCal pre-cruise adventures with honest traffic warnings."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/los-angeles.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Los Angeles cruise ports — San Pedro's World Cruise Center and Long Beach terminals, plus Hollywood, beaches, and SoCal pre-cruise adventures with honest traffic warnings.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Los Angeles Cruise Port Guide — San Pedro, Long Beach &amp; Hollywood | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Los Angeles cruise ports — San Pedro's World Cruise Center and Long Beach terminals, plus Hollywood, beaches, and SoCal pre-cruise adventures with honest traffic warnings.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/los-angeles.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -91,20 +88,12 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <section class="port-hero" id="hero" aria-label="Los Angeles cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/los-angeles/san-pedro-harbor.webp" alt="San Pedro Harbor with cruise ships docked and the LA skyline visible in the distance under California sunshine" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Los Angeles</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
-  </section>
+  
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -118,7 +107,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -133,7 +122,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -147,21 +136,33 @@ Soli Deo Gloria
     </div>
   </header>
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Los Angeles</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Los Angeles</li></ol></nav>
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Los Angeles cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/los-angeles/san-pedro-harbor.webp" alt="San Pedro Harbor with cruise ships docked and the LA skyline visible in the distance under California sunshine" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Los Angeles</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
         <section class="port-section" id="logbook">
           <h2>My Logbook: West Coast Cruising Capital</h2>
           <div class="logbook-entry clearfix">
             <p>Los Angeles sprawls impossibly wide across the Southern California basin, a metropolis of dreams and traffic that serves as the West Coast's premier cruise gateway. I've been planning my first sailing from LA for months, meticulously researching every angle of what makes this port both exciting and genuinely challenging for cruise passengers. Greater LA welcomes cruise passengers through two distinct terminals — the <strong>World Cruise Center</strong> in San Pedro and the <strong>Long Beach Cruise Terminal</strong> near the legendary Queen Mary. Yet unlike compact East Coast ports where you step off the gangway into walkable districts, LA demands respect for its legendary distances and infamous congestion. Plan carefully, and this city delivers authentic Hollywood glamour, perfect Pacific beaches, and absolutely world-class entertainment. Rush blindly into gridlocked traffic, however, and you might genuinely miss your ship entirely.</p>
             <figure class="logbook-image float-right">
-              <img src="/ports/img/los-angeles/hollywood-sign.webp" alt="The iconic Hollywood Sign on Mount Lee with the Los Angeles skyline visible in the haze below" loading="lazy"/>
+              <img src="/ports/img/los-angeles/hollywood-sign.webp" alt="The iconic Hollywood Sign on Mount Lee with the Los Angeles skyline visible in the haze below" loading="lazy">
               <figcaption>The Hollywood Sign — <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></figcaption>
             </figure>
             <p>San Pedro's facility handles the majority of cruise traffic, welcoming ships from <a href="/cruise-lines/carnival.html">Carnival</a>, <a href="/cruise-lines/princess.html">Princess</a>, and <a href="/cruise-lines/norwegian.html">Norwegian</a>. The World Cruise Center sits at Berths 91 through 93, about 25 miles south of downtown LA and roughly 30 miles from LAX — though in rush hour traffic, those miles can stretch into two-hour ordeals. Long Beach operates independently near the art deco splendor of the Queen Mary, handling certain cruise lines and itineraries. My research confirms that both locations offer modern facilities with efficient boarding processes, though neither places you within easy walking distance of major attractions. I've mapped out my exact route from my hotel to the cruise terminal to minimize any last-minute stress.</p>
             <p>The secret that savvy cruisers discover is that San Pedro itself has transformed from a working harbor town into a genuine destination. I'm looking forward to exploring the USS Iowa battleship museum that towers over the waterfront — this mighty warship served from World War II through the Gulf War, and walking her decks brings naval heritage to life. The Korean Bell of Friendship occupies a hilltop pavilion with sweeping harbor views that I've seen in countless travel photos. Point Fermin Lighthouse stands sentinel over dramatic coastal bluffs where I plan to watch my first West Coast sunset. And the San Pedro Fish Market serves fresh catches in a casual waterfront atmosphere that feels worlds away from Hollywood's tourist masses — exactly my kind of pre-cruise dinner spot.</p>
             <figure class="logbook-image float-left">
-              <img src="/ports/img/los-angeles/santa-monica-pier.webp" alt="Santa Monica Pier at sunset with the Pacific Wheel Ferris wheel lit up and palm trees silhouetted against the sky" loading="lazy"/>
+              <img src="/ports/img/los-angeles/santa-monica-pier.webp" alt="Santa Monica Pier at sunset with the Pacific Wheel Ferris wheel lit up and palm trees silhouetted against the sky" loading="lazy">
               <figcaption>Santa Monica Pier — <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></figcaption>
             </figure>
             <div class="poignant-highlight">
@@ -176,7 +177,7 @@ Soli Deo Gloria
           <h2>The Cruise Port</h2>
           <p>Los Angeles operates two distinct cruise terminals serving different cruise lines and itineraries. The <strong>World Cruise Center</strong> in San Pedro handles the majority of departures from its modern facilities at Berths 91-93, located at 100 Swinford Street, San Pedro, CA 90731. Princess, Norwegian, and most Carnival sailings depart from here.</p>
           <figure class="logbook-image">
-            <img src="/ports/img/los-angeles/uss-iowa.webp" alt="USS Iowa battleship museum docked at San Pedro with its massive gun turrets visible against the harbor" loading="lazy"/>
+            <img src="/ports/img/los-angeles/uss-iowa.webp" alt="USS Iowa battleship museum docked at San Pedro with its massive gun turrets visible against the harbor" loading="lazy">
             <figcaption>USS Iowa battleship museum — <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></figcaption>
           </figure>
           <p>The <strong>Long Beach Cruise Terminal</strong> at 231 Windsor Way, Long Beach, CA 90802 sits near the Queen Mary and handles select cruise line operations. Both terminals provide check-in areas, baggage handling, security screening, gift shops, snack bars, and passenger waiting areas. The facilities are purpose-built for efficient embarkation and disembarkation.</p>
@@ -217,7 +218,7 @@ Soli Deo Gloria
         <section class="port-section" id="excursions">
           <h2>Pre-Cruise Activities and Things to Do</h2>
           <p class="tiny" style="margin-bottom: 0.75rem; font-style: italic; color: #678;">Booking guidance: Disneyland requires advance ticket purchase and park reservations at disneyland.disney.go.com. Universal Studios also recommends advance booking. Ship excursions guarantee return timing but independent visits offer flexibility — choose based on your traffic comfort level. The USS Iowa and San Pedro attractions are easily explored without organized tours.</p>
-          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Hollywood & Beverly Hills</h4>
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Hollywood &amp; Beverly Hills</h4>
           <p>The entertainment capital delivers star-studded experiences for first-time visitors. Walk the Hollywood Boulevard Walk of Fame, press your hands into celebrity prints at TCL Chinese Theatre, and photograph the iconic Hollywood Sign from Griffith Observatory (free admission, stunning city views). Beverly Hills' Rodeo Drive offers luxury window shopping among designer boutiques. Ship excursions handle transportation efficiently; independent visitors should budget 4-6 hours including transit time. Book ahead for studio tours at Warner Bros. or Paramount for behind-the-scenes experiences.</p>
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Universal Studios Hollywood</h4>
           <p>The working film studio doubles as a theme park with Studio Tour tram rides through actual production facilities and blockbuster attractions. Harry Potter's Wizarding World, Jurassic World, and Super Nintendo World draw massive crowds. Full-day commitment required — arrive at park opening and expect evening return. Purchase tickets at universalstudioshollywood.com in advance. Express Pass significantly reduces wait times but costs extra. Ship excursions or very early independent departure recommended.</p>
@@ -227,7 +228,7 @@ Soli Deo Gloria
           <p>The "Battleship of Presidents" served from World War II through the Gulf War and now rests at San Pedro's waterfront within sight of the cruise terminals. Self-guided and docent-led tours explore the massive gun turrets, bridge, crew quarters, and mess halls. Allow 2-3 hours for thorough exploration. Easily accessible without organized excursions — walk or short taxi from World Cruise Center. Excellent choice for limited time or those avoiding LA traffic entirely.</p>
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Getty Center</h4>
           <p>World-class art museum crowning a hilltop with stunning architecture by Richard Meier. The permanent collection spans European paintings, sculptures, and decorative arts. The gardens, city views, and building itself are worth the visit even without the art. Free admission though parking costs $20. Reserve timed entry at getty.edu. Allow 3-4 hours including transit. The Getty Villa in Malibu focuses on ancient Greek and Roman art in a recreated Roman country house.</p>
-          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Santa Monica & Venice Beach</h4>
+          <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Santa Monica &amp; Venice Beach</h4>
           <p>The classic LA beach experience combines Santa Monica's iconic pier (Ferris wheel, arcade, ocean views) with Venice Beach's colorful boardwalk culture. Third Street Promenade offers shopping and dining. Watch street performers, browse the Venice canals, and grab fish tacos. Allow 4-6 hours including transit. Uber/Lyft or rental car recommended. Combine both beaches in one trip since they're adjacent — walk the oceanfront path between them.</p>
         </section>
         <section class="port-section" id="food">
@@ -279,33 +280,33 @@ Soli Deo Gloria
         </section>
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Which terminal will my cruise use — San Pedro or Long Beach?</strong><br/>A: Your cruise line determines the terminal. Check your booking confirmation and cruise documents. Most major lines (Princess, Norwegian, Carnival) use San Pedro's World Cruise Center at Berths 91-93. Some Carnival sailings depart from Long Beach near the Queen Mary. Never assume — verify before arrival.</p>
-          <p><strong>Q: How serious is Los Angeles traffic?</strong><br/>A: Very serious. Traffic can easily double your expected travel time, and rush hours (7-9 AM and 4-7 PM) can triple it. The I-405 freeway is notorious for gridlock at any hour. Always build in 60-90 minutes buffer time when returning to the ship. Missing departure due to traffic is a real risk.</p>
-          <p><strong>Q: Can I visit Disneyland on a port day?</strong><br/>A: It's possible but requires genuine commitment. Disneyland is about 30 miles from the port, and with traffic, park time, and return travel, you'll have limited hours in the parks. Book a ship excursion for guaranteed timing, or leave at park opening if going independently. Theme park tickets must be purchased in advance — same-day availability is extremely limited.</p>
-          <p><strong>Q: What can I do near the port if I don't want to go far?</strong><br/>A: San Pedro offers excellent options within 10-15 minutes of the terminal. The USS Iowa battleship museum brings naval heritage to life. Cabrillo Marine Aquarium offers free admission. The Korean Bell of Friendship provides stunning harbor views. Point Fermin Lighthouse and coastal bluffs make for scenic walks. San Pedro Fish Market serves fresh seafood with waterfront atmosphere.</p>
-          <p><strong>Q: Should I rent a car or use rideshare?</strong><br/>A: For a single port day, rideshare (Uber/Lyft) is usually more practical — no rental paperwork, no parking hassles, no stress navigating LA traffic yourself. For pre- or post-cruise stays with multiple destinations, rental cars provide better value and flexibility. Organized excursions eliminate transportation stress entirely.</p>
+          <p><strong>Q: Which terminal will my cruise use — San Pedro or Long Beach?</strong><br>A: Your cruise line determines the terminal. Check your booking confirmation and cruise documents. Most major lines (Princess, Norwegian, Carnival) use San Pedro's World Cruise Center at Berths 91-93. Some Carnival sailings depart from Long Beach near the Queen Mary. Never assume — verify before arrival.</p>
+          <p><strong>Q: How serious is Los Angeles traffic?</strong><br>A: Very serious. Traffic can easily double your expected travel time, and rush hours (7-9 AM and 4-7 PM) can triple it. The I-405 freeway is notorious for gridlock at any hour. Always build in 60-90 minutes buffer time when returning to the ship. Missing departure due to traffic is a real risk.</p>
+          <p><strong>Q: Can I visit Disneyland on a port day?</strong><br>A: It's possible but requires genuine commitment. Disneyland is about 30 miles from the port, and with traffic, park time, and return travel, you'll have limited hours in the parks. Book a ship excursion for guaranteed timing, or leave at park opening if going independently. Theme park tickets must be purchased in advance — same-day availability is extremely limited.</p>
+          <p><strong>Q: What can I do near the port if I don't want to go far?</strong><br>A: San Pedro offers excellent options within 10-15 minutes of the terminal. The USS Iowa battleship museum brings naval heritage to life. Cabrillo Marine Aquarium offers free admission. The Korean Bell of Friendship provides stunning harbor views. Point Fermin Lighthouse and coastal bluffs make for scenic walks. San Pedro Fish Market serves fresh seafood with waterfront atmosphere.</p>
+          <p><strong>Q: Should I rent a car or use rideshare?</strong><br>A: For a single port day, rideshare (Uber/Lyft) is usually more practical — no rental paperwork, no parking hassles, no stress navigating LA traffic yourself. For pre- or post-cruise stays with multiple destinations, rental cars provide better value and flexibility. Organized excursions eliminate transportation stress entirely.</p>
         </section>
         <section class="port-section photo-gallery" id="gallery">
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/los-angeles/san-pedro-harbor.webp" alt="San Pedro Harbor with cruise ships and cargo vessels under California sunshine" loading="lazy"/>
+              <img src="/ports/img/los-angeles/san-pedro-harbor.webp" alt="San Pedro Harbor with cruise ships and cargo vessels under California sunshine" loading="lazy">
               <figcaption>San Pedro Harbor cruise port<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/los-angeles/hollywood-sign.webp" alt="The iconic Hollywood Sign on Mount Lee" loading="lazy"/>
+              <img src="/ports/img/los-angeles/hollywood-sign.webp" alt="The iconic Hollywood Sign on Mount Lee" loading="lazy">
               <figcaption>The Hollywood Sign<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/los-angeles/santa-monica-pier.webp" alt="Santa Monica Pier at sunset with Ferris wheel lit up" loading="lazy"/>
+              <img src="/ports/img/los-angeles/santa-monica-pier.webp" alt="Santa Monica Pier at sunset with Ferris wheel lit up" loading="lazy">
               <figcaption>Santa Monica Pier<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/los-angeles/uss-iowa.webp" alt="USS Iowa battleship museum at San Pedro waterfront" loading="lazy"/>
+              <img src="/ports/img/los-angeles/uss-iowa.webp" alt="USS Iowa battleship museum at San Pedro waterfront" loading="lazy">
               <figcaption>USS Iowa battleship museum<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/los-angeles/venice-beach.webp" alt="Venice Beach boardwalk with palm trees and colorful street scene" loading="lazy"/>
+              <img src="/ports/img/los-angeles/venice-beach.webp" alt="Venice Beach boardwalk with palm trees and colorful street scene" loading="lazy">
               <figcaption>Venice Beach boardwalk<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
           </div>
@@ -335,8 +336,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -355,7 +356,7 @@ Soli Deo Gloria
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     </aside>
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
@@ -401,5 +402,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/miami.html
+++ b/ports/miami.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Miami cruise port — world's cruise capital with PortMiami handling 8M+ passengers annually. Parking tips, embarkation strategy, South Beach, Little Havana, and pre-cruise planning."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Miami Cruise Port Guide — PortMiami & South Beach | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Miami cruise port — world's busiest embarkation port with parking, hotels, South Beach Art Deco, Little Havana, and Everglades adventures."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/miami.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Miami cruise port — world's cruise capital with PortMiami handling 8M+ passengers annually. Parking tips, embarkation strategy, South Beach, Little Havana, and pre-cruise planning.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Miami Cruise Port Guide — PortMiami &amp; South Beach | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Miami cruise port — world's busiest embarkation port with parking, hotels, South Beach Art Deco, Little Havana, and Everglades adventures.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/miami.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Miami cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/miami/miami-skyline.webp" alt="Miami skyline with PortMiami cruise terminals in foreground and downtown skyscrapers rising against blue Florida sky" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Miami</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Miami</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Miami</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Miami cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/miami/miami-skyline.webp" alt="Miami skyline with PortMiami cruise terminals in foreground and downtown skyscrapers rising against blue Florida sky" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Miami</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've sailed from Miami seven times now, yet each embarkation still reminds me why PortMiami earned its title as the Cruise Capital of the World. That moment when you see the Miami skyline fade as your ship glides through the turquoise waters of Biscayne Bay — it never gets old. This isn't just a port; it's where the modern cruise industry was born, and with over 8 million passengers passing through annually, it's the gateway to Caribbean adventures for cruisers worldwide.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/miami/south-beach-art-deco.webp" alt="Colorful Art Deco buildings along Ocean Drive in Miami's South Beach district with palm trees and outdoor cafes" loading="lazy"/>
+              <img src="/ports/img/miami/south-beach-art-deco.webp" alt="Colorful Art Deco buildings along Ocean Drive in Miami's South Beach district with palm trees and outdoor cafes" loading="lazy">
               <figcaption>South Beach Art Deco — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>My strategy for Miami embarkation has evolved over those seven sailings. The first time, I arrived at 11am sharp when boarding opened and waited in a 90-minute security line. Never again. Now, though, I drop luggage with the porters curbside (tip $2-3 per bag), park the car, and walk in around 12:30pm when the initial rush has cleared. The porters are magic — you hand over your bags and they appear in your cabin later that afternoon. So much better than hauling suitcases through parking garages in the Florida heat.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/miami/little-havana-calle-ocho.webp" alt="Vibrant Calle Ocho street scene in Little Havana with Cuban restaurants, cigar shops, and colorful storefronts" loading="lazy"/>
+              <img src="/ports/img/miami/little-havana-calle-ocho.webp" alt="Vibrant Calle Ocho street scene in Little Havana with Cuban restaurants, cigar shops, and colorful storefronts" loading="lazy">
               <figcaption>Little Havana vibes — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -201,7 +202,7 @@ Soli Deo Gloria
           <p>PortMiami operates 10 cruise terminals along Dodge Island, handling 8+ million passengers annually — the busiest cruise port on Earth. The Port of Miami Tunnel (opened 2014) connects directly to I-395, bypassing downtown traffic. Each terminal serves specific cruise lines: Royal Caribbean at Terminal A (North America's largest cruise terminal), Norwegian at the Pearl, Carnival across several terminals, and luxury lines at smaller berths.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/miami/portmiami-terminals.webp" alt="Aerial view of PortMiami cruise terminals on Dodge Island with multiple cruise ships docked and Miami skyline in background" loading="lazy"/>
+            <img src="/ports/img/miami/portmiami-terminals.webp" alt="Aerial view of PortMiami cruise terminals on Dodge Island with multiple cruise ships docked and Miami skyline in background" loading="lazy">
             <figcaption>PortMiami terminals — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -216,7 +217,7 @@ Soli Deo Gloria
             <li><strong>By Car to Port:</strong> From I-95, take I-395 East (MacArthur Causeway) directly to Dodge Island. Follow signs for your specific terminal — they're well-marked. The Port of Miami Tunnel provides a second route from I-395, reducing downtown traffic.</li>
             <li><strong>Port Parking ($22-25/day):</strong> Reserve online at miamidade.gov/portmiami for guaranteed spots. Credit cards only. Covered and uncovered available. Drop luggage curbside first, then park — much easier than hauling bags through garages.</li>
             <li><strong>Off-Site Parking ($10-15/day):</strong> Companies like Park 'N Cruise offer shuttle service. Book in advance, check reviews, verify shuttle frequency. Save money but add time.</li>
-            <li><strong>Hotel Park & Cruise Packages:</strong> Many Miami hotels offer packages with parking included for your cruise duration. Often the best value if arriving a day early — hotel, parking, and sometimes breakfast for one price.</li>
+            <li><strong>Hotel Park &amp; Cruise Packages:</strong> Many Miami hotels offer packages with parking included for your cruise duration. Often the best value if arriving a day early — hotel, parking, and sometimes breakfast for one price.</li>
             <li><strong>Getting to South Beach:</strong> 15-20 minutes by Uber/Lyft ($15-25). Miami Beach Trolley is free but slow and doesn't run frequently. Taxis available but less convenient than rideshare apps. Consider renting a car if exploring multiple areas.</li>
           </ul>
         </section>
@@ -318,15 +319,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Where should I park at PortMiami?</strong><br/>A: Official PortMiami parking runs $22-25/day — reserve online in advance at miamidade.gov/portmiami for guaranteed spots. Off-site parking companies offer $10-15/day with shuttle service, but check reviews and verify shuttle frequency. Many hotels offer Park & Cruise packages that include parking for your cruise duration, often the best value if arriving a day early.</p>
+          <p><strong>Q: Where should I park at PortMiami?</strong><br>A: Official PortMiami parking runs $22-25/day — reserve online in advance at miamidade.gov/portmiami for guaranteed spots. Off-site parking companies offer $10-15/day with shuttle service, but check reviews and verify shuttle frequency. Many hotels offer Park &amp; Cruise packages that include parking for your cruise duration, often the best value if arriving a day early.</p>
 
-          <p><strong>Q: Should I arrive a day early in Miami?</strong><br/>A: Highly recommended, especially if flying in. Miami traffic is notoriously unpredictable, and cruise lines won't wait for delayed passengers. An extra day lets you explore South Beach, enjoy Little Havana, or simply relax without embarkation stress. Many hotels offer Park & Cruise packages that make the extra night affordable.</p>
+          <p><strong>Q: Should I arrive a day early in Miami?</strong><br>A: Highly recommended, especially if flying in. Miami traffic is notoriously unpredictable, and cruise lines won't wait for delayed passengers. An extra day lets you explore South Beach, enjoy Little Havana, or simply relax without embarkation stress. Many hotels offer Park &amp; Cruise packages that make the extra night affordable.</p>
 
-          <p><strong>Q: How early should I arrive for embarkation?</strong><br/>A: Embarkation typically opens at 11am and closes at 4pm (check your specific cruise line). The sweet spot is 12pm-2pm for moderate crowds. Don't arrive before your designated boarding time — you'll just wait in your car. Security screening and check-in usually take 30-45 minutes during peak times.</p>
+          <p><strong>Q: How early should I arrive for embarkation?</strong><br>A: Embarkation typically opens at 11am and closes at 4pm (check your specific cruise line). The sweet spot is 12pm-2pm for moderate crowds. Don't arrive before your designated boarding time — you'll just wait in your car. Security screening and check-in usually take 30-45 minutes during peak times.</p>
 
-          <p><strong>Q: What should I do the day before my cruise?</strong><br/>A: South Beach and the Art Deco District are 15 minutes away — walk Ocean Drive, enjoy the beach, grab café Cubano. Little Havana offers authentic Cuban culture and food. Wynwood Walls has world-class street art. Everglades National Park is 45 minutes west for airboat tours. All are excellent pre-cruise options.</p>
+          <p><strong>Q: What should I do the day before my cruise?</strong><br>A: South Beach and the Art Deco District are 15 minutes away — walk Ocean Drive, enjoy the beach, grab café Cubano. Little Havana offers authentic Cuban culture and food. Wynwood Walls has world-class street art. Everglades National Park is 45 minutes west for airboat tours. All are excellent pre-cruise options.</p>
 
-          <p><strong>Q: Is Miami safe for tourists?</strong><br/>A: Yes, tourist areas like South Beach, Wynwood, and Little Havana are generally safe during daytime. Standard urban awareness applies — don't leave valuables visible in parked cars, stay in well-lit areas at night. The port area is very secure with significant police presence.</p>
+          <p><strong>Q: Is Miami safe for tourists?</strong><br>A: Yes, tourist areas like South Beach, Wynwood, and Little Havana are generally safe during daytime. Standard urban awareness applies — don't leave valuables visible in parked cars, stay in well-lit areas at night. The port area is very secure with significant police presence.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -334,23 +335,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/miami/miami-skyline.webp" alt="Miami skyline with PortMiami cruise terminals in foreground and downtown skyscrapers rising against blue Florida sky" loading="lazy"/>
+              <img src="/ports/img/miami/miami-skyline.webp" alt="Miami skyline with PortMiami cruise terminals in foreground and downtown skyscrapers rising against blue Florida sky" loading="lazy">
               <figcaption>Miami skyline from Biscayne Bay — where Caribbean cruises begin<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/miami/south-beach-art-deco.webp" alt="Colorful Art Deco buildings along Ocean Drive in Miami's South Beach district with palm trees and outdoor cafes" loading="lazy"/>
+              <img src="/ports/img/miami/south-beach-art-deco.webp" alt="Colorful Art Deco buildings along Ocean Drive in Miami's South Beach district with palm trees and outdoor cafes" loading="lazy">
               <figcaption>Art Deco District — Ocean Drive's iconic architecture<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/miami/little-havana-calle-ocho.webp" alt="Vibrant Calle Ocho street scene in Little Havana with Cuban restaurants, cigar shops, and colorful storefronts" loading="lazy"/>
+              <img src="/ports/img/miami/little-havana-calle-ocho.webp" alt="Vibrant Calle Ocho street scene in Little Havana with Cuban restaurants, cigar shops, and colorful storefronts" loading="lazy">
               <figcaption>Little Havana — Calle Ocho's Cuban soul<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/miami/portmiami-terminals.webp" alt="Aerial view of PortMiami cruise terminals on Dodge Island with multiple cruise ships docked" loading="lazy"/>
+              <img src="/ports/img/miami/portmiami-terminals.webp" alt="Aerial view of PortMiami cruise terminals on Dodge Island with multiple cruise ships docked" loading="lazy">
               <figcaption>PortMiami — world's busiest cruise port<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/miami/miami-skyline.webp" alt="Stunning Miami downtown skyline reflecting on calm Biscayne Bay waters at sunset with golden light" loading="lazy"/>
+              <img src="/ports/img/miami/miami-skyline.webp" alt="Stunning Miami downtown skyline reflecting on calm Biscayne Bay waters at sunset with golden light" loading="lazy">
               <figcaption>Miami at golden hour — the view from your departing ship<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -385,8 +386,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -408,7 +409,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -459,5 +460,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Nassau cruise port with tips for Atlantis Aquaventure, Cabbage Beach, the Straw Market, authentic Bahamian conch, and Paradise Island experiences."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>Nassau Port Guide — Atlantis & Paradise Island | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Nassau — Atlantis Aquaventure, Cabbage Beach, Queen's Staircase, the Straw Market, and the best cracked conch in the Bahamas."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/nassau.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Nassau cruise port with tips for Atlantis Aquaventure, Cabbage Beach, the Straw Market, authentic Bahamian conch, and Paradise Island experiences.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>Nassau Port Guide — Atlantis &amp; Paradise Island | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to Nassau — Atlantis Aquaventure, Cabbage Beach, Queen's Staircase, the Straw Market, and the best cracked conch in the Bahamas.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/nassau.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Nassau hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/nassau/nassau-fom-7.webp" alt="Crystal clear turquoise waters of Nassau beach with Paradise Island and Atlantis Resort towers visible across the harbor under bright Bahamian skies" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Nassau</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Nassau</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Nassau</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Nassau cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/nassau/nassau-fom-7.webp" alt="Crystal clear turquoise waters of Nassau beach with Paradise Island and Atlantis Resort towers visible across the harbor under bright Bahamian skies" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Nassau</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>The sail-in to Nassau always gives me butterflies — our ship glides past Atlantis's pink towers like we're entering a giant playground while steel drums echo from the pier. By 8 a.m. the sun is already glittering off those ridiculous turquoise waters, and I'm on the first water taxi to Paradise Island before the crowds wake up. I've been to Nassau more times than I can count, yet somehow each visit reveals something I missed before. That's the magic of this port — it rewards repeat visitors while still dazzling first-timers.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/nassau/nassau-fom-8.webp" alt="Nassau harbor scene with crystal-clear turquoise Bahamian waters and boats dotting the pristine Caribbean coastline" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-8.webp" alt="Nassau harbor scene with crystal-clear turquoise Bahamian waters and boats dotting the pristine Caribbean coastline" loading="lazy">
               <figcaption>Nassau harbor scene — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>My perfect Nassau day begins straight at Atlantis Aquaventure — I buy the day pass online the night before (typically $140-180 depending on season), and it's totally worth it for the Leap of Faith slide that shoots you through a shark tank. The anticipation builds as you climb that Mayan temple, looking down at the translucent tube that plunges through the shark lagoon. I won't lie — I held my breath the first time. But the three seconds of adrenaline followed by floating through a corridor of circling sharks is unlike anything else I've experienced. After three hours of adrenaline, I sneak out the side gate to Cabbage Beach for free loungers and that powdery sand everyone dreams about.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/nassau/nassau-fom-1.webp" alt="Vibrant Nassau waterfront with colorful colonial buildings and palm trees lining the turquoise Caribbean bay" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-1.webp" alt="Vibrant Nassau waterfront with colorful colonial buildings and palm trees lining the turquoise Caribbean bay" loading="lazy">
               <figcaption>Nassau waterfront colors — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -190,7 +191,7 @@ Soli Deo Gloria
             <p>Afternoon brings a quick walk to the Queen's Staircase and Fort Fincastle — 66 steps carved from solid limestone by enslaved people between 1793 and 1794, later named in honor of Queen Victoria. Walking up those steps, running my hand along the cool limestone walls, I always think about the hands that carved this path from living rock. It's a peaceful oasis now, wrapped in tropical greenery, but it carries weight. The steps are accessible for most visitors, though wheelchair users should note the uneven surfaces at the top. From Fort Fincastle, the view across Nassau is worth every step climbed.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/nassau/nassau-fom-2.webp" alt="Colorful downtown Nassau street scene with pastel colonial buildings and Bahamian charm on full display" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-2.webp" alt="Colorful downtown Nassau street scene with pastel colonial buildings and Bahamian charm on full display" loading="lazy">
               <figcaption>Downtown Nassau charm — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -208,7 +209,7 @@ Soli Deo Gloria
           <p>Ships dock at Prince George Wharf, featuring six berth spaces positioned right next to Rawson Square in the heart of downtown Nassau — you literally walk straight into the action. Festival Place Welcome Center greets you with charming Bahamian village-inspired architecture and hosts live musical performances on Tuesdays, Fridays, and Saturdays. The terminal offers accessible ramps for wheelchair users and those with mobility challenges, plus restrooms, tourist information, and taxi coordination.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/nassau/cruise-ships-harbor.webp" alt="Multiple cruise ships docked at Nassau's Prince George Wharf with the downtown Bahamas skyline and Atlantis towers visible across the harbor" loading="lazy"/>
+            <img src="/ports/img/nassau/cruise-ships-harbor.webp" alt="Multiple cruise ships docked at Nassau's Prince George Wharf with the downtown Bahamas skyline and Atlantis towers visible across the harbor" loading="lazy">
             <figcaption>Cruise ships at Prince George Wharf — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -326,15 +327,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Is Nassau safe to walk around?</strong><br/>A: Yes — stay in the main tourist areas like Bay Street, Paradise Island, and the beach zones during daylight and you'll be perfectly fine. The port area is well-patrolled and sees thousands of cruise passengers daily. Use normal urban awareness and you'll have no problems.</p>
+          <p><strong>Q: Is Nassau safe to walk around?</strong><br>A: Yes — stay in the main tourist areas like Bay Street, Paradise Island, and the beach zones during daylight and you'll be perfectly fine. The port area is well-patrolled and sees thousands of cruise passengers daily. Use normal urban awareness and you'll have no problems.</p>
 
-          <p><strong>Q: Can I do Atlantis without staying at the resort?</strong><br/>A: Absolutely — buy the Aquaventure day pass online the night before to skip lines and guarantee availability. Day passes include all water slides, lazy rivers, pools, and beach access. Prices vary by season from $140-180 for adults. The Marine Habitat aquarium is included with the day pass.</p>
+          <p><strong>Q: Can I do Atlantis without staying at the resort?</strong><br>A: Absolutely — buy the Aquaventure day pass online the night before to skip lines and guarantee availability. Day passes include all water slides, lazy rivers, pools, and beach access. Prices vary by season from $140-180 for adults. The Marine Habitat aquarium is included with the day pass.</p>
 
-          <p><strong>Q: Which beach should I choose — Junkanoo or Cabbage Beach?</strong><br/>A: Junkanoo is free and closer (15 minute walk from port), making it perfect for a quick beach visit. Cabbage Beach on Paradise Island is prettier with powdery sand and less crowded, but requires water taxi ($8 round-trip) or taxi ($12-15). For a half-day beach visit, Cabbage Beach is worth the extra effort. For a quick dip before shopping, Junkanoo works great.</p>
+          <p><strong>Q: Which beach should I choose — Junkanoo or Cabbage Beach?</strong><br>A: Junkanoo is free and closer (15 minute walk from port), making it perfect for a quick beach visit. Cabbage Beach on Paradise Island is prettier with powdery sand and less crowded, but requires water taxi ($8 round-trip) or taxi ($12-15). For a half-day beach visit, Cabbage Beach is worth the extra effort. For a quick dip before shopping, Junkanoo works great.</p>
 
-          <p><strong>Q: Where's the best conch in Nassau?</strong><br/>A: Potter's Cay under the Paradise Island bridge — locals making conch salad fresh in front of you. It's surprisingly affordable ($12-15) and absolutely life-changing. Get there before noon for the freshest catch. Bring cash.</p>
+          <p><strong>Q: Where's the best conch in Nassau?</strong><br>A: Potter's Cay under the Paradise Island bridge — locals making conch salad fresh in front of you. It's surprisingly affordable ($12-15) and absolutely life-changing. Get there before noon for the freshest catch. Bring cash.</p>
 
-          <p><strong>Q: Is the Straw Market worth visiting?</strong><br/>A: Yes! Even if you don't buy anything, the atmosphere is pure Nassau. Great for souvenirs, straw bags, and handmade crafts. Remember that bargaining is expected and part of the fun — start at about half the asking price and negotiate with a smile.</p>
+          <p><strong>Q: Is the Straw Market worth visiting?</strong><br>A: Yes! Even if you don't buy anything, the atmosphere is pure Nassau. Great for souvenirs, straw bags, and handmade crafts. Remember that bargaining is expected and part of the fun — start at about half the asking price and negotiate with a smile.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -342,35 +343,35 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/nassau/nassau-fom-1.webp" alt="Vibrant Nassau waterfront scene with turquoise waters and palm-lined Caribbean bay under blue Bahamian skies" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-1.webp" alt="Vibrant Nassau waterfront scene with turquoise waters and palm-lined Caribbean bay under blue Bahamian skies" loading="lazy">
               <figcaption>Paradise found — the colors of the Bahamas come alive<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/nassau/nassau-fom-2.webp" alt="Postcard-perfect view of Nassau's stunning waterfront with colonial buildings and Caribbean charm" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-2.webp" alt="Postcard-perfect view of Nassau's stunning waterfront with colonial buildings and Caribbean charm" loading="lazy">
               <figcaption>Downtown Nassau waterfront at its finest<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/nassau/nassau-fom-3.webp" alt="The essence of Bahamian island life with sun, sea, and Caribbean charm on full display" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-3.webp" alt="The essence of Bahamian island life with sun, sea, and Caribbean charm on full display" loading="lazy">
               <figcaption>Sun, sea, and Bahamian charm<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/nassau/nassau-fom-4.webp" alt="Nassau harbor moments captured at golden hour with warm Caribbean light" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-4.webp" alt="Nassau harbor moments captured at golden hour with warm Caribbean light" loading="lazy">
               <figcaption>Every corner of Nassau tells a story<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/nassau/nassau-fom-5.webp" alt="Turquoise Nassau waters meeting tropical Caribbean skies in stunning contrast" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-5.webp" alt="Turquoise Nassau waters meeting tropical Caribbean skies in stunning contrast" loading="lazy">
               <figcaption>Turquoise waters meet tropical skies<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/nassau/nassau-fom-6.webp" alt="Stunning Nassau photography capturing the magic of the Bahamas through a cruiser's lens" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-6.webp" alt="Stunning Nassau photography capturing the magic of the Bahamas through a cruiser's lens" loading="lazy">
               <figcaption>The magic of Nassau through a cruiser's eyes<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/nassau/cruise-ships-harbor.webp" alt="Multiple cruise ships docked at Nassau harbor with the downtown skyline in view" loading="lazy"/>
+              <img src="/ports/img/nassau/cruise-ships-harbor.webp" alt="Multiple cruise ships docked at Nassau harbor with the downtown skyline in view" loading="lazy">
               <figcaption>Your floating hotel waiting patiently<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/nassau/nassau-fom-8.webp" alt="Nassau harbor at its Caribbean best with crystal-clear turquoise waters" loading="lazy"/>
+              <img src="/ports/img/nassau/nassau-fom-8.webp" alt="Nassau harbor at its Caribbean best with crystal-clear turquoise waters" loading="lazy">
               <figcaption>Nassau harbor at its Caribbean best<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -403,8 +404,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -426,7 +427,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -477,5 +478,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/new-orleans.html
+++ b/ports/new-orleans.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to New Orleans cruise port — beignets at Café Du Monde, authentic jazz on Frenchmen Street, Steamboat Natchez calliope, and Creole cuisine in the Big Easy."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>New Orleans Cruise Port Guide — French Quarter, Jazz & Beignets | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to New Orleans cruise port — beignets at Café Du Monde, authentic jazz on Frenchmen Street, Steamboat Natchez calliope, and Creole cuisine in the Big Easy."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/new-orleans.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to New Orleans cruise port — beignets at Café Du Monde, authentic jazz on Frenchmen Street, Steamboat Natchez calliope, and Creole cuisine in the Big Easy.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>New Orleans Cruise Port Guide — French Quarter, Jazz &amp; Beignets | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to New Orleans cruise port — beignets at Café Du Monde, authentic jazz on Frenchmen Street, Steamboat Natchez calliope, and Creole cuisine in the Big Easy.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/new-orleans.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -91,20 +88,12 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <section class="port-hero" id="hero" aria-label="New Orleans cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/new-orleans/french-quarter.webp" alt="French Quarter balconies with wrought iron railings and hanging plants in the morning light" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">New Orleans</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
-  </section>
+  
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -118,7 +107,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -133,7 +122,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -147,21 +136,33 @@ Soli Deo Gloria
     </div>
   </header>
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">New Orleans</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">New Orleans</li></ol></nav>
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="New Orleans cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/new-orleans/french-quarter.webp" alt="French Quarter balconies with wrought iron railings and hanging plants in the morning light" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">New Orleans</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
         <section class="port-section" id="logbook">
           <h2>My Logbook: Where Every Cruise Starts with a Party</h2>
           <div class="logbook-entry clearfix">
             <p>The Mississippi River has been calling me for years, and New Orleans represents everything I love about American travel — a city where French colonial grace meets African rhythms, where Creole cuisine tells centuries of cultural fusion, and where jazz floats from doorways into streets that have witnessed the birth of America's greatest musical gift to the world. Few ports demand pre-cruise days quite like the Big Easy, though I have not yet stood on those legendary levees myself or walked those celebrated streets in person with powdered sugar on my fingertips. The research alone intoxicates: powdered sugar-dusted beignets at Café Du Monde, second-line parades winding through Tremé, and the mournful brass of a funeral procession transforming into jubilant celebration. I have spent countless hours imagining my first morning in the French Quarter, the humidity wrapping around me as I step out into streets that have hosted jazz funerals, Mardi Gras parades, and centuries of extraordinary cultural fusion.</p>
             <figure class="logbook-image float-right">
-              <img src="/ports/img/new-orleans/jackson-square.webp" alt="Jackson Square with St. Louis Cathedral spires rising behind palm trees and street artists" loading="lazy"/>
+              <img src="/ports/img/new-orleans/jackson-square.webp" alt="Jackson Square with St. Louis Cathedral spires rising behind palm trees and street artists" loading="lazy">
               <figcaption>Jackson Square — <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></figcaption>
             </figure>
             <p>The cruise terminals line the mighty Mississippi, placing visitors within easy reach of the French Quarter's wrought-iron balconies and hidden courtyards. This is where the steamboat "New Orleans" first churned these waters in 1811, where paddle wheels and steam calliopes announced the river age that would carry jazz from Storyville's smoky rooms to Chicago, St. Louis, and beyond. Mark Twain knew these waters; that riverboat tradition lives on in every departure from this storied port. My imagination has traced these waters a thousand times through books and documentaries, yet nothing substitutes for actually being there and feeling the river's presence firsthand.</p>
             <p><a href="/cruise-lines/carnival.html">Carnival</a>, <a href="/cruise-lines/norwegian.html">Norwegian</a>, and <a href="/cruise-lines/royal-caribbean.html">Royal Caribbean</a> operate Western Caribbean sailings from NOLA, with departures convenient to the St. Charles streetcar line and magnificent Garden District mansions. However, the allure extends far beyond embarkation logistics — this city has consistently topped my personal wishlist of American destinations to experience before boarding any ship. When I finally make my way to NOLA, I intend to arrive at least three days early to properly absorb what generations of travelers have described as utterly intoxicating.</p>
             <figure class="logbook-image float-left">
-              <img src="/ports/img/new-orleans/steamboat-natchez.webp" alt="Steamboat Natchez on the Mississippi River with its distinctive red paddlewheel and white superstructure" loading="lazy"/>
+              <img src="/ports/img/new-orleans/steamboat-natchez.webp" alt="Steamboat Natchez on the Mississippi River with its distinctive red paddlewheel and white superstructure" loading="lazy">
               <figcaption>Steamboat Natchez — <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></figcaption>
             </figure>
             <div class="poignant-highlight">
@@ -176,7 +177,7 @@ Soli Deo Gloria
           <h2>The Cruise Port</h2>
           <p>New Orleans operates two modern cruise facilities along the Mississippi River waterfront. The <strong>Erato Street Cruise Terminal</strong> and <strong>Julia Street Cruise Terminal</strong> both offer convenient access to downtown attractions, sitting approximately one mile from the French Quarter.</p>
           <figure class="logbook-image">
-            <img src="/ports/img/new-orleans/mississippi-river.webp" alt="Mississippi River waterfront with cruise ships and the New Orleans skyline in the background" loading="lazy"/>
+            <img src="/ports/img/new-orleans/mississippi-river.webp" alt="Mississippi River waterfront with cruise ships and the New Orleans skyline in the background" loading="lazy">
             <figcaption>Mississippi River waterfront — <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></figcaption>
           </figure>
           <p>The Julia Street location places visitors directly across from the National WWII Museum — a perfect arrival or departure day activity. Both facilities offer covered parking, though reservations are strongly recommended during festival season and peak travel periods. Typical cruise parking runs $20-25 per day for the duration of your voyage.</p>
@@ -263,33 +264,33 @@ Soli Deo Gloria
         </section>
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: How many days should I spend in New Orleans before my cruise?</strong><br/>A: Minimum two to three days recommended. The city's unique blend of culture, cuisine, and music deserves unhurried exploration — rushing through would miss the essence of what makes New Orleans unforgettable. Even experienced travelers consistently wish they'd allocated more time here.</p>
-          <p><strong>Q: Can I walk from the cruise area to the French Quarter?</strong><br/>A: Yes, approximately one mile separates the cruise facilities from the Quarter. Manageable on foot if you're not hauling heavy luggage. The Riverfront Streetcar also connects the area for just $1.25. Most passengers find the walk pleasant in good weather.</p>
-          <p><strong>Q: Where should I go for authentic jazz in New Orleans?</strong><br/>A: Frenchmen Street in the Marigny neighborhood is where locals go for authentic jazz. Skip the tourist-focused Bourbon Street clubs and head to Frenchmen — intimate venues, talented musicians, and genuine neighborhood vibe. No cover charge at most venues; tip the musicians generously.</p>
-          <p><strong>Q: What's the ideal time to visit New Orleans?</strong><br/>A: Spring (March-May) and fall (October-November) deliver comfortable temperatures. Summer brings oppressive heat and humidity that can make outdoor exploration uncomfortable. Festival season (Mardi Gras, Jazz Fest) means higher prices and crowds but unmatched energy and atmosphere.</p>
-          <p><strong>Q: Do I need a car in New Orleans?</strong><br/>A: Not for exploring the French Quarter, Garden District, or downtown areas. Streetcars, walking, and rideshare services handle most visitor needs beautifully. Only rent a car if planning independent plantation tours or swamp excursions.</p>
+          <p><strong>Q: How many days should I spend in New Orleans before my cruise?</strong><br>A: Minimum two to three days recommended. The city's unique blend of culture, cuisine, and music deserves unhurried exploration — rushing through would miss the essence of what makes New Orleans unforgettable. Even experienced travelers consistently wish they'd allocated more time here.</p>
+          <p><strong>Q: Can I walk from the cruise area to the French Quarter?</strong><br>A: Yes, approximately one mile separates the cruise facilities from the Quarter. Manageable on foot if you're not hauling heavy luggage. The Riverfront Streetcar also connects the area for just $1.25. Most passengers find the walk pleasant in good weather.</p>
+          <p><strong>Q: Where should I go for authentic jazz in New Orleans?</strong><br>A: Frenchmen Street in the Marigny neighborhood is where locals go for authentic jazz. Skip the tourist-focused Bourbon Street clubs and head to Frenchmen — intimate venues, talented musicians, and genuine neighborhood vibe. No cover charge at most venues; tip the musicians generously.</p>
+          <p><strong>Q: What's the ideal time to visit New Orleans?</strong><br>A: Spring (March-May) and fall (October-November) deliver comfortable temperatures. Summer brings oppressive heat and humidity that can make outdoor exploration uncomfortable. Festival season (Mardi Gras, Jazz Fest) means higher prices and crowds but unmatched energy and atmosphere.</p>
+          <p><strong>Q: Do I need a car in New Orleans?</strong><br>A: Not for exploring the French Quarter, Garden District, or downtown areas. Streetcars, walking, and rideshare services handle most visitor needs beautifully. Only rent a car if planning independent plantation tours or swamp excursions.</p>
         </section>
         <section class="port-section photo-gallery" id="gallery">
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/new-orleans/french-quarter.webp" alt="French Quarter balconies with wrought iron railings and hanging plants" loading="lazy"/>
+              <img src="/ports/img/new-orleans/french-quarter.webp" alt="French Quarter balconies with wrought iron railings and hanging plants" loading="lazy">
               <figcaption>French Quarter architecture<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/new-orleans/jackson-square.webp" alt="Jackson Square with St. Louis Cathedral and palm trees" loading="lazy"/>
+              <img src="/ports/img/new-orleans/jackson-square.webp" alt="Jackson Square with St. Louis Cathedral and palm trees" loading="lazy">
               <figcaption>Jackson Square<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/new-orleans/steamboat-natchez.webp" alt="Steamboat Natchez on the Mississippi River" loading="lazy"/>
+              <img src="/ports/img/new-orleans/steamboat-natchez.webp" alt="Steamboat Natchez on the Mississippi River" loading="lazy">
               <figcaption>Steamboat Natchez<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/new-orleans/mississippi-river.webp" alt="Mississippi River waterfront with New Orleans skyline" loading="lazy"/>
+              <img src="/ports/img/new-orleans/mississippi-river.webp" alt="Mississippi River waterfront with New Orleans skyline" loading="lazy">
               <figcaption>Mississippi River waterfront<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/new-orleans/garden-district.webp" alt="Garden District mansion with oak trees and iron fence" loading="lazy"/>
+              <img src="/ports/img/new-orleans/garden-district.webp" alt="Garden District mansion with oak trees and iron fence" loading="lazy">
               <figcaption>Garden District mansion<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></div></figcaption>
             </figure>
           </div>
@@ -319,8 +320,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -339,7 +340,7 @@ Soli Deo Gloria
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     </aside>
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
@@ -385,5 +386,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/port-canaveral.html
+++ b/ports/port-canaveral.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Port Canaveral cruise port — where rockets and ships share the sky. Kennedy Space Center, SpaceX launches, parking tips, and embarkation for Florida's Space Coast."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Port Canaveral cruise port — where rockets and ships share the sky. Kennedy Space Center, SpaceX launches, parking tips, and embarkation for Florida's Space Coast.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Port Canaveral Cruise Port Guide — Florida's Space Coast | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Port Canaveral — where America's space program meets the sea. Kennedy Space Center, rocket launches, parking, hotels, and embarkation tips."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/port-canaveral.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Port Canaveral — where America's space program meets the sea. Kennedy Space Center, rocket launches, parking, hotels, and embarkation tips.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/port-canaveral.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Port Canaveral cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/port-canaveral/rocket-launch.webp" alt="SpaceX Falcon 9 rocket launching from Kennedy Space Center at dusk with trail of fire illuminating Florida's Space Coast sky" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Port Canaveral</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Port Canaveral</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Port Canaveral</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Port Canaveral cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/port-canaveral/rocket-launch.webp" alt="SpaceX Falcon 9 rocket launching from Kennedy Space Center at dusk with trail of fire illuminating Florida's Space Coast sky" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Port Canaveral</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've passed through Port Canaveral more times than I can count, and each visit carries that same electric wonder. This is one of the world's busiest cruise ports — over five million passengers annually — serving as Florida's gateway for Disney, Royal Caribbean, Carnival, Norwegian, and MSC cruises. But what sets this place apart isn't just the ships. It's the rockets. This is where America's space program meets the sea, and that combination creates magic unlike anywhere else on Earth.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/port-canaveral/kennedy-space-center.webp" alt="Space Shuttle Atlantis on display at Kennedy Space Center Visitor Complex with dramatic lighting against dark background" loading="lazy"/>
+              <img src="/ports/img/port-canaveral/kennedy-space-center.webp" alt="Space Shuttle Atlantis on display at Kennedy Space Center Visitor Complex with dramatic lighting against dark background" loading="lazy">
               <figcaption>Kennedy Space Center — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>The port's history is inseparable from America's space program — a partnership written in fire and salt water. The first rocket launched from Cape Canaveral on July 24, 1950, when a modified V-2 called Bumper 8 lifted skyward, three years before the port even opened in 1953. When NASA was established in 1958, and Kennedy Space Center formally named in 1963 after the fallen president, this stretch of Florida coastline became the threshold of human spaceflight. The Cape was chosen deliberately — Earth's rotation gives rockets launched eastward a velocity advantage, and launching over water toward the equator meant less risk to populated areas. Geography as destiny.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/port-canaveral/cruise-terminal.webp" alt="Modern Port Canaveral cruise terminal building with Royal Caribbean ship docked and palm trees framing the entrance" loading="lazy"/>
+              <img src="/ports/img/port-canaveral/cruise-terminal.webp" alt="Modern Port Canaveral cruise terminal building with Royal Caribbean ship docked and palm trees framing the entrance" loading="lazy">
               <figcaption>Port Canaveral terminal — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -201,7 +202,7 @@ Soli Deo Gloria
           <p>Port Canaveral operates seven cruise terminals handling over five million passengers annually — the second-busiest cruise port in the world. Disney uses Terminal 8 (with themed interiors featuring cast member greetings), Royal Caribbean uses Terminal 1, and Carnival, Norwegian, and MSC rotate through other terminals. Check your cruise documents for exact terminal assignment.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/port-canaveral/port-overview.webp" alt="Aerial view of Port Canaveral with multiple cruise ships docked at terminals and Kennedy Space Center visible in the distance" loading="lazy"/>
+            <img src="/ports/img/port-canaveral/port-overview.webp" alt="Aerial view of Port Canaveral with multiple cruise ships docked at terminals and Kennedy Space Center visible in the distance" loading="lazy">
             <figcaption>Port Canaveral overview — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -217,7 +218,7 @@ Soli Deo Gloria
             <li><strong>From Melbourne Airport (MLB):</strong> 30 minutes, a quieter alternative for those wanting to avoid Orlando entirely. Smaller airport with fewer flight options but much easier logistics.</li>
             <li><strong>Port Parking ($17-20/day):</strong> On-site parking available at each terminal. Reserve ahead for peak sailing dates at the port website — parking can fill up during busy periods. Credit cards accepted.</li>
             <li><strong>Off-Site Parking ($12-15/day):</strong> Several third-party lots nearby with shuttle service to terminals. Check reviews and verify shuttle frequency before booking. Savings are modest but add up for longer cruises.</li>
-            <li><strong>Hotel Park & Cruise:</strong> Many area hotels offer packages with parking included. Radisson Resort at the Port is popular with shuttle service. Country Inn & Suites offers free parking for up to 8 days with cruise packages.</li>
+            <li><strong>Hotel Park &amp; Cruise:</strong> Many area hotels offer packages with parking included. Radisson Resort at the Port is popular with shuttle service. Country Inn &amp; Suites offers free parking for up to 8 days with cruise packages.</li>
             <li><strong>Getting to Kennedy Space Center:</strong> 20 minutes from the port. Uber/Lyft works but can be pricey for return. Consider rental car if planning extended Space Coast exploration.</li>
           </ul>
         </section>
@@ -273,7 +274,7 @@ Soli Deo Gloria
           <p>The Space Coast offers fresh seafood and casual beach dining:</p>
           <ul>
             <li><strong>Grills Seafood Deck (Port Canaveral, $$):</strong> Waterfront dining overlooking the port. Watch cruise ships depart while eating fresh catch. My pre-cruise go-to for grouper sandwiches and cold beer.</li>
-            <li><strong>Fishlips Waterfront Bar & Grill (Port Canaveral, $$):</strong> Another excellent waterfront option with live music weekends. Good for sunset drinks and seafood.</li>
+            <li><strong>Fishlips Waterfront Bar &amp; Grill (Port Canaveral, $$):</strong> Another excellent waterfront option with live music weekends. Good for sunset drinks and seafood.</li>
             <li><strong>Florida's Fresh Grill (Cocoa Beach, $$):</strong> Farm-to-table Florida cuisine. Excellent seafood and steaks. Slightly upscale for special occasions.</li>
             <li><strong>Jazzy's (Cocoa Beach, $):</strong> Mainely Lobster rolls and casual beach fare. Great for quick lunch near the beach.</li>
             <li><strong>Sunrise Diner (Cocoa Beach, $):</strong> Classic breakfast spot. Huge portions, friendly service, reasonable prices.</li>
@@ -320,15 +321,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Is Kennedy Space Center worth visiting before a cruise?</strong><br/>A: Absolutely — it's one of the best attractions in Florida and unlike anything else. Stand beneath a Saturn V rocket, see Space Shuttle Atlantis, touch a moon rock, meet real astronauts. Plan a full day, or at least half a day for highlights. Book in advance for guaranteed entry during peak season.</p>
+          <p><strong>Q: Is Kennedy Space Center worth visiting before a cruise?</strong><br>A: Absolutely — it's one of the best attractions in Florida and unlike anything else. Stand beneath a Saturn V rocket, see Space Shuttle Atlantis, touch a moon rock, meet real astronauts. Plan a full day, or at least half a day for highlights. Book in advance for guaranteed entry during peak season.</p>
 
-          <p><strong>Q: How far is Port Canaveral from Orlando airport?</strong><br/>A: 45-60 minutes via SR-528 (Beachline Expressway). Uber/Lyft runs $50-70. Multiple shuttle companies offer transfers at lower cost. Allow extra time during theme park peaks and holidays when traffic can back up.</p>
+          <p><strong>Q: How far is Port Canaveral from Orlando airport?</strong><br>A: 45-60 minutes via SR-528 (Beachline Expressway). Uber/Lyft runs $50-70. Multiple shuttle companies offer transfers at lower cost. Allow extra time during theme park peaks and holidays when traffic can back up.</p>
 
-          <p><strong>Q: Can I watch a rocket launch during my cruise?</strong><br/>A: Check the SpaceX launch schedule at spacex.com/launches before your trip. SpaceX launches frequently from Cape Canaveral. Jetty Park and Playalinda Beach offer free public viewing. If a launch coincides with your port stay, watch from the ship's deck — it's unforgettable.</p>
+          <p><strong>Q: Can I watch a rocket launch during my cruise?</strong><br>A: Check the SpaceX launch schedule at spacex.com/launches before your trip. SpaceX launches frequently from Cape Canaveral. Jetty Park and Playalinda Beach offer free public viewing. If a launch coincides with your port stay, watch from the ship's deck — it's unforgettable.</p>
 
-          <p><strong>Q: Where should I park at Port Canaveral?</strong><br/>A: On-site parking at each terminal costs $17-20/day. Reserve ahead for peak sailing dates at the port website. Off-site lots nearby offer cheaper rates ($12-15/day) with shuttle service. Many hotels offer Park & Cruise packages that include parking for your cruise duration.</p>
+          <p><strong>Q: Where should I park at Port Canaveral?</strong><br>A: On-site parking at each terminal costs $17-20/day. Reserve ahead for peak sailing dates at the port website. Off-site lots nearby offer cheaper rates ($12-15/day) with shuttle service. Many hotels offer Park &amp; Cruise packages that include parking for your cruise duration.</p>
 
-          <p><strong>Q: Which terminal is my ship at?</strong><br/>A: Check your cruise documents — terminals vary by cruise line. Disney uses Terminal 8 (themed with cast members), Royal Caribbean uses Terminal 1, and others rotate through remaining terminals.</p>
+          <p><strong>Q: Which terminal is my ship at?</strong><br>A: Check your cruise documents — terminals vary by cruise line. Disney uses Terminal 8 (themed with cast members), Royal Caribbean uses Terminal 1, and others rotate through remaining terminals.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -336,23 +337,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/port-canaveral/rocket-launch.webp" alt="SpaceX Falcon 9 rocket launching from Kennedy Space Center at dusk with trail of fire illuminating Florida's Space Coast sky" loading="lazy"/>
+              <img src="/ports/img/port-canaveral/rocket-launch.webp" alt="SpaceX Falcon 9 rocket launching from Kennedy Space Center at dusk with trail of fire illuminating Florida's Space Coast sky" loading="lazy">
               <figcaption>SpaceX launch — where dreams reach for the stars<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/port-canaveral/kennedy-space-center.webp" alt="Space Shuttle Atlantis on display at Kennedy Space Center Visitor Complex with dramatic lighting" loading="lazy"/>
+              <img src="/ports/img/port-canaveral/kennedy-space-center.webp" alt="Space Shuttle Atlantis on display at Kennedy Space Center Visitor Complex with dramatic lighting" loading="lazy">
               <figcaption>Space Shuttle Atlantis — suspended in eternal flight<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/port-canaveral/cruise-terminal.webp" alt="Modern Port Canaveral cruise terminal building with cruise ship docked and palm trees" loading="lazy"/>
+              <img src="/ports/img/port-canaveral/cruise-terminal.webp" alt="Modern Port Canaveral cruise terminal building with cruise ship docked and palm trees" loading="lazy">
               <figcaption>Port Canaveral terminal — gateway to Caribbean adventures<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/port-canaveral/port-overview.webp" alt="Aerial view of Port Canaveral with cruise ships docked and Kennedy Space Center visible" loading="lazy"/>
+              <img src="/ports/img/port-canaveral/port-overview.webp" alt="Aerial view of Port Canaveral with cruise ships docked and Kennedy Space Center visible" loading="lazy">
               <figcaption>Where rockets and ships share the sky<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/port-canaveral/cocoa-beach.webp" alt="Cocoa Beach coastline with Atlantic waves breaking on Florida's Space Coast under blue sky" loading="lazy"/>
+              <img src="/ports/img/port-canaveral/cocoa-beach.webp" alt="Cocoa Beach coastline with Atlantic waves breaking on Florida's Space Coast under blue sky" loading="lazy">
               <figcaption>Cocoa Beach — classic Florida surf town<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -388,8 +389,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, founder and author of In the Wake cruise travel logbook" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -411,7 +412,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -462,5 +463,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/san-juan.html
+++ b/ports/san-juan.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to San Juan cruise port — El Morro fortress, Old San Juan blue cobblestones, authentic mofongo, and the birthplace of the piña colada. US territory means no passport needed."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
-  <title>San Juan Cruise Port Guide — El Morro, Old San Juan & Mofongo | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to San Juan cruise port — El Morro fortress, Old San Juan blue cobblestones, mofongo, and the birthplace of the piña colada. US territory means no passport needed."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/san-juan.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to San Juan cruise port — El Morro fortress, Old San Juan blue cobblestones, authentic mofongo, and the birthplace of the piña colada. US territory means no passport needed.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <title>San Juan Cruise Port Guide — El Morro, Old San Juan &amp; Mofongo | In the Wake</title>
+  <meta name="description" content="First-person logbook guide to San Juan cruise port — El Morro fortress, Old San Juan blue cobblestones, mofongo, and the birthplace of the piña colada. US territory means no passport needed.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/san-juan.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -91,20 +88,12 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <section class="port-hero" id="hero" aria-label="San Juan cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/san-juan/el-morro-fortress.webp" alt="El Morro fortress rising above the Atlantic Ocean with waves crashing against centuries-old walls at sunset" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">San Juan</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
-  </section>
+  
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -118,7 +107,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -133,7 +122,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -147,22 +136,34 @@ Soli Deo Gloria
     </div>
   </header>
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">San Juan</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">San Juan</li></ol></nav>
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="San Juan cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/san-juan/el-morro-fortress.webp" alt="El Morro fortress rising above the Atlantic Ocean with waves crashing against centuries-old walls at sunset" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">San Juan</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
         <section class="port-section" id="logbook">
           <h2>My Logbook: 500 Years of Wonder at the Gangway</h2>
           <div class="logbook-entry clearfix">
             <p>Sailing past <strong>El Morro</strong> fortress at sunrise with waves crashing against those centuries-old walls is one of cruising's most breathtaking arrivals. The six-level citadel rises 140 feet above the Atlantic, its weathered stone a testament to the Spanish Empire's determination to protect their New World gateway. San Juan is the only port where I can step off the gangway and be standing in a 500-year-old UNESCO World Heritage city within five minutes — no taxis, no transfers, just centuries of wonder at my fingertips. Yet even after a dozen visits, I still pause at the pier to take in that view of the old city rising above the harbor walls.</p>
             <figure class="logbook-image float-right">
-              <img src="/ports/img/san-juan/san-juan-1.webp" alt="Colorful colonial buildings lining the cobblestone streets of Old San Juan" loading="lazy"/>
+              <img src="/ports/img/san-juan/san-juan-1.webp" alt="Colorful colonial buildings lining the cobblestone streets of Old San Juan" loading="lazy">
               <figcaption>Old San Juan streets — <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></figcaption>
             </figure>
             <p>Founded in 1521, San Juan stands among the oldest European settlements in the Americas. Walk these streets and you're tracing layers of time — indigenous Taíno pathways overlaid with Spanish colonial planning, African influences woven into the cultural fabric, Caribbean rhythms mixed with American practicality. In 1983, UNESCO recognized this extraordinary convergence by designating "La Fortaleza and San Juan National Site" as a World Heritage Site, acknowledging what every visitor instinctively feels: this place preserves something irreplaceable, a living chronicle of empires, cultures, and centuries woven into every stone.</p>
             <p>My perfect San Juan day starts at 8 a.m., stepping off the ship at Pier 3 or 4 right into the heart of Old San Juan. First stop: a café con leche and fresh mallorca (sweet bread dusted with powdered sugar) at <strong>Café Mallorca</strong> on San Francisco Street. Properly caffeinated, I wind through the narrow streets toward El Morro, those distinctive blue cobblestones (actually <em>adoquines</em>, blocks cast from iron furnace slag brought as ship ballast from Spain) gleaming after the morning rain.</p>
             <p>The walk to El Morro passes <strong>La Fortaleza</strong>, the oldest executive mansion in continuous use in the Western Hemisphere. Puerto Rico's governors have occupied this fortress-residence since 1540, an unbroken chain of administration spanning nearly five centuries. Beyond it, candy-colored colonial buildings with intricate iron balconies line the streets, and tiny plazas shelter old men playing dominoes and stray cats napping in the sun. Every street corner reveals another chapter of this remarkable fusion of worlds.</p>
             <figure class="logbook-image float-left">
-              <img src="/ports/img/san-juan/san-juan-4.webp" alt="El Morro fortress walls rising above the Atlantic Ocean with sentry boxes visible" loading="lazy"/>
+              <img src="/ports/img/san-juan/san-juan-4.webp" alt="El Morro fortress walls rising above the Atlantic Ocean with sentry boxes visible" loading="lazy">
               <figcaption>El Morro ramparts — <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></figcaption>
             </figure>
             <div class="poignant-highlight">
@@ -178,7 +179,7 @@ Soli Deo Gloria
           <h2>The Cruise Port</h2>
           <p>San Juan welcomes roughly two million cruise passengers annually through its port infrastructure. The majority of cruise ships dock at the <strong>Old San Juan Piers</strong> (Piers 3, 4, and sometimes Pier 6), which sit directly adjacent to the colonial district. When I say "walk off the ship to attractions," I mean it literally — you'll disembark, clear the terminal building, and find yourself on streets that have existed since the 1500s.</p>
           <figure class="logbook-image">
-            <img src="/ports/img/san-juan/san-juan-2.webp" alt="Christopher Columbus statue in Plaza Colón with palm trees and colonial architecture" loading="lazy"/>
+            <img src="/ports/img/san-juan/san-juan-2.webp" alt="Christopher Columbus statue in Plaza Colón with palm trees and colonial architecture" loading="lazy">
             <figcaption>Plaza Colón in Old San Juan — <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></figcaption>
           </figure>
           <p>Some larger vessels or those arriving when the Old San Juan piers are at capacity will dock at <strong>Pan American Pier</strong>, situated closer to the Puerto Rico Convention Center. This terminal lies a couple miles from the core, making walking impractical. Taxis congregate right at the terminal exit, and the ride to Old San Juan runs about 10 minutes depending on traffic. Uber and Lyft also operate throughout San Juan, often at competitive rates.</p>
@@ -273,33 +274,33 @@ Soli Deo Gloria
         </section>
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Do I need a passport for San Juan?</strong><br/>A: No — Puerto Rico is a US territory, so American citizens only need a valid ID. USD is accepted everywhere, your cell phone works normally with US carriers, and all purchases return home duty-free. It's America with better food and weather.</p>
-          <p><strong>Q: Where is the best mofongo in San Juan?</strong><br/>A: El Jibarito on Sol Street is legendary for authentic mofongo. For elevated versions, try Santaella or Marmalade. Get it relleno (stuffed) with camarones al ajillo (garlic shrimp) for the full experience. Cash only at El Jibarito.</p>
-          <p><strong>Q: How far is El Morro from the cruise port?</strong><br/>A: From the Old San Juan piers (3, 4, or 6), El Morro is a 15-20 minute walk through scenic colonial streets with blue cobblestones. The walk is half the pleasure. A free trolley also connects the piers to the fortress area.</p>
-          <p><strong>Q: Should I visit El Morro or San Cristóbal?</strong><br/>A: Both! The $10 admission covers both fortresses for the entire day. El Morro has the iconic ocean views, lighthouse, and kite-flying lawn. San Cristóbal is larger with an extensive tunnel system. If forced to choose one, El Morro is the signature San Juan experience.</p>
-          <p><strong>Q: What if it rains?</strong><br/>A: Take the Bacardi distillery tour — ferry from Pier 2, free shuttle, free tour with tastings. Or explore the many museums, galleries, and shops of Old San Juan. Afternoon showers typically pass within an hour, often ending with rainbows over the blue cobblestones.</p>
+          <p><strong>Q: Do I need a passport for San Juan?</strong><br>A: No — Puerto Rico is a US territory, so American citizens only need a valid ID. USD is accepted everywhere, your cell phone works normally with US carriers, and all purchases return home duty-free. It's America with better food and weather.</p>
+          <p><strong>Q: Where is the best mofongo in San Juan?</strong><br>A: El Jibarito on Sol Street is legendary for authentic mofongo. For elevated versions, try Santaella or Marmalade. Get it relleno (stuffed) with camarones al ajillo (garlic shrimp) for the full experience. Cash only at El Jibarito.</p>
+          <p><strong>Q: How far is El Morro from the cruise port?</strong><br>A: From the Old San Juan piers (3, 4, or 6), El Morro is a 15-20 minute walk through scenic colonial streets with blue cobblestones. The walk is half the pleasure. A free trolley also connects the piers to the fortress area.</p>
+          <p><strong>Q: Should I visit El Morro or San Cristóbal?</strong><br>A: Both! The $10 admission covers both fortresses for the entire day. El Morro has the iconic ocean views, lighthouse, and kite-flying lawn. San Cristóbal is larger with an extensive tunnel system. If forced to choose one, El Morro is the signature San Juan experience.</p>
+          <p><strong>Q: What if it rains?</strong><br>A: Take the Bacardi distillery tour — ferry from Pier 2, free shuttle, free tour with tastings. Or explore the many museums, galleries, and shops of Old San Juan. Afternoon showers typically pass within an hour, often ending with rainbows over the blue cobblestones.</p>
         </section>
         <section class="port-section photo-gallery" id="gallery">
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/san-juan/san-juan-1.webp" alt="Colorful colonial buildings with iron balconies lining Old San Juan streets" loading="lazy"/>
+              <img src="/ports/img/san-juan/san-juan-1.webp" alt="Colorful colonial buildings with iron balconies lining Old San Juan streets" loading="lazy">
               <figcaption>Colonial architecture of Old San Juan<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA)</div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/san-juan/san-juan-2.webp" alt="Christopher Columbus statue in Plaza Colón with palm trees" loading="lazy"/>
+              <img src="/ports/img/san-juan/san-juan-2.webp" alt="Christopher Columbus statue in Plaza Colón with palm trees" loading="lazy">
               <figcaption>Plaza Colón and Columbus statue<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (Public domain)</div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/san-juan/san-juan-3.webp" alt="Blue cobblestone streets of Old San Juan glistening in the light" loading="lazy"/>
+              <img src="/ports/img/san-juan/san-juan-3.webp" alt="Blue cobblestone streets of Old San Juan glistening in the light" loading="lazy">
               <figcaption>Blue adoquine cobblestones<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/san-juan/san-juan-4.webp" alt="El Morro fortress walls and sentry boxes rising above the Atlantic" loading="lazy"/>
+              <img src="/ports/img/san-juan/san-juan-4.webp" alt="El Morro fortress walls and sentry boxes rising above the Atlantic" loading="lazy">
               <figcaption>El Morro fortress ramparts<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/san-juan/paseo-princesa.webp" alt="Paseo de la Princesa waterfront promenade at sunset with artisan vendors and palm trees" loading="lazy"/>
+              <img src="/ports/img/san-juan/paseo-princesa.webp" alt="Paseo de la Princesa waterfront promenade at sunset with artisan vendors and palm trees" loading="lazy">
               <figcaption>Paseo de la Princesa at sunset<div class="photo-credit">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0)</div></figcaption>
             </figure>
           </div>
@@ -329,8 +330,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -349,7 +350,7 @@ Soli Deo Gloria
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     </aside>
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
@@ -395,5 +396,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/seattle.html
+++ b/ports/seattle.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Seattle cruise port — America's premier gateway to Alaska. Pike Place Market, Space Needle, embarkation tips, parking, and Pacific Northwest pre-cruise adventures."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Seattle cruise port — America's premier gateway to Alaska. Pike Place Market, Space Needle, embarkation tips, parking, and Pacific Northwest pre-cruise adventures.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Seattle Cruise Port Guide — Gateway to Alaska | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Seattle cruise port — Pike Place Market, Space Needle, embarkation tips, parking, and Pacific Northwest pre-cruise adventures in the Emerald City."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/seattle.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Seattle cruise port — Pike Place Market, Space Needle, embarkation tips, parking, and Pacific Northwest pre-cruise adventures in the Emerald City.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/seattle.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -92,15 +89,7 @@ Soli Deo Gloria
 </head>
 <body class="page">
   <!-- HERO SECTION - placed first for ITC validator section ordering -->
-  <section class="port-hero" id="hero" aria-label="Seattle cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/seattle/space-needle-skyline.webp" alt="Seattle skyline with Space Needle and Mount Rainier visible in the distance under Pacific Northwest blue sky with cruise ships in Elliott Bay" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Seattle</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
 
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <span role="status" aria-live="polite" aria-atomic="true" class="sr-only"></span>
@@ -109,7 +98,7 @@ Soli Deo Gloria
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -123,7 +112,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -138,7 +127,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -153,11 +142,23 @@ Soli Deo Gloria
   </header>
 
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Seattle</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Seattle</li></ol></nav>
 
     <div style="grid-column: 1; grid-row: 1;">
 
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Seattle cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/seattle/space-needle-skyline.webp" alt="Seattle skyline with Space Needle and Mount Rainier visible in the distance under Pacific Northwest blue sky with cruise ships in Elliott Bay" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Seattle</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
 
         <!-- LOGBOOK SECTION - 800+ words, 10+ first-person pronouns -->
         <section class="port-section" id="logbook">
@@ -166,7 +167,7 @@ Soli Deo Gloria
             <p>I've been dreaming about Alaska for years. Not the Alaska of cruise brochures — glaciers framed by deck chairs — but the real Alaska. The one where humpback whales breach next to fishing boats, where bald eagles outnumber tourists, where glacier ice that took ten thousand years to form calves into the sea with a thunder that shakes your bones. And for me, that dream begins in Seattle.</p>
 
             <figure class="logbook-image float-right">
-              <img src="/ports/img/seattle/pike-place-market.webp" alt="Famous Pike Place Market sign with fresh fish, flower vendors, and early morning shoppers in downtown Seattle" loading="lazy"/>
+              <img src="/ports/img/seattle/pike-place-market.webp" alt="Famous Pike Place Market sign with fresh fish, flower vendors, and early morning shoppers in downtown Seattle" loading="lazy">
               <figcaption>Pike Place Market — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -175,7 +176,7 @@ Soli Deo Gloria
             <p>What fascinates me most is Seattle's history as a gateway. This city has been sending dreamers north since 1897, when gold fever gripped the nation and thousands of prospectors flooded through Elliott Bay on their way to the Klondike. The city marketed itself as the "Gateway to Alaska" — a title it still holds today. I walk Pioneer Square and imagine those prospectors loading supplies, not knowing if they'd strike it rich or freeze on some nameless Yukon trail. Their adventurous spirit shaped modern Seattle, and I feel that same pull northward whenever I study the map.</p>
 
             <figure class="logbook-image float-left">
-              <img src="/ports/img/seattle/elliott-bay-waterfront.webp" alt="Seattle waterfront along Elliott Bay with cruise ships docked and the Great Wheel visible on the pier" loading="lazy"/>
+              <img src="/ports/img/seattle/elliott-bay-waterfront.webp" alt="Seattle waterfront along Elliott Bay with cruise ships docked and the Great Wheel visible on the pier" loading="lazy">
               <figcaption>Elliott Bay waterfront — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
 
@@ -203,7 +204,7 @@ Soli Deo Gloria
           <p>Seattle operates two cruise terminals along Elliott Bay. Smith Cove (Pier 91), located about 10 minutes from downtown, handles Carnival, Holland America, Princess, and Royal Caribbean. The terminal offers 1,100 parking spots, modern facilities, and efficient check-in processes. Bell Street Pier (Pier 66) sits downtown, within walking distance of Pike Place Market and major attractions — serving Celebrity and Norwegian cruise lines.</p>
 
           <figure class="logbook-image">
-            <img src="/ports/img/seattle/cruise-terminal-pier91.webp" alt="Smith Cove cruise terminal at Pier 91 with Royal Caribbean ship docked and Seattle skyline visible in the background" loading="lazy"/>
+            <img src="/ports/img/seattle/cruise-terminal-pier91.webp" alt="Smith Cove cruise terminal at Pier 91 with Royal Caribbean ship docked and Seattle skyline visible in the background" loading="lazy">
             <figcaption>Smith Cove Terminal — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
 
@@ -329,15 +330,15 @@ Soli Deo Gloria
         <!-- FAQ SECTION - 200+ words -->
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Which cruise terminal will my ship use in Seattle?</strong><br/>A: Seattle has two terminals. Smith Cove (Pier 91) serves Carnival, Holland America, Princess, and Royal Caribbean — located 10 minutes from downtown. Bell Street Pier (Pier 66) serves Celebrity and Norwegian — conveniently downtown near Pike Place. Check your cruise documents for terminal assignment.</p>
+          <p><strong>Q: Which cruise terminal will my ship use in Seattle?</strong><br>A: Seattle has two terminals. Smith Cove (Pier 91) serves Carnival, Holland America, Princess, and Royal Caribbean — located 10 minutes from downtown. Bell Street Pier (Pier 66) serves Celebrity and Norwegian — conveniently downtown near Pike Place. Check your cruise documents for terminal assignment.</p>
 
-          <p><strong>Q: How do I get from SEA-TAC Airport to the Seattle cruise port?</strong><br/>A: Link Light Rail runs from SEA-TAC to downtown Westlake Station ($3.25, 40 minutes). From Westlake, take taxi or rideshare to terminals. Uber/Lyft direct from airport runs $40-55. Traditional taxi costs $45-60. The Link is most economical for solo travelers.</p>
+          <p><strong>Q: How do I get from SEA-TAC Airport to the Seattle cruise port?</strong><br>A: Link Light Rail runs from SEA-TAC to downtown Westlake Station ($3.25, 40 minutes). From Westlake, take taxi or rideshare to terminals. Uber/Lyft direct from airport runs $40-55. Traditional taxi costs $45-60. The Link is most economical for solo travelers.</p>
 
-          <p><strong>Q: Should I do a one-way or round-trip Alaska cruise from Seattle?</strong><br/>A: One-way cruises (Seattle to Vancouver or reverse) see more of the Inside Passage and visit more ports like Juneau, Ketchikan, and Skagway. Round-trips are more convenient since you return to your starting city — simpler for flights. One-way offers maximum Alaska exposure; round-trip offers maximum convenience.</p>
+          <p><strong>Q: Should I do a one-way or round-trip Alaska cruise from Seattle?</strong><br>A: One-way cruises (Seattle to Vancouver or reverse) see more of the Inside Passage and visit more ports like Juneau, Ketchikan, and Skagway. Round-trips are more convenient since you return to your starting city — simpler for flights. One-way offers maximum Alaska exposure; round-trip offers maximum convenience.</p>
 
-          <p><strong>Q: What's the weather like in Seattle before Alaska cruises?</strong><br/>A: Peak Alaska cruise season (May-September) brings pleasant Seattle weather in the 60s-70s°F. Always bring layers since Pacific Northwest weather can change quickly. Light rain is possible any time, but dramatic storms are rare in summer.</p>
+          <p><strong>Q: What's the weather like in Seattle before Alaska cruises?</strong><br>A: Peak Alaska cruise season (May-September) brings pleasant Seattle weather in the 60s-70s°F. Always bring layers since Pacific Northwest weather can change quickly. Light rain is possible any time, but dramatic storms are rare in summer.</p>
 
-          <p><strong>Q: What should I do with an extra day in Seattle?</strong><br/>A: Pike Place Market for the morning (arrive at 9am opening), then Space Needle and Chihuly Garden for the afternoon. If you have more time, the Boeing Factory Tour is worth the trip north, or take the Bainbridge Island ferry for stunning skyline views.</p>
+          <p><strong>Q: What should I do with an extra day in Seattle?</strong><br>A: Pike Place Market for the morning (arrive at 9am opening), then Space Needle and Chihuly Garden for the afternoon. If you have more time, the Boeing Factory Tour is worth the trip north, or take the Bainbridge Island ferry for stunning skyline views.</p>
         </section>
 
         <!-- GALLERY SECTION -->
@@ -345,23 +346,23 @@ Soli Deo Gloria
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/seattle/space-needle-skyline.webp" alt="Seattle skyline featuring the Space Needle with Mount Rainier visible in the distance" loading="lazy"/>
+              <img src="/ports/img/seattle/space-needle-skyline.webp" alt="Seattle skyline featuring the Space Needle with Mount Rainier visible in the distance" loading="lazy">
               <figcaption>Seattle skyline with Space Needle and Mount Rainier<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/seattle/pike-place-market.webp" alt="Famous Pike Place Market neon sign with flower vendors and shoppers below" loading="lazy"/>
+              <img src="/ports/img/seattle/pike-place-market.webp" alt="Famous Pike Place Market neon sign with flower vendors and shoppers below" loading="lazy">
               <figcaption>Pike Place Market — Seattle's soul since 1907<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/seattle/elliott-bay-waterfront.webp" alt="Seattle waterfront along Elliott Bay with Great Wheel and cruise ships visible" loading="lazy"/>
+              <img src="/ports/img/seattle/elliott-bay-waterfront.webp" alt="Seattle waterfront along Elliott Bay with Great Wheel and cruise ships visible" loading="lazy">
               <figcaption>Elliott Bay waterfront with the Great Wheel<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/seattle/cruise-terminal-pier91.webp" alt="Smith Cove cruise terminal at Pier 91 with large cruise ship docked" loading="lazy"/>
+              <img src="/ports/img/seattle/cruise-terminal-pier91.webp" alt="Smith Cove cruise terminal at Pier 91 with large cruise ship docked" loading="lazy">
               <figcaption>Smith Cove Terminal at Pier 91<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/seattle/chihuly-glass.webp" alt="Colorful blown glass sculpture by Dale Chihuly at Chihuly Garden and Glass museum" loading="lazy"/>
+              <img src="/ports/img/seattle/chihuly-glass.webp" alt="Colorful blown glass sculpture by Dale Chihuly at Chihuly Garden and Glass museum" loading="lazy">
               <figcaption>Chihuly Garden and Glass installation<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -397,8 +398,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -420,7 +421,7 @@ Soli Deo Gloria
       </section>
     </aside>
 
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
 
   <footer class="wrap" role="contentinfo">
@@ -471,5 +472,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>

--- a/ports/tampa.html
+++ b/ports/tampa.html
@@ -1,22 +1,19 @@
 <!--
 Soli Deo Gloria
--->
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Tampa cruise port — Florida's Gulf Coast gateway featuring Ybor City cigar heritage, Cuban sandwiches, Busch Gardens, and waterfront pre-cruise exploring."/>
-  <meta name="last-reviewed" content="2025-12-27"/>
-  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+--><!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="ai-summary" content="First-person logbook guide to Tampa cruise port — Florida's Gulf Coast gateway featuring Ybor City cigar heritage, Cuban sandwiches, Busch Gardens, and waterfront pre-cruise exploring.">
+  <meta name="last-reviewed" content="2025-12-27">
+  <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Tampa Cruise Port Guide — Florida's Gulf Coast Gateway | In the Wake</title>
-  <meta name="description" content="First-person logbook guide to Tampa cruise port — Ybor City cigar heritage, Cuban sandwiches, Busch Gardens, and waterfront pre-cruise exploring on Florida's Gulf Coast."/>
-  <link rel="canonical" href="https://cruisinginthewake.com/ports/tampa.html"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <meta name="description" content="First-person logbook guide to Tampa cruise port — Ybor City cigar heritage, Cuban sandwiches, Busch Gardens, and waterfront pre-cruise exploring on Florida's Gulf Coast.">
+  <link rel="canonical" href="https://cruisinginthewake.com/ports/tampa.html">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <script>if('serviceWorker' in navigator){ window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{})); }</script>
-  <link rel="stylesheet" href="/assets/styles.css"/>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
-  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0"/>
+  <link rel="stylesheet" href="/assets/styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+  <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -91,20 +88,12 @@ Soli Deo Gloria
   </script>
 </head>
 <body class="page">
-  <section class="port-hero" id="hero" aria-label="Tampa cruise port hero image">
-    <div class="port-hero-image">
-      <img src="/ports/img/tampa/ybor-city-streetscape.webp" alt="Historic brick streets of Ybor City with wrought-iron balconies, cigar shops, and Spanish-style architecture under Florida sunshine" loading="eager" fetchpriority="high"/>
-      <div class="port-hero-overlay">
-        <h1 class="port-hero-title">Tampa</h1>
-      </div>
-    </div>
-    <p class="port-hero-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
-  </section>
+  
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async" loading="lazy">
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -118,7 +107,7 @@ Soli Deo Gloria
       <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
         <a class="nav-pill" href="/">Home</a>
         <div class="nav-dropdown" data-nav="planning">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/planning.html">Planning (overview)</a>
             <a href="/ships.html">Ships</a>
@@ -133,7 +122,7 @@ Soli Deo Gloria
           </div>
         </div>
         <div class="nav-dropdown" data-nav="travel">
-          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">▾</span></button>
           <div class="dropdown-menu" role="menu">
             <a href="/travel.html">Travel (overview)</a>
             <a href="/solo.html">Solo</a>
@@ -147,21 +136,33 @@ Soli Deo Gloria
     </div>
   </header>
   <main class="wrap page-grid" id="main-content" role="main">
-    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> &rsaquo; </li><li style="display: inline;"><a href="/ports.html">Ports</a> &rsaquo; </li><li style="display: inline;" aria-current="page">Tampa</li></ol></nav>
+    <nav aria-label="Breadcrumb" style="grid-column: 1 / -1; margin-bottom: 1rem;"><ol style="list-style: none; padding: 0; margin: 0; font-size: 0.9rem; color: #666;"><li style="display: inline;"><a href="/">Home</a> › </li><li style="display: inline;"><a href="/ports.html">Ports</a> › </li><li style="display: inline;" aria-current="page">Tampa</li></ol></nav>
     <div style="grid-column: 1; grid-row: 1;">
       <article class="card">
+        <!-- Hero section inside card -->
+        <section class="port-hero" id="hero" aria-label="Tampa cruise port hero image" style="margin: -1.5rem -1.5rem 1.5rem -1.5rem; border-radius: 12px 12px 0 0; overflow: hidden;">
+          <div class="port-hero-image" style="position: relative;">
+            <img src="/ports/img/tampa/ybor-city-streetscape.webp" alt="Historic brick streets of Ybor City with wrought-iron balconies, cigar shops, and Spanish-style architecture under Florida sunshine" loading="eager" fetchpriority="high" style="width: 100%; height: 300px; object-fit: cover;">
+            <div class="port-hero-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <h1 class="port-hero-title" style="font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, serif; font-size: clamp(2.5rem, 8vw, 5rem); font-weight: 700; color: #fff; text-shadow: 2px 2px 8px rgba(0,0,0,0.7), 0 0 40px rgba(0,0,0,0.5); letter-spacing: 0.12em; text-transform: uppercase; margin: 0;">Tampa</h1>
+            </div>
+          </div>
+          <p class="port-hero-credit" style="text-align: right; font-size: 0.75rem; margin: 0.5rem 1rem 0; color: #666;">Photo: <a href="https://commons.wikimedia.org" target="_blank" rel="noopener">Wikimedia Commons</a></p>
+        </section>
+
+
         <section class="port-section" id="logbook">
           <h2>My Logbook: Where Cigars Built a City</h2>
           <div class="logbook-entry clearfix">
             <p>I've sailed from Tampa, and this port surprised me in ways I didn't expect. While Miami and Port Canaveral grab the headlines, Tampa quietly offers one of Florida's most rewarding pre-cruise experiences. The Gulf Coast setting feels different from the Atlantic ports — more relaxed, less frantic, with a working-city authenticity that I find refreshing. And then there's Ybor City, which became my favorite unexpected discovery.</p>
             <figure class="logbook-image float-right">
-              <img src="/ports/img/tampa/columbia-restaurant.webp" alt="Historic Columbia Restaurant in Ybor City with Spanish tile work and ornate interior, Florida's oldest restaurant since 1905" loading="lazy"/>
+              <img src="/ports/img/tampa/columbia-restaurant.webp" alt="Historic Columbia Restaurant in Ybor City with Spanish tile work and ornate interior, Florida's oldest restaurant since 1905" loading="lazy">
               <figcaption>Columbia Restaurant — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
             <p>I walked the brick streets of Ybor City the afternoon before my cruise, and I kept thinking about the thousands of hands that once rolled cigars in these buildings. In 1886, Vicente Martinez Ybor moved his cigar operations from Key West to this palmetto-covered tract northeast of Tampa. The decision transformed everything. Cuban workers followed, then Spaniards and Italians, each wave of immigrants bringing their own mutual aid societies, newspapers, and traditions. By 1900, Tampa had claimed the title "Cigar Capital of the World" — and they meant it.</p>
             <p>The numbers still astonish me. At the industry's peak in 1929, more than 200 factories employed thousands of skilled workers who hand-rolled an astounding 500 million cigars in a single year. I stood in front of one of those old factory buildings — now a boutique hotel — and tried to imagine the scene: workers bent over their rolling tables, lectores reading newspapers aloud to keep them informed and entertained, the air thick with the sweet scent of Cuban tobacco. The cigar industry didn't just employ people; it created an entire culture.</p>
             <figure class="logbook-image float-left">
-              <img src="/ports/img/tampa/cruise-terminal-waterfront.webp" alt="Port Tampa Bay cruise terminal with Royal Caribbean ship docked and Tampa skyline visible in the background" loading="lazy"/>
+              <img src="/ports/img/tampa/cruise-terminal-waterfront.webp" alt="Port Tampa Bay cruise terminal with Royal Caribbean ship docked and Tampa skyline visible in the background" loading="lazy">
               <figcaption>Port Tampa Bay — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
             </figure>
             <p>What moves me about Ybor City is how it refused to disappear. The cigar industry declined through the Great Depression and beyond — machines replaced hands, tastes changed, factories closed. By the 1970s, the district was dangerous and abandoned. But in the late 1990s, preservation efforts and investment brought the brick streets back to life. Today I walk past cigar shops where craftsmen still roll by hand, using the same techniques those Cuban masters brought over a century ago. The Columbia Restaurant has served Cuban food since 1905, and I had one of the best Cuban sandwiches of my life at their original location.</p>
@@ -179,7 +180,7 @@ Soli Deo Gloria
           <h2>The Cruise Port</h2>
           <p>Port Tampa Bay operates cruise terminals in the Channelside District at 1101 Channelside Drive. Royal Caribbean, Carnival, Norwegian, and Celebrity all sail from here, offering Western Caribbean, Eastern Caribbean, Cuba, and Mexican Riviera itineraries. The port handles over one million cruise passengers annually, making it a major Florida homeport despite less name recognition than Miami or Port Canaveral.</p>
           <figure class="logbook-image">
-            <img src="/ports/img/tampa/port-tampa-bay.webp" alt="Port Tampa Bay cruise terminal entrance with palm trees and covered passenger drop-off area" loading="lazy"/>
+            <img src="/ports/img/tampa/port-tampa-bay.webp" alt="Port Tampa Bay cruise terminal entrance with palm trees and covered passenger drop-off area" loading="lazy">
             <figcaption>Port Tampa Bay cruise terminal — <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></figcaption>
           </figure>
           <p>Both cruise terminals are wheelchair accessible with modern facilities and efficient check-in processes. Embarkation typically runs 11am-2pm. The terminal address is 1101 Channelside Drive, Tampa FL 33602. Drop luggage with porters curbside before parking in the adjacent garage. Currency is US dollars throughout, and the port area offers restrooms, information desks, and the Florida Aquarium within walking distance.</p>
@@ -277,33 +278,33 @@ Soli Deo Gloria
         </section>
         <section class="port-section" id="faq">
           <h2>Frequently Asked Questions</h2>
-          <p><strong>Q: Which cruise lines sail from Tampa?</strong><br/>A: Royal Caribbean, Carnival, Norwegian, and Celebrity all sail from Port Tampa Bay. Ships depart for Western Caribbean, Eastern Caribbean, Cuba, and Mexican Riviera itineraries. The port handles over one million passengers annually.</p>
-          <p><strong>Q: How far is Tampa Airport from the cruise port?</strong><br/>A: Tampa International Airport (TPA) is just 20-25 minutes from the cruise port — one of the easiest airport-to-port connections in Florida. Uber/Lyft runs $15-25. Several hotels offer free cruise shuttles including Hampton Inn Ybor City.</p>
-          <p><strong>Q: Tampa vs. Port Canaveral — which is better?</strong><br/>A: Tampa offers easier parking ($17/day), less congestion, and Ybor City's unique heritage. Port Canaveral is closer to Orlando theme parks and Kennedy Space Center. Choose based on whether you want theme park access or a more relaxed, culturally rich pre-cruise experience.</p>
-          <p><strong>Q: Is Ybor City worth visiting before a Tampa cruise?</strong><br/>A: Absolutely — this is my top recommendation. The National Historic Landmark District was the "Cigar Capital of the World." Cuban sandwiches, hand-rolled cigars, and the free TECO streetcar makes it easy to explore. The Columbia Restaurant (since 1905) is worth the visit alone.</p>
-          <p><strong>Q: How much is cruise port parking in Tampa?</strong><br/>A: Port Tampa Bay garage costs $17/day — some of the best rates among major Florida cruise ports. Off-site lots offer rates as low as $11/day with shuttle service. Reserve ahead during peak sailing dates and holidays.</p>
+          <p><strong>Q: Which cruise lines sail from Tampa?</strong><br>A: Royal Caribbean, Carnival, Norwegian, and Celebrity all sail from Port Tampa Bay. Ships depart for Western Caribbean, Eastern Caribbean, Cuba, and Mexican Riviera itineraries. The port handles over one million passengers annually.</p>
+          <p><strong>Q: How far is Tampa Airport from the cruise port?</strong><br>A: Tampa International Airport (TPA) is just 20-25 minutes from the cruise port — one of the easiest airport-to-port connections in Florida. Uber/Lyft runs $15-25. Several hotels offer free cruise shuttles including Hampton Inn Ybor City.</p>
+          <p><strong>Q: Tampa vs. Port Canaveral — which is better?</strong><br>A: Tampa offers easier parking ($17/day), less congestion, and Ybor City's unique heritage. Port Canaveral is closer to Orlando theme parks and Kennedy Space Center. Choose based on whether you want theme park access or a more relaxed, culturally rich pre-cruise experience.</p>
+          <p><strong>Q: Is Ybor City worth visiting before a Tampa cruise?</strong><br>A: Absolutely — this is my top recommendation. The National Historic Landmark District was the "Cigar Capital of the World." Cuban sandwiches, hand-rolled cigars, and the free TECO streetcar makes it easy to explore. The Columbia Restaurant (since 1905) is worth the visit alone.</p>
+          <p><strong>Q: How much is cruise port parking in Tampa?</strong><br>A: Port Tampa Bay garage costs $17/day — some of the best rates among major Florida cruise ports. Off-site lots offer rates as low as $11/day with shuttle service. Reserve ahead during peak sailing dates and holidays.</p>
         </section>
         <section class="port-section photo-gallery" id="gallery">
           <h2>Photo Gallery</h2>
           <div class="gallery-grid">
             <figure class="gallery-item">
-              <img src="/ports/img/tampa/ybor-city-streetscape.webp" alt="Historic brick streets of Ybor City with wrought-iron balconies and cigar shops" loading="lazy"/>
+              <img src="/ports/img/tampa/ybor-city-streetscape.webp" alt="Historic brick streets of Ybor City with wrought-iron balconies and cigar shops" loading="lazy">
               <figcaption>Ybor City — Cigar Capital of the World<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/tampa/columbia-restaurant.webp" alt="Historic Columbia Restaurant interior with Spanish tile work and ornate architecture" loading="lazy"/>
+              <img src="/ports/img/tampa/columbia-restaurant.webp" alt="Historic Columbia Restaurant interior with Spanish tile work and ornate architecture" loading="lazy">
               <figcaption>Columbia Restaurant — Florida's oldest since 1905<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/tampa/cruise-terminal-waterfront.webp" alt="Port Tampa Bay cruise terminal with cruise ship docked and Tampa skyline visible" loading="lazy"/>
+              <img src="/ports/img/tampa/cruise-terminal-waterfront.webp" alt="Port Tampa Bay cruise terminal with cruise ship docked and Tampa skyline visible" loading="lazy">
               <figcaption>Port Tampa Bay cruise terminal<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/tampa/tampa-riverwalk.webp" alt="Tampa Riverwalk along Hillsborough River with downtown skyline and palm trees" loading="lazy"/>
+              <img src="/ports/img/tampa/tampa-riverwalk.webp" alt="Tampa Riverwalk along Hillsborough River with downtown skyline and palm trees" loading="lazy">
               <figcaption>Tampa Riverwalk waterfront path<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
             <figure class="gallery-item">
-              <img src="/ports/img/tampa/florida-aquarium.webp" alt="Florida Aquarium building on Tampa waterfront near cruise terminals" loading="lazy"/>
+              <img src="/ports/img/tampa/florida-aquarium.webp" alt="Florida Aquarium building on Tampa waterfront near cruise terminals" loading="lazy">
               <figcaption>Florida Aquarium — steps from the cruise port<div class="photo-credit">Photo: <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></div></figcaption>
             </figure>
           </div>
@@ -334,8 +335,8 @@ Soli Deo Gloria
         <h3 id="author-heading">About the Author</h3>
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
-            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy"/>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp">
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Ken Baker, cruise travel writer and founder of In the Wake" decoding="async" loading="lazy">
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
@@ -354,7 +355,7 @@ Soli Deo Gloria
         <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles…</p>
       </section>
     </aside>
-    <p style="margin-top: 2rem;"><a href="/ports.html">&larr; Back to Ports Guide</a></p>
+    <p style="margin-top: 2rem;"><a href="/ports.html">← Back to Ports Guide</a></p>
   </main>
   <footer class="wrap" role="contentinfo">
     <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
@@ -400,5 +401,6 @@ Soli Deo Gloria
     }
   });
   </script>
-</body>
-</html>
+
+
+</body></html>


### PR DESCRIPTION
Move hero sections from body top to inside article card with proper styling and Wikimedia Commons attribution for:
- abu-dhabi, acapulco, adelaide, agadir, akureyri, amber-cove
- anchorage, antigua, aqaba, ascension, cozumel, ft-lauderdale
- galveston, grand-cayman, honolulu, lanzarote, los-angeles, miami
- nassau, new-orleans, port-canaveral, san-juan, seattle, tampa

Also adds fix-hero-position.js script for batch hero fixes.