### PR TITLE
Replace specialty-dining.svg placeholder with categorized images

### DIFF
--- a/assets/js/restaurants-dynamic.js
+++ b/assets/js/restaurants-dynamic.js
@@ -81,7 +81,7 @@
     'lime-and-coconut': '/assets/images/restaurants/photos/bar-lounge.jpg',
 
     // Default placeholder
-    '_default': '/assets/images/restaurants/specialty-dining.svg'
+    '_default': '/assets/images/restaurants/photos/formal-dining.webp'
   };
 
   // CTA/pitch text for venues (what makes this venue special)

--- a/restaurants/150-central-park.html
+++ b/restaurants/150-central-park.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">150 Central Park</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/adagio-dining-room.html
+++ b/restaurants/adagio-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Adagio Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Ship availability information coming soon.</p>
@@ -238,7 +238,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -289,7 +289,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/american-icon-grill.html
+++ b/restaurants/american-icon-grill.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">American Icon Grill</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Ship availability information coming soon.</p>
@@ -238,7 +238,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -289,7 +289,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -245,7 +245,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">AquaDome Market</h1>
       <p class="subtitle">Royal Caribbean — Complimentary Food Hall (Icon Class)</p>
@@ -257,7 +257,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -409,7 +409,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -420,7 +420,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You’ll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>AquaDome Market is exclusive to Icon-class ships:</p>
@@ -433,7 +433,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Logbook Review -->
   <section class="card" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -497,7 +497,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/aquarius-dining-room.html
+++ b/restaurants/aquarius-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Aquarius Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -257,7 +257,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Basecamp</h1>
       <p class="subtitle">Royal Caribbean — Thrill Island Quick-Service (Icon Class)</p>
@@ -269,7 +269,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -339,7 +339,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -350,7 +350,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You’ll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>Basecamp is located in the Thrill Island neighborhood on Icon-class ships:</p>
@@ -363,7 +363,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Logbook Review -->
   <section class="card" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -427,7 +427,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/ben-and-jerrys.html
+++ b/restaurants/ben-and-jerrys.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Ben & Jerry's</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -243,7 +243,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -294,7 +294,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/boardwalk-dog-house.html
+++ b/restaurants/boardwalk-dog-house.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Boardwalk Dog House</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -245,7 +245,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Café @ Two70</h1>
       <p class="subtitle">Royal Caribbean — Complimentary Gourmet-Casual with Panoramic Views</p>
@@ -257,7 +257,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -332,7 +332,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -343,7 +343,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You’ll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>Café @ Two70 is available on Quantum and Quantum Ultra class ships (e.g., Odyssey, Anthem, Ovation), inside the Two70 venue.</p>
@@ -356,7 +356,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Logbook Review -->
   <section class="card" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -420,7 +420,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/cantina-fresca.html
+++ b/restaurants/cantina-fresca.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Cantina Fresca</h1>
       <p class="subtitle">Royal Caribbean — Bar & Lounge</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/cascades-dining-room.html
+++ b/restaurants/cascades-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Cascades Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/celebration-table.html
+++ b/restaurants/celebration-table.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Celebration Table</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/desserted.html
+++ b/restaurants/desserted.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Desserted</h1>
       <p class="subtitle">Royal Caribbean — Bar & Lounge</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/devinly-decadence.html
+++ b/restaurants/devinly-decadence.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Devinly Decadence</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/dining-activities.html
+++ b/restaurants/dining-activities.html
@@ -222,7 +222,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card">
-    <img class="wm" src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="">
+    <img class="wm" src="/assets/images/restaurants/photos/formal-dining.webp" alt="">
     <div class="card__content">
       <h2>Overview</h2>
       <p>Royal Caribbean offers a rotating schedule of culinary workshops and dessert classes. Each class includes hands-on instruction and ingredients.</p>
@@ -235,7 +235,7 @@ All work on this project is offered as a gift to God.
 
     <!-- Candy Sushi -->
     <article class="card activity">
-      <img class="wm" src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="">
+      <img class="wm" src="/assets/images/restaurants/photos/formal-dining.webp" alt="">
       <div class="activity__media">
         <img src="https://cruisinginthewake.com/assets/restaurants/activities/candy-sushi_thumb.jpg" alt="Candy Sushi Making Class" loading="lazy" width="420" height="315">
       </div>
@@ -251,7 +251,7 @@ All work on this project is offered as a gift to God.
 
     <!-- On a Roll Sushi -->
     <article class="card activity">
-      <img class="wm" src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="">
+      <img class="wm" src="/assets/images/restaurants/photos/formal-dining.webp" alt="">
       <div class="activity__media">
         <img src="https://cruisinginthewake.com/assets/restaurants/activities/on-a-roll_thumb.jpg" alt="On a Roll Sushi Making Class" loading="lazy" width="420" height="315">
       </div>
@@ -267,7 +267,7 @@ All work on this project is offered as a gift to God.
 
     <!-- Cupcake Decorating -->
     <article class="card activity">
-      <img class="wm" src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="">
+      <img class="wm" src="/assets/images/restaurants/photos/formal-dining.webp" alt="">
       <div class="activity__media">
         <img src="https://cruisinginthewake.com/assets/restaurants/activities/cupcake-class_thumb.jpg" alt="Sprinkle Time Cupcake Decorating Class" loading="lazy" width="420" height="315">
       </div>
@@ -283,7 +283,7 @@ All work on this project is offered as a gift to God.
 
     <!-- Taste of Royal — Lunch -->
     <article class="card activity">
-      <img class="wm" src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="">
+      <img class="wm" src="/assets/images/restaurants/photos/formal-dining.webp" alt="">
       <div class="activity__media">
         <img src="https://cruisinginthewake.com/assets/restaurants/activities/taste-of-royal_thumb.jpg" alt="Taste of Royal — Lunch" loading="lazy" width="420" height="315">
       </div>
@@ -299,7 +299,7 @@ All work on this project is offered as a gift to God.
 
     <!-- Sushi & Sake — Lunch -->
     <article class="card activity">
-      <img class="wm" src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="">
+      <img class="wm" src="/assets/images/restaurants/photos/formal-dining.webp" alt="">
       <div class="activity__media">
         <img src="https://cruisinginthewake.com/assets/restaurants/activities/sushi-and-sake-lunch_thumb.jpg" alt="Sushi &amp; Sake — Lunch" loading="lazy" width="420" height="315">
       </div>
@@ -320,7 +320,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Logbook -->
   <section class="card">
-    <img class="wm" src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="">
+    <img class="wm" src="/assets/images/restaurants/photos/formal-dining.webp" alt="">
     <div class="card__content">
       <h2>Logbook — Guest Soundings</h2>
       <p class="pill"><strong>Full disclosure:</strong> I have not yet attended every activity fleetwide. Until I do, this Logbook is an aggregate of vetted guest soundings, taken in their own wake, trimmed and edited to our dining standards.</p>
@@ -332,7 +332,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card">
-    <img class="wm" src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="">
+    <img class="wm" src="/assets/images/restaurants/photos/formal-dining.webp" alt="">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul><li>Royal Caribbean Cruise Planner (screenshots) — <a href="/ships/rcl/radiance-of-the-seas.html">Radiance of the Seas</a></li></ul>

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -257,7 +257,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">The Dog House</h1>
       <p class="subtitle">Royal Caribbean — Complimentary Boardwalk Hot Dogs &amp; Sausages</p>
@@ -269,7 +269,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -362,7 +362,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -373,7 +373,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You’ll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>The Dog House is a Boardwalk staple on Oasis-class ships (plus select sister ships):</p>
@@ -386,7 +386,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Logbook Review -->
   <section class="card" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -450,7 +450,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/edelweiss-dining-room.html
+++ b/restaurants/edelweiss-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Edelweiss Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -245,7 +245,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">El Loco Fresh</h1>
       <p class="subtitle">Royal Caribbean — Complimentary Pool-Deck Mexican</p>
@@ -257,7 +257,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -328,7 +328,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -339,7 +339,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You’ll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>El Loco Fresh appears across Oasis and Icon class (plus select <a href="/ships.html#freedom-class">Freedom class</a>), typically near the pool deck.</p>
@@ -352,7 +352,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Logbook Review -->
   <section class="card" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -416,7 +416,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/empire-supper-club.html
+++ b/restaurants/empire-supper-club.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Empire Supper Club</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/fish-and-ships.html
+++ b/restaurants/fish-and-ships.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Fish & Ships</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/great-gatsby-dining-room.html
+++ b/restaurants/great-gatsby-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Great Gatsby Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/hooked-seafood.html
+++ b/restaurants/hooked-seafood.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Hooked Seafood</h1>
       <p class="subtitle">Royal Caribbean — Specialty Seafood</p>
@@ -219,7 +219,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Prices -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Menu &amp; Prices</h2>
       <p class="price-note"><strong>Pricing:</strong> Cover charge $44.99 (includes appetizer, entrée, dessert) or à la carte on some ships. Lobster and premium items may have upcharges.</p>
@@ -278,7 +278,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -289,7 +289,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -303,7 +303,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -354,7 +354,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/johnny-rockets.html
+++ b/restaurants/johnny-rockets.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Johnny Rockets</h1>
       <p class="subtitle">Royal Caribbean — Classic American Diner</p>
@@ -219,7 +219,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Prices -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Menu &amp; Prices</h2>
       <p class="price-note"><strong>Pricing:</strong> $14.99 cover charge for lunch/dinner includes entrée, fries, and unlimited soft drinks. <strong>Breakfast is FREE on Oasis Class ships.</strong></p>
@@ -280,7 +280,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -291,7 +291,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -306,7 +306,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -357,7 +357,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/lincoln-park-supper-club.html
+++ b/restaurants/lincoln-park-supper-club.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Lincoln Park Supper Club</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -223,7 +223,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Main Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Complimentary Dining</p>
@@ -251,7 +251,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -418,7 +418,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -429,7 +429,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You’ll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>The Main Dining Room appears on nearly every Royal Caribbean ship:</p>
@@ -442,7 +442,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -497,7 +497,7 @@ All work on this project is offered as a gift to God.
 
   <!-- FAQ Section -->
   <section class="card" id="faq">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Frequently Asked Questions</h2>
 
@@ -525,7 +525,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/minstrel-dining-room.html
+++ b/restaurants/minstrel-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Minstrel Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/my-fair-lady-dining-room.html
+++ b/restaurants/my-fair-lady-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">My Fair Lady Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -247,7 +247,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Park Café</h1>
       <p class="subtitle">Royal Caribbean — Complimentary Deli &amp; Salads</p>
@@ -259,7 +259,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -365,7 +365,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -376,7 +376,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You’ll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>Park Café appears primarily on Oasis and Icon class ships (plus select others):</p>
@@ -389,7 +389,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -460,7 +460,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Attribution & Caveats</h2>
       <ul>

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -237,7 +237,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Pearl Café</h1>
       <p class="subtitle">Royal Caribbean — 24/7 Elevated Grab-and-Go (Icon Class)</p>
@@ -249,7 +249,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -322,7 +322,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -333,7 +333,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You’ll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>Pearl Café is exclusive to Icon-class ships (Deck 6, near the Pearl installation):</p>
@@ -346,7 +346,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Logbook Review -->
   <section class="card" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -410,7 +410,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/pier-7.html
+++ b/restaurants/pier-7.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Pier 7</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/playmakers.html
+++ b/restaurants/playmakers.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Playmakers Sports Bar & Arcade</h1>
       <p class="subtitle">Royal Caribbean — Bar & Lounge</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -244,7 +244,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -295,7 +295,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/portside-bbq.html
+++ b/restaurants/portside-bbq.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Portside BBQ</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/quill-and-compass.html
+++ b/restaurants/quill-and-compass.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Quill & Compass</h1>
       <p class="subtitle">Royal Caribbean — Bar & Lounge</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/reflections-dining-room.html
+++ b/restaurants/reflections-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Reflections Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/ritas-cantina.html
+++ b/restaurants/ritas-cantina.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Rita's Cantina</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/royal-railway.html
+++ b/restaurants/royal-railway.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Royal Railway – Utopia Station</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/rye-and-bean.html
+++ b/restaurants/rye-and-bean.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Rye & Bean</h1>
       <p class="subtitle">Royal Caribbean — Bar & Lounge</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/sabor-taqueria.html
+++ b/restaurants/sabor-taqueria.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Sabor Taqueria & Tequila Bar</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Ship availability information coming soon.</p>
@@ -238,7 +238,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -289,7 +289,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/sabor.html
+++ b/restaurants/sabor.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Sabor Modern Mexican</h1>
       <p class="subtitle">Royal Caribbean — Specialty Mexican</p>
@@ -219,7 +219,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Prices -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Menu &amp; Prices</h2>
       <p class="price-note"><strong>Pricing:</strong> À la carte ($5–$25 per item). Shared plates encouraged. Tequila flights and premium margaritas available.</p>
@@ -273,7 +273,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -297,7 +297,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -348,7 +348,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/sapphire-dining-room.html
+++ b/restaurants/sapphire-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Sapphire Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/sapphire-restaurant.html
+++ b/restaurants/sapphire-restaurant.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Sapphire Restaurant</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Ship availability information coming soon.</p>
@@ -238,7 +238,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -289,7 +289,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/solarium-cafe.html
+++ b/restaurants/solarium-cafe.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Solarium Café</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/sprinkles.html
+++ b/restaurants/sprinkles.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Sprinkles</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/starbucks.html
+++ b/restaurants/starbucks.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Starbucks</h1>
       <p class="subtitle">Royal Caribbean — Bar & Lounge</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -242,7 +242,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -293,7 +293,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/sugar-beach.html
+++ b/restaurants/sugar-beach.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Sugar Beach</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -242,7 +242,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -293,7 +293,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -249,7 +249,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Surfside Eatery</h1>
       <p class="subtitle">Royal Caribbean — Family Buffet in the Surfside Neighborhood (Icon Class)</p>
@@ -261,7 +261,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -360,7 +360,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -371,7 +371,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You’ll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>Surfside Eatery is exclusive to the Icon-class Surfside neighborhood:</p>
@@ -384,7 +384,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Logbook Review -->
   <section class="card" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -448,7 +448,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/the-dining-room.html
+++ b/restaurants/the-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">The Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/the-grande.html
+++ b/restaurants/the-grande.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">The Grande</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Ship availability information coming soon.</p>
@@ -238,7 +238,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -289,7 +289,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/the-overlook.html
+++ b/restaurants/the-overlook.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">The Overlook</h1>
       <p class="subtitle">Royal Caribbean — Bar & Lounge</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/the-pit-stop.html
+++ b/restaurants/the-pit-stop.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">The Pit Stop</h1>
       <p class="subtitle">Royal Caribbean — Bar & Lounge</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Ship availability information coming soon.</p>
@@ -238,7 +238,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -289,7 +289,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/hotdog.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/tides-dining-room.html
+++ b/restaurants/tides-dining-room.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Tides Dining Room</h1>
       <p class="subtitle">Royal Caribbean — Dining</p>
@@ -218,7 +218,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -229,7 +229,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -241,7 +241,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -292,7 +292,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -235,7 +235,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Windjammer Marketplace</h1>
       <p class="subtitle">Royal Caribbean — Complimentary Buffet</p>
@@ -263,7 +263,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Price -->
   <section class="card" id="menu-prices">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Price</h2>
       <p class="price-note">
@@ -444,7 +444,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -455,7 +455,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Availability -->
   <section class="card" id="availability">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You’ll Find It</h2>
       <p>Windjammer Marketplace appears on virtually every Royal Caribbean ship:</p>
@@ -468,7 +468,7 @@ All work on this project is offered as a gift to God.
 
  <!-- The Logbook — Real Guest Soundings -->
 <section class="card" id="logbook">
-  <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+  <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
   <div class="card__content prose">
     <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -538,7 +538,7 @@ All work on this project is offered as a gift to God.
 
   <!-- FAQ -->
   <section class="card" id="faq">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Frequently Asked Questions</h2>
 
@@ -567,7 +567,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="https://cruisinginthewake.com/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/buffet.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>

--- a/restaurants/wonderland.html
+++ b/restaurants/wonderland.html
@@ -193,7 +193,7 @@ All work on this project is offered as a gift to God.
   <div>
   <!-- Overview -->
   <section class="card" id="overview">
-    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h1 class="page-title">Wonderland</h1>
       <p class="subtitle">Royal Caribbean — Imaginative Dining Experience</p>
@@ -219,7 +219,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Experience -->
   <section class="card" id="menu-experience">
-    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>The Wonderland Experience</h2>
       <p class="price-note"><strong>Pricing:</strong> Cover charge $49–55 includes multi-course tasting menu with theatrical presentations. Wine pairings available for additional charge.</p>
@@ -269,7 +269,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Special Accommodations -->
   <section class="card" id="accommodations">
-    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Special Accommodations</h2>
       <div class="allergen-micro" role="note" aria-label="Allergen and dietary information">
@@ -280,7 +280,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Where You'll Find It -->
   <section class="card" id="availability">
-    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Where You'll Find It</h2>
       <p>Available on the following Royal Caribbean ships:</p>
@@ -294,7 +294,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook — Real Guest Soundings</h2>
 
@@ -345,7 +345,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Sources -->
   <section class="card" id="sources">
-    <img src="/assets/images/restaurants/specialty-dining.svg" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
     <div class="card__content">
       <h2>Sources &amp; Attribution</h2>
       <ul>


### PR DESCRIPTION
Update 53 venue pages to use appropriate Wikimedia Commons images:
- Dining rooms → formal-dining.webp
- Cafes/bakeries → croissant.webp
- Bars/lounges → cocktail.webp
- Italian/specialty → italian.webp
- BBQ/casual → hotdog.webp
- Buffets/markets → buffet.webp
- Mexican → pizza.webp
- Seafood → sushi.webp

Also update restaurants-dynamic.js default image to use webp format.