### PR TITLE
Upgrade Batch 44 ports to ITC v1.1 (mystery-island, nagasaki, napier,…

### DIFF
--- a/ports/mystery-island.html
+++ b/ports/mystery-island.html
@@ -8,7 +8,7 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="ai-summary" content="First-person logbook guide to Mystery Island cruise port in Vanuatu with tips for pristine beaches, snorkeling in crystal waters, local handicraft vendors arriving by boat, and discovering an uninhabited South Pacific paradise."/>
   <meta name="last-reviewed" content="2025-12-14"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Mystery Island (Vanuatu) Port Guide — Uninhabited Paradise | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Mystery Island, Vanuatu — pristine white sand beaches, crystal-clear snorkeling, local Aneityumese vendors arriving by boat, and experiencing an uninhabited South Pacific island where nature remains untouched."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/mystery-island.html"/>
@@ -26,6 +26,25 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Mystery Island (Vanuatu)", "item": "https://cruisinginthewake.com/ports/mystery-island.html"}
     ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://cruisinginthewake.com/ports/mystery-island.html",
+    "name": "Mystery Island (Vanuatu) Port Guide — Uninhabited Paradise | In the Wake",
+    "description": "First-person logbook guide to Mystery Island cruise port in Vanuatu with tips for pristine beaches, snorkeling in crystal waters, local handicraft vendors arriving by boat, and discovering an uninhabited South Pacific paradise.",
+    "dateModified": "2025-12-14",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Mystery Island",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": -19.8333,
+        "longitude": 169.8167
+      }
+    }
   }
   </script>
   <script type="application/ld+json">
@@ -245,6 +264,11 @@ Soli Deo Gloria
             <li>If you seek organized activities, shopping districts, cultural tours, or dining options, Mystery Island will disappoint. If you seek pure natural beauty and unhurried beach time, it's paradise. Adjust expectations accordingly.</li>
             <li>Early morning snorkeling offers best visibility and fewer swimmers. Arrive on first or second tender for prime beach spots and quieter island experience.</li>
           </ul>
+        </section>
+
+        <section class="port-section author-note-disclaimer">
+          <h3>Author's Note</h3>
+          <p class="disclaimer-text"><em>Until I have sailed this port myself, these notes are soundings in another's wake—gathered from travelers I trust, charts I've studied, and the most reliable accounts I can find. I've done my best to triangulate the truth, but firsthand observation always reveals what even the best research can miss. When I finally drop anchor here, I'll return to these pages and correct my course.</em></p>
         </section>
 
         <section class="port-section">

--- a/ports/nagasaki.html
+++ b/ports/nagasaki.html
@@ -6,9 +6,9 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="Pastoral logbook guide to Nagasaki cruise port: Peace Park and Atomic Bomb Museum, Dejima's 200-year isolation story, Glover Garden's Scottish merchant legacy, and the layers of Portuguese, Dutch, and Chinese heritage that shaped Japan's window to the West."/>
+  <meta name="ai-summary" content="Logbook guide to Nagasaki: Peace Park and Atomic Bomb Museum, Dejima's 200-year isolation, Glover Garden's Scottish legacy, and Portuguese, Dutch, Chinese heritage that shaped Japan's window to the West."/>
   <meta name="last-reviewed" content="2025-12-17"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Nagasaki Port Guide — Peace, History & Dutch Heritage | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Nagasaki — the Peace Memorial, Dejima's fan-shaped island of isolation, Thomas Glover's Scottish legacy, and Japan's profound window to the world."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/nagasaki.html"/>
@@ -26,6 +26,25 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Nagasaki", "item": "https://cruisinginthewake.com/ports/nagasaki.html"}
     ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://cruisinginthewake.com/ports/nagasaki.html",
+    "name": "Nagasaki Port Guide — Peace, History & Dutch Heritage | In the Wake",
+    "description": "Logbook guide to Nagasaki: Peace Park and Atomic Bomb Museum, Dejima's 200-year isolation, Glover Garden's Scottish legacy, and Portuguese, Dutch, Chinese heritage that shaped Japan's window to the West.",
+    "dateModified": "2025-12-17",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Nagasaki",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 32.7503,
+        "longitude": 129.8779
+      }
+    }
   }
   </script>
   <script type="application/ld+json">
@@ -55,6 +74,14 @@ Soli Deo Gloria
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Thomas Glover was a Scottish merchant who helped modernize Japan by supplying arms during the revolution that toppled the shogunate and contributing to the founding of Mitsubishi. His mansion in Glover Garden is the oldest Western-style wooden residence in Japan (built 1863), and his Japanese wife inspired Puccini's opera Madame Butterfly."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is the tram easy to navigate?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Lines are numbered, stops announced in English, and the ¥600 day pass offers unlimited rides. It's one of Japan's most visitor-friendly transit systems."
         }
       }
     ]
@@ -212,6 +239,11 @@ Soli Deo Gloria
             <li><strong>Kakuni:</strong> Braised pork belly, Nagasaki-style — melt-in-your-mouth tender</li>
             <li><strong>Biwa:</strong> Loquat — the local fruit, often made into jellies and sweets</li>
           </ul>
+        </section>
+
+        <section class="port-section author-note-disclaimer">
+          <h3>Author's Note</h3>
+          <p class="disclaimer-text"><em>Until I have sailed this port myself, these notes are soundings in another's wake—gathered from travelers I trust, charts I've studied, and the most reliable accounts I can find. I've done my best to triangulate the truth, but firsthand observation always reveals what even the best research can miss. When I finally drop anchor here, I'll return to these pages and correct my course.</em></p>
         </section>
 
         <section class="port-section">

--- a/ports/napier.html
+++ b/ports/napier.html
@@ -8,7 +8,7 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="ai-summary" content="First-person logbook guide to Napier cruise port—risen from 1931 earthquake, rebuilt in Art Deco splendor. Explore zigzag facades, gannet colonies, Hawke's Bay wine country, and Marine Parade's sun-drenched promenade."/>
   <meta name="last-reviewed" content="2025-12-17"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Napier Port Guide — Art Deco Capital & Wine Country | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Napier—Art Deco capital rebuilt after 1931 earthquake, Hawke's Bay wineries, Cape Kidnappers gannets, and New Zealand's oldest wine region under endless sunshine."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/napier.html"/>
@@ -26,6 +26,25 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Napier", "item": "https://cruisinginthewake.com/ports/napier.html"}
     ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://cruisinginthewake.com/ports/napier.html",
+    "name": "Napier Port Guide — Art Deco Capital & Wine Country | In the Wake",
+    "description": "First-person logbook guide to Napier cruise port—risen from 1931 earthquake, rebuilt in Art Deco splendor. Explore zigzag facades, gannet colonies, Hawke's Bay wine country, and Marine Parade's sun-drenched promenade.",
+    "dateModified": "2025-12-17",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Napier",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": -39.4902,
+        "longitude": 176.9120
+      }
+    }
   }
   </script>
   <script type="application/ld+json">
@@ -251,6 +270,11 @@ Soli Deo Gloria
             <li><strong>Artisan Cheese:</strong> Local cheesemakers produce excellent farmhouse varieties</li>
             <li><strong>Fresh Produce:</strong> The fertile plains yield abundant fruit and vegetables — visit the Farmers Market</li>
           </ul>
+        </section>
+
+        <section class="port-section author-note-disclaimer">
+          <h3>Author's Note</h3>
+          <p class="disclaimer-text"><em>Until I have sailed this port myself, these notes are soundings in another's wake—gathered from travelers I trust, charts I've studied, and the most reliable accounts I can find. I've done my best to triangulate the truth, but firsthand observation always reveals what even the best research can miss. When I finally drop anchor here, I'll return to these pages and correct my course.</em></p>
         </section>
 
         <section class="port-section">

--- a/ports/naples.html
+++ b/ports/naples.html
@@ -12,9 +12,9 @@ All work on this project is offered as a gift to God.
   <meta name="referrer" content="no-referrer-when-downgrade"/>
 
   <!-- ICP-Lite v1.0 -->
-  <meta name="ai-summary" content="First-person logbook guide to Naples, founded ~600 BCE by Greeks from Cumae as Neapolis ('New City'). Ancient city with 2,800 years of continuous habitation, UNESCO World Heritage Site (1995). Gateway to Pompeii (destroyed AD 79 by Vesuvius), Amalfi Coast, and home to Naples Archaeological Museum (world's finest Pompeii/Herculaneum collection). Castel dell'Ovo built on site where last Western Roman Emperor Romulus Augustulus was exiled (476 AD). Birthplace of pizza Margherita (1889)."/>
+  <meta name="ai-summary" content="First-person logbook guide to Naples cruise port—ancient Greek city founded ~600 BCE with 2,800 years of history. Gateway to Pompeii (destroyed AD 79), Amalfi Coast, world-class Archaeological Museum, and birthplace of pizza Margherita (1889)."/>
   <meta name="last-reviewed" content="2025-12-17"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- SEO -->
   <title>Naples Port Guide — Pompeii & Amalfi Coast | In the Wake</title>
@@ -64,9 +64,19 @@ All work on this project is offered as a gift to God.
   {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "name": "Naples Port Guide",
-    "url": "https://cruisinginthewake.com/ports/naples.html",
-    "description": "First-person logbook guide to Naples with tips for visiting Pompeii, the Amalfi Coast, and Sorrento."
+    "@id": "https://cruisinginthewake.com/ports/naples.html",
+    "name": "Naples Port Guide — Pompeii & Amalfi Coast | In the Wake",
+    "description": "First-person logbook guide to Naples cruise port—ancient Greek city founded ~600 BCE with 2,800 years of history. Gateway to Pompeii (destroyed AD 79), Amalfi Coast, world-class Archaeological Museum, and birthplace of pizza Margherita (1889).",
+    "dateModified": "2025-12-17",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Naples",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 40.8518,
+        "longitude": 14.2681
+      }
+    }
   }
   </script>
 
@@ -335,6 +345,11 @@ All work on this project is offered as a gift to God.
         <li><strong>naples-1.webp</strong>: WikiMedia Commons (CC BY-SA)</li><li><strong>naples-2.webp</strong>: WikiMedia Commons (CC BY-SA)</li><li><strong>naples-3.webp</strong>: WikiMedia Commons (CC BY-SA)</li><li><strong>naples-4.webp</strong>: WikiMedia Commons (CC BY-SA)</li>
       </ul>
       <p><em>Images sourced from WikiMedia Commons under Creative Commons licenses.</em></p>
+    </section>
+
+    <section class="port-section author-note-disclaimer">
+      <h3>Author's Note</h3>
+      <p class="disclaimer-text"><em>Until I have sailed this port myself, these notes are soundings in another's wake—gathered from travelers I trust, charts I've studied, and the most reliable accounts I can find. I've done my best to triangulate the truth, but firsthand observation always reveals what even the best research can miss. When I finally drop anchor here, I'll return to these pages and correct my course.</em></p>
     </section>
 
   </article>


### PR DESCRIPTION
… naples)

Updated 4 ports to ICP-Lite v1.4 compliance (nassau already compliant, skipped):

- mystery-island: Added WebPage JSON-LD, Level 1 Author's Note (already had 5 FAQ)
- nagasaki: Trimmed ai-summary 257→207 chars, expanded FAQPage 3→4 questions, added WebPage JSON-LD, Level 1 Author's Note
- napier: Added WebPage JSON-LD, Level 1 Author's Note (already had 6 FAQ)
- naples: Trimmed ai-summary 518→249 chars, added WebPage JSON-LD, Level 1 Author's Note (already had 4 FAQ)

All ports now include:
- ICP-Lite v1.4 content-protocol
- WebPage JSON-LD with @id, description, dateModified, mainEntity
- Minimum 4 FAQ questions in FAQPage JSON-LD
- Level 1 Author's Note disclaimer section

Progress: 209 of 331 ports at ITC v1.1 (63.1%)