### PR TITLE
Upgrade Batch 45 ports to ITC v1.1 (nawiliwili, newcastle, newport, n…

### DIFF
--- a/ports/nawiliwili.html
+++ b/ports/nawiliwili.html
@@ -8,7 +8,7 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="ai-summary" content="First-person logbook guide to Nawiliwili Harbor (opened 1930), gateway to Kauai's Waimea Canyon and Na Pali Coast, with sugar plantation heritage from Lihue Plantation (1849-2000) and wiliwili tree legacy."/>
   <meta name="last-reviewed" content="2025-12-18"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Nawiliwili Port Guide — Kauai's Na Pali & Waimea Canyon | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Nawiliwili, Kauai — Waimea Canyon, Na Pali coast catamaran, most dramatically beautiful Hawaiian island."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/nawiliwili.html"/>
@@ -35,7 +35,66 @@ Soli Deo Gloria
     ]
   }
   </script>
-  
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://cruisinginthewake.com/ports/nawiliwili.html",
+    "name": "Nawiliwili Port Guide — Kauai's Na Pali & Waimea Canyon | In the Wake",
+    "description": "First-person logbook guide to Nawiliwili Harbor (opened 1930), gateway to Kauai's Waimea Canyon and Na Pali Coast, with sugar plantation heritage from Lihue Plantation (1849-2000) and wiliwili tree legacy.",
+    "dateModified": "2025-12-18",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Nawiliwili, Kauai, Hawaii",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 21.9544,
+        "longitude": -159.3539
+      }
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is Nawiliwili worth visiting from a cruise ship?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Nawiliwili is the gateway to Kauai, the most beautiful Hawaiian island accessible from a cruise ship. The combination of Waimea Canyon's dramatic red cliffs and the Na Pali Coast's cathedral-like valleys makes it worth every minute."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the best thing to do in Nawiliwili/Kauai?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The best experience combines a morning drive to Waimea Canyon (the 'Grand Canyon of the Pacific') with an afternoon Na Pali Coast catamaran tour from Port Allen, featuring sea caves, waterfalls, and snorkeling in pristine waters."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How long does a Na Pali Coast boat tour take?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A Na Pali Coast catamaran tour takes 5-6 hours round-trip including the 30-minute drive to Port Allen. Tours depart from Port Allen on Kauai's west side and include snorkeling, dolphin watching, and waterfall viewing."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can you walk from the cruise port in Nawiliwili?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, you can walk to harbor shops and the Aloha Center from the port, but exploring Kauai's main attractions requires a rental car. The island's roads are good and traffic is minimal."
+        }
+      }
+    ]
+  }
+  </script>
+
   <!-- Swiper CSS/JS (primary + CDN fallback) -->
   <script>
   (function ensureSwiper(){
@@ -209,6 +268,11 @@ Soli Deo Gloria
 
         <h4>Island Culture</h4>
         <p>Kauai's one-lane bridges and roaming chickens are part of the charm – slow down and wave; the aloha spirit rewards patience.</p>
+      </section>
+
+      <section class="port-section author-note-disclaimer">
+        <h3>Author's Note</h3>
+        <p class="disclaimer-text"><em>Until I have sailed this port myself, these notes are soundings in another's wake—gathered from travelers I trust, charts I've studied, and the most reliable accounts I can find. I've done my best to triangulate the truth, but firsthand observation always reveals what even the best research can miss. When I finally drop anchor here, I'll return to these pages and correct my course.</em></p>
       </section>
 
       <section class="port-section port-map-section" id="port-map-section">

--- a/ports/newcastle.html
+++ b/ports/newcastle.html
@@ -8,7 +8,7 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="ai-summary" content="First-person logbook guide to Newcastle with tips for Angel of the North, Tyne bridges, Geordie culture, Quayside; founded as Roman fort Pons Aelius (AD 122) and named for Norman castle (1080)."/>
   <meta name="last-reviewed" content="2025-12-18"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Newcastle Port Guide — Angel of the North & Geordie Warmth | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Newcastle upon Tyne, England — seven bridges, Angel of the North, Geordie warmth, best nightlife in Britain."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/newcastle.html"/>
@@ -34,6 +34,65 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Newcastle", "item": "https://cruisinginthewake.com/ports/newcastle.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://cruisinginthewake.com/ports/newcastle.html",
+    "name": "Newcastle Port Guide — Angel of the North & Geordie Warmth | In the Wake",
+    "description": "First-person logbook guide to Newcastle with tips for Angel of the North, Tyne bridges, Geordie culture, Quayside; founded as Roman fort Pons Aelius (AD 122) and named for Norman castle (1080).",
+    "dateModified": "2025-12-18",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Newcastle upon Tyne, England",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 54.9680,
+        "longitude": -1.6170
+      }
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is Newcastle worth visiting from a cruise ship?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Newcastle is the friendliest British port city, offering a warm Geordie welcome, historic Quayside bridges, and the iconic Angel of the North sculpture. The combination of industrial heritage and genuine warmth makes it memorable."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the best thing to see in Newcastle?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The Quayside bridges including the famous Tyne Bridge and tilting Gateshead Millennium Bridge, combined with a trip to see Antony Gormley's Angel of the North with its massive 54-meter wingspan."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How long does it take to visit the Angel of the North?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A round-trip visit to the Angel of the North takes about 3 hours, including a 20-minute train journey each way from Newcastle city center."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can you walk from the cruise port to Newcastle city center?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No, you cannot walk from Tyne Commission Quay to the city center. A free shuttle service is provided to transport cruise passengers to downtown Newcastle."
+        }
+      }
     ]
   }
   </script>
@@ -156,6 +215,11 @@ Soli Deo Gloria
         <figcaption>Newcastle scenery — <a href="https://commons.wikimedia.org/w/index.php?search=Newcastle&title=Special:MediaSearch&type=image" target="_blank" rel="noopener">WikiMedia Commons</a> (CC BY-SA)</figcaption>
       </figure>
 
+      </section>
+
+      <section class="port-section author-note-disclaimer">
+        <h3>Author's Note</h3>
+        <p class="disclaimer-text"><em>Until I have sailed this port myself, these notes are soundings in another's wake—gathered from travelers I trust, charts I've studied, and the most reliable accounts I can find. I've done my best to triangulate the truth, but firsthand observation always reveals what even the best research can miss. When I finally drop anchor here, I'll return to these pages and correct my course.</em></p>
       </section>
 
       <section class="port-section">

--- a/ports/newport.html
+++ b/ports/newport.html
@@ -6,9 +6,9 @@ Soli Deo Gloria
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="ai-summary" content="First-person logbook guide to Newport (founded 1639), featuring Gilded Age mansions built 1870-1910: The Breakers (1893-1895, Cornelius Vanderbilt II), Marble House (1892, $11M), Rosecliff (1902, Stanford White), Château-sur-Mer (1852). Includes Cliff Walk, sailing capital history, and religious liberty heritage from 1641 Town Statutes."/>
+  <meta name="ai-summary" content="First-person logbook guide to Newport's Gilded Age mansions (1870-1910): The Breakers, Marble House, Rosecliff, Château-sur-Mer. Includes Cliff Walk, sailing capital heritage, and religious liberty from 1639 founding."/>
   <meta name="last-reviewed" content="2025-12-18"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Newport Port Guide — Gilded Age Mansions & Cliff Walk | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Newport, Rhode Island — Gilded Age mansions, Cliff Walk, The Breakers, America's sailing capital, and 1890s elegance."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/newport.html"/>
@@ -32,6 +32,65 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Newport", "item": "https://cruisinginthewake.com/ports/newport.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://cruisinginthewake.com/ports/newport.html",
+    "name": "Newport Port Guide — Gilded Age Mansions & Cliff Walk | In the Wake",
+    "description": "First-person logbook guide to Newport's Gilded Age mansions (1870-1910): The Breakers, Marble House, Rosecliff, Château-sur-Mer. Includes Cliff Walk, sailing capital heritage, and religious liberty from 1639 founding.",
+    "dateModified": "2025-12-18",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Newport, Rhode Island",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 41.4901,
+        "longitude": -71.3128
+      }
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Is Newport worth visiting from a cruise ship?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes — Newport offers living history of American wealth through its Gilded Age mansions, particularly The Breakers. The combination of architectural splendor, the scenic Cliff Walk, and America's sailing heritage makes it a worthwhile port."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the best mansion to visit in Newport?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The Breakers, hands down. This 70-room masterpiece completed in 1895 for Cornelius Vanderbilt II showcases the pinnacle of Gilded Age excess with imported marble and gold leaf throughout."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How long does the Cliff Walk take?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The Cliff Walk takes 1-2 hours one way to complete. This 3.5-mile path runs between the Atlantic Ocean and the grand mansions, offering spectacular views of both."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is a tender required to reach Newport?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, cruise ships cannot dock at Newport and must tender passengers ashore. Once in town, the area is walkable or accessible via trolley."
+        }
+      }
     ]
   }
   </script>
@@ -158,6 +217,11 @@ Soli Deo Gloria
         <figcaption>Newport scenery — <a href="https://commons.wikimedia.org/w/index.php?search=Newport&title=Special:MediaSearch&type=image" target="_blank" rel="noopener">WikiMedia Commons</a> (CC BY-SA)</figcaption>
       </figure>
 
+      </section>
+
+      <section class="port-section author-note-disclaimer">
+        <h3>Author's Note</h3>
+        <p class="disclaimer-text"><em>Until I have sailed this port myself, these notes are soundings in another's wake—gathered from travelers I trust, charts I've studied, and the most reliable accounts I can find. I've done my best to triangulate the truth, but firsthand observation always reveals what even the best research can miss. When I finally drop anchor here, I'll return to these pages and correct my course.</em></p>
       </section>
 
       <section class="port-section">

--- a/ports/nha-trang.html
+++ b/ports/nha-trang.html
@@ -8,7 +8,7 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="ai-summary" content="First-person logbook guide to Nha Trang cruise port in Vietnam with tips for ancient Cham towers, pristine beaches, cable car rides to Vinpearl Island, snorkeling Hon Mun reefs, and discovering Vietnam's premier beach resort city."/>
   <meta name="last-reviewed" content="2025-12-13"/>
-  <meta name="content-protocol" content="ICP-Lite v1.0"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
   <title>Nha Trang, Vietnam Port Guide — Beach Paradise Where History Meets Turquoise Waters | In the Wake</title>
   <meta name="description" content="First-person logbook guide to Nha Trang, Vietnam — ancient Po Nagar Cham Towers, pristine beaches, Vinpearl Island cable car, Hon Mun Marine Protected Area snorkeling, Ba Ho Waterfalls, and exploring Vietnam's most beautiful bay."/>
   <link rel="canonical" href="https://cruisinginthewake.com/ports/nha-trang.html"/>
@@ -26,6 +26,25 @@ Soli Deo Gloria
       {"@type": "ListItem", "position": 2, "name": "Ports", "item": "https://cruisinginthewake.com/ports.html"},
       {"@type": "ListItem", "position": 3, "name": "Nha Trang, Vietnam", "item": "https://cruisinginthewake.com/ports/nha-trang.html"}
     ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://cruisinginthewake.com/ports/nha-trang.html",
+    "name": "Nha Trang, Vietnam Port Guide — Beach Paradise Where History Meets Turquoise Waters | In the Wake",
+    "description": "First-person logbook guide to Nha Trang cruise port in Vietnam with tips for ancient Cham towers, pristine beaches, cable car rides to Vinpearl Island, snorkeling Hon Mun reefs, and discovering Vietnam's premier beach resort city.",
+    "dateModified": "2025-12-13",
+    "mainEntity": {
+      "@type": "Place",
+      "name": "Nha Trang, Vietnam",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 12.2388,
+        "longitude": 109.1967
+      }
+    }
   }
   </script>
   <script type="application/ld+json">
@@ -55,6 +74,14 @@ Soli Deo Gloria
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Yes, Hon Mun Marine Protected Area offers excellent snorkeling with colorful coral reefs, tropical fish, and crystal-clear waters. Island hopping tours typically include snorkeling equipment and visit multiple reef sites."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What should I eat in Nha Trang?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Bún chả cá (fish cake noodle soup) is Nha Trang's signature dish. Fresh lobster and seafood at beachfront restaurants are excellent. Try nem nướng (grilled pork spring rolls) and bánh căn (tiny rice pancakes). Street food is safe and delicious."
         }
       }
     ]
@@ -190,6 +217,11 @@ Soli Deo Gloria
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">National Oceanographic Museum</h4>
           <p>Vietnam's marine research institute and aquarium — 20,000+ preserved specimens, live exhibits with sea turtles, sharks, tropical fish. Educational and family-friendly. Entry ~30,000 VND ($1.25). Near Cau Da Port. 1-2 hours. Provides context for marine diversity you'll see snorkeling.</p>
+        </section>
+
+        <section class="port-section author-note-disclaimer">
+          <h3>Author's Note</h3>
+          <p class="disclaimer-text"><em>Until I have sailed this port myself, these notes are soundings in another's wake—gathered from travelers I trust, charts I've studied, and the most reliable accounts I can find. I've done my best to triangulate the truth, but firsthand observation always reveals what even the best research can miss. When I finally drop anchor here, I'll return to these pages and correct my course.</em></p>
         </section>
 
         <section class="port-section port-map-section" id="port-map-section">


### PR DESCRIPTION
…ha-trang)

Updated 4 ports to ICP-Lite v1.4 compliance (new-orleans already compliant, skipped):

- nawiliwili: Created FAQPage 0→4 questions, added WebPage JSON-LD, Level 1 Author's Note
- newcastle: Created FAQPage 0→4 questions, added WebPage JSON-LD, Level 1 Author's Note
- newport: Trimmed ai-summary 340→218 chars, created FAQPage 0→4 questions, added WebPage JSON-LD, Level 1 Author's Note
- nha-trang: Expanded FAQPage 3→4 questions, added WebPage JSON-LD, Level 1 Author's Note

All ports now include:
- ICP-Lite v1.4 content-protocol
- WebPage JSON-LD with @id, description, dateModified, mainEntity
- Minimum 4 FAQ questions in FAQPage JSON-LD
- Level 1 Author's Note disclaimer section

Progress: 213 of 331 ports at ITC v1.1 (64.4%)