### PR TITLE
Add 11 missing ports to tracker and geo data

### DIFF
--- a/assets/data/ports/ports-geo.json
+++ b/assets/data/ports/ports-geo.json
@@ -322,6 +322,16 @@
     {"id": "st-helena", "name": "St. Helena", "lat": -15.9650, "lon": -5.7089, "url": "/ports/st-helena.html", "region": "South Atlantic"},
     {"id": "ascension", "name": "Ascension Island", "lat": -7.9467, "lon": -14.3559, "url": "/ports/ascension.html", "region": "South Atlantic"},
     {"id": "mumbai", "name": "Mumbai", "lat": 18.9220, "lon": 72.8347, "url": "/ports/mumbai.html", "region": "Asia"},
-    {"id": "cochin", "name": "Cochin (Kochi)", "lat": 9.9312, "lon": 76.2673, "url": "/ports/cochin.html", "region": "Asia"}
+    {"id": "cochin", "name": "Cochin (Kochi)", "lat": 9.9312, "lon": 76.2673, "url": "/ports/cochin.html", "region": "Asia"},
+    {"id": "charleston", "name": "Charleston", "lat": 32.7765, "lon": -79.9311, "url": "/ports/charleston.html", "region": "US Atlantic"},
+    {"id": "freeport", "name": "Freeport (Grand Bahama)", "lat": 26.5285, "lon": -78.6947, "url": "/ports/freeport.html", "region": "Caribbean"},
+    {"id": "ft-lauderdale", "name": "Fort Lauderdale", "lat": 26.1224, "lon": -80.1373, "url": "/ports/ft-lauderdale.html", "region": "US Atlantic"},
+    {"id": "gatun-lake", "name": "Gatun Lake", "lat": 9.2000, "lon": -79.9200, "url": "/ports/gatun-lake.html", "region": "Central America"},
+    {"id": "harvest-caye", "name": "Harvest Caye", "lat": 16.4333, "lon": -88.4167, "url": "/ports/harvest-caye.html", "region": "Caribbean"},
+    {"id": "jacksonville", "name": "Jacksonville", "lat": 30.3322, "lon": -81.6557, "url": "/ports/jacksonville.html", "region": "US Atlantic"},
+    {"id": "miami", "name": "Miami", "lat": 25.7617, "lon": -80.1918, "url": "/ports/miami.html", "region": "US Atlantic"},
+    {"id": "philipsburg", "name": "Philipsburg (St. Maarten)", "lat": 18.0237, "lon": -63.0458, "url": "/ports/philipsburg.html", "region": "Caribbean"},
+    {"id": "puerto-limon", "name": "Puerto Limón", "lat": 9.9903, "lon": -83.0298, "url": "/ports/puerto-limon.html", "region": "Central America"},
+    {"id": "royal-beach-club-nassau", "name": "Royal Beach Club Paradise Island", "lat": 25.0887, "lon": -77.3153, "url": "/ports/royal-beach-club-nassau.html", "region": "Caribbean"}
   ]
 }

--- a/tools/port-tracker.html
+++ b/tools/port-tracker.html
@@ -203,7 +203,7 @@ Soli Deo Gloria
             </p>
             <div class="callout-box tiny">
               <ul class="list-indent">
-                <li><strong>147+ ports</strong> across all continents</li>
+                <li><strong>330+ ports</strong> across all continents</li>
                 <li><strong>Auto-saves</strong> to your browser</li>
                 <li><strong>Export/import</strong> your data</li>
               </ul>
@@ -284,7 +284,7 @@ Soli Deo Gloria
 (function() {
   'use strict';
   
-  // Port database - all 323 ports with metadata and URLs
+  // Port database - all 333 ports with metadata and URLs (plus 29 homeport entries)
   const PORTS_DB = [
   {
     "id": "ajaccio",
@@ -1716,7 +1716,18 @@ Soli Deo Gloria
   { "id": "hp-copenhagen", "name": "Copenhagen", "country": "Denmark", "region": "Homeports", "continent": "Europe", "url": "/ports/copenhagen.html" },
   { "id": "hp-amsterdam", "name": "Amsterdam", "country": "Netherlands", "region": "Homeports", "continent": "Europe", "url": "/ports/amsterdam.html" },
   { "id": "hp-singapore", "name": "Singapore", "country": "Singapore", "region": "Homeports", "continent": "Asia", "url": "/ports/singapore.html" },
-  { "id": "hp-hong-kong", "name": "Hong Kong", "country": "China", "region": "Homeports", "continent": "Asia", "url": "/ports/hong-kong.html" }
+  { "id": "hp-hong-kong", "name": "Hong Kong", "country": "China", "region": "Homeports", "continent": "Asia", "url": "/ports/hong-kong.html" },
+  // Additional Ports (Batch 14)
+  { "id": "charleston", "name": "Charleston", "country": "United States", "region": "Homeports", "continent": "North America", "url": "/ports/charleston.html" },
+  { "id": "freeport", "name": "Freeport (Grand Bahama)", "country": "Bahamas", "region": "Caribbean", "continent": "North America", "url": "/ports/freeport.html" },
+  { "id": "ft-lauderdale", "name": "Fort Lauderdale", "country": "United States", "region": "Homeports", "continent": "North America", "url": "/ports/ft-lauderdale.html" },
+  { "id": "gatun-lake", "name": "Gatun Lake", "country": "Panama", "region": "Caribbean", "continent": "North America", "url": "/ports/gatun-lake.html" },
+  { "id": "harvest-caye", "name": "Harvest Caye", "country": "Belize", "region": "Caribbean", "continent": "North America", "url": "/ports/harvest-caye.html" },
+  { "id": "jacksonville", "name": "Jacksonville", "country": "United States", "region": "Homeports", "continent": "North America", "url": "/ports/jacksonville.html" },
+  { "id": "miami", "name": "Miami", "country": "United States", "region": "Homeports", "continent": "North America", "url": "/ports/miami.html" },
+  { "id": "philipsburg", "name": "Philipsburg (St. Maarten)", "country": "Sint Maarten", "region": "Caribbean", "continent": "North America", "url": "/ports/philipsburg.html" },
+  { "id": "puerto-limon", "name": "Puerto Limón", "country": "Costa Rica", "region": "Caribbean", "continent": "North America", "url": "/ports/puerto-limon.html" },
+  { "id": "royal-beach-club-nassau", "name": "Royal Beach Club Paradise Island", "country": "Bahamas", "region": "Caribbean", "continent": "North America", "url": "/ports/royal-beach-club-nassau.html" }
 ];
   
   // Bingo card definitions


### PR DESCRIPTION
- Added ports: charleston, freeport, ft-lauderdale, gatun-lake, harvest-caye, jacksonville, miami, philipsburg, puerto-limon, royal-beach-club-nassau
- All 333 port pages now synced with ports-geo.json
- Updated port-tracker.html PORTS_DB to include all ports
- Updated port count in Quick Guide (147+ → 330+)