### PR TITLE
Update author bio to remove specific sailing count

### DIFF
--- a/authors/ken-baker.html
+++ b/authors/ken-baker.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="referrer" content="no-referrer">
-  <meta name="ai-summary" content="Ken Baker — Founder of In the Wake. Pastor, photographer, and cruise enthusiast with 50+ sailings. Expertise in Royal Caribbean, accessibility, and solo cruising.">
+  <meta name="ai-summary" content="Ken Baker — Founder of In the Wake. Pastor, photographer, and seasoned cruiser. Expertise in Royal Caribbean, accessibility, and solo cruising.">
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.0">
   <meta name="theme-color" content="#0e6e8e">

--- a/fix_port_pages.py
+++ b/fix_port_pages.py
@@ -80,7 +80,7 @@ def fix_port_page(file_path):
         </a>
         <div>
           <h4 style="margin: 0 0 0.25rem;"><a href="/authors/ken-baker.html">Ken Baker</a></h4>
-          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. 50+ sailings and counting.</p>
+          <p style="margin: 0; font-size: 0.85rem; color: #666;">Founder of In the Wake. Seasoned cruiser and counting.</p>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
         "name": "Who runs In the Wake?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "In the Wake is founded and maintained by Ken Baker, a pastor, photographer, and cruise enthusiast with 50+ sailings."
+          "text": "In the Wake is founded and maintained by Ken Baker, a pastor, photographer, and seasoned cruise enthusiast."
         }
       }
     ]
@@ -534,7 +534,7 @@
 
         <details class="faq-item">
           <summary>Who runs In the Wake?</summary>
-          <p class="faq-answer">In the Wake is founded and maintained by Ken Baker, a pastor, photographer, and cruise enthusiast with 50+ sailings. Learn more on our <a href="/about-us.html">About page</a>.</p>
+          <p class="faq-answer">In the Wake is founded and maintained by Ken Baker, a pastor, photographer, and cruise enthusiast with years of experience at sea. Learn more on our <a href="/about-us.html">About page</a>.</p>
         </details>
       </section>
     </section>


### PR DESCRIPTION
Replace "50+ sailings" with varied non-specific phrasing:
- index.html (JSON-LD): "seasoned cruise enthusiast"
- index.html (FAQ): "cruise enthusiast with years of experience at sea"
- authors/ken-baker.html: "seasoned cruiser"
- fix_port_pages.py template: "Seasoned cruiser and counting"