### PR TITLE
Audit tenderPort field: Fix 18 incorrectly marked tender ports

### DIFF
--- a/assets/data/ports/port-registry.json
+++ b/assets/data/ports/port-registry.json
@@ -132,7 +132,7 @@
       "region": "caribbean",
       "climatePattern": "tropical-hurricane",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/belize.html",
       "lastVerified": "2025-12-31"
     },
@@ -264,7 +264,7 @@
       "region": "caribbean",
       "climatePattern": "tropical-hurricane",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/virgin-gorda.html",
       "lastVerified": "2025-12-31"
     },
@@ -385,7 +385,7 @@
       "region": "mediterranean",
       "climatePattern": "mediterranean",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/villefranche.html",
       "lastVerified": "2025-12-31"
     },
@@ -407,7 +407,7 @@
       "region": "mediterranean",
       "climatePattern": "mediterranean",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/cannes.html",
       "lastVerified": "2025-12-31"
     },
@@ -462,7 +462,7 @@
       "region": "mediterranean",
       "climatePattern": "mediterranean",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/kotor.html",
       "lastVerified": "2025-12-31"
     },
@@ -979,7 +979,7 @@
       "region": "new-england",
       "climatePattern": "temperate-atlantic",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/bar-harbor.html",
       "lastVerified": "2025-12-31"
     },
@@ -1089,7 +1089,7 @@
       "region": "northern-europe",
       "climatePattern": "northern-europe",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/geiranger.html",
       "lastVerified": "2025-12-31"
     },
@@ -1441,7 +1441,7 @@
       "region": "mediterranean",
       "climatePattern": "mediterranean",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/amalfi.html",
       "lastVerified": "2025-12-31"
     },
@@ -2409,7 +2409,7 @@
       "region": "caribbean",
       "climatePattern": "tropical-hurricane",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/st-barts.html",
       "lastVerified": "2025-12-31"
     },
@@ -2508,7 +2508,7 @@
       "region": "asia",
       "climatePattern": "asian-monsoon",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/koh-samui.html",
       "lastVerified": "2025-12-31"
     },
@@ -2552,7 +2552,7 @@
       "region": "mediterranean",
       "climatePattern": "mediterranean",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/sorrento.html",
       "lastVerified": "2025-12-31"
     },
@@ -2563,7 +2563,7 @@
       "region": "asia",
       "climatePattern": "asian-monsoon",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/komodo.html",
       "lastVerified": "2025-12-31"
     },
@@ -2618,7 +2618,7 @@
       "region": "mediterranean",
       "climatePattern": "mediterranean",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/hvar.html",
       "lastVerified": "2025-12-31"
     },
@@ -2640,7 +2640,7 @@
       "region": "other",
       "climatePattern": "tropical-hurricane",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/falkland-islands.html",
       "lastVerified": "2025-12-31"
     },
@@ -2662,7 +2662,7 @@
       "region": "asia",
       "climatePattern": "asian-monsoon",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/nha-trang.html",
       "lastVerified": "2025-12-31"
     },
@@ -2827,7 +2827,7 @@
       "region": "mediterranean",
       "climatePattern": "mediterranean",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/patmos.html",
       "lastVerified": "2025-12-31"
     },
@@ -3245,7 +3245,7 @@
       "region": "other",
       "climatePattern": "tropical-hurricane",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/mystery-island.html",
       "lastVerified": "2025-12-31"
     },
@@ -3256,7 +3256,7 @@
       "region": "other",
       "climatePattern": "tropical-hurricane",
       "tier": 2,
-      "tenderPort": false,
+      "tenderPort": true,
       "pageUrl": "/ports/lifou.html",
       "lastVerified": "2025-12-31"
     },


### PR DESCRIPTION
Verified tender port status using multiple authoritative sources (CruiseMapper, CruiseCritic, official port authorities, cruise line websites). Changed tenderPort from false to true for:

Caribbean:
- Belize City (tender-only, no deep water dock)
- Virgin Gorda (ships anchor, tender to yacht harbor)
- St. Barts (no cruise dock, tender to Gustavia)

Mediterranean:
- Villefranche (ships anchor in bay, tender ashore)
- Cannes (tender-only for large ships)
- Kotor (most ships anchor and tender)
- Amalfi (harbor too shallow, tender to Marina Piccola)
- Sorrento (tender-only to Marina Piccola)
- Hvar (large ships anchor and tender)
- Patmos (ships anchor in Skala bay, tender ashore)

Northern Europe:
- Geiranger (tender port with optional floating pier)
- Bar Harbor (all ships anchor and tender)

Asia/Pacific:
- Koh Samui (ships anchor offshore, tender to Nathon)
- Nha Trang (tender port using ship's lifeboats)
- Komodo (no docking facilities, tender to Loh Liang)
- Mystery Island (uninhabited, tender only)
- Lifou (tender to Easo pier)

Other:
- Falkland Islands/Stanley (tender with zodiacs)

Previously marked ports verified as correct:
- Grand Cayman, Santorini, Glacier Bay, Hubbard Glacier, Bora Bora, Portofino, Capri, Moorea (all correctly TRUE)