### PR TITLE
Add trust-badge and last-reviewed validation to all validators

### DIFF
--- a/UNFINISHED_TASKS.md
+++ b/UNFINISHED_TASKS.md
@@ -3178,11 +3178,12 @@ The CHAFF items are rejected because they require real-time data infrastructure 
 - [ ] Create `/ports/tender-ports.html` index page with alphabetical listing
 - [ ] Add link to tender port index from ports.html navigation
 
-##### 2. "No Ads" Trust Messaging
+##### 2. "No Ads" Trust Messaging ✅ PARTIAL
 **Source:** Cruise Critic B2
 **Effort:** Low | **Impact:** High
+**Status:** PARTIAL - Footer trust badge added 2026-01-01
+- [x] Add trust statement to footer ✅ (2026-01-01) — `<p class="trust-badge">✓ No ads. No tracking. No affiliate links.</p>` added to all 766 HTML pages
 - [ ] Add "No ads, no affiliate links, no sponsored content" statement to about-us.html
-- [ ] Consider adding trust statement to footer or sidebar
 - [ ] Create "Our Promise" or "Editorial Independence" section
 
 ##### 3. Stateroom Checker Promotion
@@ -3425,11 +3426,17 @@ The CHAFF items are rejected because they require real-time data infrastructure 
 
 #### P4 — New Recommendations from Extended Analysis (ChatGPT + Batched Competitors)
 
-##### 30. "Last Reviewed" Stamps on Port Pages
+##### 30. "Last Reviewed" Stamps on Port Pages ✅ PARTIAL
 **Source:** ChatGPT C11
 **Effort:** Low | **Impact:** High
-- [ ] Add visible "Last reviewed: [date]" stamp to each port page
-- [ ] Include brief "What changed" changelog line
+**Status:** PARTIAL - 311/333 port pages have stamps (2026-01-01)
+- [x] Add visible "Last reviewed: January 2026" stamp to port pages ✅ (2026-01-01) — 311 port pages updated
+- [ ] **22 port pages need manual stamp addition** (non-standard templates):
+  - cephalonia, christchurch, curacao, durban, gatun-lake, hamburg
+  - harvest-caye, hurghada, incheon, kota-kinabalu, lautoka, luanda
+  - melbourne, mindelo, mobile, mombasa, port-everglades, port-miami
+  - port-moresby, praia, san-diego, sihanoukville, st-maarten, yangon
+- [ ] Include brief "What changed" changelog line (future enhancement)
 - [ ] Builds trust; differentiates from outdated competitor content
 
 ##### 31. Tool Release Notes / Changelog Page
@@ -3813,9 +3820,9 @@ These features are NOT being built now, but could be explored for future sustain
 #### 🚀 SUGGESTED SPRINT PLAN
 
 **Sprint 1 (Week 1-2): Trust & Visibility**
-- [ ] #2 "No Ads" Trust Messaging
+- [x] #2 "No Ads" Trust Messaging ✅ PARTIAL (footer badge done 2026-01-01)
 - [ ] #6 "Works Offline" Marketing
-- [ ] #30 "Last Reviewed" Stamps
+- [x] #30 "Last Reviewed" Stamps ✅ PARTIAL (311/333 ports done 2026-01-01, 22 need manual addition)
 - [ ] #31 Tool Release Notes Page
 - [ ] #41 Accessibility Equipment Guide
 

--- a/admin/post-write-validate.sh
+++ b/admin/post-write-validate.sh
@@ -299,6 +299,24 @@ for file in $FILES; do
         echo -e "   ${RED}✗${NC} Unbalanced <div> tags ($OPEN_DIVS opening, $CLOSE_DIVS closing)"
         ((TOTAL_ERRORS++))
       fi
+
+      # Trust badge check (all pages)
+      if grep -q 'class="trust-badge"' "$file" 2>/dev/null; then
+        echo -e "   ${GREEN}✓${NC} Trust badge present in footer"
+      else
+        echo -e "   ${RED}✗${NC} Missing trust badge in footer"
+        ((TOTAL_ERRORS++))
+      fi
+
+      # Last-reviewed stamp check (port pages only)
+      if [[ "$file" == *"/ports/"* ]]; then
+        if grep -q 'class="last-reviewed"' "$file" 2>/dev/null; then
+          echo -e "   ${GREEN}✓${NC} Last-reviewed stamp present"
+        else
+          echo -e "   ${YELLOW}⚠${NC}  Missing last-reviewed stamp on port page"
+          ((TOTAL_WARNINGS++))
+        fi
+      fi
       ;;
 
     *.js)

--- a/admin/validate-port-page.js
+++ b/admin/validate-port-page.js
@@ -761,6 +761,46 @@ function validateRubric($) {
 }
 
 /**
+ * Validate trust badge in footer
+ */
+function validateTrustBadge($) {
+  const errors = [];
+  const warnings = [];
+
+  const trustBadge = $('footer .trust-badge, footer p.trust-badge');
+  if (trustBadge.length === 0) {
+    errors.push({
+      section: 'footer',
+      rule: 'trust_badge_missing',
+      message: 'Missing trust badge in footer. Expected: <p class="trust-badge">✓ No ads. No tracking. No affiliate links.</p>',
+      severity: 'BLOCKING'
+    });
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Validate last-reviewed stamp
+ */
+function validateLastReviewedStamp($) {
+  const errors = [];
+  const warnings = [];
+
+  const lastReviewedStamp = $('p.last-reviewed, .last-reviewed');
+  if (lastReviewedStamp.length === 0) {
+    warnings.push({
+      section: 'content',
+      rule: 'last_reviewed_stamp_missing',
+      message: 'Missing visible "Last reviewed" stamp. Expected: <p class="last-reviewed">Last reviewed: [Month Year]</p>',
+      severity: 'WARNING'
+    });
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
  * Validate a single port page
  */
 async function validatePortPage(filepath) {
@@ -784,6 +824,8 @@ async function validatePortPage(filepath) {
     const wordResult = validateWordCounts($);
     const imageResult = validateImages($);
     const rubricResult = validateRubric($);
+    const trustBadgeResult = validateTrustBadge($);
+    const lastReviewedResult = validateLastReviewedStamp($);
 
     // Collect all errors
     results.blocking_errors.push(...icpResult.errors);
@@ -791,6 +833,7 @@ async function validatePortPage(filepath) {
     results.blocking_errors.push(...wordResult.errors);
     results.blocking_errors.push(...imageResult.errors);
     results.blocking_errors.push(...rubricResult.errors);
+    results.blocking_errors.push(...trustBadgeResult.errors);
 
     // Collect all warnings
     results.warnings.push(...icpResult.warnings);
@@ -798,6 +841,7 @@ async function validatePortPage(filepath) {
     results.warnings.push(...wordResult.warnings);
     results.warnings.push(...imageResult.warnings);
     results.warnings.push(...rubricResult.warnings);
+    results.warnings.push(...lastReviewedResult.warnings);
 
     // Calculate score (start at 100, deduct for errors/warnings)
     results.score = 100;


### PR DESCRIPTION
- Update UNFINISHED_TASKS.md: Mark #2 and #30 as partial complete, list 22 ports needing manual last-reviewed stamps
- validate-icp-lite-v14.js: Add validateTrustBadge() and validateLastReviewedStamp() functions
- validate-port-page.js: Add trust badge (blocking) and last-reviewed (warning) validation
- post-write-validate.sh: Add trust badge and last-reviewed checks for HTML files

Trust badge is now a blocking error; missing last-reviewed is a warning on port pages.