### PR TITLE
FEAT: Add Internet at Sea planning page

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -279,6 +279,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/accessibility.html
+++ b/accessibility.html
@@ -277,6 +277,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/admin/reports/sw-health.html
+++ b/admin/reports/sw-health.html
@@ -246,6 +246,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/articles.html
+++ b/articles.html
@@ -221,6 +221,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/cruise-lines.html
+++ b/cruise-lines.html
@@ -331,6 +331,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/cruise-lines/carnival.html
+++ b/cruise-lines/carnival.html
@@ -208,6 +208,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/cruise-lines/celebrity.html
+++ b/cruise-lines/celebrity.html
@@ -208,6 +208,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/cruise-lines/disney.html
+++ b/cruise-lines/disney.html
@@ -208,6 +208,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/cruise-lines/holland-america.html
+++ b/cruise-lines/holland-america.html
@@ -208,6 +208,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/cruise-lines/msc.html
+++ b/cruise-lines/msc.html
@@ -208,6 +208,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/cruise-lines/royal-caribbean.html
+++ b/cruise-lines/royal-caribbean.html
@@ -135,6 +135,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/cruise-lines/viking.html
+++ b/cruise-lines/viking.html
@@ -175,6 +175,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -174,6 +174,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -344,6 +344,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/drink-packages.html
+++ b/drink-packages.html
@@ -141,6 +141,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/index.html
+++ b/index.html
@@ -313,6 +313,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/internet-at-sea.html
+++ b/internet-at-sea.html
@@ -1,0 +1,786 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+  <!-- ======================================================
+       In the Wake — Internet at Sea Guide
+       Version: 3.010.300  |  Soli Deo Gloria ✝️
+
+       ✅ WCAG 2.1 Level AA Compliant
+       ✅ SEO Optimized (JSON-LD, OpenGraph, Twitter Cards)
+       ✅ AI-First SEO with ICP-Lite v1.4
+       ====================================================== -->
+
+  <!-- Core -->
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer-when-downgrade"/>
+
+<!-- ai-breadcrumbs
+     entity: Internet at Sea
+     type: Planning Guide
+     parent: /planning.html
+     category: Cruise Planning
+     updated: 2026-01-02
+     expertise: Cruise Wi-Fi, cellular roaming, Starlink, connectivity
+     target-audience: Cruise planners, remote workers, families needing connectivity
+     answer-first: How cruise Wi-Fi works, how to avoid roaming fees, and how to choose the right connectivity plan for your sailing.
+     -->
+
+  <!-- ICP-Lite v1.4 -->
+  <meta name="ai-summary" content="Complete guide to cruise ship internet: Wi-Fi packages, avoiding cellular roaming fees, Starlink coverage, and cruise line pricing for Royal Caribbean, Norwegian, Carnival, and MSC."/>
+  <meta name="last-reviewed" content="2026-01-02"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+
+  <!-- SEO -->
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.300"/>
+  <meta name="author" content="In the Wake"/>
+
+  <!-- Title & SEO -->
+  <title>Internet at Sea — Cruise Wi-Fi, Roaming, &amp; Starlink Guide | In the Wake</title>
+  <meta name="description" content="Complete guide to cruise ship internet: Wi-Fi packages, avoiding cellular roaming fees, Starlink coverage, and cruise line pricing for Royal Caribbean, Norwegian, Carnival, and MSC."/>
+  <link rel="canonical" href="https://cruisinginthewake.com/internet-at-sea.html"/>
+
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Internet at Sea — Cruise Wi-Fi &amp; Connectivity Guide"/>
+  <meta property="og:description" content="How cruise Wi-Fi works, how to avoid surprise roaming fees, and how to choose the right plan for your sailing."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/internet-at-sea.html"/>
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary"/>
+  <meta name="twitter:title" content="Internet at Sea — Cruise Wi-Fi Guide"/>
+
+  <!-- JSON-LD: BreadcrumbList -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/"},
+      {"@type": "ListItem", "position": 2, "name": "Planning", "item": "https://cruisinginthewake.com/planning.html"},
+      {"@type": "ListItem", "position": 3, "name": "Internet at Sea", "item": "https://cruisinginthewake.com/internet-at-sea.html"}
+    ]
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "How do I avoid huge cell phone bills on a cruise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Turn on Airplane Mode before the ship leaves port, then enable Wi-Fi while keeping Airplane Mode on. Turn off Cellular Data and Data Roaming. This prevents your phone from connecting to expensive maritime cellular networks while still allowing you to use ship Wi-Fi."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Do cruise ships have Starlink now?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes, several cruise lines have deployed Starlink. Royal Caribbean's VOOM is powered by Starlink fleetwide, and Norwegian also uses Starlink for their Wi-Fi. Performance has generally improved, though speeds can still vary with location, congestion, and weather conditions."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Will my VPN work on a cruise ship?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "It depends on the cruise line. Norwegian's Streaming package explicitly includes VPN access. Carnival states VPN connections are not supported. Royal Caribbean and MSC vary by ship and network configuration. Ask in your ship's Facebook group for recent reports."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can I use an eSIM instead of cruise Wi-Fi?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "An eSIM is helpful in port when you can connect to local cellular networks. However, it won't help you at sea—there are no cell towers in the ocean. For connectivity while sailing, you'll need the ship's Wi-Fi."
+        }
+      }
+    ]
+  }
+  </script>
+
+  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Internet at Sea — Cruise Wi-Fi &amp; Connectivity Guide",
+    "url": "https://cruisinginthewake.com/internet-at-sea.html",
+    "description": "Complete guide to cruise ship internet: Wi-Fi packages, avoiding cellular roaming fees, Starlink coverage, and cruise line pricing for Royal Caribbean, Norwegian, Carnival, and MSC.",
+    "dateModified": "2026-01-02"
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <!-- LCP Optimization: Preload critical hero images -->
+  <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+  <!-- Service Worker Registration -->
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <!-- ARIA Live Regions -->
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <!-- HEADER -->
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+      </div>
+      <!-- Mobile hamburger button -->
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+
+    <div class="hero" role="img" aria-label="Ship wake at sunrise">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a>
+      </div>
+    </div>
+  </header>
+
+  <!-- MAIN -->
+  <main id="main-content" class="wrap page-grid" role="main">
+    <!-- Main Content -->
+    <section style="grid-column: 1; grid-row: 1;">
+      <h1>Internet at Sea</h1>
+      <p class="intro">How cruise Wi-Fi actually works, how to avoid surprise roaming fees, and how to choose the right plan for your sailing.</p>
+
+      <div class="banner warn tiny" style="margin: 1rem 0;">
+        <strong>Prices change.</strong> The figures below represent what they were the last time we verified them. Always check your cruise line's current pricing before booking.
+      </div>
+
+      <!-- Jump Links -->
+      <nav class="jump-links" aria-label="Page sections" style="margin: 1.5rem 0; padding: 1rem; background: #f8fafc; border-radius: 8px;">
+        <strong>On this page:</strong>
+        <ul style="margin: 0.5rem 0 0; padding-left: 1.25rem; columns: 2; column-gap: 2rem;">
+          <li><a href="#quick-setup">Quick Setup</a></li>
+          <li><a href="#cellular-warning">Cellular at Sea</a></li>
+          <li><a href="#wifi-esim-plans">Wi-Fi vs eSIM vs Plans</a></li>
+          <li><a href="#starlink">Starlink at Sea</a></li>
+          <li><a href="#cruise-line-pricing">Cruise Line Pricing</a></li>
+          <li><a href="#vpn-work">VPN &amp; Remote Work</a></li>
+          <li><a href="#imessage">iMessage &amp; Notifications</a></li>
+          <li><a href="#money-saving">Money-Saving Tips</a></li>
+          <li><a href="#troubleshooting">Troubleshooting</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ul>
+      </nav>
+
+      <!-- Quick Setup -->
+      <section id="quick-setup">
+        <h2>Quick Setup (Do This Before Sailaway)</h2>
+
+        <p>The simplest way to avoid surprise charges is to lock your phone down before the ship leaves port. This takes about 60 seconds.</p>
+
+        <div class="package-card" style="margin: 1rem 0;">
+          <h3>The 60-Second Safe Mode</h3>
+          <ol>
+            <li><strong>Turn Airplane Mode ON</strong></li>
+            <li><strong>Turn Wi-Fi ON</strong> (you can enable Wi-Fi while Airplane Mode is on)</li>
+            <li><strong>Turn Cellular Data OFF</strong></li>
+            <li><strong>Turn Data Roaming OFF</strong></li>
+            <li><strong>Disable Wi-Fi Assist</strong> (iPhone) or <strong>Adaptive Connectivity</strong> (Android) — these can quietly switch to cellular when Wi-Fi is weak</li>
+          </ol>
+          <p class="tiny" style="margin-top: 1rem;">This configuration lets you use ship Wi-Fi while preventing any cellular connections.</p>
+        </div>
+
+        <h3>Before You Leave Home</h3>
+        <p>Download what you'll need while you still have fast, free internet:</p>
+        <ul>
+          <li><strong>Offline maps</strong> for your ports (Google Maps, Apple Maps)</li>
+          <li><strong>Boarding documents</strong> and cruise line app data</li>
+          <li><strong>Music and podcasts</strong> for sea days</li>
+          <li><strong>Shows and movies</strong> — verify they play offline before you sail</li>
+          <li><strong>Two-factor authentication backup codes</strong> — you may not have signal when you need them</li>
+        </ul>
+      </section>
+
+      <!-- Cellular Warning -->
+      <section id="cellular-warning">
+        <h2>The #1 Mistake: Cellular at Sea</h2>
+
+        <p>Many cruise ships operate a <strong>maritime cellular network</strong>. If your phone connects to it, you'll be billed at rates that don't resemble normal international roaming. Some cruisers have reported bills of hundreds or even thousands of dollars.</p>
+
+        <div class="banner warn" style="margin: 1rem 0;">
+          <strong>Maritime roaming is different.</strong> Your carrier may not include it in your international plan. Check your carrier's specific cruise/ship roaming terms before sailing.
+        </div>
+
+        <p><strong>The solution:</strong> Airplane Mode is the simplest hard lock. You can still use Wi-Fi while Airplane Mode is enabled.</p>
+
+        <h3>Cuba-Specific Note</h3>
+        <p>If your itinerary passes near Cuba, your phone may connect to Cuban cellular networks or maritime roaming depending on your location. Roaming terms for Cuba are often different from other Caribbean destinations. Check with your carrier before sailing—or simply keep Airplane Mode on.</p>
+      </section>
+
+      <!-- Wi-Fi vs eSIM vs Plans -->
+      <section id="wifi-esim-plans">
+        <h2>Wi-Fi vs eSIM vs International Plans</h2>
+
+        <h3>Cruise Ship Wi-Fi</h3>
+        <ul>
+          <li>Works at sea and throughout the ship</li>
+          <li>Typically sold by the day or for the entire voyage</li>
+          <li>Quality varies by ship, region, time of day, and how many passengers are online</li>
+          <li>Pre-cruise pricing is usually cheaper than buying onboard</li>
+        </ul>
+
+        <h3>eSIM (Ports Only)</h3>
+        <ul>
+          <li>Helpful when you're in port and want local data without hunting for a SIM card</li>
+          <li><strong>Does not work at sea</strong> — there are no cell towers in the ocean</li>
+          <li>Can be more affordable than international roaming for port days</li>
+        </ul>
+
+        <h3>International Plan from Your Carrier</h3>
+        <ul>
+          <li>Useful in port (sometimes cheaper than eSIM depending on your itinerary)</li>
+          <li><strong>Does not protect you from maritime cellular charges</strong> unless you manage settings carefully</li>
+          <li>Check if your plan explicitly covers cruise ships—most don't</li>
+        </ul>
+
+        <p><strong>Bottom line:</strong> Ship Wi-Fi is your only option at sea. eSIMs and international plans help in port but won't replace onboard connectivity.</p>
+      </section>
+
+      <!-- Starlink -->
+      <section id="starlink">
+        <h2>Starlink at Sea</h2>
+
+        <h3>The Good News</h3>
+        <p>Several cruise lines have deployed Starlink satellite connectivity, which has generally improved both capacity and reliability compared to older satellite systems.</p>
+        <ul>
+          <li><strong>Royal Caribbean:</strong> VOOM is powered by Starlink fleetwide</li>
+          <li><strong>Norwegian:</strong> Markets their Wi-Fi as "powered by Starlink"</li>
+        </ul>
+
+        <h3>The Reality Check</h3>
+        <p>Even with Starlink, cruise ship internet is still satellite internet serving thousands of passengers. Performance varies with:</p>
+        <ul>
+          <li><strong>Location:</strong> Coverage density is higher in some regions than others</li>
+          <li><strong>Congestion:</strong> Peak evening hours can be slower</li>
+          <li><strong>Weather:</strong> Heavy rain or storms can affect connectivity</li>
+          <li><strong>Ship load:</strong> More passengers online means slower speeds for everyone</li>
+        </ul>
+
+        <p>If you're crossing the Pacific or in remote areas, expect slower speeds than you'd get sailing the Caribbean. This isn't a flaw—it's physics.</p>
+      </section>
+
+      <!-- Cruise Line Pricing -->
+      <section id="cruise-line-pricing">
+        <h2>Cruise Line Wi-Fi Pricing</h2>
+
+        <p>Wi-Fi pricing varies significantly by cruise line, ship, sailing date, and whether you book pre-cruise or onboard. The figures below are representative examples—always check your actual booking for current prices.</p>
+
+        <!-- Royal Caribbean -->
+        <div class="package-card" style="margin: 1.5rem 0;">
+          <h3>Royal Caribbean — VOOM</h3>
+
+          <p>VOOM Surf + Stream is the standard package for most uses. Pricing varies by sailing.</p>
+
+          <h4>Typical Pricing (Pre-Cruise)</h4>
+          <ul>
+            <li><strong>Most commonly reported:</strong> $20–$23 per guest per day</li>
+            <li><strong>Sale pricing (Black Friday, etc.):</strong> As low as $15.99/day reported</li>
+            <li><strong>Higher-end pricing:</strong> $30–$32/day seen on some sailings</li>
+          </ul>
+
+          <h4>Crown &amp; Anchor Loyalty Benefits</h4>
+          <ul>
+            <li><strong>Diamond:</strong> 1 free day of VOOM Surf+Stream</li>
+            <li><strong>Diamond Plus:</strong> 2 free days</li>
+            <li><strong>Pinnacle:</strong> Unlimited Surf+Stream for 1 device for the full sailing</li>
+          </ul>
+
+          <h4>Suite Inclusions</h4>
+          <p>Royal Suite Class (Star/Sky) generally includes Surf+Stream (1 device per person), but there are ship and class exceptions. Check Royal's FAQ for your specific booking.</p>
+
+          <p class="tiny" style="margin-top: 1rem;"><strong>Your sailing is the truth.</strong> Check the Cruise Planner price for your specific ship and date.</p>
+        </div>
+
+        <!-- Norwegian -->
+        <div class="package-card" style="margin: 1.5rem 0;">
+          <h3>Norwegian Cruise Line</h3>
+
+          <h4>Free at Sea Wi-Fi (Included Minutes)</h4>
+          <p>Norwegian's Free at Sea promotion includes Wi-Fi minutes:</p>
+          <ul>
+            <li>Per person, 1 login per guest, 1 device at a time</li>
+            <li>Minutes-based (not unlimited) and no streaming</li>
+            <li>Minutes vary by sailing length—check your booking's exact offer</li>
+            <li>Not available at certain private destinations</li>
+          </ul>
+
+          <h4>Paid Unlimited Options</h4>
+          <ul>
+            <li><strong>Unlimited Wi-Fi (non-streaming):</strong> ~$29.99/day per stateroom</li>
+            <li><strong>Unlimited Wi-Fi (streaming):</strong> ~$39.99/day per stateroom</li>
+            <li><strong>Extra device:</strong> ~$14.99/day</li>
+          </ul>
+
+          <div class="package-note" style="margin-top: 1rem;">
+            <strong>VPN Note:</strong> NCL's Streaming package explicitly includes VPN access and allows video chat where coverage permits.
+          </div>
+        </div>
+
+        <!-- Carnival -->
+        <div class="package-card" style="margin: 1.5rem 0;">
+          <h3>Carnival Cruise Line</h3>
+
+          <p>Carnival publishes clear pricing tiers:</p>
+
+          <table class="comparison-table" style="margin: 1rem 0;">
+            <thead>
+              <tr>
+                <th>Plan</th>
+                <th>Pre-Cruise</th>
+                <th>Onboard</th>
+                <th>24-Hour</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>Social</strong></td>
+                <td>From $18.70/day</td>
+                <td>$22/day</td>
+                <td>—</td>
+              </tr>
+              <tr>
+                <td><strong>Value</strong></td>
+                <td>From $22.10/day</td>
+                <td>$26/day</td>
+                <td>$28</td>
+              </tr>
+              <tr>
+                <td><strong>Premium</strong></td>
+                <td>From $23.80/day</td>
+                <td>$28/day</td>
+                <td>$35</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h4>Important Carnival Notes</h4>
+          <ul>
+            <li>Speeds vary by location and time of day</li>
+            <li>Certain sites are blocked</li>
+            <li><strong>VPN connections are not supported</strong></li>
+          </ul>
+
+          <p class="tiny">Carnival explicitly recommends using Airplane Mode to avoid roaming fees.</p>
+        </div>
+
+        <!-- MSC -->
+        <div class="package-card" style="margin: 1.5rem 0;">
+          <h3>MSC Cruises</h3>
+
+          <p>MSC offers Browse and Browse &amp; Stream packages, but pricing often appears during booking rather than as a public table.</p>
+
+          <h4>Example Pricing (Not Universal)</h4>
+          <ul>
+            <li><strong>7-night sailing:</strong> ~$112 (Browse) / ~$140 (Browse &amp; Stream) reported</li>
+            <li><strong>6-night sailing:</strong> ~$99 (Browse &amp; Stream) reported</li>
+          </ul>
+
+          <h4>Voyagers Club Benefits</h4>
+          <ul>
+            <li>5% discount on internet packages</li>
+            <li>Free Browse Package available at some loyalty tiers—verify with your booking</li>
+          </ul>
+
+          <p class="tiny">MSC pricing varies significantly by ship and itinerary. Check your booking for accurate quotes.</p>
+        </div>
+      </section>
+
+      <!-- VPN & Remote Work -->
+      <section id="vpn-work">
+        <h2>VPN &amp; Remote Work</h2>
+
+        <h3>Will My VPN Work?</h3>
+        <p>This varies by cruise line:</p>
+        <ul>
+          <li><strong>Carnival:</strong> VPN not supported</li>
+          <li><strong>Norwegian:</strong> VPN included with Streaming package</li>
+          <li><strong>Royal Caribbean / MSC:</strong> Varies by ship and network configuration</li>
+        </ul>
+
+        <p><strong>Best practice:</strong> Join your ship's Facebook group before sailing and ask specifically: "Did VPN work reliably on [ship name]?" You'll get recent, real-world reports.</p>
+
+        <h3>Video Calls</h3>
+        <p>Video calls (Zoom, FaceTime, Teams) may work on higher-tier packages, but ship latency and congestion can make them inconsistent. If you have critical work calls:</p>
+        <ul>
+          <li>Schedule them for off-peak hours (early morning is often best)</li>
+          <li>Have a backup plan (audio-only, rescheduling)</li>
+          <li>Test connectivity before your call starts</li>
+        </ul>
+
+        <h3>Security Practices</h3>
+        <ul>
+          <li><strong>Enable 2FA before sailing</strong> and store backup codes offline</li>
+          <li><strong>Avoid sensitive banking</strong> on ship networks when possible</li>
+          <li><strong>Update your devices before the cruise</strong> — don't burn ship bandwidth on OS updates</li>
+        </ul>
+      </section>
+
+      <!-- iMessage & Push Notifications -->
+      <section id="imessage">
+        <h2>iMessage &amp; Push Notifications</h2>
+
+        <h3>The Official Answer</h3>
+        <p>Apple's documentation is clear: iMessage uses internet (Wi-Fi or cellular data). Without a connection, messages won't send.</p>
+
+        <h3>What Cruisers Report</h3>
+        <p>Some cruisers report that text-only iMessages occasionally work on the ship's free intranet without purchasing a Wi-Fi package. Others report it doesn't work at all.</p>
+
+        <div class="banner" style="margin: 1rem 0;">
+          <strong>Set expectations:</strong> If iMessage happens to work without a paid package, treat it as an unexpected mercy—not something to build your communication plan on.
+        </div>
+
+        <p>For reliable communication, purchase a Wi-Fi package or use the cruise line's app for ship-to-ship messaging (many cruise apps offer free onboard messaging).</p>
+      </section>
+
+      <!-- Money-Saving Tips -->
+      <section id="money-saving">
+        <h2>Money-Saving Tips</h2>
+
+        <ul>
+          <li><strong>Buy pre-cruise</strong> — onboard pricing is typically 20-30% higher</li>
+          <li><strong>Watch for sales</strong> — Black Friday, wave season, and flash sales offer significant discounts</li>
+          <li><strong>Re-check pricing</strong> — some lines allow cancel/rebuy if prices drop before sailing</li>
+          <li><strong>Consider one login, rotate devices</strong> — works for couples/families who don't need simultaneous access</li>
+          <li><strong>Do heavy uploads/downloads in port</strong> — use trusted shore Wi-Fi for large files</li>
+          <li><strong>Download entertainment before you sail</strong> — don't stream on expensive ship bandwidth</li>
+          <li><strong>Use ship apps for coordination</strong> — many cruise lines offer free onboard messaging through their apps</li>
+        </ul>
+      </section>
+
+      <!-- Troubleshooting -->
+      <section id="troubleshooting">
+        <h2>Troubleshooting</h2>
+
+        <h3>"Why is it so slow?"</h3>
+        <p>Ship internet serves thousands of passengers over satellite. Common causes of slowdowns:</p>
+        <ul>
+          <li>Peak evening hours (everyone's online after dinner)</li>
+          <li>Remote locations with less satellite coverage</li>
+          <li>Weather affecting satellite signal</li>
+          <li>Many passengers streaming video simultaneously</li>
+        </ul>
+
+        <h3>"Why won't my VPN connect?"</h3>
+        <p>Some cruise lines block VPN traffic. On Carnival, VPN is explicitly unsupported. Try connecting without VPN first to confirm your base connection works.</p>
+
+        <h3>"Why did my phone bill spike?"</h3>
+        <p>Your phone connected to maritime cellular. Check your settings—Cellular Data and Data Roaming should be OFF, and Airplane Mode should be ON while at sea.</p>
+
+        <h3>"Can I FaceTime/Zoom?"</h3>
+        <p>Plan and coverage dependent. Some packages explicitly support video chat "where coverage allows." Test during off-peak hours and have a backup plan.</p>
+      </section>
+
+      <!-- FAQ Section -->
+      <section class="card faq" id="faq" style="margin: 1.5rem 0; padding: 1rem;">
+        <h2 style="margin: 0 0 1rem; font-size: 1.25rem;">Frequently Asked Questions</h2>
+
+        <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+          <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I avoid huge cell phone bills on a cruise?</summary>
+          <p style="margin: 0.5rem 0; padding-left: 1rem;">Turn on Airplane Mode before the ship leaves port, then enable Wi-Fi while keeping Airplane Mode on. Turn off Cellular Data and Data Roaming. This prevents your phone from connecting to expensive maritime cellular networks while still allowing you to use ship Wi-Fi.</p>
+        </details>
+
+        <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+          <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Do cruise ships have Starlink now?</summary>
+          <p style="margin: 0.5rem 0; padding-left: 1rem;">Yes, several cruise lines have deployed Starlink. Royal Caribbean's VOOM is powered by Starlink fleetwide, and Norwegian also uses Starlink for their Wi-Fi. Performance has generally improved, though speeds can still vary with location, congestion, and weather conditions.</p>
+        </details>
+
+        <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+          <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Will my VPN work on a cruise ship?</summary>
+          <p style="margin: 0.5rem 0; padding-left: 1rem;">It depends on the cruise line. Norwegian's Streaming package explicitly includes VPN access. Carnival states VPN connections are not supported. Royal Caribbean and MSC vary by ship and network configuration. Ask in your ship's Facebook group for recent reports.</p>
+        </details>
+
+        <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+          <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Can I use an eSIM instead of cruise Wi-Fi?</summary>
+          <p style="margin: 0.5rem 0; padding-left: 1rem;">An eSIM is helpful in port when you can connect to local cellular networks. However, it won't help you at sea—there are no cell towers in the ocean. For connectivity while sailing, you'll need the ship's Wi-Fi.</p>
+        </details>
+
+        <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+          <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
+          <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides community insights gathered from cruiser reports, cruise line documentation, and practical experience. Prices and policies change—always confirm with your cruise line before making decisions.</p>
+        </details>
+      </section>
+
+      <!-- Crowd Notes -->
+      <section id="crowd-notes" style="margin: 1.5rem 0; padding: 1rem; background: #f0f7fa; border-radius: 8px;">
+        <h2 style="margin-top: 0;">Help Us Keep This Current</h2>
+        <p>Ship internet changes constantly. If you've recently sailed and have specific information about Wi-Fi performance, VPN functionality, or pricing, we'd love to hear from you.</p>
+        <p>Especially useful:</p>
+        <ul>
+          <li>Ship name and sailing date</li>
+          <li>Route/region (Caribbean, Alaska, Pacific, etc.)</li>
+          <li>Did VPN work? Which provider?</li>
+          <li>Were video calls stable?</li>
+          <li>Any blocked apps or services?</li>
+        </ul>
+        <p><a href="/about-us.html">Contact us</a> with your reports.</p>
+      </section>
+    </section>
+
+    <!-- RIGHT RAIL -->
+    <aside class="rail" role="complementary" aria-label="Author & articles" style="grid-column: 2; grid-row: 1;">
+      <!-- Quick Answer Box -->
+      <section class="card" style="background: #f0f7fa; border-left: 4px solid #0e6e8e;">
+        <h3 style="margin-top: 0;">Quick Answer</h3>
+        <p class="tiny"><strong>Avoid roaming charges:</strong> Turn on Airplane Mode, then enable Wi-Fi. Keep Cellular Data and Data Roaming OFF.</p>
+        <p class="tiny"><strong>At sea:</strong> Ship Wi-Fi is your only option. eSIMs don't work in the ocean.</p>
+        <p class="tiny"><strong>Save money:</strong> Buy Wi-Fi pre-cruise. Watch for sales.</p>
+      </section>
+
+      <!-- Author card -->
+      <section class="card author-card-vertical" aria-labelledby="author-heading">
+        <h3 id="author-heading">About the Author</h3>
+        <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+          <picture>
+            <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+          </picture>
+        </a>
+        <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+        <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+        <p class="tiny">
+          <a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        </p>
+      </section>
+
+      <!-- Related Pages -->
+      <section class="card" aria-labelledby="related-heading">
+        <h3 id="related-heading">Related Planning</h3>
+        <ul class="tiny" style="padding-left: 1rem;">
+          <li><a href="/planning.html">Planning Overview</a></li>
+          <li><a href="/packing-lists.html">Packing Lists</a></li>
+          <li><a href="/drink-packages.html">Drink Packages</a></li>
+          <li><a href="/travel.html">Travel Guide</a></li>
+        </ul>
+      </section>
+
+      <!-- Recent Stories rail -->
+      <section class="card" aria-labelledby="recent-rail-title">
+        <h3 id="recent-rail-title">Recent Stories</h3>
+        <p class="tiny content-text" style="margin-bottom: 0.75rem;">
+          Real cruising experiences, practical guides, and heartfelt reflections from our community.
+        </p>
+        <nav id="recent-rail-nav-top" class="rail-nav" aria-label="Article pagination" style="display:none; margin-bottom: 0.5rem;"></nav>
+        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <nav id="recent-rail-nav-bottom" class="rail-nav" aria-label="Article pagination" style="display:none; margin-top: 0.75rem;"></nav>
+        <p id="recent-rail-fallback" class="tiny" style="color: #666;">Loading articles…</p>
+      </section>
+
+      <!-- Authors rail -->
+      <section class="card" aria-labelledby="authors-rail-title">
+        <h3 id="authors-rail-title">Our Authors</h3>
+        <p class="tiny content-text" style="margin-bottom: 0.75rem;">
+          The voices behind In the Wake — cruisers, storytellers, and fellow travelers.
+        </p>
+        <div id="authors-rail" class="rail-list" aria-live="polite"></div>
+      </section>
+    </aside>
+
+  </main>
+
+  <!-- FOOTER -->
+  <footer class="wrap" role="contentinfo">
+    <p>© 2025 In the Wake · A Cruise Traveler's Logbook · All rights reserved. <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span></p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> ·
+      <a href="/terms.html">Terms</a> ·
+      <a href="/about-us.html">About</a> ·
+      <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. ✝️</p>
+    <p class="trust-badge">✓ No ads. No tracking. No affiliate links.</p>
+  </footer>
+
+  <!-- Navigation Dropdown Script -->
+  <script src="/assets/js/dropdown.js"></script>
+
+  <!-- In-App Browser Detection & Escape Banner -->
+  <script src="/assets/js/in-app-browser-escape.js"></script>
+
+  <!-- Article & Author Loader -->
+  <script>
+  (function(){
+    const ARTICLES_PER_PAGE = 6;
+    let allArticles = [];
+    let currentPage = 0;
+
+    async function loadArticles(){
+      fetch('/assets/data/articles/index.json')
+        .then(r => r.ok ? r.json() : Promise.reject('Failed to load'))
+        .then(data => {
+          allArticles = (data.articles || [])
+            .filter(a => a.status === 'published')
+            .sort((a, b) => new Date(b.published) - new Date(a.published));
+          renderPage(0);
+        })
+        .catch(() => {
+          document.getElementById('recent-rail-fallback').textContent = 'Unable to load articles.';
+        });
+    }
+
+    function renderPage(page){
+      currentPage = page;
+      const start = page * ARTICLES_PER_PAGE;
+      const pageArticles = allArticles.slice(start, start + ARTICLES_PER_PAGE);
+      const totalPages = Math.ceil(allArticles.length / ARTICLES_PER_PAGE);
+
+      const container = document.getElementById('recent-rail');
+      const fallback = document.getElementById('recent-rail-fallback');
+      const navTop = document.getElementById('recent-rail-nav-top');
+      const navBottom = document.getElementById('recent-rail-nav-bottom');
+
+      if(!pageArticles.length){
+        fallback.textContent = 'No articles available.';
+        return;
+      }
+      fallback.style.display = 'none';
+
+      container.innerHTML = pageArticles.map(a => {
+        const thumb = a.thumbnail || '/assets/img/default-thumb.jpg';
+        const authorName = a.author?.name || 'Unknown';
+        const href = '/solo/' + a.slug + '.html';
+        return '<a href="' + href + '" class="rail-item" style="display:flex;gap:0.75rem;align-items:center;padding:0.5rem 0;border-bottom:1px solid #e0e8f0;text-decoration:none;color:inherit;">' +
+          '<img src="' + thumb + '" alt="" width="56" height="56" style="border-radius:8px;object-fit:cover;flex-shrink:0;" loading="lazy"/>' +
+          '<span style="display:flex;flex-direction:column;gap:0.15rem;min-width:0;">' +
+            '<strong style="font-size:0.92rem;line-height:1.3;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;">' + a.title + '</strong>' +
+            '<span class="tiny" style="color:#5a7a8a;">by ' + authorName + '</span>' +
+          '</span></a>';
+      }).join('');
+
+      // Render pagination
+      if(totalPages > 1){
+        const navHTML = '<div style="display:flex;justify-content:space-between;align-items:center;">' +
+          '<button onclick="window.__articlesNav(' + (page - 1) + ')" ' + (page === 0 ? 'disabled style="opacity:0.4;cursor:default;"' : '') + ' style="background:#0e6e8e;color:#fff;border:none;padding:0.4rem 0.8rem;border-radius:6px;font-size:0.85rem;cursor:pointer;">← Newer</button>' +
+          '<span class="tiny" style="color:#5a7a8a;">' + (page + 1) + ' / ' + totalPages + '</span>' +
+          '<button onclick="window.__articlesNav(' + (page + 1) + ')" ' + (page >= totalPages - 1 ? 'disabled style="opacity:0.4;cursor:default;"' : '') + ' style="background:#0e6e8e;color:#fff;border:none;padding:0.4rem 0.8rem;border-radius:6px;font-size:0.85rem;cursor:pointer;">Older →</button>' +
+        '</div>';
+        navTop.innerHTML = navHTML;
+        navBottom.innerHTML = navHTML;
+        navTop.style.display = 'block';
+        navBottom.style.display = 'block';
+      }
+    }
+
+    window.__articlesNav = renderPage;
+
+    function loadAuthors(){
+      fetch('/data/authors.json')
+        .then(r => r.ok ? r.json() : Promise.reject('Failed'))
+        .then(data => {
+          const authors = data.authors || [];
+          const container = document.getElementById('authors-rail');
+          if(!authors.length || !container) return;
+
+          // Context-aware author filtering
+          const path = location.pathname.toLowerCase();
+          const isHome = path === '/' || path === '/index.html';
+          const isAuthorsPage = path.includes('/authors');
+          const isTinaArticle = path.includes('why-i-started-solo-cruising') || path.includes('why-i-choose-to-cruise-solo');
+
+          let filtered = authors;
+          if(isHome || isAuthorsPage){
+            // Show all authors on home and authors pages
+            filtered = authors;
+          } else if(isTinaArticle){
+            // Show Tina on her article
+            filtered = authors.filter(a => a.slug === 'tina-maulsby');
+          } else {
+            // Show only Ken everywhere else
+            filtered = authors.filter(a => a.slug === 'ken-baker');
+          }
+
+          if(!filtered.length) return;
+          container.innerHTML = filtered.map(a => {
+            const img = a.webp || a.image || '/assets/img/default-avatar.jpg';
+            return '<a href="' + a.url + '" class="rail-item" style="display:flex;gap:0.75rem;align-items:center;padding:0.5rem 0;border-bottom:1px solid #e0e8f0;text-decoration:none;color:inherit;">' +
+              '<img src="' + img + '" alt="" width="48" height="48" style="border-radius:50%;object-fit:cover;flex-shrink:0;" loading="lazy"/>' +
+              '<span style="display:flex;flex-direction:column;gap:0.1rem;">' +
+                '<strong style="font-size:0.92rem;">' + a.name + '</strong>' +
+                '<span class="tiny" style="color:#5a7a8a;">' + (a.roles ? a.roles[0] : 'Contributor') + '</span>' +
+              '</span></a>';
+          }).join('');
+        })
+        .catch(() => {});
+    }
+
+    if(document.readyState === 'loading'){
+      document.addEventListener('DOMContentLoaded', () => { loadArticles(); loadAuthors(); });
+    } else {
+      loadArticles(); loadAuthors();
+    }
+  })();
+  </script>
+</body>
+</html>

--- a/packing-lists.html
+++ b/packing-lists.html
@@ -276,6 +276,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/planning.html
+++ b/planning.html
@@ -281,6 +281,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports.html
+++ b/ports.html
@@ -234,6 +234,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/abu-dhabi.html
+++ b/ports/abu-dhabi.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/acapulco.html
+++ b/ports/acapulco.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/adelaide.html
+++ b/ports/adelaide.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/agadir.html
+++ b/ports/agadir.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ajaccio.html
+++ b/ports/ajaccio.html
@@ -147,6 +147,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/akureyri.html
+++ b/ports/akureyri.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/alesund.html
+++ b/ports/alesund.html
@@ -133,6 +133,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/amalfi.html
+++ b/ports/amalfi.html
@@ -149,6 +149,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/amber-cove.html
+++ b/ports/amber-cove.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/amsterdam.html
+++ b/ports/amsterdam.html
@@ -164,6 +164,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/anchorage.html
+++ b/ports/anchorage.html
@@ -142,6 +142,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/antigua.html
+++ b/ports/antigua.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/apia.html
+++ b/ports/apia.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/aqaba.html
+++ b/ports/aqaba.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ascension.html
+++ b/ports/ascension.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/athens.html
+++ b/ports/athens.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/auckland.html
+++ b/ports/auckland.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bali.html
+++ b/ports/bali.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/baltimore.html
+++ b/ports/baltimore.html
@@ -121,6 +121,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bangkok.html
+++ b/ports/bangkok.html
@@ -155,6 +155,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bar-harbor.html
+++ b/ports/bar-harbor.html
@@ -133,6 +133,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/barbados.html
+++ b/ports/barbados.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/barcelona.html
+++ b/ports/barcelona.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bay-of-islands.html
+++ b/ports/bay-of-islands.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/belfast.html
+++ b/ports/belfast.html
@@ -131,6 +131,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/belize.html
+++ b/ports/belize.html
@@ -147,6 +147,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bergen.html
+++ b/ports/bergen.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bermuda.html
+++ b/ports/bermuda.html
@@ -137,6 +137,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bilbao.html
+++ b/ports/bilbao.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bodrum.html
+++ b/ports/bodrum.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bonaire.html
+++ b/ports/bonaire.html
@@ -139,6 +139,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bora-bora.html
+++ b/ports/bora-bora.html
@@ -78,6 +78,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/bordeaux.html
+++ b/ports/bordeaux.html
@@ -149,6 +149,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/boston.html
+++ b/ports/boston.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/brisbane.html
+++ b/ports/brisbane.html
@@ -139,6 +139,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/brunei.html
+++ b/ports/brunei.html
@@ -129,6 +129,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/buenos-aires.html
+++ b/ports/buenos-aires.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/busan.html
+++ b/ports/busan.html
@@ -78,6 +78,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cabo-san-lucas.html
+++ b/ports/cabo-san-lucas.html
@@ -77,6 +77,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cadiz.html
+++ b/ports/cadiz.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cagliari.html
+++ b/ports/cagliari.html
@@ -146,6 +146,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cairns.html
+++ b/ports/cairns.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/callao.html
+++ b/ports/callao.html
@@ -169,6 +169,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cannes.html
+++ b/ports/cannes.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cape-town.html
+++ b/ports/cape-town.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/capri.html
+++ b/ports/capri.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cartagena-spain.html
+++ b/ports/cartagena-spain.html
@@ -146,6 +146,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cartagena.html
+++ b/ports/cartagena.html
@@ -139,6 +139,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/casablanca.html
+++ b/ports/casablanca.html
@@ -146,6 +146,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/catania.html
+++ b/ports/catania.html
@@ -154,6 +154,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cephalonia.html
+++ b/ports/cephalonia.html
@@ -143,6 +143,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/charleston.html
+++ b/ports/charleston.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/charlottetown.html
+++ b/ports/charlottetown.html
@@ -130,6 +130,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cherbourg.html
+++ b/ports/cherbourg.html
@@ -146,6 +146,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/christchurch.html
+++ b/ports/christchurch.html
@@ -132,6 +132,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/civitavecchia.html
+++ b/ports/civitavecchia.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cochin.html
+++ b/ports/cochin.html
@@ -123,6 +123,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -211,6 +211,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/colombo.html
+++ b/ports/colombo.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/colon.html
+++ b/ports/colon.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/copenhagen.html
+++ b/ports/copenhagen.html
@@ -121,6 +121,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/corfu.html
+++ b/ports/corfu.html
@@ -149,6 +149,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/corinto.html
+++ b/ports/corinto.html
@@ -124,6 +124,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cork.html
+++ b/ports/cork.html
@@ -139,6 +139,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/costa-maya.html
+++ b/ports/costa-maya.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/cozumel.html
+++ b/ports/cozumel.html
@@ -151,6 +151,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/curacao.html
+++ b/ports/curacao.html
@@ -160,6 +160,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/da-nang.html
+++ b/ports/da-nang.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/dakar.html
+++ b/ports/dakar.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/darwin.html
+++ b/ports/darwin.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/doha.html
+++ b/ports/doha.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/dominica.html
+++ b/ports/dominica.html
@@ -147,6 +147,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/doubtful-sound.html
+++ b/ports/doubtful-sound.html
@@ -157,6 +157,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/dover.html
+++ b/ports/dover.html
@@ -149,6 +149,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/dravuni.html
+++ b/ports/dravuni.html
@@ -122,6 +122,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/dubai.html
+++ b/ports/dubai.html
@@ -129,6 +129,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/dublin.html
+++ b/ports/dublin.html
@@ -151,6 +151,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/dubrovnik.html
+++ b/ports/dubrovnik.html
@@ -137,6 +137,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/dunedin.html
+++ b/ports/dunedin.html
@@ -101,6 +101,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/durban.html
+++ b/ports/durban.html
@@ -141,6 +141,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/easter-island.html
+++ b/ports/easter-island.html
@@ -125,6 +125,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/edinburgh.html
+++ b/ports/edinburgh.html
@@ -101,6 +101,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/endicott-arm.html
+++ b/ports/endicott-arm.html
@@ -155,6 +155,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ensenada.html
+++ b/ports/ensenada.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/falkland-islands.html
+++ b/ports/falkland-islands.html
@@ -119,6 +119,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/fiji.html
+++ b/ports/fiji.html
@@ -109,6 +109,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/flam.html
+++ b/ports/flam.html
@@ -78,6 +78,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/fortaleza.html
+++ b/ports/fortaleza.html
@@ -122,6 +122,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/freeport.html
+++ b/ports/freeport.html
@@ -176,6 +176,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/fremantle.html
+++ b/ports/fremantle.html
@@ -78,6 +78,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ft-lauderdale.html
+++ b/ports/ft-lauderdale.html
@@ -113,6 +113,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/fukuoka.html
+++ b/ports/fukuoka.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/funchal.html
+++ b/ports/funchal.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/galveston.html
+++ b/ports/galveston.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/gatun-lake.html
+++ b/ports/gatun-lake.html
@@ -111,6 +111,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/gdansk.html
+++ b/ports/gdansk.html
@@ -121,6 +121,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/geiranger.html
+++ b/ports/geiranger.html
@@ -78,6 +78,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/genoa.html
+++ b/ports/genoa.html
@@ -149,6 +149,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/gibraltar.html
+++ b/ports/gibraltar.html
@@ -149,6 +149,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/gijon.html
+++ b/ports/gijon.html
@@ -150,6 +150,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/glacier-bay.html
+++ b/ports/glacier-bay.html
@@ -268,6 +268,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/goa.html
+++ b/ports/goa.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/gothenburg.html
+++ b/ports/gothenburg.html
@@ -133,6 +133,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/gran-canaria.html
+++ b/ports/gran-canaria.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/grand-cayman.html
+++ b/ports/grand-cayman.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/grand-turk.html
+++ b/ports/grand-turk.html
@@ -147,6 +147,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/greenock.html
+++ b/ports/greenock.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/grenada.html
+++ b/ports/grenada.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/guadeloupe.html
+++ b/ports/guadeloupe.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/guam.html
+++ b/ports/guam.html
@@ -153,6 +153,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/guayaquil.html
+++ b/ports/guayaquil.html
@@ -130,6 +130,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ha-long-bay.html
+++ b/ports/ha-long-bay.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/haifa.html
+++ b/ports/haifa.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/haines.html
+++ b/ports/haines.html
@@ -188,6 +188,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/hakodate.html
+++ b/ports/hakodate.html
@@ -165,6 +165,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/halifax.html
+++ b/ports/halifax.html
@@ -132,6 +132,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/hamburg.html
+++ b/ports/hamburg.html
@@ -143,6 +143,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/harvest-caye.html
+++ b/ports/harvest-caye.html
@@ -111,6 +111,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/helsinki.html
+++ b/ports/helsinki.html
@@ -152,6 +152,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/heraklion.html
+++ b/ports/heraklion.html
@@ -151,6 +151,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/hilo.html
+++ b/ports/hilo.html
@@ -147,6 +147,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/hiroshima.html
+++ b/ports/hiroshima.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ho-chi-minh-city.html
+++ b/ports/ho-chi-minh-city.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ho-chi-minh.html
+++ b/ports/ho-chi-minh.html
@@ -159,6 +159,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/hobart.html
+++ b/ports/hobart.html
@@ -121,6 +121,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/holyhead.html
+++ b/ports/holyhead.html
@@ -135,6 +135,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/honfleur.html
+++ b/ports/honfleur.html
@@ -151,6 +151,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/hong-kong.html
+++ b/ports/hong-kong.html
@@ -159,6 +159,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/honolulu.html
+++ b/ports/honolulu.html
@@ -113,6 +113,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/huatulco.html
+++ b/ports/huatulco.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/hubbard-glacier.html
+++ b/ports/hubbard-glacier.html
@@ -188,6 +188,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/hurghada.html
+++ b/ports/hurghada.html
@@ -134,6 +134,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/hvar.html
+++ b/ports/hvar.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ibiza.html
+++ b/ports/ibiza.html
@@ -163,6 +163,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/icy-strait-point.html
+++ b/ports/icy-strait-point.html
@@ -203,6 +203,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/incheon.html
+++ b/ports/incheon.html
@@ -144,6 +144,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/invergordon.html
+++ b/ports/invergordon.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/istanbul.html
+++ b/ports/istanbul.html
@@ -79,6 +79,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/jacksonville.html
+++ b/ports/jacksonville.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/jamaica.html
+++ b/ports/jamaica.html
@@ -212,6 +212,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/jeju.html
+++ b/ports/jeju.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/juneau.html
+++ b/ports/juneau.html
@@ -204,6 +204,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ketchikan.html
+++ b/ports/ketchikan.html
@@ -204,6 +204,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/key-west.html
+++ b/ports/key-west.html
@@ -150,6 +150,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/kiel.html
+++ b/ports/kiel.html
@@ -134,6 +134,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/kirkwall.html
+++ b/ports/kirkwall.html
@@ -132,6 +132,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/klaipeda.html
+++ b/ports/klaipeda.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/kobe.html
+++ b/ports/kobe.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/koh-samui.html
+++ b/ports/koh-samui.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/komodo.html
+++ b/ports/komodo.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/kona.html
+++ b/ports/kona.html
@@ -145,6 +145,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/koper.html
+++ b/ports/koper.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/kota-kinabalu.html
+++ b/ports/kota-kinabalu.html
@@ -136,6 +136,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/kotor.html
+++ b/ports/kotor.html
@@ -150,6 +150,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/kusadasi.html
+++ b/ports/kusadasi.html
@@ -202,6 +202,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/la-coruna.html
+++ b/ports/la-coruna.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/la-spezia.html
+++ b/ports/la-spezia.html
@@ -79,6 +79,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/labadee.html
+++ b/ports/labadee.html
@@ -186,6 +186,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/langkawi.html
+++ b/ports/langkawi.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/lanzarote.html
+++ b/ports/lanzarote.html
@@ -119,6 +119,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/lautoka.html
+++ b/ports/lautoka.html
@@ -142,6 +142,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/le-havre.html
+++ b/ports/le-havre.html
@@ -149,6 +149,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/lerwick.html
+++ b/ports/lerwick.html
@@ -131,6 +131,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/lifou.html
+++ b/ports/lifou.html
@@ -124,6 +124,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/limassol.html
+++ b/ports/limassol.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/lisbon.html
+++ b/ports/lisbon.html
@@ -151,6 +151,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/liverpool.html
+++ b/ports/liverpool.html
@@ -151,6 +151,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/livorno.html
+++ b/ports/livorno.html
@@ -151,6 +151,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/lombok.html
+++ b/ports/lombok.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/los-angeles.html
+++ b/ports/los-angeles.html
@@ -113,6 +113,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/luanda.html
+++ b/ports/luanda.html
@@ -141,6 +141,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/lyttelton.html
+++ b/ports/lyttelton.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/malaga.html
+++ b/ports/malaga.html
@@ -164,6 +164,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/maldives.html
+++ b/ports/maldives.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/manaus.html
+++ b/ports/manaus.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/manila.html
+++ b/ports/manila.html
@@ -159,6 +159,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/manta.html
+++ b/ports/manta.html
@@ -131,6 +131,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/manzanillo.html
+++ b/ports/manzanillo.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/maputo.html
+++ b/ports/maputo.html
@@ -124,6 +124,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/marseille.html
+++ b/ports/marseille.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/martinique.html
+++ b/ports/martinique.html
@@ -149,6 +149,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/maui.html
+++ b/ports/maui.html
@@ -130,6 +130,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/mauritius.html
+++ b/ports/mauritius.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/mazatlan.html
+++ b/ports/mazatlan.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/melbourne.html
+++ b/ports/melbourne.html
@@ -114,6 +114,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/messina.html
+++ b/ports/messina.html
@@ -147,6 +147,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/miami.html
+++ b/ports/miami.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/milford-sound.html
+++ b/ports/milford-sound.html
@@ -157,6 +157,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/mindelo.html
+++ b/ports/mindelo.html
@@ -133,6 +133,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/mobile.html
+++ b/ports/mobile.html
@@ -117,6 +117,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/mombasa.html
+++ b/ports/mombasa.html
@@ -148,6 +148,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/monte-carlo.html
+++ b/ports/monte-carlo.html
@@ -152,6 +152,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/montego-bay.html
+++ b/ports/montego-bay.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/montevideo.html
+++ b/ports/montevideo.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/moorea.html
+++ b/ports/moorea.html
@@ -100,6 +100,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/mumbai.html
+++ b/ports/mumbai.html
@@ -165,6 +165,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/muscat.html
+++ b/ports/muscat.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/mykonos.html
+++ b/ports/mykonos.html
@@ -137,6 +137,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/mystery-island.html
+++ b/ports/mystery-island.html
@@ -124,6 +124,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/nagasaki.html
+++ b/ports/nagasaki.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/napier.html
+++ b/ports/napier.html
@@ -132,6 +132,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/naples.html
+++ b/ports/naples.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/nawiliwili.html
+++ b/ports/nawiliwili.html
@@ -144,6 +144,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/new-orleans.html
+++ b/ports/new-orleans.html
@@ -113,6 +113,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/newcastle.html
+++ b/ports/newcastle.html
@@ -133,6 +133,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/newport.html
+++ b/ports/newport.html
@@ -131,6 +131,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/nha-trang.html
+++ b/ports/nha-trang.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/norwegian-fjords.html
+++ b/ports/norwegian-fjords.html
@@ -137,6 +137,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/nosy-be.html
+++ b/ports/nosy-be.html
@@ -127,6 +127,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/noumea.html
+++ b/ports/noumea.html
@@ -119,6 +119,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ocho-rios.html
+++ b/ports/ocho-rios.html
@@ -119,6 +119,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/olden.html
+++ b/ports/olden.html
@@ -171,6 +171,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/osaka.html
+++ b/ports/osaka.html
@@ -78,6 +78,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/oslo.html
+++ b/ports/oslo.html
@@ -151,6 +151,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/palau.html
+++ b/ports/palau.html
@@ -152,6 +152,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/palma.html
+++ b/ports/palma.html
@@ -168,6 +168,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/panama-canal.html
+++ b/ports/panama-canal.html
@@ -139,6 +139,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/papeete.html
+++ b/ports/papeete.html
@@ -78,6 +78,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/patmos.html
+++ b/ports/patmos.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/penang.html
+++ b/ports/penang.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/philipsburg.html
+++ b/ports/philipsburg.html
@@ -152,6 +152,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/phuket.html
+++ b/ports/phuket.html
@@ -78,6 +78,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/picton.html
+++ b/ports/picton.html
@@ -124,6 +124,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/pitcairn.html
+++ b/ports/pitcairn.html
@@ -124,6 +124,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ponta-delgada.html
+++ b/ports/ponta-delgada.html
@@ -116,6 +116,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/port-canaveral.html
+++ b/ports/port-canaveral.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/port-elizabeth.html
+++ b/ports/port-elizabeth.html
@@ -124,6 +124,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/port-everglades.html
+++ b/ports/port-everglades.html
@@ -129,6 +129,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/port-miami.html
+++ b/ports/port-miami.html
@@ -129,6 +129,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/port-moresby.html
+++ b/ports/port-moresby.html
@@ -143,6 +143,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/portimao.html
+++ b/ports/portimao.html
@@ -142,6 +142,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/portland-maine.html
+++ b/ports/portland-maine.html
@@ -147,6 +147,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/portland.html
+++ b/ports/portland.html
@@ -124,6 +124,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/porto.html
+++ b/ports/porto.html
@@ -140,6 +140,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/portofino.html
+++ b/ports/portofino.html
@@ -107,6 +107,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/praia.html
+++ b/ports/praia.html
@@ -132,6 +132,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/progreso.html
+++ b/ports/progreso.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/puerto-caldera.html
+++ b/ports/puerto-caldera.html
@@ -123,6 +123,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/puerto-limon.html
+++ b/ports/puerto-limon.html
@@ -146,6 +146,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/puerto-madryn.html
+++ b/ports/puerto-madryn.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/puerto-vallarta.html
+++ b/ports/puerto-vallarta.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/punta-arenas.html
+++ b/ports/punta-arenas.html
@@ -123,6 +123,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/puntarenas.html
+++ b/ports/puntarenas.html
@@ -123,6 +123,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/quebec-city.html
+++ b/ports/quebec-city.html
@@ -122,6 +122,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ravenna.html
+++ b/ports/ravenna.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/recife.html
+++ b/ports/recife.html
@@ -121,6 +121,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/reykjavik.html
+++ b/ports/reykjavik.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/rhodes.html
+++ b/ports/rhodes.html
@@ -140,6 +140,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/riga.html
+++ b/ports/riga.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/rio-de-janeiro.html
+++ b/ports/rio-de-janeiro.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/roatan.html
+++ b/ports/roatan.html
@@ -167,6 +167,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/rostock.html
+++ b/ports/rostock.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/royal-beach-club-nassau.html
+++ b/ports/royal-beach-club-nassau.html
@@ -175,6 +175,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/safaga.html
+++ b/ports/safaga.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/saguenay.html
+++ b/ports/saguenay.html
@@ -130,6 +130,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/saint-john.html
+++ b/ports/saint-john.html
@@ -130,6 +130,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/saipan.html
+++ b/ports/saipan.html
@@ -119,6 +119,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/salalah.html
+++ b/ports/salalah.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/salvador.html
+++ b/ports/salvador.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/samana.html
+++ b/ports/samana.html
@@ -154,6 +154,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/san-diego.html
+++ b/ports/san-diego.html
@@ -119,6 +119,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/san-francisco.html
+++ b/ports/san-francisco.html
@@ -122,6 +122,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/san-juan.html
+++ b/ports/san-juan.html
@@ -113,6 +113,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/santorini.html
+++ b/ports/santorini.html
@@ -137,6 +137,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/santos.html
+++ b/ports/santos.html
@@ -132,6 +132,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/scotland.html
+++ b/ports/scotland.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/seattle.html
+++ b/ports/seattle.html
@@ -118,6 +118,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/seward.html
+++ b/ports/seward.html
@@ -188,6 +188,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/seychelles.html
+++ b/ports/seychelles.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/shanghai.html
+++ b/ports/shanghai.html
@@ -147,6 +147,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/sharm-el-sheikh.html
+++ b/ports/sharm-el-sheikh.html
@@ -128,6 +128,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/sihanoukville.html
+++ b/ports/sihanoukville.html
@@ -137,6 +137,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/singapore.html
+++ b/ports/singapore.html
@@ -147,6 +147,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/sitka.html
+++ b/ports/sitka.html
@@ -204,6 +204,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/skagway.html
+++ b/ports/skagway.html
@@ -204,6 +204,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/sorrento.html
+++ b/ports/sorrento.html
@@ -124,6 +124,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/south-georgia.html
+++ b/ports/south-georgia.html
@@ -124,6 +124,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/south-pacific.html
+++ b/ports/south-pacific.html
@@ -140,6 +140,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/southampton.html
+++ b/ports/southampton.html
@@ -161,6 +161,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/split.html
+++ b/ports/split.html
@@ -147,6 +147,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/st-barts.html
+++ b/ports/st-barts.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/st-helena.html
+++ b/ports/st-helena.html
@@ -123,6 +123,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/st-kitts.html
+++ b/ports/st-kitts.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/st-lucia.html
+++ b/ports/st-lucia.html
@@ -108,6 +108,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/st-maarten.html
+++ b/ports/st-maarten.html
@@ -151,6 +151,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/st-petersburg.html
+++ b/ports/st-petersburg.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/st-thomas.html
+++ b/ports/st-thomas.html
@@ -191,6 +191,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/stavanger.html
+++ b/ports/stavanger.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/stockholm.html
+++ b/ports/stockholm.html
@@ -147,6 +147,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/suva.html
+++ b/ports/suva.html
@@ -115,6 +115,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/sydney-ns.html
+++ b/ports/sydney-ns.html
@@ -122,6 +122,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/sydney.html
+++ b/ports/sydney.html
@@ -156,6 +156,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/taipei.html
+++ b/ports/taipei.html
@@ -156,6 +156,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tallinn.html
+++ b/ports/tallinn.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tampa.html
+++ b/ports/tampa.html
@@ -113,6 +113,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tangier.html
+++ b/ports/tangier.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/taormina.html
+++ b/ports/taormina.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tauranga.html
+++ b/ports/tauranga.html
@@ -99,6 +99,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tenerife.html
+++ b/ports/tenerife.html
@@ -99,6 +99,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tianjin.html
+++ b/ports/tianjin.html
@@ -166,6 +166,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tokyo.html
+++ b/ports/tokyo.html
@@ -131,6 +131,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tonga.html
+++ b/ports/tonga.html
@@ -99,6 +99,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tortola.html
+++ b/ports/tortola.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tracy-arm.html
+++ b/ports/tracy-arm.html
@@ -139,6 +139,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/trieste.html
+++ b/ports/trieste.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tristan-da-cunha.html
+++ b/ports/tristan-da-cunha.html
@@ -128,6 +128,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tromso.html
+++ b/ports/tromso.html
@@ -136,6 +136,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/tunis.html
+++ b/ports/tunis.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/ushuaia.html
+++ b/ports/ushuaia.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/valencia.html
+++ b/ports/valencia.html
@@ -171,6 +171,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/valletta.html
+++ b/ports/valletta.html
@@ -138,6 +138,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/valparaiso.html
+++ b/ports/valparaiso.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/vancouver.html
+++ b/ports/vancouver.html
@@ -161,6 +161,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/vanuatu.html
+++ b/ports/vanuatu.html
@@ -128,6 +128,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/venice.html
+++ b/ports/venice.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/victoria-bc.html
+++ b/ports/victoria-bc.html
@@ -136,6 +136,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/vigo.html
+++ b/ports/vigo.html
@@ -152,6 +152,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/villefranche.html
+++ b/ports/villefranche.html
@@ -174,6 +174,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/virgin-gorda.html
+++ b/ports/virgin-gorda.html
@@ -152,6 +152,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/walvis-bay.html
+++ b/ports/walvis-bay.html
@@ -119,6 +119,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/warnemunde.html
+++ b/ports/warnemunde.html
@@ -136,6 +136,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/waterford.html
+++ b/ports/waterford.html
@@ -136,6 +136,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/wellington.html
+++ b/ports/wellington.html
@@ -136,6 +136,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/whittier.html
+++ b/ports/whittier.html
@@ -139,6 +139,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/yangon.html
+++ b/ports/yangon.html
@@ -144,6 +144,7 @@ Soli Deo Gloria
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/zadar.html
+++ b/ports/zadar.html
@@ -151,6 +151,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/zakynthos.html
+++ b/ports/zakynthos.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/zanzibar.html
+++ b/ports/zanzibar.html
@@ -120,6 +120,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/zeebrugge.html
+++ b/ports/zeebrugge.html
@@ -135,6 +135,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ports/zihuatanejo.html
+++ b/ports/zihuatanejo.html
@@ -70,6 +70,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/privacy.html
+++ b/privacy.html
@@ -180,6 +180,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants.html
+++ b/restaurants.html
@@ -267,6 +267,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/1400-lobby-bar.html
+++ b/restaurants/1400-lobby-bar.html
@@ -198,6 +198,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/150-central-park.html
+++ b/restaurants/150-central-park.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/adagio-dining-room.html
+++ b/restaurants/adagio-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/adventure-dunes.html
+++ b/restaurants/adventure-dunes.html
@@ -193,6 +193,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/adventure-ocean.html
+++ b/restaurants/adventure-ocean.html
@@ -112,7 +112,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/amber-and-oak.html
+++ b/restaurants/amber-and-oak.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/american-icon-grill.html
+++ b/restaurants/american-icon-grill.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/aqua-theater.html
+++ b/restaurants/aqua-theater.html
@@ -127,6 +127,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -176,6 +176,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/aquarium-bar.html
+++ b/restaurants/aquarium-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/aquarius-dining-room.html
+++ b/restaurants/aquarius-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/aquatheater.html
+++ b/restaurants/aquatheater.html
@@ -190,6 +190,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/arcade.html
+++ b/restaurants/arcade.html
@@ -119,7 +119,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/bamboo-room.html
+++ b/restaurants/bamboo-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -193,6 +193,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/bell-and-barley.html
+++ b/restaurants/bell-and-barley.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/ben-and-jerrys.html
+++ b/restaurants/ben-and-jerrys.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/bionic-bar.html
+++ b/restaurants/bionic-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/boardwalk-dog-house.html
+++ b/restaurants/boardwalk-dog-house.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/boleros.html
+++ b/restaurants/boleros.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/brass-and-bock.html
+++ b/restaurants/brass-and-bock.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/bubbles.html
+++ b/restaurants/bubbles.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/bull-and-bear-pub.html
+++ b/restaurants/bull-and-bear-pub.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -138,6 +138,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -176,6 +176,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/cantina-fresca.html
+++ b/restaurants/cantina-fresca.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/carousel.html
+++ b/restaurants/carousel.html
@@ -112,7 +112,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/cascades-dining-room.html
+++ b/restaurants/cascades-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/casino-bar.html
+++ b/restaurants/casino-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/casino.html
+++ b/restaurants/casino.html
@@ -117,7 +117,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/celebration-table.html
+++ b/restaurants/celebration-table.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/central-park.html
+++ b/restaurants/central-park.html
@@ -190,6 +190,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/champagne-bar.html
+++ b/restaurants/champagne-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -140,6 +140,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/chic.html
+++ b/restaurants/chic.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/chops.html
+++ b/restaurants/chops.html
@@ -198,6 +198,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/cloud-17.html
+++ b/restaurants/cloud-17.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -138,6 +138,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/comedy-live.html
+++ b/restaurants/comedy-live.html
@@ -126,6 +126,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/concierge-lounge.html
+++ b/restaurants/concierge-lounge.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/congo-bar.html
+++ b/restaurants/congo-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/cosmopolitan-club.html
+++ b/restaurants/cosmopolitan-club.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/crown-and-castle-pub.html
+++ b/restaurants/crown-and-castle-pub.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/crown-and-kettle.html
+++ b/restaurants/crown-and-kettle.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/dazzles.html
+++ b/restaurants/dazzles.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/desserted.html
+++ b/restaurants/desserted.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/devinly-decadence.html
+++ b/restaurants/devinly-decadence.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/diamond-club.html
+++ b/restaurants/diamond-club.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -192,6 +192,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/dining-activities.html
+++ b/restaurants/dining-activities.html
@@ -154,6 +154,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -193,6 +193,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/duck-and-dog-pub.html
+++ b/restaurants/duck-and-dog-pub.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/dueling-pianos.html
+++ b/restaurants/dueling-pianos.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/edelweiss-dining-room.html
+++ b/restaurants/edelweiss-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -176,6 +176,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/empire-supper-club.html
+++ b/restaurants/empire-supper-club.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/english-pub.html
+++ b/restaurants/english-pub.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/fish-and-ships.html
+++ b/restaurants/fish-and-ships.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/fitness-center.html
+++ b/restaurants/fitness-center.html
@@ -119,7 +119,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/flowrider.html
+++ b/restaurants/flowrider.html
@@ -126,6 +126,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/game-reserve.html
+++ b/restaurants/game-reserve.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/giovannis-italian-kitchen.html
+++ b/restaurants/giovannis-italian-kitchen.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/giovannis.html
+++ b/restaurants/giovannis.html
@@ -170,6 +170,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/globe-and-atlas.html
+++ b/restaurants/globe-and-atlas.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/great-gatsby-dining-room.html
+++ b/restaurants/great-gatsby-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/hooked-seafood.html
+++ b/restaurants/hooked-seafood.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/hot-pot.html
+++ b/restaurants/hot-pot.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/izumi-in-the-park.html
+++ b/restaurants/izumi-in-the-park.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/izumi.html
+++ b/restaurants/izumi.html
@@ -159,6 +159,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/jamies-italian.html
+++ b/restaurants/jamies-italian.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/johnny-rockets.html
+++ b/restaurants/johnny-rockets.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/la-patisserie.html
+++ b/restaurants/la-patisserie.html
@@ -198,6 +198,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -184,6 +184,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/leaf-and-bean.html
+++ b/restaurants/leaf-and-bean.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/lime-and-coconut.html
+++ b/restaurants/lime-and-coconut.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/lincoln-park-supper-club.html
+++ b/restaurants/lincoln-park-supper-club.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/lobby-bar.html
+++ b/restaurants/lobby-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/lous-jazz-n-blues.html
+++ b/restaurants/lous-jazz-n-blues.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/mason-jar.html
+++ b/restaurants/mason-jar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/mdr.html
+++ b/restaurants/mdr.html
@@ -179,6 +179,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/minstrel-dining-room.html
+++ b/restaurants/minstrel-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/music-hall.html
+++ b/restaurants/music-hall.html
@@ -204,6 +204,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/my-fair-lady-dining-room.html
+++ b/restaurants/my-fair-lady-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/north-star-bar.html
+++ b/restaurants/north-star-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/north-star.html
+++ b/restaurants/north-star.html
@@ -112,7 +112,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/oasis-bar.html
+++ b/restaurants/oasis-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/olive-or-twist.html
+++ b/restaurants/olive-or-twist.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/on-air-club.html
+++ b/restaurants/on-air-club.html
@@ -127,6 +127,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/on-air.html
+++ b/restaurants/on-air.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/park-cafe.html
+++ b/restaurants/park-cafe.html
@@ -183,6 +183,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -168,6 +168,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/pesky-parrot.html
+++ b/restaurants/pesky-parrot.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/pier-7.html
+++ b/restaurants/pier-7.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/pig-and-whistle-pub.html
+++ b/restaurants/pig-and-whistle-pub.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/playmakers.html
+++ b/restaurants/playmakers.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/plaza-bar.html
+++ b/restaurants/plaza-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/pool-bar.html
+++ b/restaurants/pool-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/portside-bbq.html
+++ b/restaurants/portside-bbq.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/quill-and-compass.html
+++ b/restaurants/quill-and-compass.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/r-bar.html
+++ b/restaurants/r-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/reflections-dining-room.html
+++ b/restaurants/reflections-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/ripcord-by-ifly.html
+++ b/restaurants/ripcord-by-ifly.html
@@ -112,7 +112,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/rising-tide-bar.html
+++ b/restaurants/rising-tide-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/ritas-cantina.html
+++ b/restaurants/ritas-cantina.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/rock-climbing.html
+++ b/restaurants/rock-climbing.html
@@ -112,7 +112,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/room-service.html
+++ b/restaurants/room-service.html
@@ -192,6 +192,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/royal-promenade.html
+++ b/restaurants/royal-promenade.html
@@ -190,6 +190,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/royal-railway.html
+++ b/restaurants/royal-railway.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/royal-theater.html
+++ b/restaurants/royal-theater.html
@@ -204,6 +204,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/rye-and-bean.html
+++ b/restaurants/rye-and-bean.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sabor-taqueria.html
+++ b/restaurants/sabor-taqueria.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sabor.html
+++ b/restaurants/sabor.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -152,6 +152,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sapphire-dining-room.html
+++ b/restaurants/sapphire-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sapphire-restaurant.html
+++ b/restaurants/sapphire-restaurant.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/schooner-bar.html
+++ b/restaurants/schooner-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/seaplex.html
+++ b/restaurants/seaplex.html
@@ -127,6 +127,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sichuan-red.html
+++ b/restaurants/sichuan-red.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/silk.html
+++ b/restaurants/silk.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sky-bar.html
+++ b/restaurants/sky-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sky-lounge.html
+++ b/restaurants/sky-lounge.html
@@ -126,6 +126,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/solarium-bar.html
+++ b/restaurants/solarium-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -129,6 +129,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/solarium-cafe.html
+++ b/restaurants/solarium-cafe.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/solarium.html
+++ b/restaurants/solarium.html
@@ -112,7 +112,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -200,6 +200,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/splashaway-bay.html
+++ b/restaurants/splashaway-bay.html
@@ -135,6 +135,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/spotlight-karaoke.html
+++ b/restaurants/spotlight-karaoke.html
@@ -126,6 +126,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sprinkles.html
+++ b/restaurants/sprinkles.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/star-lounge.html
+++ b/restaurants/star-lounge.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/starbucks.html
+++ b/restaurants/starbucks.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/studio-b.html
+++ b/restaurants/studio-b.html
@@ -126,6 +126,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sugar-beach.html
+++ b/restaurants/sugar-beach.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/suite-lounge.html
+++ b/restaurants/suite-lounge.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/sunshine-bar.html
+++ b/restaurants/sunshine-bar.html
@@ -198,6 +198,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -185,6 +185,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/swim-and-tonic.html
+++ b/restaurants/swim-and-tonic.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/tavern-bar.html
+++ b/restaurants/tavern-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/the-bamboo-room.html
+++ b/restaurants/the-bamboo-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/the-dining-room.html
+++ b/restaurants/the-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/the-grande.html
+++ b/restaurants/the-grande.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -185,6 +185,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/the-overlook.html
+++ b/restaurants/the-overlook.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/the-pit-stop.html
+++ b/restaurants/the-pit-stop.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/tides-dining-room.html
+++ b/restaurants/tides-dining-room.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/trellis-bar.html
+++ b/restaurants/trellis-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/two70-bar.html
+++ b/restaurants/two70-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/two70.html
+++ b/restaurants/two70.html
@@ -205,6 +205,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/ultimate-abyss.html
+++ b/restaurants/ultimate-abyss.html
@@ -190,6 +190,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/viking-crown-lounge.html
+++ b/restaurants/viking-crown-lounge.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/vintages.html
+++ b/restaurants/vintages.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -183,6 +183,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/vitality-spa.html
+++ b/restaurants/vitality-spa.html
@@ -112,7 +112,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/restaurants/vortex.html
+++ b/restaurants/vortex.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/wig-and-gavel.html
+++ b/restaurants/wig-and-gavel.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/windjammer.html
+++ b/restaurants/windjammer.html
@@ -190,6 +190,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/wipeout-bar.html
+++ b/restaurants/wipeout-bar.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/wonderland.html
+++ b/restaurants/wonderland.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/zanzibar-lounge.html
+++ b/restaurants/zanzibar-lounge.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/restaurants/zip-line.html
+++ b/restaurants/zip-line.html
@@ -112,7 +112,8 @@ All work on this project is offered as a gift to God.
           <a href="/ships.html">Ships</a>
           <a href="/restaurants.html">Restaurants &amp; Menus</a>
           <a href="/ports.html">Ports</a>
-          <a href="/drink-packages.html">Drink Packages</a>
+          <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
           <a href="/drink-calculator.html">Drink Calculator</a>
           <a href="/stateroom-check.html">Stateroom Check</a>
           <a href="/cruise-lines.html">Cruise Lines</a>

--- a/search.html
+++ b/search.html
@@ -135,6 +135,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships.html
+++ b/ships.html
@@ -714,6 +714,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-breeze.html
+++ b/ships/carnival/carnival-breeze.html
@@ -92,6 +92,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-celebration.html
+++ b/ships/carnival/carnival-celebration.html
@@ -288,6 +288,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-conquest.html
+++ b/ships/carnival/carnival-conquest.html
@@ -104,6 +104,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-dream.html
+++ b/ships/carnival/carnival-dream.html
@@ -89,6 +89,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-ecstasy.html
+++ b/ships/carnival/carnival-ecstasy.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-elation.html
+++ b/ships/carnival/carnival-elation.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-encounter.html
+++ b/ships/carnival/carnival-encounter.html
@@ -223,6 +223,7 @@ if ('serviceWorker' in navigator) {
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-fantasy.html
+++ b/ships/carnival/carnival-fantasy.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-fascination.html
+++ b/ships/carnival/carnival-fascination.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-festivale.html
+++ b/ships/carnival/carnival-festivale.html
@@ -208,7 +208,8 @@ if ('serviceWorker' in navigator) {
       <a href="/ships.html">Ships</a>
       <a href="/restaurants.html">Restaurants &amp; Menus</a>
       <a href="/ports.html">Ports</a>
-      <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
       <a href="/cruise-lines.html">Cruise Lines</a>
     </div>
   </div>

--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -230,7 +230,8 @@ if ('serviceWorker' in navigator) {
       <a href="/ships.html">Ships</a>
       <a href="/restaurants.html">Restaurants &amp; Menus</a>
       <a href="/ports.html">Ports</a>
-      <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
       <a href="/cruise-lines.html">Cruise Lines</a>
     </div>
   </div>

--- a/ships/carnival/carnival-freedom.html
+++ b/ships/carnival/carnival-freedom.html
@@ -89,6 +89,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-glory.html
+++ b/ships/carnival/carnival-glory.html
@@ -89,6 +89,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -110,7 +110,8 @@
       <a href="/ships.html">Ships</a>
       <a href="/restaurants.html">Restaurants &amp; Menus</a>
       <a href="/ports.html">Ports</a>
-      <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
       <a href="/cruise-lines.html">Cruise Lines</a>
     </div>
   </div>

--- a/ships/carnival/carnival-imagination.html
+++ b/ships/carnival/carnival-imagination.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-inspiration.html
+++ b/ships/carnival/carnival-inspiration.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-jubilee.html
+++ b/ships/carnival/carnival-jubilee.html
@@ -344,6 +344,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-legend.html
+++ b/ships/carnival/carnival-legend.html
@@ -75,6 +75,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-liberty.html
+++ b/ships/carnival/carnival-liberty.html
@@ -89,6 +89,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-luminosa.html
+++ b/ships/carnival/carnival-luminosa.html
@@ -89,6 +89,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-magic.html
+++ b/ships/carnival/carnival-magic.html
@@ -92,6 +92,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-mardi-gras.html
+++ b/ships/carnival/carnival-mardi-gras.html
@@ -330,6 +330,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-miracle.html
+++ b/ships/carnival/carnival-miracle.html
@@ -75,6 +75,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -110,7 +110,8 @@
       <a href="/ships.html">Ships</a>
       <a href="/restaurants.html">Restaurants &amp; Menus</a>
       <a href="/ports.html">Ports</a>
-      <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/drink-packages.html">Drink Packages</a>
       <a href="/cruise-lines.html">Cruise Lines</a>
     </div>
   </div>

--- a/ships/carnival/carnival-paradise.html
+++ b/ships/carnival/carnival-paradise.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-pride.html
+++ b/ships/carnival/carnival-pride.html
@@ -75,6 +75,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-radiance.html
+++ b/ships/carnival/carnival-radiance.html
@@ -220,6 +220,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-sensation.html
+++ b/ships/carnival/carnival-sensation.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-spirit.html
+++ b/ships/carnival/carnival-spirit.html
@@ -75,6 +75,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-splendor.html
+++ b/ships/carnival/carnival-splendor.html
@@ -220,6 +220,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-sunrise.html
+++ b/ships/carnival/carnival-sunrise.html
@@ -220,6 +220,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-valor.html
+++ b/ships/carnival/carnival-valor.html
@@ -89,6 +89,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnival-vista.html
+++ b/ships/carnival/carnival-vista.html
@@ -113,6 +113,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/carnivale-1956.html
+++ b/ships/carnival/carnivale-1956.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/celebration-1987.html
+++ b/ships/carnival/celebration-1987.html
@@ -43,6 +43,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/festivale-1961.html
+++ b/ships/carnival/festivale-1961.html
@@ -43,6 +43,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/holiday-1985.html
+++ b/ships/carnival/holiday-1985.html
@@ -43,6 +43,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/index.html
+++ b/ships/carnival/index.html
@@ -277,6 +277,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/jubilee-1986.html
+++ b/ships/carnival/jubilee-1986.html
@@ -43,6 +43,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/mardi-gras-1972.html
+++ b/ships/carnival/mardi-gras-1972.html
@@ -48,6 +48,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/tropicale-1981.html
+++ b/ships/carnival/tropicale-1981.html
@@ -43,6 +43,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/unnamed-project-ace-1.html
+++ b/ships/carnival/unnamed-project-ace-1.html
@@ -321,6 +321,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/unnamed-project-ace-2.html
+++ b/ships/carnival/unnamed-project-ace-2.html
@@ -321,6 +321,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/carnival/unnamed-project-ace-3.html
+++ b/ships/carnival/unnamed-project-ace-3.html
@@ -321,6 +321,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-ascent.html
+++ b/ships/celebrity-cruises/celebrity-ascent.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-beyond.html
+++ b/ships/celebrity-cruises/celebrity-beyond.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-century.html
+++ b/ships/celebrity-cruises/celebrity-century.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-compass.html
+++ b/ships/celebrity-cruises/celebrity-compass.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-constellation.html
+++ b/ships/celebrity-cruises/celebrity-constellation.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-eclipse.html
+++ b/ships/celebrity-cruises/celebrity-eclipse.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-edge.html
+++ b/ships/celebrity-cruises/celebrity-edge.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-equinox.html
+++ b/ships/celebrity-cruises/celebrity-equinox.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-flora.html
+++ b/ships/celebrity-cruises/celebrity-flora.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-galaxy.html
+++ b/ships/celebrity-cruises/celebrity-galaxy.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-infinity.html
+++ b/ships/celebrity-cruises/celebrity-infinity.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-mercury.html
+++ b/ships/celebrity-cruises/celebrity-mercury.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-millennium.html
+++ b/ships/celebrity-cruises/celebrity-millennium.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-reflection.html
+++ b/ships/celebrity-cruises/celebrity-reflection.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-seeker.html
+++ b/ships/celebrity-cruises/celebrity-seeker.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-silhouette.html
+++ b/ships/celebrity-cruises/celebrity-silhouette.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-solstice.html
+++ b/ships/celebrity-cruises/celebrity-solstice.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-summit.html
+++ b/ships/celebrity-cruises/celebrity-summit.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-xpedition.html
+++ b/ships/celebrity-cruises/celebrity-xpedition.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-xperience.html
+++ b/ships/celebrity-cruises/celebrity-xperience.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/celebrity-xploration.html
+++ b/ships/celebrity-cruises/celebrity-xploration.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/horizon.html
+++ b/ships/celebrity-cruises/horizon.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/index.html
+++ b/ships/celebrity-cruises/index.html
@@ -64,6 +64,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/ss-meridian.html
+++ b/ships/celebrity-cruises/ss-meridian.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/unnamed-edge-class.html
+++ b/ships/celebrity-cruises/unnamed-edge-class.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/unnamed-project-nirvana.html
+++ b/ships/celebrity-cruises/unnamed-project-nirvana.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/unnamed-river-class-x6.html
+++ b/ships/celebrity-cruises/unnamed-river-class-x6.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/celebrity-cruises/zenith.html
+++ b/ships/celebrity-cruises/zenith.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/grandeur-of-the-seas.html
+++ b/ships/grandeur-of-the-seas.html
@@ -205,6 +205,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/amsterdam.html
+++ b/ships/holland-america-line/amsterdam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/edam.html
+++ b/ships/holland-america-line/edam.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/eurodam.html
+++ b/ships/holland-america-line/eurodam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/index.html
+++ b/ships/holland-america-line/index.html
@@ -64,6 +64,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/koningsdam.html
+++ b/ships/holland-america-line/koningsdam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/leerdam.html
+++ b/ships/holland-america-line/leerdam.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/maartensdijk.html
+++ b/ships/holland-america-line/maartensdijk.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/maasdam.html
+++ b/ships/holland-america-line/maasdam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/nieuw-amsterdam-ii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-ii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/nieuw-amsterdam-iii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/nieuw-amsterdam-iv.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iv.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/nieuw-amsterdam-v.html
+++ b/ships/holland-america-line/nieuw-amsterdam-v.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/nieuw-amsterdam.html
+++ b/ships/holland-america-line/nieuw-amsterdam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/nieuw-statendam.html
+++ b/ships/holland-america-line/nieuw-statendam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/none-announced.html
+++ b/ships/holland-america-line/none-announced.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/noordam-ii.html
+++ b/ships/holland-america-line/noordam-ii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/noordam-iii.html
+++ b/ships/holland-america-line/noordam-iii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/noordam-iv.html
+++ b/ships/holland-america-line/noordam-iv.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/noordam.html
+++ b/ships/holland-america-line/noordam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/oosterdam.html
+++ b/ships/holland-america-line/oosterdam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/p-caland.html
+++ b/ships/holland-america-line/p-caland.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/potsdam.html
+++ b/ships/holland-america-line/potsdam.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/prinsendam-i.html
+++ b/ships/holland-america-line/prinsendam-i.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/prinsendam-ii.html
+++ b/ships/holland-america-line/prinsendam-ii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/rijndam-ii.html
+++ b/ships/holland-america-line/rijndam-ii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/rijndam.html
+++ b/ships/holland-america-line/rijndam.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/rotterdam-iv.html
+++ b/ships/holland-america-line/rotterdam-iv.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/rotterdam-v.html
+++ b/ships/holland-america-line/rotterdam-v.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/rotterdam-vi.html
+++ b/ships/holland-america-line/rotterdam-vi.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/rotterdam.html
+++ b/ships/holland-america-line/rotterdam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/ryndam.html
+++ b/ships/holland-america-line/ryndam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/statendam-ii.html
+++ b/ships/holland-america-line/statendam-ii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/statendam-iii.html
+++ b/ships/holland-america-line/statendam-iii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/statendam.html
+++ b/ships/holland-america-line/statendam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/veendam-ii.html
+++ b/ships/holland-america-line/veendam-ii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/veendam-iii.html
+++ b/ships/holland-america-line/veendam-iii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/veendam-iv.html
+++ b/ships/holland-america-line/veendam-iv.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/veendam.html
+++ b/ships/holland-america-line/veendam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/volendam-ii.html
+++ b/ships/holland-america-line/volendam-ii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/volendam-iii.html
+++ b/ships/holland-america-line/volendam-iii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/volendam.html
+++ b/ships/holland-america-line/volendam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/w-a-scholten.html
+++ b/ships/holland-america-line/w-a-scholten.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/westerdam-i.html
+++ b/ships/holland-america-line/westerdam-i.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/westerdam-ii.html
+++ b/ships/holland-america-line/westerdam-ii.html
@@ -133,6 +133,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/holland-america-line/zaandam.html
+++ b/ships/holland-america-line/zaandam.html
@@ -134,6 +134,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/index.html
+++ b/ships/index.html
@@ -142,6 +142,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/msc/msc-world-america.html
+++ b/ships/msc/msc-world-america.html
@@ -206,6 +206,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/quiz.html
+++ b/ships/quiz.html
@@ -640,6 +640,7 @@
             <a href="/ships/quiz.html">Ship Quiz</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -352,6 +352,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -347,6 +347,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -347,6 +347,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -347,6 +347,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/discovery-class-ship-tbn.html
+++ b/ships/rcl/discovery-class-ship-tbn.html
@@ -304,6 +304,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -352,6 +352,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -354,6 +354,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -352,6 +352,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/icon-class-ship-tbn-2027.html
+++ b/ships/rcl/icon-class-ship-tbn-2027.html
@@ -350,6 +350,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/icon-class-ship-tbn-2028.html
+++ b/ships/rcl/icon-class-ship-tbn-2028.html
@@ -350,6 +350,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/icon-of-the-seas.html
+++ b/ships/rcl/icon-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/legend-of-the-seas-1995-built.html
+++ b/ships/rcl/legend-of-the-seas-1995-built.html
@@ -338,6 +338,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
+++ b/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html
@@ -344,6 +344,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/legend-of-the-seas.html
+++ b/ships/rcl/legend-of-the-seas.html
@@ -336,6 +336,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/majesty-of-the-seas.html
+++ b/ships/rcl/majesty-of-the-seas.html
@@ -360,6 +360,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -354,6 +354,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/monarch-of-the-seas.html
+++ b/ships/rcl/monarch-of-the-seas.html
@@ -355,6 +355,7 @@ updated: 2025-11-18
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -354,6 +354,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/nordic-empress.html
+++ b/ships/rcl/nordic-empress.html
@@ -337,6 +337,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/nordic-prince.html
+++ b/ships/rcl/nordic-prince.html
@@ -290,6 +290,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/oasis-class-ship-tbn-2028.html
+++ b/ships/rcl/oasis-class-ship-tbn-2028.html
@@ -315,6 +315,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -339,6 +339,7 @@ updated: 2025-12-29
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2028.html
@@ -344,6 +344,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
+++ b/ships/rcl/quantum-ultra-class-ship-tbn-2029.html
@@ -344,6 +344,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -357,6 +357,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -352,6 +352,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -354,6 +354,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/song-of-america.html
+++ b/ships/rcl/song-of-america.html
@@ -187,6 +187,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/song-of-norway.html
+++ b/ships/rcl/song-of-norway.html
@@ -339,6 +339,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/sovereign-of-the-seas.html
+++ b/ships/rcl/sovereign-of-the-seas.html
@@ -331,6 +331,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -331,6 +331,7 @@ updated: 2025-12-27
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/splendour-of-the-seas.html
+++ b/ships/rcl/splendour-of-the-seas.html
@@ -355,6 +355,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/star-class-ship-tbn-2028.html
+++ b/ships/rcl/star-class-ship-tbn-2028.html
@@ -344,6 +344,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/star-of-the-seas.html
+++ b/ships/rcl/star-of-the-seas.html
@@ -353,6 +353,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/sun-viking.html
+++ b/ships/rcl/sun-viking.html
@@ -306,6 +306,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -332,6 +332,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -331,6 +331,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/viking-serenade.html
+++ b/ships/rcl/viking-serenade.html
@@ -307,6 +307,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -352,6 +352,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -331,6 +331,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -331,6 +331,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/rooms.html
+++ b/ships/rooms.html
@@ -198,6 +198,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/ships/template.html
+++ b/ships/template.html
@@ -199,6 +199,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/solo.html
+++ b/solo.html
@@ -405,6 +405,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/solo/accessible-cruising.html
+++ b/solo/accessible-cruising.html
@@ -157,6 +157,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/solo/freedom-of-your-own-wake.html
+++ b/solo/freedom-of-your-own-wake.html
@@ -157,6 +157,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/solo/in-the-wake-of-grief.html
+++ b/solo/in-the-wake-of-grief.html
@@ -222,6 +222,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/solo/solo-cruisers-companion.html
+++ b/solo/solo-cruisers-companion.html
@@ -176,6 +176,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/solo/solo-cruising-practical-guide.html
+++ b/solo/solo-cruising-practical-guide.html
@@ -136,6 +136,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/solo/visiting-the-united-states-before-your-cruise.html
+++ b/solo/visiting-the-united-states-before-your-cruise.html
@@ -133,6 +133,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/solo/why-i-started-solo-cruising.html
+++ b/solo/why-i-started-solo-cruising.html
@@ -141,6 +141,7 @@
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/stateroom-check.html
+++ b/stateroom-check.html
@@ -275,6 +275,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/terms.html
+++ b/terms.html
@@ -137,6 +137,7 @@ All work on this project is offered as a gift to God.
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/tools/port-tracker.html
+++ b/tools/port-tracker.html
@@ -64,6 +64,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/tools/ship-tracker.html
+++ b/tools/ship-tracker.html
@@ -76,6 +76,7 @@ Soli Deo Gloria
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>

--- a/travel.html
+++ b/travel.html
@@ -362,6 +362,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
             <a href="/ships.html">Ships</a>
             <a href="/restaurants.html">Restaurants &amp; Menus</a>
             <a href="/ports.html">Ports</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
             <a href="/drink-packages.html">Drink Packages</a>
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>


### PR DESCRIPTION
Created comprehensive guide to cruise ship internet connectivity:
- Quick setup guide for avoiding maritime roaming fees
- Comparison of Wi-Fi vs eSIM vs international plans
- Starlink at Sea coverage and reality check
- Cruise line pricing for RCL, NCL, Carnival, and MSC
- VPN and remote work considerations
- Money-saving tips and troubleshooting

Added page to Planning dropdown navigation across 702 site pages.
Follows ITW standards: ICP-Lite v1.4, WCAG 2.1 AA, Soli Deo Gloria.