### PR TITLE
Restructure ports.html with complete 333-port directory and enhanced …

### DIFF
--- a/assets/data/ports/port-summaries.json
+++ b/assets/data/ports/port-summaries.json
@@ -1,0 +1,5352 @@
+{
+  "generated": "2026-01-02T18:48:33.805Z",
+  "totalPorts": 333,
+  "ports": [
+    {
+      "slug": "abu-dhabi",
+      "name": "Abu Dhabi",
+      "description": "Abu Dhabi is the UAE's elegant capital — visit the awe-inspiring Sheikh Zayed Grand Mosque (free, modest dress required), explore world art at Louvre Abu Dhabi, or thrill at Ferrari World on Yas Island.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/abu-dhabi.html"
+    },
+    {
+      "slug": "acapulco",
+      "name": "Acapulco",
+      "description": "Acapulco is Mexico's legendary Pacific resort — don't miss the iconic La Quebrada cliff divers (1pm show fits cruise schedules), explore Fort San Diego's colonial legacy, and enjoy fresh ceviche on the bay.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/acapulco.html"
+    },
+    {
+      "slug": "adelaide",
+      "name": "Adelaide",
+      "description": "Adelaide is Australia's wine capital — gateway to 200+ cellar doors including legendary Barossa Valley ($150-250 tours).",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/adelaide.html"
+    },
+    {
+      "slug": "agadir",
+      "name": "Agadir",
+      "description": "Agadir is Morocco's modern beach resort — 10 km of Atlantic sand, Paradise Valley mountain oasis, massive Souk El Had market, and Kasbah ruins with sunset views.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/agadir.html"
+    },
+    {
+      "slug": "ajaccio",
+      "name": "Ajaccio (Corsica)",
+      "description": "Ajaccio is Napoleon's birthplace, rich with history, art, and Corsican charm.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/ajaccio.html"
+    },
+    {
+      "slug": "akureyri",
+      "name": "Akureyri, Iceland",
+      "description": "Akureyri offers world-class whale watching from the pier (€85-150), Goðafoss waterfall 30 minutes away (€80-120 tours), and Lake Mývatn geothermal wonders (€150-200 full-day).",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/akureyri.html"
+    },
+    {
+      "slug": "alesund",
+      "name": "Ålesund",
+      "description": "Ålesund is pure Art Nouveau fairy tale rebuilt after a 1904 fire – pastel buildings, turrets, and islands scattered like confetti in the fjord.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/alesund.html"
+    },
+    {
+      "slug": "amalfi",
+      "name": "Amalfi (Salerno)",
+      "description": "Salerno is the smart gateway to the Amalfi Coast – Positano, Amalfi, and Ravello without the insane tender crowds of Sorrento.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/amalfi.html"
+    },
+    {
+      "slug": "amber-cove",
+      "name": "Amber Cove",
+      "description": "Amber Cove is Carnival's purpose-built Dominican Republic port with a massive complimentary pool complex, zip lines ($49-89), and easy access to authentic Puerto Plata.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/amber-cove.html"
+    },
+    {
+      "slug": "amsterdam",
+      "name": "Amsterdam",
+      "description": "Amsterdam's cruise terminal is right behind Centraal Station — you step off and you're instantly in one of the most beautiful cities on earth.",
+      "region": "northern-europe",
+      "tier": 1,
+      "url": "/ports/amsterdam.html"
+    },
+    {
+      "slug": "anchorage",
+      "name": "Anchorage",
+      "description": "Anchorage is Alaska's gateway city — ships dock at Seward (2.",
+      "region": "alaska",
+      "tier": 2,
+      "url": "/ports/anchorage.html"
+    },
+    {
+      "slug": "antigua",
+      "name": "Antigua",
+      "description": "Antigua cruise port guide featuring Nelson's Dockyard UNESCO site, 365 beaches, English Harbour, Shirley Heights lookout, and Caribbean naval traditions.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/antigua.html"
+    },
+    {
+      "slug": "apia",
+      "name": "Apia, Samoa",
+      "description": "Apia cruise port guide featuring Robert Louis Stevenson Museum, To Sua Ocean Trench, Samoa Cultural Village, Papaseea Sliding Rocks, and authentic Polynesian culture.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/apia.html"
+    },
+    {
+      "slug": "aqaba",
+      "name": "Aqaba",
+      "description": "Aqaba cruise port guide featuring Petra day trips, Wadi Rum desert, Red Sea diving and snorkeling, and Jordan's ancient gateway to archaeological wonders.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/aqaba.html"
+    },
+    {
+      "slug": "aruba",
+      "name": "Aruba",
+      "description": "Aruba cruise port guide featuring Eagle Beach, Oranjestad Dutch colonial downtown, Arikok National Park desert landscapes, and Caribbean sunshine outside the hurricane belt.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/aruba.html"
+    },
+    {
+      "slug": "ascension",
+      "name": "Ascension Island",
+      "description": "Ascension Island cruise port guide featuring Green Mountain cloud forest, sea turtle nesting beaches, volcanic landscapes, and one of the most remote ports in the South Atlantic.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/ascension.html"
+    },
+    {
+      "slug": "athens",
+      "name": "Athens (Piraeus)",
+      "description": "Athens cruise port guide featuring the Acropolis, Parthenon, Ancient Agora, Plaka neighborhood, and the birthplace of Western democracy and philosophy.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/athens.html"
+    },
+    {
+      "slug": "auckland",
+      "name": "Auckland",
+      "description": "Auckland cruise port guide featuring Sky Tower views, Waiheke Island wine tours, Maori cultural performances, volcanic landscapes, and New Zealand's City of Sails adventure.",
+      "region": "pacific",
+      "tier": 1,
+      "url": "/ports/auckland.html"
+    },
+    {
+      "slug": "bali",
+      "name": "Bali (Benoa)",
+      "description": "Bali cruise port guide featuring Uluwatu temple kecak fire dance, Ubud rice terraces and monkey forest, Tanah Lot sunset temple, and Hindu spirituality on Indonesia's Island of the Gods.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/bali.html"
+    },
+    {
+      "slug": "baltimore",
+      "name": "Baltimore",
+      "description": "Baltimore is more than a cruise gateway — it's where the Star-Spangled Banner was born.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/baltimore.html"
+    },
+    {
+      "slug": "bangkok",
+      "name": "Bangkok / Laem Chabang",
+      "description": "First-person Bangkok cruise guide: Grand Palace's royal history, Temple of the Emerald Buddha, Wat Arun's porcelain-encrusted tower, Wat Pho's golden Reclining Buddha, street food crawls, and sunset rooftop bars.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/bangkok.html"
+    },
+    {
+      "slug": "bar-harbor",
+      "name": "Bar Harbor",
+      "description": "Bar Harbor is your gateway to Acadia National Park — rugged coastline, Cadillac Mountain sunrises, and lobster so fresh it's still mad about it.",
+      "region": "new-england",
+      "tier": 2,
+      "url": "/ports/bar-harbor.html"
+    },
+    {
+      "slug": "barbados",
+      "name": "Barbados",
+      "description": "First-person logbook guide to Barbados — UNESCO World Heritage Bridgetown, Mount Gay distillery (1703), St Nicholas Abbey, Carlisle Bay beaches, and the birthplace of rum punch.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/barbados.html"
+    },
+    {
+      "slug": "barcelona",
+      "name": "Barcelona",
+      "description": "Barcelona is a major embarkation port and Mediterranean highlight.",
+      "region": "mediterranean",
+      "tier": 1,
+      "url": "/ports/barcelona.html"
+    },
+    {
+      "slug": "bay-of-islands",
+      "name": "Bay of Islands, New Zealand",
+      "description": "First-person logbook guide to Bay of Islands, New Zealand — Waitangi Treaty Grounds, Hole in the Rock boat trips, Russell whaling heritage, wild dolphin swimming, Haruru Falls, and 144 subtropical islands where modern New Zealand began.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/bay-of-islands.html"
+    },
+    {
+      "slug": "belfast",
+      "name": "Belfast",
+      "description": "Belfast has completely transformed and now scores 4.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/belfast.html"
+    },
+    {
+      "slug": "belize",
+      "name": "Belize City",
+      "description": "Belize is the port where you skip the city and go full adventure – cave tubing through bat-filled caves, Great Blue Hole scenic flights, and Mayan ruins.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/belize.html"
+    },
+    {
+      "slug": "bergen",
+      "name": "Bergen",
+      "description": "Bergen is seven mountains, colorful Hanseatic wharf houses, and rain that somehow makes everything more beautiful – the gateway to the fjords.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/bergen.html"
+    },
+    {
+      "slug": "bermuda",
+      "name": "Bermuda",
+      "description": "Bermuda delivers pink sand shores at Horseshoe Bay, British-Caribbean charm, rum swizzles, and exceptional safety—all wrapped in mid-Atlantic beauty.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/bermuda.html"
+    },
+    {
+      "slug": "bilbao",
+      "name": "Bilbao",
+      "description": "Bilbao is living proof that architecture can save a city.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/bilbao.html"
+    },
+    {
+      "slug": "bodrum",
+      "name": "Bodrum, Turkey",
+      "description": "First-person logbook guide to Bodrum, Turkey — ancient Halicarnassus, the Mausoleum (Seven Wonders of the Ancient World), Castle of St.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/bodrum.html"
+    },
+    {
+      "slug": "bonaire",
+      "name": "Bonaire",
+      "description": "Bonaire is the Caribbean's diver's paradise – 85+ dive sites with 100+ feet visibility, entire coastline protected as marine park since 1979 (470+ fish species, 57 coral types).",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/bonaire.html"
+    },
+    {
+      "slug": "bora-bora",
+      "name": "Bora Bora",
+      "description": "First-person logbook guide to Bora Bora — the Pearl of the Pacific.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/bora-bora.html"
+    },
+    {
+      "slug": "bordeaux",
+      "name": "Bordeaux",
+      "description": "Bordeaux is golden stone, grand boulevards, and the wine capital of the world – with the stunning Cité du Vin museum shaped like a wine decanter.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/bordeaux.html"
+    },
+    {
+      "slug": "boston",
+      "name": "Boston",
+      "description": "Boston is history you can touch — Freedom Trail, Fenway (if in season), North End cannoli, and clam chowder that ruins all other chowder forever.",
+      "region": "new-england",
+      "tier": 1,
+      "url": "/ports/boston.html"
+    },
+    {
+      "slug": "brisbane",
+      "name": "Brisbane",
+      "description": "First-person logbook: Brisbane's Portside Wharf, South Bank riverside, scenic river cruises to Lone Pine Koala Sanctuary with 130+ koalas, and why Queensland's subtropical warmth makes this Australia's most welcoming port.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/brisbane.html"
+    },
+    {
+      "slug": "brunei",
+      "name": "Brunei",
+      "description": "First-person logbook guide to Bandar Seri Begawan, Brunei — golden mosques, stilted water villages, royal splendor, and navigating this serene sultanate.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/brunei.html"
+    },
+    {
+      "slug": "buenos-aires",
+      "name": "Buenos Aires",
+      "description": "First-person logbook guide to Buenos Aires — La Boca's colorful shipyard houses painted with leftover ship paint, Recoleta Cemetery where flowers always cover Evita's tomb, passionate tango born in immigrant milongas, and 13 million Porteños who made the Paris of South America distinctly Argentine.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/buenos-aires.html"
+    },
+    {
+      "slug": "busan",
+      "name": "Busan",
+      "description": "First-person logbook: Busan, South Korea's largest port — cliff-perched temples, colorful Gamcheon art village, legendary Jagalchi fish market, mountain monasteries, and the warmth of a city that never forgot the sea.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/busan.html"
+    },
+    {
+      "slug": "cabo-san-lucas",
+      "name": "Cabo San Lucas",
+      "description": "Cabo San Lucas is where desert cliffs plunge into two seas at the iconic Land's End arch.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/cabo-san-lucas.html"
+    },
+    {
+      "slug": "cadiz",
+      "name": "Cadiz",
+      "description": "Cádiz is the oldest continuously inhabited city in Western Europe, founded by Phoenicians in 1100 BC.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/cadiz.html"
+    },
+    {
+      "slug": "cagliari",
+      "name": "Cagliari (Sardinia)",
+      "description": "Cagliari is Sardinia's ancient capital (154,000 souls) built on Neolithic foundations—just 800m from your ship to medieval Castello towers, Bastione di Saint Remy panoramas, the 13th-century Cathedral, and 8km Poetto Beach that rivals the Caribbean.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/cagliari.html"
+    },
+    {
+      "slug": "cairns",
+      "name": "Cairns",
+      "description": "First-person logbook guide to Cairns — 1876 gold port, gateway to the 2,300km Great Barrier Reef and 180-million-year-old Daintree Rainforest, where two UNESCO sites meet at Cape Tribulation.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/cairns.html"
+    },
+    {
+      "slug": "callao",
+      "name": "Callao",
+      "description": "Callao is the port for Lima, Peru's capital and a UNESCO World Heritage Site.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/callao.html"
+    },
+    {
+      "slug": "cannes",
+      "name": "Cannes",
+      "description": "Cannes is red carpets, rosé on the beach, and the Croisette promenade that makes you feel like you're in a French movie – even without the film festival.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/cannes.html"
+    },
+    {
+      "slug": "cape-liberty",
+      "name": "Cape Liberty",
+      "description": "New York's smart cruiser alternative — stunning Statue of Liberty sailaway views, easier parking than Manhattan, and the entire city just across the harbor.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/cape-liberty.html"
+    },
+    {
+      "slug": "cape-town",
+      "name": "Cape Town",
+      "description": "First-person logbook guide to Cape Town — Table Mountain cable car since 1929, Robben Island tours with former prisoners, historic Constantia wine estates from 1685, Cape of Good Hope, and South Africa's legislative capital where two oceans meet.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/cape-town.html"
+    },
+    {
+      "slug": "capri",
+      "name": "Capri, Italy",
+      "description": "First-person logbook guide to Capri — Blue Grotto sea cave with glowing azure water, Monte Solaro panoramas, La Piazzetta's dolce vita lifestyle, Faraglioni rock formations, and the island paradise that captivated emperors and artists.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/capri.html"
+    },
+    {
+      "slug": "cartagena-spain",
+      "name": "Cartagena, Spain",
+      "description": "Cartagena is a perfectly preserved Roman theater, Art Nouveau buildings, and a harbor full of history – Spain's most surprising cruise port.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/cartagena-spain.html"
+    },
+    {
+      "slug": "cartagena",
+      "name": "Cartagena",
+      "description": "Cartagena's walled city is a UNESCO jewel box of colonial architecture, colorful balconies dripping with bougainvillea, emerald museums, and street life that makes you want to dance salsa at 3 p.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/cartagena.html"
+    },
+    {
+      "slug": "casablanca",
+      "name": "Casablanca",
+      "description": "Casablanca is the massive Hassan II Mosque rising from the Atlantic – one of the few mosques non-Muslims can enter – plus art-deco architecture and real Moroccan city energy.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/casablanca.html"
+    },
+    {
+      "slug": "catania",
+      "name": "Catania",
+      "description": "Catania is the \"Black Baroque\" city — born Greek in 729 BC, destroyed by Etna and earthquake, rebuilt in dark lava stone as a UNESCO World Heritage masterpiece.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/catania.html"
+    },
+    {
+      "slug": "cephalonia",
+      "name": "Cephalonia (Kefalonia), Greece - Largest Ionian Island",
+      "description": "First-person logbook entry from Cephalonia: Greece's largest Ionian island with 50,000 years of history, Melissani Cave's crystal waters, Myrtos Beach, ancient castles, Drogarati Cave, and resilience after the 1953 earthquake.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/cephalonia.html"
+    },
+    {
+      "slug": "charleston",
+      "name": "Charleston",
+      "description": "Charleston is America's most charming cruise homeport — where Fort Sumter guards the harbor, Rainbow Row lines the waterfront, and Lowcountry hospitality makes arriving a day early absolutely essential.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/charleston.html"
+    },
+    {
+      "slug": "charlottetown",
+      "name": "Charlottetown",
+      "description": "Birthplace of Canada, Anne of Green Gables, red sand beaches, and Cows ice cream that ruins you for all other ice cream.",
+      "region": "new-england",
+      "tier": 2,
+      "url": "/ports/charlottetown.html"
+    },
+    {
+      "slug": "cherbourg",
+      "name": "Cherbourg",
+      "description": "Cherbourg is umbrellas on the promenade, the largest artificial harbor in the world, and perfect Normandy charm with D-Day beaches an easy drive away.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/cherbourg.html"
+    },
+    {
+      "slug": "christchurch",
+      "name": "Christchurch (Lyttelton)",
+      "description": "Discover Christchurch and Lyttelton Port: New Zealand's oldest established city, the Garden City rebuilt after devastating 2011 earthquakes.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/christchurch.html"
+    },
+    {
+      "slug": "civitavecchia",
+      "name": "Civitavecchia (Rome)",
+      "description": "Civitavecchia is Rome's cruise port, 80km and 90 minutes from the city.",
+      "region": "mediterranean",
+      "tier": 1,
+      "url": "/ports/civitavecchia.html"
+    },
+    {
+      "slug": "cochin",
+      "name": "Cochin (Kochi), India",
+      "description": "First-person logbook guide to Cochin (Kochi), India — Chinese fishing nets, Fort Kochi colonial heritage, Mattancherry Palace, Jewish synagogue, Kathakali dance, Kerala backwaters, and discovering where spice trade history meets living tradition.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/cochin.html"
+    },
+    {
+      "slug": "cococay",
+      "name": "Perfect Day at CocoCay — Royal Caribbean's Private Island",
+      "description": "Perfect Day at CocoCay is Royal Caribbean's $250 million private island paradise in the Bahamas — featuring the tallest waterslides in North America, the Caribbean's largest freshwater pool, and pristine beaches.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/cococay.html"
+    },
+    {
+      "slug": "colombo",
+      "name": "Colombo, Sri Lanka",
+      "description": "First-person logbook guide to Colombo, Sri Lanka — Gangaramaya Temple, elephant orphanages, Ceylon tea country, Pettah Market, and exploring the island where ancient wisdom meets tropical beauty.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/colombo.html"
+    },
+    {
+      "slug": "colon",
+      "name": "Colón",
+      "description": "First-person logbook guide to Colón, Panama — witnessing the Panama Canal's Agua Clara Locks, Fort San Lorenzo UNESCO World Heritage site, Portobelo Spanish colonial history, Gamboa Rainforest adventures, and experiencing one of the world's great engineering wonders.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/colon.html"
+    },
+    {
+      "slug": "copenhagen",
+      "name": "Copenhagen",
+      "description": "Copenhagen is consistently voted the #1 Northern Europe port — colorful Nyhavn, magical Tivoli Gardens, the Little Mermaid, and smørrebrød sandwiches.",
+      "region": "northern-europe",
+      "tier": 1,
+      "url": "/ports/copenhagen.html"
+    },
+    {
+      "slug": "corfu",
+      "name": "Corfu",
+      "description": "Corfu Old Town is Venetian charm with British and French twists, surrounded by emerald hills and some of the prettiest beaches in the Ionian.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/corfu.html"
+    },
+    {
+      "slug": "corinto",
+      "name": "Corinto",
+      "description": "First-person logbook guide to Corinto, Nicaragua — exploring colonial León's UNESCO heritage churches and cathedral, volcano boarding down Cerro Negro's black slopes, visiting Las Peñitas beach, experiencing Nicaragua's revolutionary history, authentic local markets, and discovering Central America's most authentic and least-touristed destination.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/corinto.html"
+    },
+    {
+      "slug": "cork",
+      "name": "Cork/Cobh",
+      "description": "Cobh is the heartbreakingly beautiful last port of call for the Titanic and a million Irish emigrants, with the world's steepest streets and a cathedral that towers over everything.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/cork.html"
+    },
+    {
+      "slug": "costa-maya",
+      "name": "Costa Maya",
+      "description": "Costa Maya is the perfect \"Mayan Riviera meets chill beach town\" day—crystal-clear snorkeling on the Mesoamerican Reef, authentic (less-touristy) ruins at Chacchoben, and the laid-back fishing village of Mahahual make it one of Mexico's best cruise stops.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/costa-maya.html"
+    },
+    {
+      "slug": "cozumel",
+      "name": "Cozumel — Mexico's Premier",
+      "description": "First-person logbook guide to Cozumel — snorkeling, beach clubs, Mayan culture, and why it's the Caribbean's most visited cruise destination.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/cozumel.html"
+    },
+    {
+      "slug": "curacao",
+      "name": "Curaçao",
+      "description": "Curaçao has the prettiest port entrance in the Caribbean with Handelskade's rainbow buildings reflecting in the water.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/curacao.html"
+    },
+    {
+      "slug": "da-nang",
+      "name": "Da Nang",
+      "description": "First-person logbook guide to Da Nang — where a 666-meter dragon breathes fire over the Han River, three UNESCO World Heritage sites await within an hour's drive, and the spirit of the ancient Champa kingdom still whispers through marble caves and jungle-shrouded temples.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/da-nang.html"
+    },
+    {
+      "slug": "dakar",
+      "name": "Dakar, Senegal",
+      "description": "First-person logbook guide to Dakar, Senegal — Gorée Island UNESCO World Heritage site, African Renaissance Monument, Lac Rose Pink Lake, Sandaga Market, Grand Mosque, and experiencing Senegal's legendary Teranga hospitality at Africa's westernmost point.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/dakar.html"
+    },
+    {
+      "slug": "darwin",
+      "name": "Darwin",
+      "description": "First-person logbook guide to Darwin, Australia — gateway to the Top End, saltwater crocodile territory, Kakadu's UNESCO wetlands and Aboriginal rock art, WWII bombing history, Adelaide River cruises, and Mindil Beach sunset traditions.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/darwin.html"
+    },
+    {
+      "slug": "doha",
+      "name": "Doha, Qatar",
+      "description": "First-person logbook guide to Doha, Qatar — Museum of Islamic Art, Souq Waqif traditional market, Corniche waterfront promenade, Katara Cultural Village, and discovering where ancient Arabian traditions flourish beneath gleaming skyscrapers.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/doha.html"
+    },
+    {
+      "slug": "dominica",
+      "name": "Dominica (Waitukubuli)",
+      "description": "Waitukubuli – \"tall is her body\" – Dominica is the Nature Island with 9 active volcanoes, 365 rivers, and rainforests covering 2/3 of the island.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/dominica.html"
+    },
+    {
+      "slug": "doubtful-sound",
+      "name": "Doubtful Sound Guide — New Zealand's Deepest Fjord Scenic Cruising",
+      "description": "Doubtful Sound is New Zealand's largest and deepest fjord — 40 kilometers of pristine wilderness where cruise ships glide through dramatic scenery featuring hundreds of waterfalls, resident dolphins, and the unforgettable \"Sound of Silence\" tradition.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/doubtful-sound.html"
+    },
+    {
+      "slug": "dover",
+      "name": "Dover",
+      "description": "Dover is white cliffs, a massive medieval castle, and the gateway to London or Canterbury – England's front door.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/dover.html"
+    },
+    {
+      "slug": "dravuni",
+      "name": "Dravuni Island",
+      "description": "First-person logbook guide to Dravuni Island, Fiji — authentic village life, traditional kava ceremony welcomes, pristine coral beach snorkeling, and experiencing genuine Fijian hospitality on an island of 100 souls.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/dravuni.html"
+    },
+    {
+      "slug": "dubai",
+      "name": "Dubai",
+      "description": "First-person logbook guide to Dubai—Mina Rashid terminal, Burj Khalifa's soaring heights, Palm Jumeirah, historic Al Fahidi quarter, Gold Souk, and a city that tells two stories at once: heritage trading port and modern global hub.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/dubai.html"
+    },
+    {
+      "slug": "dublin",
+      "name": "Dublin & Cobh",
+      "description": "Ireland is where cruisers report the friendliest people on the planet (4.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/dublin.html"
+    },
+    {
+      "slug": "dubrovnik",
+      "name": "Dubrovnik",
+      "description": "Dubrovnik is Lord Byron's \"Pearl of the Adriatic\"—a UNESCO-listed city with 2km of 13th-century walls encircling 700 years of maritime republic legacy, where red roofs cascade down to the impossibly blue Adriatic and every stone tells a story of independence and resilience.",
+      "region": "mediterranean",
+      "tier": 1,
+      "url": "/ports/dubrovnik.html"
+    },
+    {
+      "slug": "dunedin",
+      "name": "Dunedin",
+      "description": "First-person logbook guide to Dunedin's Scottish soul — 1848 founding, gold rush prosperity, ornate Railway Station 'Gingerbread House', Larnach Castle on Otago Peninsula, royal albatross colony, hoiho penguins, and Victorian grandeur at the end of the world.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/dunedin.html"
+    },
+    {
+      "slug": "durban",
+      "name": "Durban, South Africa - Sunny Beaches and Zulu Heritage",
+      "description": "Discover Durban's Golden Mile beaches, rich Indian heritage, and Zulu culture.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/durban.html"
+    },
+    {
+      "slug": "easter-island",
+      "name": "Easter Island (Rapa Nui)",
+      "description": "First-person logbook guide to Easter Island (Rapa Nui), Chile — 887 moai statues at Rano Raraku quarry, Ahu Tongariki's 15 restored moai, Polynesian culture, volcanic landscapes, and discovering the world's most remote inhabited island in the South Pacific.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/easter-island.html"
+    },
+    {
+      "slug": "edinburgh",
+      "name": "Edinburgh/Leith",
+      "description": "First-person logbook guide to Edinburgh via Leith, South Queensferry, Newhaven, or Rosyth — Edinburgh Castle commanding from volcanic Castle Rock since the 2nd century, the Royal Mile's 1.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/edinburgh.html"
+    },
+    {
+      "slug": "endicott-arm",
+      "name": "Endicott Arm & Dawes Glacier Guide — Alaska",
+      "description": "Endicott Arm is a spectacular 30-mile Alaskan fjord ending at Dawes Glacier—often used as a Tracy Arm alternative, but many passengers prefer it for its intimate glacier views, abundant seal colonies, and fewer crowds.",
+      "region": "alaska",
+      "tier": 2,
+      "url": "/ports/endicott-arm.html"
+    },
+    {
+      "slug": "ensenada",
+      "name": "Ensenada",
+      "description": "Ensenada cruise port guide featuring Valle de Guadalupe wine country, La Bufadora blowhole, legendary fish tacos, and Hussong's Cantina birthplace of the margarita.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/ensenada.html"
+    },
+    {
+      "slug": "falkland-islands",
+      "name": "Falkland Islands (Port Stanley)",
+      "description": "Falkland Islands cruise port guide featuring King penguin colonies at Volunteer Point, windswept Stanley town, 1982 war memorials, and wildlife encounters at the edge of the South Atlantic.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/falkland-islands.html"
+    },
+    {
+      "slug": "fiji",
+      "name": "Fiji (Lautoka)",
+      "description": "First-person logbook guide to Lautoka, Fiji — 333 islands with 3,500 years of Melanesian heritage, kava ceremonies, firewalking traditions, Sigatoka Sand Dunes archaeology, world-class diving in the Soft Coral Capital, and experiencing authentic Fijian bula hospitality.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/fiji.html"
+    },
+    {
+      "slug": "flam",
+      "name": "Flåm",
+      "description": "First-person logbook guide to Flåm — the legendary Flåmsbana Railway (20 years in the making), Stegastein viewpoint 650m above Aurlandsfjord, UNESCO Nærøyfjord cruises, and Norway's most dramatic fjord scenery in the heart of Sognefjord country.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/flam.html"
+    },
+    {
+      "slug": "fortaleza",
+      "name": "Fortaleza",
+      "description": "First-person logbook guide to Fortaleza, Brazil — exploring Beach Park's legendary waterslides, Praia do Futuro's lobster barracas, the historic center's colonial architecture, traditional jangada sailboats, and the laid-back beach culture of Ceará's capital.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/fortaleza.html"
+    },
+    {
+      "slug": "freeport",
+      "name": "Freeport (Grand Bahama)",
+      "description": "Freeport on Grand Bahama offers pristine Gold Rock Beach, excellent snorkeling at Deadman's Reef near Port Lucaya Marketplace, and laid-back Bahamian vibes.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/freeport.html"
+    },
+    {
+      "slug": "fremantle",
+      "name": "Fremantle",
+      "description": "First-person logbook guide to Fremantle — UNESCO World Heritage convict prison with haunting tunnel tours, markets trading since 1897, bohemian 'Freo' atmosphere, and Perth's historic gateway at the Swan River mouth.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/fremantle.html"
+    },
+    {
+      "slug": "ft-lauderdale",
+      "name": "Fort Lauderdale",
+      "description": "Florida's second-busiest cruise port with 4M+ passengers annually — easier logistics than Miami, 7 miles of pristine Atlantic coastline, Las Olas Boulevard dining, and Water Taxi tours through 300+ miles of canals.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/ft-lauderdale.html"
+    },
+    {
+      "slug": "fukuoka",
+      "name": "Fukuoka",
+      "description": "First-person logbook guide to Fukuoka — Hakata Port's rich trading history with China and Korea, authentic tonkotsu ramen with kaedama noodle refills, yatai food stalls on Nakasu Island, Kushida Shrine's Yamakasa festival, and Sumiyoshi's ancient Shinto heritage.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/fukuoka.html"
+    },
+    {
+      "slug": "funchal",
+      "name": "Funchal, Madeira",
+      "description": "First-person logbook guide to Funchal, Madeira — capital of this volcanic Atlantic island for five centuries.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/funchal.html"
+    },
+    {
+      "slug": "galveston",
+      "name": "Galveston",
+      "description": "America's fourth busiest cruise port and Texas's gateway to the Western Caribbean.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/galveston.html"
+    },
+    {
+      "slug": "gatun-lake",
+      "name": "Gatun Lake Guide — Panama Canal Transit Experience",
+      "description": "Gatun Lake is the massive man-made freshwater lake at the heart of the Panama Canal.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/gatun-lake.html"
+    },
+    {
+      "slug": "gdansk",
+      "name": "Gdansk",
+      "description": "Gdansk is amber, solidarity, and perfectly rebuilt Hanseatic façades along the Motława River – the phoenix city that rose from ashes.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/gdansk.html"
+    },
+    {
+      "slug": "geiranger",
+      "name": "Geiranger Fjord",
+      "description": "Logbook reflections from Geirangerfjord — UNESCO World Heritage site sculpted 120,000 years ago, where Seven Sisters waterfall plunges 410m and abandoned farms tell stories of resilience and loss.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/geiranger.html"
+    },
+    {
+      "slug": "genoa",
+      "name": "Genoa",
+      "description": "Genoa is the underrated grand old lady of the Italian Riviera – massive palazzi, Europe's biggest medieval center, and the best focaccia you'll ever taste.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/genoa.html"
+    },
+    {
+      "slug": "gibraltar",
+      "name": "Gibraltar",
+      "description": "Gibraltar is a British Overseas Territory since 1704, home to the legendary Rock—one of Hercules' Pillars—rising 1,400 ft above the Strait.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/gibraltar.html"
+    },
+    {
+      "slug": "gijon",
+      "name": "Gijón",
+      "description": "Gijón is Asturias' soul on the Bay of Biscay — Celtic Green Coast, Eduardo Chillida's horizon sculpture, Roman baths, and cider culture.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/gijon.html"
+    },
+    {
+      "slug": "glacier-bay",
+      "name": "Glacier Bay — Alaska's Crown Jewel Scenic Cruising",
+      "description": "Glacier Bay is the crown jewel of Alaska cruising — 65 miles of fjord, 15 tidewater glaciers, park rangers narrating from the bow, and the 250-foot Margerie Glacier wall calving thunder into the sea.",
+      "region": "alaska",
+      "tier": 1,
+      "url": "/ports/glacier-bay.html"
+    },
+    {
+      "slug": "goa",
+      "name": "Goa (Mormugao)",
+      "description": "First-person logbook guide to Mormugao Port, Goa — UNESCO World Heritage churches in Old Goa, Portuguese colonial architecture, golden beaches from Anjuna to Benaulim, vindaloo and feni, exploring India's smallest state shaped by 451 years of Portuguese rule.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/goa.html"
+    },
+    {
+      "slug": "gothenburg",
+      "name": "Gothenburg",
+      "description": "Gothenburg is trams, seafood, and Scandinavian cool – the friendliest big city in Sweden with an archipelago of car-free islands 20 minutes away.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/gothenburg.html"
+    },
+    {
+      "slug": "gran-canaria",
+      "name": "Gran Canaria (Las Palmas)",
+      "description": "First-person logbook guide to Las Palmas, Gran Canaria — stunning Maspalomas Dunes, colonial Vegueta quarter, Casa de Colón, Playa de las Canteras beach, and discovering the Canary Islands' most diverse landscape.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/gran-canaria.html"
+    },
+    {
+      "slug": "grand-cayman",
+      "name": "Grand Cayman",
+      "description": "Grand Cayman delivers Stingray City sandbar (bucket list!",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/grand-cayman.html"
+    },
+    {
+      "slug": "grand-turk",
+      "name": "Grand Turk",
+      "description": "Grand Turk delivers the postcard Caribbean fantasy: turquoise water so clear you can see starfish from the ship, perfect Governor's Beach, and some of the best wall-diving/snorkeling in the hemisphere.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/grand-turk.html"
+    },
+    {
+      "slug": "greenock",
+      "name": "Greenock",
+      "description": "First-person logbook guide to Greenock — Scotland's gateway port for Glasgow Cathedral, Kelvingrove Museum, Loch Lomond, Stirling Castle, and discovering the heart of Scotland from this Clyde estuary port.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/greenock.html"
+    },
+    {
+      "slug": "grenada",
+      "name": "Grenada",
+      "description": "Grenada produces 1/3 of the world's nutmeg and is the true Spice Isle.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/grenada.html"
+    },
+    {
+      "slug": "guadeloupe",
+      "name": "Guadeloupe",
+      "description": "Guadeloupe is a butterfly-shaped island paradise where an active volcano meets pristine beaches, French boulangeries serve pain au chocolat steps from turquoise water, and the island Columbus called \"Karukéra\" (Island of Beautiful Waters) delivers authentic French-Caribbean flair.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/guadeloupe.html"
+    },
+    {
+      "slug": "guam",
+      "name": "Guam",
+      "description": "Guam delivers profound WWII history at War in the Pacific National Historical Park, 4,000 years of Chamorro culture, world-class diving on sunken wrecks, and Tumon Bay's pristine beaches — America's furthest west territory, where the day begins.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/guam.html"
+    },
+    {
+      "slug": "guayaquil",
+      "name": "Guayaquil",
+      "description": "Guayaquil is Ecuador's largest city and main Galápagos gateway, featuring Malecón 2000 riverfront, Las Peñas historic hillside district (444 steps), iguana-filled parks, coastal cuisine, and vibrant urban renewal.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/guayaquil.html"
+    },
+    {
+      "slug": "ha-long-bay",
+      "name": "Ha Long Bay, Vietnam",
+      "description": "First-person logbook guide to Ha Long Bay, Vietnam — UNESCO World Heritage limestone karsts, Sung Sot Cave exploration, kayaking hidden lagoons, Cua Van floating village, and sailing through Vietnam's emerald dreamscape.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/ha-long-bay.html"
+    },
+    {
+      "slug": "haifa",
+      "name": "Haifa, Israel",
+      "description": "First-person logbook guide to Haifa, Israel — UNESCO Bahá'í Gardens, day tours to Jerusalem and Bethlehem, Nazareth and the Sea of Galilee, ancient Caesarea, and the profound experience of walking where biblical history unfolded.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/haifa.html"
+    },
+    {
+      "slug": "haines",
+      "name": "Haines — Alaska's Hidden Gem for Eagles & Wilderness",
+      "description": "Haines is Alaska's hidden gem — home to the world's largest bald eagle gathering, authentic small-town charm, stunning mountain scenery, and a genuine frontier atmosphere without the cruise-ship crowds.",
+      "region": "alaska",
+      "tier": 2,
+      "url": "/ports/haines.html"
+    },
+    {
+      "slug": "hakodate",
+      "name": "Hakodate",
+      "description": "Hakodate is where Japan opened to the world — climb Mount Hakodate for million-dollar night views, feast on uni and ikura at the 5am market, wander Western-style streets where Russian churches meet Buddhist temples, and ride vintage streetcars through history.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/hakodate.html"
+    },
+    {
+      "slug": "halifax",
+      "name": "Halifax",
+      "description": "Halifax is friendly, walkable, and has the best waterfront boardwalk in Atlantic Canada.",
+      "region": "new-england",
+      "tier": 1,
+      "url": "/ports/halifax.html"
+    },
+    {
+      "slug": "hamburg",
+      "name": "Hamburg",
+      "description": "Explore Hamburg's UNESCO Speicherstadt warehouses, architectural marvel Elbphilharmonie, and maritime heritage through a sailor's reflective lens.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/hamburg.html"
+    },
+    {
+      "slug": "harvest-caye",
+      "name": "Harvest Caye",
+      "description": "Harvest Caye port guide — Norwegian Cruise Line's 75-acre private island in Belize with lagoon beach, zipline tours, wildlife sanctuary, pool complex, and Caribbean island relaxation.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/harvest-caye.html"
+    },
+    {
+      "slug": "helsinki",
+      "name": "Helsinki",
+      "description": "Helsinki is the underrated Nordic gem — clean, friendly, and packed with design.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/helsinki.html"
+    },
+    {
+      "slug": "heraklion",
+      "name": "Heraklion (Crete)",
+      "description": "Heraklion is the gateway to Knossos — Europe's oldest palace, birthplace of the Minotaur myth, and the only place you'll see 4,000-year-old frescoes still glowing with color.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/heraklion.html"
+    },
+    {
+      "slug": "hilo",
+      "name": "Hilo",
+      "description": "Hilo is waterfalls every five minutes, active volcanoes, and the greenest, rainiest, most authentic side of the Big Island.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/hilo.html"
+    },
+    {
+      "slug": "hiroshima",
+      "name": "Hiroshima",
+      "description": "First-person logbook guide to Hiroshima — where August 6, 1945 transformed a city into a messenger of peace.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/hiroshima.html"
+    },
+    {
+      "slug": "ho-chi-minh-city",
+      "name": "Ho Chi Minh City",
+      "description": "First-person logbook guide to Ho Chi Minh City via Phu My port — Cu Chi Tunnels' underground war history, French colonial architecture by Gustave Eiffel, Reunification Palace, and the irrepressible energy of Vietnam's largest city.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/ho-chi-minh-city.html"
+    },
+    {
+      "slug": "ho-chi-minh",
+      "name": "Ho Chi Minh City (Saigon)",
+      "description": "First-person guide to Ho Chi Minh City cruise port: War Remnants Museum, Cu Chi Tunnels, Notre-Dame Cathedral, vibrant markets, and iconic street food.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/ho-chi-minh.html"
+    },
+    {
+      "slug": "hobart",
+      "name": "Hobart",
+      "description": "First-person logbook guide to Hobart — founded 1804 as penal colony, transformed by MONA (Australia's largest private museum), Salamanca's Georgian warehouses, Mount Wellington's 1,271m summit, gateway to Antarctica, Cascade Brewery (1824), and Tasmania's wild beauty.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/hobart.html"
+    },
+    {
+      "slug": "holyhead",
+      "name": "Holyhead",
+      "description": "Holyhead is the gateway to Snowdonia and Anglesey – mountains, castles, and the Welsh village with the longest name in Europe.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/holyhead.html"
+    },
+    {
+      "slug": "honfleur",
+      "name": "Honfleur",
+      "description": "Honfleur is the prettiest harbor in Normandy – colorful tall houses reflected in the Vieux Bassin and the birthplace of Impressionism.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/honfleur.html"
+    },
+    {
+      "slug": "hong-kong",
+      "name": "Hong Kong",
+      "description": "First-person guide to Hong Kong cruise port: Victoria Harbour's colonial history, historic Star Ferry (1888), Victoria Peak tram, Temple Street Night Market, and the contrast between ancient fishing villages and modern skyscrapers.",
+      "region": "asia",
+      "tier": 1,
+      "url": "/ports/hong-kong.html"
+    },
+    {
+      "slug": "honolulu",
+      "name": "Honolulu",
+      "description": "Honolulu gives you Waikiki's iconic golden sand, Pearl Harbor's solemn memorials, and Diamond Head's panoramic payoff — the one Hawaiian port where you can actually do it all in a single day.",
+      "region": "pacific",
+      "tier": 1,
+      "url": "/ports/honolulu.html"
+    },
+    {
+      "slug": "huatulco",
+      "name": "Huatulco",
+      "description": "Huatulco is Mexico's eco-planned coastal paradise—nine protected bays with pristine national park snorkeling, authentic Oaxacan cuisine in La Crucecita, and coffee plantation tours into the Sierra Madre.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/huatulco.html"
+    },
+    {
+      "slug": "hubbard-glacier",
+      "name": "Hubbard Glacier — North America's Largest Tidewater Glacier",
+      "description": "Hubbard Glacier is North America's largest tidewater glacier — a 6-mile wall of ancient ice rising 400 feet above Yakutat Bay.",
+      "region": "alaska",
+      "tier": 2,
+      "url": "/ports/hubbard-glacier.html"
+    },
+    {
+      "slug": "hurghada",
+      "name": "Hurghada, Egypt: Red Sea Resort and Marine Life Haven -",
+      "description": "Discover Hurghada's vibrant coral reefs, Giftun Islands marine park, desert adventures, and the gateway to ancient Luxor.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/hurghada.html"
+    },
+    {
+      "slug": "hvar",
+      "name": "Hvar, Croatia",
+      "description": "First-person logbook guide to Hvar, Croatia — lavender fields, Stari Grad Plain UNESCO site, Fortica fortress, Europe's first public theater, Pakleni Islands, and exploring the sunniest place in Croatia.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/hvar.html"
+    },
+    {
+      "slug": "ibiza",
+      "name": "Ibiza",
+      "description": "Ibiza reveals 2,600+ years of history: Phoenician Ibossim (654 BCE), Puig des Molins necropolis (best-preserved ancient cemetery in Mediterranean), UNESCO-listed Renaissance Dalt Vila (1999), mythic Es Vedrà island, Formentera's turquoise beaches (30-minute ferry), and legendary club scene.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/ibiza.html"
+    },
+    {
+      "slug": "icy-strait-point",
+      "name": "Icy Strait Point — Alaska's Authentic Tlingit Port",
+      "description": "Icy Strait Point is Alaska's most authentic cruise experience — 100% Huna Tlingit-owned, world-class whale watching, the world's longest zipline, and all profits stay with the local Indigenous community.",
+      "region": "alaska",
+      "tier": 2,
+      "url": "/ports/icy-strait-point.html"
+    },
+    {
+      "slug": "incheon",
+      "name": "Incheon, South Korea - Gateway Port & Historic Landing Site",
+      "description": "First-hand account of Incheon, South Korea - gateway to Seoul, historic treaty port, and site of the pivotal Korean War landing.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/incheon.html"
+    },
+    {
+      "slug": "invergordon",
+      "name": "Invergordon",
+      "description": "Invergordon is the gateway to Loch Ness, Inverness, and the Highlands – dramatic glens, castles, and the best chance for Nessie sightings from a cruise ship.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/invergordon.html"
+    },
+    {
+      "slug": "istanbul",
+      "name": "Istanbul",
+      "description": "First-person logbook guide to Istanbul — Hagia Sophia, Blue Mosque, Grand Bazaar, Bosphorus cruise, and the ancient meeting point of Europe and Asia.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/istanbul.html"
+    },
+    {
+      "slug": "jacksonville",
+      "name": "Jacksonville",
+      "description": "Jacksonville offers a low-key Florida cruise experience with beautiful Atlantic beaches, manageable parking, and easy access for Southeast cruisers.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/jacksonville.html"
+    },
+    {
+      "slug": "jamaica",
+      "name": "Jamaica (Falmouth)",
+      "description": "Jamaica is all about Dunn's River Falls climbing, Blue Hole cliff jumping, and the best jerk chicken you'll ever eat at Scotchies.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/jamaica.html"
+    },
+    {
+      "slug": "jeju",
+      "name": "Jeju Island, South Korea",
+      "description": "First-person logbook guide to Jeju Island, South Korea — UNESCO triple crown volcanic landscapes, Manjanggul lava tubes, Seongsan Sunrise Peak, Hallasan Mountain, haenyeo sea women divers, and exploring Korea's mystical island paradise.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/jeju.html"
+    },
+    {
+      "slug": "juneau",
+      "name": "Juneau — Alaska's Adventure Capital",
+      "description": "Juneau is Alaska's capital and adventure heart — Mendenhall Glacier, legendary whale watching, and stunning fjord scenery make it consistently the highest-rated Alaska port among cruisers, scoring 4.",
+      "region": "alaska",
+      "tier": 1,
+      "url": "/ports/juneau.html"
+    },
+    {
+      "slug": "ketchikan",
+      "name": "Ketchikan — Alaska's First City",
+      "description": "Ketchikan is Alaska's First City and most walkable cruise port — Creek Street's colorful boardwalks, world-class totem poles, and Misty Fjords flightseeing that makes you believe in something bigger than yourself.",
+      "region": "alaska",
+      "tier": 1,
+      "url": "/ports/ketchikan.html"
+    },
+    {
+      "slug": "key-west",
+      "name": "Key West",
+      "description": "Key West is quirky, colorful, and 100% unfiltered America with roosters roaming free, six-toed cats, and the best key lime pie on the planet.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/key-west.html"
+    },
+    {
+      "slug": "kiel",
+      "name": "Kiel",
+      "description": "Kiel is the sailing capital of Germany – Olympic harbor, massive locks, and the world's busiest canal right at your gangway.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/kiel.html"
+    },
+    {
+      "slug": "kirkwall",
+      "name": "Kirkwall",
+      "description": "Kirkwall is 5,000 years of continuous history – Neolithic villages older than the pyramids, Viking cathedrals, and the best whisky in Scotland.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/kirkwall.html"
+    },
+    {
+      "slug": "klaipeda",
+      "name": "Klaipeda",
+      "description": "First-person logbook guide to Klaipeda, Lithuania — UNESCO Curonian Spit sand dunes, Hill of Witches sculpture trail, German half-timbered Old Town, Baltic beaches at Smiltynė, and discovering Lithuania's only seaport.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/klaipeda.html"
+    },
+    {
+      "slug": "kobe",
+      "name": "Kobe, Japan",
+      "description": "First-person logbook guide to Kobe, Japan — rebuilt after the 1995 earthquake, gateway opened to foreign trade in the 1860s, featuring Kitano's Meiji-era mansions, Nada's seven-century sake tradition, Kyoto's golden temples, Osaka's neon energy, world-famous Kobe beef, and the resilient spirit of a harbor city that welcomed the world.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/kobe.html"
+    },
+    {
+      "slug": "koh-samui",
+      "name": "Koh Samui, Thailand",
+      "description": "First-person logbook guide to Koh Samui tender port — Big Buddha Temple, Wat Plai Laem, Chaweng Beach, Na Muang Waterfalls, and exploring Thailand's tropical island of golden statues and gentle hospitality.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/koh-samui.html"
+    },
+    {
+      "slug": "komodo",
+      "name": "Komodo (Indonesia)",
+      "description": "First-person logbook guide to Komodo, Indonesia — tender port to Komodo National Park, face-to-face encounters with prehistoric dragons on Rinca and Komodo islands, volcanic landscapes, and trekking through one of Earth's last untamed wilderness areas.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/komodo.html"
+    },
+    {
+      "slug": "kona",
+      "name": "Kailua-Kona",
+      "description": "Kailua-Kona is historic villages, world-famous coffee, and one of the planet's best night manta experiences – all from a walkable/tender port.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/kona.html"
+    },
+    {
+      "slug": "koper",
+      "name": "Koper",
+      "description": "Koper is a miniature Venice with Slovenian prices – Venetian palaces, Tito Square, and the entire Istrian coast waiting 20 minutes away.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/koper.html"
+    },
+    {
+      "slug": "kota-kinabalu",
+      "name": "Kota Kinabalu, Malaysia: Borneo Gateway & Mount Kinabalu Views",
+      "description": "A reflective cruise port guide to Kota Kinabalu, Sabah - where Borneo's highest peak meets turquoise marine parks, indigenous cultures, and the vibrant heart of Malaysian Borneo.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/kota-kinabalu.html"
+    },
+    {
+      "slug": "kotor",
+      "name": "Kotor",
+      "description": "Kotor is a medieval town tucked into Europe's southernmost fjord with mountains plunging straight into the sea — dramatic doesn't begin to describe it.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/kotor.html"
+    },
+    {
+      "slug": "kusadasi",
+      "name": "Kusadasi &amp; Ephesus — Turkey's Ancient Wonder",
+      "description": "Kusadasi is Turkey's gateway to Ephesus — one of the best-preserved ancient cities in the world.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/kusadasi.html"
+    },
+    {
+      "slug": "la-coruna",
+      "name": "La Coruña",
+      "description": "La Coruña is the City of Glass – Roman lighthouse still working after 1,900 years, galleries in glazed balconies, and beaches right in the city center.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/la-coruna.html"
+    },
+    {
+      "slug": "la-spezia",
+      "name": "La Spezia",
+      "description": "First-person logbook guide to La Spezia in Italy's Gulf of Poets — gateway to UNESCO Cinque Terre's five painted villages, Byron's Romantic coastline, naval heritage, and Ligurian focaccia traditions.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/la-spezia.html"
+    },
+    {
+      "slug": "labadee",
+      "name": "Labadee — Royal Caribbean's Private Haiti Destination",
+      "description": "Labadee is Royal Caribbean's original private destination on Haiti's secluded north coast — dramatic mountains dropping to pristine beaches, the world's longest zip line over water (2,600 feet!",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/labadee.html"
+    },
+    {
+      "slug": "langkawi",
+      "name": "Langkawi",
+      "description": "First-person logbook guide to Langkawi, Malaysia — UNESCO Global Geopark archipelago with ancient limestone karsts, SkyCab cable car to Gunung Mat Chinchang, curved SkyBridge, Kilim mangrove forests, and 99 islands in the Andaman Sea.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/langkawi.html"
+    },
+    {
+      "slug": "lanzarote",
+      "name": "Lanzarote (Arrecife)",
+      "description": "First-person logbook guide to Arrecife, Lanzarote — stunning Timanfaya National Park volcanic landscape, Jameos del Agua caves, César Manrique's architectural legacy, La Geria wine region, and discovering the Canary Islands' most dramatic scenery.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/lanzarote.html"
+    },
+    {
+      "slug": "lautoka",
+      "name": "Lautoka, Fiji: Sugar City and Gateway to Paradise",
+      "description": "Discover Lautoka, Fiji's Sugar City on western Viti Levu.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/lautoka.html"
+    },
+    {
+      "slug": "le-havre",
+      "name": "Le Havre",
+      "description": "Le Havre is the realistic gateway to Paris – six hours round-trip on excellent trains for the City of Light in a single (very full) day.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/le-havre.html"
+    },
+    {
+      "slug": "lerwick",
+      "name": "Lerwick",
+      "description": "Lerwick is Britain's northernmost town – ponies the size of dogs, Viking fire festivals, and cliffs full of puffins closer to Norway than London.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/lerwick.html"
+    },
+    {
+      "slug": "lifou",
+      "name": "Lifou, Loyalty Islands",
+      "description": "First-person logbook guide to Lifou, Loyalty Islands, New Caledonia — Jinek Bay snorkeling, Jokin Cliffs limestone formations, Notre-Dame de Lourdes Chapel, Kanak cultural villages, vanilla plantations, pristine coral reefs, and experiencing authentic Melanesian island life.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/lifou.html"
+    },
+    {
+      "slug": "limassol",
+      "name": "Limassol, Cyprus",
+      "description": "First-person logbook guide to Limassol, Cyprus — ancient Greek amphitheaters at Kourion, Crusader castles where Richard the Lionheart married, Temple of Apollo, Commandaria wine, and walking through 4,000 years of Mediterranean history.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/limassol.html"
+    },
+    {
+      "slug": "lisbon",
+      "name": "Lisbon",
+      "description": "Lisbon is seven hills of colorful tiles, melancholy fado music, and pastel de nata still warm from the oven – one of Europe's most soulful capitals.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/lisbon.html"
+    },
+    {
+      "slug": "liverpool",
+      "name": "Liverpool",
+      "description": "Liverpool is The Beatles, two cathedrals, the best maritime museum in Britain, and the friendliest Scouse welcome you'll ever get.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/liverpool.html"
+    },
+    {
+      "slug": "livorno",
+      "name": "Livorno (Florence & Pisa)",
+      "description": "Livorno is one of Italy's busiest cruise ports and your gateway to Tuscany's greatest treasures — Renaissance Florence and Pisa's Leaning Tower.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/livorno.html"
+    },
+    {
+      "slug": "lombok",
+      "name": "Lombok",
+      "description": "First-person logbook guide to Lombok, Indonesia — Mount Rinjani volcano, Gili Islands without cars, traditional Sasak villages, pink coral beaches, and experiencing authentic Indonesian culture beyond Bali's crowds.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/lombok.html"
+    },
+    {
+      "slug": "los-angeles",
+      "name": "Los Angeles",
+      "description": "Southern California's cruise gateway serves Mexican Riviera and Hawaii itineraries from two terminals.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/los-angeles.html"
+    },
+    {
+      "slug": "luanda",
+      "name": "Luanda, Angola: A Maritime Guide to Africa's Oil Capital",
+      "description": "A sailor's guide to Luanda, Angola - exploring the Portuguese colonial fortress, Ilha peninsula, and the stark contrasts of Africa's third-largest city.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/luanda.html"
+    },
+    {
+      "slug": "lyttelton",
+      "name": "Lyttelton",
+      "description": "First-person logbook guide to Lyttelton — port of Canterbury pilgrims, Antarctic expedition history, earthquake recovery story, and gateway to Christchurch's gardens and resilience.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/lyttelton.html"
+    },
+    {
+      "slug": "malaga",
+      "name": "Málaga",
+      "description": "Málaga was founded by Phoenicians around 1000 BC and is Picasso's birthplace (1881).",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/malaga.html"
+    },
+    {
+      "slug": "maldives",
+      "name": "Maldives (Malé)",
+      "description": "First-person logbook guide to Malé, Maldives — whale shark diving, coral stone mosques, fish markets, pristine atolls, and swimming in the impossible turquoise of the Indian Ocean's 1,200-island paradise.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/maldives.html"
+    },
+    {
+      "slug": "manaus",
+      "name": "Manaus, Brazil",
+      "description": "First-person logbook guide to Manaus, Brazil — Teatro Amazonas opera house, Meeting of the Waters, swimming with pink dolphins, piranha fishing, indigenous villages, and discovering the heart of the Amazon rainforest.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/manaus.html"
+    },
+    {
+      "slug": "manila",
+      "name": "Manila",
+      "description": "First-person guide to Manila cruise port: Intramuros walled city, Fort Santiago, colonial churches, vibrant jeepney culture, and world-class museums.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/manila.html"
+    },
+    {
+      "slug": "manta",
+      "name": "Manta",
+      "description": "Manta is Ecuador's largest seaport and the world's tuna capital.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/manta.html"
+    },
+    {
+      "slug": "manzanillo",
+      "name": "Manzanillo",
+      "description": "Manzanillo is Mexico's authentic Pacific coast experience—world-class sailfish sportfishing, twin golden bays, the iconic Las Hadas resort from \"10,\" and real working-city character.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/manzanillo.html"
+    },
+    {
+      "slug": "maputo",
+      "name": "Maputo",
+      "description": "First-person logbook guide to Maputo — Eiffel-designed railway station, Portuguese colonial architecture, Inhaca Island marine reserve, piri piri prawns, and discovering Mozambique's coastal capital.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/maputo.html"
+    },
+    {
+      "slug": "marseille",
+      "name": "Marseille",
+      "description": "Marseille is France's oldest city (founded 600 BCE) and a gritty, authentic Mediterranean port.",
+      "region": "mediterranean",
+      "tier": 1,
+      "url": "/ports/marseille.html"
+    },
+    {
+      "slug": "martinique",
+      "name": "Martinique",
+      "description": "Martinique is France in the Caribbean – use euros, speak French, and explore Les Salines beach, Saint-Pierre ruins (once the \"Paris of the Caribbean\" until Mount Pelée's 1902 eruption), rhum agricole tasting, and pain au chocolat that rivals Paris.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/martinique.html"
+    },
+    {
+      "slug": "maui",
+      "name": "Maui",
+      "description": "Ships dock at Kahului on the Valley Isle.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/maui.html"
+    },
+    {
+      "slug": "mauritius",
+      "name": "Mauritius (Port Louis)",
+      "description": "First-person logbook guide to Port Louis, Mauritius — Aapravasi Ghat indentured labor history, vibrant Central Market, Blue Penny Museum, Black River Gorges National Park, and discovering Mark Twain's island paradise.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/mauritius.html"
+    },
+    {
+      "slug": "mazatlan",
+      "name": "Mazatlan",
+      "description": "Mazatlan—the \"Pearl of the Pacific\"—offers both Golden Zone beach resort vibes and an authentically restored Centro Historico with 500-year-old buildings.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/mazatlan.html"
+    },
+    {
+      "slug": "melbourne",
+      "name": "Melbourne",
+      "description": "Australia's cultural capital and cruise gateway to New Zealand and the South Pacific — Victorian-era laneways transformed into street art galleries, legendary coffee culture crafted by passionate baristas, and a constantly evolving urban canvas that has earned Melbourne its reputation as one of the world's most liveable cities.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/melbourne.html"
+    },
+    {
+      "slug": "messina",
+      "name": "Messina",
+      "description": "Messina is the gateway to Taormina – Greek theater with an active volcano backdrop and the prettiest town on the Ionian coast.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/messina.html"
+    },
+    {
+      "slug": "miami",
+      "name": "Miami",
+      "description": "Miami is the Cruise Capital of the World — PortMiami handles 8M+ passengers annually.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/miami.html"
+    },
+    {
+      "slug": "milford-sound",
+      "name": "Milford Sound Guide — Eighth Wonder of the World",
+      "description": "Milford Sound is a dramatic 15km fjord in Fiordland National Park — scenic cruising only with Mitre Peak rising 1,692m straight from the sea, cascading waterfalls, ancient rainforest, and UNESCO World Heritage wilderness that earns its title as the eighth wonder of the world.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/milford-sound.html"
+    },
+    {
+      "slug": "mindelo",
+      "name": "Mindelo, Cape Verde: Cultural Heart of the Atlantic",
+      "description": "Experience Mindelo, São Vicente - birthplace of Cesária Évora, cultural capital of Cape Verde, where morna music fills colonial streets and Porto Grande welcomes sailors to Africa's soulful archipelago.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/mindelo.html"
+    },
+    {
+      "slug": "mobile",
+      "name": "Mobile",
+      "description": "Alabama's charming cruise port where Southern hospitality meets the birthplace of Mardi Gras — the USS Alabama, historic district, and Gulf Coast warmth await.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/mobile.html"
+    },
+    {
+      "slug": "mombasa",
+      "name": "Mombasa",
+      "description": "Your complete guide to Mombasa, Kenya - explore Fort Jesus, Old Town's Swahili architecture, pristine Diani Beach, and gateway to Tsavo safari adventures.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/mombasa.html"
+    },
+    {
+      "slug": "monte-carlo",
+      "name": "Monte Carlo (Monaco)",
+      "description": "Monaco is pure glamour on steroids – supercars, yachts the size of cruise ships, and the Casino that looks exactly like the movies promised.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/monte-carlo.html"
+    },
+    {
+      "slug": "montego-bay",
+      "name": "Montego Bay",
+      "description": "First-person logbook guide to Montego Bay — legendary Doctor's Cave Beach healing waters, Hip Strip tourist hub, Rose Hall haunted great house, and discovering Jamaica's vibrant cruise capital with its beaches, culture, and Caribbean warmth.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/montego-bay.html"
+    },
+    {
+      "slug": "montevideo",
+      "name": "Montevideo",
+      "description": "First-person logbook guide to Montevideo — historic Ciudad Vieja walkable from the cruise terminal, legendary Mercado del Puerto grilled meats, Teatro Solís opera house, and discovering Uruguay's surprisingly charming capital.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/montevideo.html"
+    },
+    {
+      "slug": "moorea",
+      "name": "Moorea (French Polynesia)",
+      "description": "First-person logbook guide to Moorea, French Polynesia — Belvedere Lookout over Cook's Bay and Ōpūnohu Bay, lagoon tours with stingrays and blacktip reef sharks, black pearl shopping, Tiki Village cultural experiences, and exploring the heart-shaped volcanic island.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/moorea.html"
+    },
+    {
+      "slug": "mumbai",
+      "name": "Mumbai",
+      "description": "First-person guide to Mumbai cruise port: Gateway of India, Taj Mahal Palace Hotel, Elephanta Caves, Bollywood, and why this vibrant megacity captivates every visitor.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/mumbai.html"
+    },
+    {
+      "slug": "muscat",
+      "name": "Muscat",
+      "description": "First-person logbook guide to Muscat — Sultan Qaboos Grand Mosque, the legendary Mutrah Souq, frankincense heritage, and discovering Oman's graceful Arabian capital.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/muscat.html"
+    },
+    {
+      "slug": "mykonos",
+      "name": "Mykonos",
+      "description": "Mykonos is the quintessential Greek island—a maze of white-washed buildings, iconic windmills, and Little Venice waterfront, plus day trips to sacred Delos and world-famous shores.",
+      "region": "mediterranean",
+      "tier": 1,
+      "url": "/ports/mykonos.html"
+    },
+    {
+      "slug": "mystery-island",
+      "name": "Mystery Island (Vanuatu)",
+      "description": "First-person logbook guide to Mystery Island, Vanuatu — pristine white sand beaches, crystal-clear snorkeling, local Aneityumese vendors arriving by boat, and experiencing an uninhabited South Pacific island where nature remains untouched.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/mystery-island.html"
+    },
+    {
+      "slug": "nagasaki",
+      "name": "Nagasaki",
+      "description": "First-person logbook guide to Nagasaki — the Peace Memorial, Dejima's fan-shaped island of isolation, Thomas Glover's Scottish legacy, and Japan's profound window to the world.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/nagasaki.html"
+    },
+    {
+      "slug": "napier",
+      "name": "Napier",
+      "description": "First-person logbook guide to Napier—Art Deco capital rebuilt after 1931 earthquake, Hawke's Bay wineries, Cape Kidnappers gannets, and New Zealand's oldest wine region under endless sunshine.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/napier.html"
+    },
+    {
+      "slug": "naples",
+      "name": "Naples",
+      "description": "Naples serves as gateway to Pompeii (35 min by train), Herculaneum, Mount Vesuvius, and the Amalfi Coast.",
+      "region": "mediterranean",
+      "tier": 1,
+      "url": "/ports/naples.html"
+    },
+    {
+      "slug": "nassau",
+      "name": "Nassau",
+      "description": "Nassau delivers Atlantis Aquaventure thrills, gorgeous Cabbage Beach, duty-free shopping, the famous Straw Market, and life-changing cracked conch at Potter's Cay — all within easy reach of the cruise port.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/nassau.html"
+    },
+    {
+      "slug": "nawiliwili",
+      "name": "Nawiliwili",
+      "description": "Nawiliwili is Kauai's only cruise port – Waimea Canyon, the Na Pali coast, and more chickens than people on the Garden Isle.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/nawiliwili.html"
+    },
+    {
+      "slug": "new-orleans",
+      "name": "New Orleans",
+      "description": "America's most captivating cruise homeport — powdered sugar beignets, authentic jazz on Frenchmen Street, Creole cuisine, and centuries of culture in walkable neighborhoods.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/new-orleans.html"
+    },
+    {
+      "slug": "newcastle",
+      "name": "Newcastle",
+      "description": "Newcastle is seven bridges, proper Geordie warmth, the Angel of the North watching over everything, and the best nightlife in Britain.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/newcastle.html"
+    },
+    {
+      "slug": "newport",
+      "name": "Newport",
+      "description": "Gilded Age mansions, Cliff Walk, and sailboats everywhere — America's sailing capital feels like the Hamptons in 1890.",
+      "region": "new-england",
+      "tier": 2,
+      "url": "/ports/newport.html"
+    },
+    {
+      "slug": "nha-trang",
+      "name": "Nha Trang, Vietnam",
+      "description": "First-person logbook guide to Nha Trang, Vietnam — ancient Po Nagar Cham Towers, pristine beaches, Vinpearl Island cable car, Hon Mun Marine Protected Area snorkeling, Ba Ho Waterfalls, and exploring Vietnam's most beautiful bay.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/nha-trang.html"
+    },
+    {
+      "slug": "norwegian-fjords",
+      "name": "Norwegian Fjords",
+      "description": "Norwegian fjord ports (Geiranger, Flam, Olden, Ålesund) offer the most spectacular scenery in cruising.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/norwegian-fjords.html"
+    },
+    {
+      "slug": "nosy-be",
+      "name": "Nosy Be, Madagascar",
+      "description": "First-person logbook guide to Nosy Be, Madagascar — ylang-ylang plantations on Perfume Island, Lokobe Reserve lemurs, pristine coral reefs, sacred banyan tree, and discovering Madagascar's fragrant island escape.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/nosy-be.html"
+    },
+    {
+      "slug": "noumea",
+      "name": "Noumea, New Caledonia",
+      "description": "First-person logbook guide to Noumea, New Caledonia — UNESCO lagoons, Amedee Island lighthouse, swimming with turtles at Signal Island, Tjibaou Cultural Centre, French cuisine, and exploring where Melanesian culture meets Parisian charm.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/noumea.html"
+    },
+    {
+      "slug": "ocho-rios",
+      "name": "Ocho Rios",
+      "description": "First-person logbook guide to Ocho Rios, Jamaica — climbing the iconic 180-foot Dunn's River Falls, Mystic Mountain bobsled thrills, Blue Hole jungle swimming, dolphin encounters, and experiencing authentic Jamaican warmth.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/ocho-rios.html"
+    },
+    {
+      "slug": "olden",
+      "name": "Olden — Norway's Briksdal Glacier Village",
+      "description": "Olden is a tiny Norwegian fjord village beneath Briksdal Glacier — troll cars ascend to mainland Europe's largest glacier, Oldedalen valley waterfalls cascade from mountains, and Olden's white church stands in profound mountain silence.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/olden.html"
+    },
+    {
+      "slug": "osaka",
+      "name": "Osaka",
+      "description": "First-person logbook guide to Osaka — exploring Dotonbori's historic 1612 canal, tasting takoyaki where it was invented, discovering Osaka Castle's resilient history, embracing kuidaore culture, and venturing to Kyoto, Nara, and Himeji.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/osaka.html"
+    },
+    {
+      "slug": "oslo",
+      "name": "Oslo",
+      "description": "Oslo's Oslofjord sail-in past islands and red cabins is stunning.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/oslo.html"
+    },
+    {
+      "slug": "palau",
+      "name": "Palau / Koror",
+      "description": "First-person guide to Palau cruise port in Koror: Jellyfish Lake with stingless golden jellies, Rock Islands UNESCO site, world-class diving at Blue Corner, Milky Way lagoon, and WWII history at Peleliu.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/palau.html"
+    },
+    {
+      "slug": "palma",
+      "name": "Palma de Mallorca",
+      "description": "Palma de Mallorca is a top-rated Mediterranean port with a stunning Gothic cathedral, charming old town, and easy beach access.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/palma.html"
+    },
+    {
+      "slug": "panama-canal",
+      "name": "Panama Canal Transit Guide — Locks & Engineering Marvel",
+      "description": "Transiting the Panama Canal is the single most fascinating \"port\" day you will ever have on a cruise — a man-made wonder that still blows minds 110 years later.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/panama-canal.html"
+    },
+    {
+      "slug": "papeete",
+      "name": "Papeete",
+      "description": "First-person logbook guide to Papeete, Tahiti — birthplace of overwater bungalows, home to Gauguin's finest works (1891-1901), Le Marché market, black pearls, vanilla, and French Polynesia's vibrant capital where 118 islands converge.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/papeete.html"
+    },
+    {
+      "slug": "patmos",
+      "name": "Patmos",
+      "description": "First-person logbook guide to Patmos, Greece — the Cave of the Apocalypse, Monastery of St.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/patmos.html"
+    },
+    {
+      "slug": "penang",
+      "name": "Penang",
+      "description": "First-person logbook guide to Penang — exploring Georgetown's UNESCO heritage architecture, Ernest Zacharevic's iconic street art, Khoo Kongsi clan temple, Kek Lok Si's Buddhist grandeur, and discovering where four cultures paint one astonishing canvas through legendary street food.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/penang.html"
+    },
+    {
+      "slug": "philipsburg",
+      "name": "Philipsburg / St. Maarten",
+      "description": "Complete cruise guide to Philipsburg, St.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/philipsburg.html"
+    },
+    {
+      "slug": "phuket",
+      "name": "Phuket",
+      "description": "First-person logbook guide to Phuket — the gleaming Big Buddha, colorful Sino-Portuguese shophouses of Old Town, Patong's water sports and nightlife, tranquil family beaches, and Sirinat's coral gardens where turtles nest.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/phuket.html"
+    },
+    {
+      "slug": "picton",
+      "name": "Picton",
+      "description": "First-person logbook guide to Picton — gateway to the Marlborough Sounds' ancient flooded valleys, Queen Charlotte Track hiking from Ship Cove, world-renowned Marlborough wine country, and New Zealand's serene South Island harbor where wilderness meets working port.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/picton.html"
+    },
+    {
+      "slug": "pitcairn",
+      "name": "Pitcairn Island",
+      "description": "First-person logbook guide to Pitcairn Island — HMS Bounty mutineer descendants, world's most remote inhabited island, longboat landing only, population of 50, Christian's Cave, Bounty Bay, and experiencing the world's smallest democracy in the South Pacific.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/pitcairn.html"
+    },
+    {
+      "slug": "ponta-delgada",
+      "name": "Ponta Delgada",
+      "description": "First-person logbook guide to Ponta Delgada, Azores — stunning Sete Cidades twin lakes, year-round whale watching, volcanic Furnas Valley, geothermal wonders, and the mid-Atlantic crossing everyone should experience.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/ponta-delgada.html"
+    },
+    {
+      "slug": "port-canaveral",
+      "name": "Port Canaveral",
+      "description": "Port Canaveral is where America's space program meets the sea — 15 miles from Kennedy Space Center, with SpaceX launches lighting the sky.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/port-canaveral.html"
+    },
+    {
+      "slug": "port-elizabeth",
+      "name": "Port Elizabeth (Gqeberha)",
+      "description": "First-person logbook guide to Port Elizabeth (Gqeberha) — malaria-free elephant encounters at Addo, stunning Garden Route drives, pristine beaches, friendly city atmosphere, and exploring South Africa's Eastern Cape Province.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/port-elizabeth.html"
+    },
+    {
+      "slug": "port-everglades",
+      "name": "Port Everglades",
+      "description": "Fort Lauderdale's world-class cruise hub with one of cruising's best airport-to-port connections — beaches, Las Olas Boulevard, and the water taxi \"Venice of America\" experience await.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/port-everglades.html"
+    },
+    {
+      "slug": "port-miami",
+      "name": "PortMiami",
+      "description": "The Cruise Capital of the World with stunning new terminals — South Beach, Little Havana, Wynwood Walls, and Miami's vibrant culture make pre-cruise days unforgettable.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/port-miami.html"
+    },
+    {
+      "slug": "port-moresby",
+      "name": "Port Moresby, Papua New Guinea - Gateway to Tribal Cultures & WWII History",
+      "description": "Explore Port Moresby, PNG's vibrant capital on the Coral Sea.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/port-moresby.html"
+    },
+    {
+      "slug": "portimao",
+      "name": "Portimão",
+      "description": "Portimão is golden Algarve cliffs tumbling into turquoise water, Benagil Cave's cathedral of light, sardine fishing heritage, and 300 days of sunshine a year on Portugal's southern coast.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/portimao.html"
+    },
+    {
+      "slug": "portland-maine",
+      "name": "Portland, Maine",
+      "description": "Portland, Maine is six lighthouses including George Washington's Portland Head Light, working lobster boat tours hauling traps in season, cobblestone Old Port streets, and lobster rolls that taste like they came from the trap an hour ago.",
+      "region": "new-england",
+      "tier": 2,
+      "url": "/ports/portland-maine.html"
+    },
+    {
+      "slug": "portland",
+      "name": "Portland",
+      "description": "Portland is the Jurassic Coast – Chesil Beach's 18-mile pebble ridge, Portland Bill lighthouse, and fossils literally falling out of the cliffs.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/portland.html"
+    },
+    {
+      "slug": "porto",
+      "name": "Porto",
+      "description": "Porto is terracotta roofs cascading down to the Douro, port wine lodges, and the most beautiful train station in Europe covered in azulejos.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/porto.html"
+    },
+    {
+      "slug": "portofino",
+      "name": "Portofino, Italy",
+      "description": "First-person logbook guide to Portofino — ancient Roman harbor transformed into luxury destination.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/portofino.html"
+    },
+    {
+      "slug": "praia",
+      "name": "Praia, Cape Verde:",
+      "description": "First-hand guide to visiting Praia, Cape Verde by cruise ship.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/praia.html"
+    },
+    {
+      "slug": "progreso",
+      "name": "Progreso",
+      "description": "Progreso is your gateway to Chichen Itza—one of the New Seven Wonders of the World—via the world's longest pier.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/progreso.html"
+    },
+    {
+      "slug": "puerto-caldera",
+      "name": "Puerto Caldera",
+      "description": "First-person logbook guide to Puerto Caldera, Costa Rica — exploring the modern cruise terminal closer to San José, Carara National Park's scarlet macaw colonies, Tárcoles River's massive crocodiles, rainforest canopy adventures, sloth sanctuaries, coffee plantations, and immersive eco-tourism experiences in Central America's biodiversity jewel.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/puerto-caldera.html"
+    },
+    {
+      "slug": "puerto-limon",
+      "name": "Puerto Limón",
+      "description": "Puerto Limón is your gateway to Costa Rica's Caribbean rainforest — sloths, monkeys, jungle canals, zip-lines, and the kind of wild that makes you remember what alive means.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/puerto-limon.html"
+    },
+    {
+      "slug": "puerto-madryn",
+      "name": "Puerto Madryn, Argentina",
+      "description": "First-person logbook guide to Puerto Madryn, Argentina — Southern Right Whale watching from shore and boat, Valdés Peninsula UNESCO World Heritage Site, penguin colonies, orca hunting grounds, and discovering Patagonia's wild beauty.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/puerto-madryn.html"
+    },
+    {
+      "slug": "puerto-vallarta",
+      "name": "Puerto Vallarta",
+      "description": "Puerto Vallarta is Pacific Mexico's most walkable and culturally rich cruise port—the Malecon boardwalk, bronze sculptures, art galleries, Our Lady of Guadalupe church, Zona Romantica's intimate restaurants, and Sierra Madre mountain backdrop.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/puerto-vallarta.html"
+    },
+    {
+      "slug": "punta-arenas",
+      "name": "Punta Arenas",
+      "description": "First-person logbook guide to Punta Arenas — Strait of Magellan crossing, Magdalena Island penguin colonies, Fort Bulnes historical site, Torres del Paine National Park gateway, and navigating Chile's southernmost continental city.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/punta-arenas.html"
+    },
+    {
+      "slug": "puntarenas",
+      "name": "Puntarenas",
+      "description": "First-person logbook guide to Puntarenas, Costa Rica — exploring Carara National Park's scarlet macaw sanctuary, Manuel Antonio beaches and wildlife, Monteverde cloud forest, thrilling zip-line canopy tours, sloth encounters, and embracing the Pura Vida spirit of Costa Rica's Pacific coast.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/puntarenas.html"
+    },
+    {
+      "slug": "quebec-city",
+      "name": "Quebec City",
+      "description": "Quebec City is the only walled city in North America north of Mexico and a UNESCO World Heritage Site since 1985.",
+      "region": "new-england",
+      "tier": 1,
+      "url": "/ports/quebec-city.html"
+    },
+    {
+      "slug": "ravenna",
+      "name": "Ravenna",
+      "description": "Ravenna is the world capital of Byzantine mosaics – eight UNESCO sites glowing with gold and color that haven't faded in 1,500 years.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/ravenna.html"
+    },
+    {
+      "slug": "recife",
+      "name": "Recife",
+      "description": "First-person logbook guide to Recife, Brazil — exploring the Venice of Brazil's bridges and canals, Olinda's UNESCO colonial streets, vibrant frevo rhythms, and the Dutch colonial heritage of Pernambuco's capital.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/recife.html"
+    },
+    {
+      "slug": "reykjavik",
+      "name": "Reykjavik",
+      "description": "Reykjavik is gateway to Iceland's otherworldly landscapes.",
+      "region": "northern-europe",
+      "tier": 1,
+      "url": "/ports/reykjavik.html"
+    },
+    {
+      "slug": "rhodes",
+      "name": "Rhodes",
+      "description": "Rhodes is the best-preserved medieval city in Europe — a living fortress with 4 km of walls, palaces, mosques, and a street where knights actually rode horses down.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/rhodes.html"
+    },
+    {
+      "slug": "riga",
+      "name": "Riga",
+      "description": "Riga is the Art Nouveau capital of the world wrapped in a Hanseatic old town with the biggest market halls in Europe.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/riga.html"
+    },
+    {
+      "slug": "rio-de-janeiro",
+      "name": "Rio de Janeiro",
+      "description": "First-person logbook guide to Rio de Janeiro cruise port — Christ the Redeemer atop Corcovado, Sugarloaf's cable car to 1,296-foot summit, Copacabana's golden sands, Carnival's samba heartbeat, and why Cariocas call it Cidade Maravilhosa since 1565.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/rio-de-janeiro.html"
+    },
+    {
+      "slug": "roatan",
+      "name": "Roatán",
+      "description": "Roatán is the port everyone underestimates and falls in love with — West Bay Beach has world-class snorkeling right off shore, Gumbalimba Park has monkeys that climb on you, and it's the cheapest perfect beach day in the Caribbean.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/roatan.html"
+    },
+    {
+      "slug": "rostock",
+      "name": "Rostock (Warnemünde)",
+      "description": "First-person logbook guide to Rostock/Warnemünde, Germany — Hanseatic League history, gateway to Berlin, St.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/rostock.html"
+    },
+    {
+      "slug": "royal-beach-club-nassau",
+      "name": "Royal Beach Club Paradise Island Guide — Royal Caribbean's Nassau Beach Club",
+      "description": "Royal Beach Club Paradise Island is Royal Caribbean's premium private beach destination in Nassau — think pristine powder-sand beaches, swim-up bars, overwater cabanas, and Bahamian cultural experiences without the cruise port crowds.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/royal-beach-club-nassau.html"
+    },
+    {
+      "slug": "safaga",
+      "name": "Safaga",
+      "description": "First-person logbook guide to Safaga — gateway to Luxor's Valley of the Kings, world-class Red Sea diving, and therapeutic mineral waters along Egypt's eastern shore.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/safaga.html"
+    },
+    {
+      "slug": "saguenay",
+      "name": "Saguenay",
+      "description": "Saguenay Fjord is jaw-dropping — steep cliffs, beluga whales, and fall colors that look photoshopped.",
+      "region": "new-england",
+      "tier": 2,
+      "url": "/ports/saguenay.html"
+    },
+    {
+      "slug": "saint-john",
+      "name": "Saint John",
+      "description": "Saint John (Bay of Fundy) has the world's highest tides, Reversing Falls, and the best coastal scenery in the Maritimes.",
+      "region": "new-england",
+      "tier": 2,
+      "url": "/ports/saint-john.html"
+    },
+    {
+      "slug": "saipan",
+      "name": "Saipan",
+      "description": "First-person logbook guide to Saipan — exploring WWII memorials, diving The Grotto, Managaha Island beaches, and discovering the largest island of the Northern Mariana Islands.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/saipan.html"
+    },
+    {
+      "slug": "salalah",
+      "name": "Salalah",
+      "description": "First-person logbook guide to Salalah — the perfume capital of Arabia, UNESCO frankincense sites, Al Baleed archaeological park, and the magical khareef monsoon season.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/salalah.html"
+    },
+    {
+      "slug": "salvador",
+      "name": "Salvador, Brazil",
+      "description": "First-person logbook guide to Salvador, Brazil — Pelourinho UNESCO World Heritage site, baroque São Francisco Church, Afro-Brazilian culture, capoeira performances, colonial architecture, and discovering Brazil's first capital.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/salvador.html"
+    },
+    {
+      "slug": "samana",
+      "name": "Samaná",
+      "description": "Samaná Bay in whale season (mid-January to late March) offers the most reliable, jaw-dropping humpback whale encounters in the entire Caribbean — with a 95% success rate, you'll witness 1,500-2,000 humpbacks that journey 5,000+ miles from the North Atlantic to the warm, shallow waters of this protected Marine Mammals Sanctuary (est.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/samana.html"
+    },
+    {
+      "slug": "san-diego",
+      "name": "San Diego",
+      "description": "America's Finest City with perfect weather year-round — the USS Midway, San Diego Zoo, Gaslamp Quarter, and one of the closest airport-to-port connections anywhere.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/san-diego.html"
+    },
+    {
+      "slug": "san-francisco",
+      "name": "San Francisco, USA",
+      "description": "First-person logbook guide to San Francisco — walking the Golden Gate Bridge, touring Alcatraz, riding cable cars, tasting clam chowder at Fisherman's Wharf, and discovering the neighborhoods that make this California city unforgettable.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/san-francisco.html"
+    },
+    {
+      "slug": "san-juan",
+      "name": "San Juan",
+      "description": "San Juan is my favorite walkable port — step off the ship into a 500-year-old UNESCO city with El Morro fortress, blue cobblestone streets, incredible mofongo, and the birthplace of the piña colada.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/san-juan.html"
+    },
+    {
+      "slug": "santorini",
+      "name": "Santorini",
+      "description": "Santorini means sailing into the collapsed heart of a volcano that exploded around 1600 BC—a flooded caldera with white-washed villages clinging to 300-meter cliffs, iconic blue-domed churches, Bronze Age ruins at Akrotiri, and some of the most dramatic sunsets in the Mediterranean.",
+      "region": "mediterranean",
+      "tier": 1,
+      "url": "/ports/santorini.html"
+    },
+    {
+      "slug": "santos",
+      "name": "Santos",
+      "description": "First-person logbook guide to Santos — Brazil's largest port, Coffee Museum, beachfront gardens, and gateway to São Paulo.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/santos.html"
+    },
+    {
+      "slug": "scotland",
+      "name": "Edinburgh & Glasgow",
+      "description": "South Queensferry (Edinburgh) and Greenock (Glasgow) are both 4.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/scotland.html"
+    },
+    {
+      "slug": "seattle",
+      "name": "Seattle",
+      "description": "America's premier gateway to Alaska — Pike Place Market fish throwers, the Space Needle, world-class coffee, and stunning mountain views make arriving early essential.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/seattle.html"
+    },
+    {
+      "slug": "seward",
+      "name": "Seward — Gateway to Kenai Fjords & Alaska's Best Wildlife",
+      "description": "Seward is the gateway to Kenai Fjords National Park — offering what many call the best single-day wildlife experience in Alaska.",
+      "region": "alaska",
+      "tier": 2,
+      "url": "/ports/seward.html"
+    },
+    {
+      "slug": "seychelles",
+      "name": "Seychelles (Victoria, Mahé)",
+      "description": "First-person logbook guide to Victoria, Mahé — pristine beaches, giant tortoises at Botanical Gardens, Sainte Anne Marine National Park, Hindu temples, and exploring the Seychelles' granite island paradise.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/seychelles.html"
+    },
+    {
+      "slug": "shanghai",
+      "name": "Shanghai",
+      "description": "First-person guide to Shanghai cruise port: The Bund's colonial architecture, futuristic Pudong, Ming Dynasty Yu Garden, French Concession history, and the city where past meets future.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/shanghai.html"
+    },
+    {
+      "slug": "sharm-el-sheikh",
+      "name": "Sharm el-Sheikh",
+      "description": "First-person logbook guide to Sharm el-Sheikh — world-class diving at Ras Mohammed and Tiran Island, St.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/sharm-el-sheikh.html"
+    },
+    {
+      "slug": "sihanoukville",
+      "name": "Sihanoukville, Cambodia - Beach Resort & Island Gateway",
+      "description": "A cruise guide to Sihanoukville, Cambodia's premier beach destination and gateway to pristine Gulf of Thailand islands.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/sihanoukville.html"
+    },
+    {
+      "slug": "singapore",
+      "name": "Singapore",
+      "description": "First-person guide to Singapore cruise port: Gardens by the Bay, Marina Bay Sands, hawker centers, and why it's Asia's top-rated port.",
+      "region": "asia",
+      "tier": 1,
+      "url": "/ports/singapore.html"
+    },
+    {
+      "slug": "sitka",
+      "name": "Sitka — Russian America & Wildlife",
+      "description": "Sitka blends Russian onion domes with Tlingit totems, sea otters floating in kelp beds, and Mount Edgecumbe watching over everything like Alaska's Fuji.",
+      "region": "alaska",
+      "tier": 1,
+      "url": "/ports/sitka.html"
+    },
+    {
+      "slug": "skagway",
+      "name": "Skagway — Gold Rush Gateway",
+      "description": "Skagway is pure 1898 Gold Rush fever frozen in time — the legendary White Pass Railway, wooden boardwalks, and trails where thousands once hauled a ton of supplies toward Klondike gold.",
+      "region": "alaska",
+      "tier": 1,
+      "url": "/ports/skagway.html"
+    },
+    {
+      "slug": "sorrento",
+      "name": "Sorrento, Italy",
+      "description": "First-person logbook guide to Sorrento, Italy — perched at the northern gateway to the Amalfi Coast, where ships tender to Marina Piccola, Sfusato Amalfitano lemons perfume the air, and centuries of limoncello tradition meet Pompeii's ruins and Capri's azure waters.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/sorrento.html"
+    },
+    {
+      "slug": "south-georgia",
+      "name": "South Georgia Island",
+      "description": "First-person logbook guide to South Georgia Island — 200,000+ King penguins at Salisbury Plain, Ernest Shackleton's grave at Grytviken, abandoned whaling stations, elephant seals, wandering albatross, and sub-Antarctic wilderness where ice meets ocean.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/south-georgia.html"
+    },
+    {
+      "slug": "south-pacific",
+      "name": "South Pacific Islands",
+      "description": "First-person guide to South Pacific cruise ports: Bora Bora, Tahiti, Moorea, Fiji, Vanuatu, and Nouméa – turquoise lagoons and paradise islands.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/south-pacific.html"
+    },
+    {
+      "slug": "southampton",
+      "name": "Southampton",
+      "description": "Southampton is the UK's busiest cruise port (3M+ passengers, £1B economy impact) and Titanic's home port — she departed Berth 44 on April 10, 1912.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/southampton.html"
+    },
+    {
+      "slug": "split",
+      "name": "Split",
+      "description": "Split is Diocletian's retirement palace turned living city — Romans, Venetians, and modern Croatians all sharing the same marble streets.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/split.html"
+    },
+    {
+      "slug": "st-barts",
+      "name": "St. Barts",
+      "description": "First-person logbook guide to St.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/st-barts.html"
+    },
+    {
+      "slug": "st-helena",
+      "name": "St. Helena",
+      "description": "First-person logbook guide to St.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/st-helena.html"
+    },
+    {
+      "slug": "st-kitts",
+      "name": "St. Kitts",
+      "description": "The first West Indian island colonized by Europeans (1623), St. Kitts offers Cockleshell Beach with Killer Bee rum punch, the \"Gibraltar of the West Indies\" Brimstone Hill Fortress (UNESCO 1999), and a historic 1912 sugar railway now carrying passengers on a three-hour island tour with rum punch and choir singing.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/st-kitts.html"
+    },
+    {
+      "slug": "st-lucia",
+      "name": "St. Lucia",
+      "description": "First-person logbook guide to St.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/st-lucia.html"
+    },
+    {
+      "slug": "st-maarten",
+      "name": "St. Maarten",
+      "description": "St. Maarten is a dual-nation island with Maho Beach jet-blast plane spotting on the Dutch side and Orient Beach rosé on the French side — two countries, one perfect day.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/st-maarten.html"
+    },
+    {
+      "slug": "st-petersburg",
+      "name": "St. Petersburg",
+      "description": "St. Petersburg is imperial excess on steroids – golden spires, canals, and palaces that make Versailles look modest.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/st-petersburg.html"
+    },
+    {
+      "slug": "st-thomas",
+      "name": "St. Thomas",
+      "description": "St. Thomas is my absolute favorite Caribbean day — Magens Bay (top-10 beach in the world), Paradise Point Bushwackers with 360° views, duty-free shopping, and the convenience of US territory.",
+      "region": "caribbean",
+      "tier": 1,
+      "url": "/ports/st-thomas.html"
+    },
+    {
+      "slug": "stavanger",
+      "name": "Stavanger",
+      "description": "Stavanger is white wooden houses, street art, and the gateway to Pulpit Rock and Lysefjord – Norway's adventure capital with surprising charm.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/stavanger.html"
+    },
+    {
+      "slug": "stockholm",
+      "name": "Stockholm",
+      "description": "Stockholm spans 14 islands connected by bridges and ferries.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/stockholm.html"
+    },
+    {
+      "slug": "suva",
+      "name": "Suva",
+      "description": "First-person logbook guide to Suva, Fiji — Kings Wharf downtown access, Fiji Museum cannibal forks and Pacific artifacts, largest South Pacific market, colonial Government Buildings, Colo-i-Suva Forest Park waterfalls, kava ceremonies, and discovering multi-ethnic Fijian warmth.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/suva.html"
+    },
+    {
+      "slug": "sydney-ns",
+      "name": "Sydney",
+      "description": "Sydney is the gateway to Cape Breton — biggest fiddle, friendliest people, and Cabot Trail if overnight.",
+      "region": "new-england",
+      "tier": 2,
+      "url": "/ports/sydney-ns.html"
+    },
+    {
+      "slug": "sydney",
+      "name": "Sydney",
+      "description": "Sydney features Opera House, Harbour Bridge, Bondi Beach, and spectacular harbour entrance.",
+      "region": "pacific",
+      "tier": 1,
+      "url": "/ports/sydney.html"
+    },
+    {
+      "slug": "taipei",
+      "name": "Taipei (Keelung)",
+      "description": "First-person logbook guide to Taipei via historic Keelung Port — from Spanish traders to night market treasures, Jiufen's mining village magic, ancient temples, and Taiwan's extraordinary food culture.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/taipei.html"
+    },
+    {
+      "slug": "tallinn",
+      "name": "Tallinn",
+      "description": "Tallinn is a perfectly preserved Hanseatic fairy tale – orange roofs, church spires, and medieval walls that make you feel like you've time-traveled to 1450.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/tallinn.html"
+    },
+    {
+      "slug": "tampa",
+      "name": "Tampa",
+      "description": "Florida's underrated Gulf Coast gem — Ybor City Cuban sandwiches, free TECO streetcar, Busch Gardens coasters, and some of the best parking rates among major cruise ports.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/tampa.html"
+    },
+    {
+      "slug": "tangier",
+      "name": "Tangier",
+      "description": "Tangier is the gateway where Europe and Africa kiss – a swirling medina, Atlantic beaches, and the smell of mint tea and spices that hits you the moment you step off.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/tangier.html"
+    },
+    {
+      "slug": "taormina",
+      "name": "Taormina",
+      "description": "Taormina is the jewel of Sicily — perched on a cliff above the Ionian Sea with the legendary Teatro Greco framing views of Mount Etna, centuries of layered history from Greeks to Grand Tour aristocrats, and the kind of beauty that has captivated travelers for over two thousand years.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/taormina.html"
+    },
+    {
+      "slug": "tauranga",
+      "name": "Tauranga",
+      "description": "Reflective logbook guide to Tauranga — where Captain Cook's 'Bay of Plenty' meets ancient Māori heritage, geothermal valleys bubble beside redwood forests, and hobbit holes nestle among kiwifruit orchards in New Zealand's fertile heartland.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/tauranga.html"
+    },
+    {
+      "slug": "tenerife",
+      "name": "Tenerife",
+      "description": "First-person logbook guide to Tenerife — ascending Spain's highest peak Mount Teide, UNESCO colonial La Laguna, volcanic landscapes, Loro Parque, world-class stargazing, and discovering the Canary Islands' largest island.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/tenerife.html"
+    },
+    {
+      "slug": "tianjin",
+      "name": "Tianjin",
+      "description": "First-person guide to Tianjin cruise port: Beijing gateway with Great Wall, Forbidden City, Temple of Heaven, and Tianjin's Italian Concession streets.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/tianjin.html"
+    },
+    {
+      "slug": "tokyo",
+      "name": "Tokyo / Yokohama",
+      "description": "First-person guide to Tokyo and Yokohama cruise ports: Historic Osanbashi Pier since 1894, Mount Fuji views, ancient temples, Shibuya Crossing, TeamLab art, and the contrast of tradition meeting ultra-modern technology.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/tokyo.html"
+    },
+    {
+      "slug": "tonga",
+      "name": "Tonga (Nuku'alofa)",
+      "description": "First-person logbook guide to Nuku'alofa, Tonga — the Royal Palace, Mapu'a'a Vaea Blowholes shooting ocean spray skyward, Ha'amonga 'a Maui Trilithon, island snorkeling, and exploring the Pacific's only remaining Polynesian kingdom.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/tonga.html"
+    },
+    {
+      "slug": "tortola",
+      "name": "Tortola",
+      "description": "Tortola – \"Land of the Turtle Dove\" and the Sailing Capital of the Caribbean – is your gateway to the BVI.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/tortola.html"
+    },
+    {
+      "slug": "tracy-arm",
+      "name": "Tracy Arm Fjord Guide — Alaska's Narrow Glacier Wonder",
+      "description": "Tracy Arm is a stunning alternative to Glacier Bay—a narrow 30-mile fjord with 4,000-foot granite walls, twin Sawyer Glaciers actively calving, and icebergs packed with lounging harbor seals.",
+      "region": "alaska",
+      "tier": 2,
+      "url": "/ports/tracy-arm.html"
+    },
+    {
+      "slug": "trieste",
+      "name": "Trieste",
+      "description": "Trieste is elegant Habsburg cafés, the largest sea-facing piazza in Italy, and a literary soul that feels like Vienna and Venice had a baby on the Adriatic.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/trieste.html"
+    },
+    {
+      "slug": "tristan-da-cunha",
+      "name": "Tristan da Cunha",
+      "description": "First-person logbook guide to Tristan da Cunha — the world's most remote inhabited island, 1,750 miles from the nearest land, Edinburgh of the Seven Seas settlement, volcanic Queen Mary's Peak, rockhopper penguins, and the extraordinary resilience of 250 souls living at the edge of the world.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/tristan-da-cunha.html"
+    },
+    {
+      "slug": "tromso",
+      "name": "Tromsø",
+      "description": "Tromsø is the Arctic capital – midnight sun or northern lights, reindeer sledding, and the stunning Arctic Cathedral glowing across the fjord.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/tromso.html"
+    },
+    {
+      "slug": "tunis",
+      "name": "Tunis (La Goulette)",
+      "description": "La Goulette is your gateway to Carthage, Sidi Bou Said's blue-and-white perfection, and Tunis medina – three UNESCO sites in one day.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/tunis.html"
+    },
+    {
+      "slug": "ushuaia",
+      "name": "Ushuaia",
+      "description": "First-person logbook guide to Ushuaia — world's southernmost city, Tierra del Fuego National Park, Beagle Channel wildlife, End of the World Train, Antarctica expeditions, and standing at the edge of civilization.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/ushuaia.html"
+    },
+    {
+      "slug": "valencia",
+      "name": "Valencia",
+      "description": "Valencia was founded 138 BC as Roman Valentia, meaning \"strength.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/valencia.html"
+    },
+    {
+      "slug": "valletta",
+      "name": "Valletta (Malta)",
+      "description": "Valletta is Europe's smallest capital and a UNESCO World Heritage Site (since 1980) — a fortress city founded March 28, 1566 by Grand Master Jean de Valette after the Knights of St. John survived the Great Siege of 1565.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/valletta.html"
+    },
+    {
+      "slug": "valparaiso",
+      "name": "Valparaíso",
+      "description": "First-person logbook guide to Valparaíso — UNESCO World Heritage hillside neighborhoods, historic ascensores funiculars, Pablo Neruda's La Sebastiana house, vibrant street art, and discovering Chile's wonderfully chaotic cultural capital.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/valparaiso.html"
+    },
+    {
+      "slug": "vancouver",
+      "name": "Vancouver",
+      "description": "Vancouver is the premier Alaska cruise gateway — Canada Place terminal sits beneath five iconic white sails, with Stanley Park, Granville Island, and world-class Asian cuisine making extra pre-cruise days essential.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/vancouver.html"
+    },
+    {
+      "slug": "vanuatu",
+      "name": "Vanuatu (Port Vila)",
+      "description": "First-person logbook guide to Port Vila, Vanuatu — Melanesian cultural villages, world's only underwater post office at Hideaway Island, Mele Cascades waterfalls, Blue Lagoon natural pool, and exploring this culturally diverse South Pacific nation.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/vanuatu.html"
+    },
+    {
+      "slug": "venice",
+      "name": "Venice",
+      "description": "Large ships now dock at Marghera on the mainland (20-30 min transfer to Venice).",
+      "region": "mediterranean",
+      "tier": 1,
+      "url": "/ports/venice.html"
+    },
+    {
+      "slug": "victoria-bc",
+      "name": "Victoria BC",
+      "description": "Victoria is the perfect civilized bookend — Butchart Gardens in full bloom, high tea at the Empress, Parliament lit like a fairy tale, and harbor seals begging for popcorn.",
+      "region": "alaska",
+      "tier": 2,
+      "url": "/ports/victoria-bc.html"
+    },
+    {
+      "slug": "vigo",
+      "name": "Vigo",
+      "description": "Vigo is the gateway to the Cíes Islands – Atlantic paradise with beaches that regularly top \"best in the world\" lists and only 2,200 visitors a day.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/vigo.html"
+    },
+    {
+      "slug": "villefranche",
+      "name": "Villefranche-sur-Mer (Nice & Monaco)",
+      "description": "Villefranche-sur-Mer is a tender port with one of the Mediterranean's deepest natural harbors, dating to 130 BC.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/villefranche.html"
+    },
+    {
+      "slug": "virgin-gorda",
+      "name": "Virgin Gorda",
+      "description": "The Baths at Virgin Gorda is the single most spectacular beach formation in the entire Caribbean — gigantic granite boulders creating grottoes, secret pools, and tunnels that lead to Devil's Bay, one of the world's most beautiful beaches.",
+      "region": "caribbean",
+      "tier": 2,
+      "url": "/ports/virgin-gorda.html"
+    },
+    {
+      "slug": "walvis-bay",
+      "name": "Walvis Bay (Namibia)",
+      "description": "First-person logbook guide to Walvis Bay, Namibia — thousands of pink flamingos, gateway to Sossusvlei's red dunes and Deadvlei, Sandwich Harbour's surreal desert-ocean collision, seal kayaking, and Skeleton Coast mystique.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/walvis-bay.html"
+    },
+    {
+      "slug": "warnemunde",
+      "name": "Warnemünde",
+      "description": "Warnemünde is a perfect German beach town, but everyone uses it as the gateway to Berlin – three hours each way for the German capital experience.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/warnemunde.html"
+    },
+    {
+      "slug": "waterford",
+      "name": "Waterford",
+      "description": "Waterford is Viking triangles, the finest crystal in the world, and the oldest city in Ireland with a medieval museum shaped like a Viking longship.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/waterford.html"
+    },
+    {
+      "slug": "wellington",
+      "name": "Wellington",
+      "description": "First-person logbook guide to Wellington — Te Papa's colossal squid and Māori treasures, Cuba Street's creative spirit, Zealandia ecosanctuary, and experiencing New Zealand's windswept southern capital.",
+      "region": "pacific",
+      "tier": 2,
+      "url": "/ports/wellington.html"
+    },
+    {
+      "slug": "whittier",
+      "name": "Whittier",
+      "description": "Whittier is bizarre (everyone lives in one Soviet-looking building) but Prince William Sound's 26 Glaciers cruise is arguably the best glacier day in Alaska—more calving than Glacier Bay, wildlife everywhere, and glacier ice cocktails on deck.",
+      "region": "alaska",
+      "tier": 2,
+      "url": "/ports/whittier.html"
+    },
+    {
+      "slug": "yangon",
+      "name": "Yangon (Rangoon), Myanmar: Golden Spires and Colonial Echoes - In the Wake",
+      "description": "A cruise port guide to Yangon, Myanmar - from the shimmering Shwedagon Pagoda to British colonial architecture, tea shop culture, and the complex beauty of Burma's former capital.",
+      "region": "asia",
+      "tier": 2,
+      "url": "/ports/yangon.html"
+    },
+    {
+      "slug": "zadar",
+      "name": "Zadar",
+      "description": "Zadar is Roman ruins, a Sea Organ that plays music with the waves, and a Greeting to the Sun light show – the coolest small city on the Adriatic.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/zadar.html"
+    },
+    {
+      "slug": "zakynthos",
+      "name": "Zakynthos (Zante), Greece",
+      "description": "First-person logbook guide to Zakynthos (Zante), Greece — Navagio Shipwreck Beach, Blue Caves, loggerhead sea turtles, Venetian fortress, St.",
+      "region": "mediterranean",
+      "tier": 2,
+      "url": "/ports/zakynthos.html"
+    },
+    {
+      "slug": "zanzibar",
+      "name": "Zanzibar, Tanzania",
+      "description": "First-person logbook guide to Zanzibar, Tanzania — Stone Town UNESCO World Heritage Site, historic carved doors, spice island tours, Prison Island tortoises, and exploring the cultural crossroads of Africa and Arabia.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/zanzibar.html"
+    },
+    {
+      "slug": "zeebrugge",
+      "name": "Zeebrugge/Bruges",
+      "description": "Zeebrugge is the gateway to Bruges – a perfectly preserved medieval fairy-tale city of canals, swans, and more chocolate shops per square meter than anywhere on Earth.",
+      "region": "northern-europe",
+      "tier": 2,
+      "url": "/ports/zeebrugge.html"
+    },
+    {
+      "slug": "zihuatanejo",
+      "name": "Zihuatanejo",
+      "description": "Zihuatanejo is the authentic Mexican fishing village Andy Dufresne dreamed about in Shawshank Redemption—tender landings, golden beaches at Playa La Ropa and Las Gatas, fresh seafood, and an unhurried pace that modern resorts can't replicate.",
+      "region": "other",
+      "tier": 2,
+      "url": "/ports/zihuatanejo.html"
+    }
+  ],
+  "byRegion": {
+    "other": [
+      {
+        "slug": "abu-dhabi",
+        "name": "Abu Dhabi",
+        "description": "Abu Dhabi is the UAE's elegant capital — visit the awe-inspiring Sheikh Zayed Grand Mosque (free, modest dress required), explore world art at Louvre Abu Dhabi, or thrill at Ferrari World on Yas Island.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/abu-dhabi.html"
+      },
+      {
+        "slug": "acapulco",
+        "name": "Acapulco",
+        "description": "Acapulco is Mexico's legendary Pacific resort — don't miss the iconic La Quebrada cliff divers (1pm show fits cruise schedules), explore Fort San Diego's colonial legacy, and enjoy fresh ceviche on the bay.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/acapulco.html"
+      },
+      {
+        "slug": "agadir",
+        "name": "Agadir",
+        "description": "Agadir is Morocco's modern beach resort — 10 km of Atlantic sand, Paradise Valley mountain oasis, massive Souk El Had market, and Kasbah ruins with sunset views.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/agadir.html"
+      },
+      {
+        "slug": "apia",
+        "name": "Apia, Samoa",
+        "description": "Apia cruise port guide featuring Robert Louis Stevenson Museum, To Sua Ocean Trench, Samoa Cultural Village, Papaseea Sliding Rocks, and authentic Polynesian culture.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/apia.html"
+      },
+      {
+        "slug": "aqaba",
+        "name": "Aqaba",
+        "description": "Aqaba cruise port guide featuring Petra day trips, Wadi Rum desert, Red Sea diving and snorkeling, and Jordan's ancient gateway to archaeological wonders.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/aqaba.html"
+      },
+      {
+        "slug": "ascension",
+        "name": "Ascension Island",
+        "description": "Ascension Island cruise port guide featuring Green Mountain cloud forest, sea turtle nesting beaches, volcanic landscapes, and one of the most remote ports in the South Atlantic.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/ascension.html"
+      },
+      {
+        "slug": "baltimore",
+        "name": "Baltimore",
+        "description": "Baltimore is more than a cruise gateway — it's where the Star-Spangled Banner was born.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/baltimore.html"
+      },
+      {
+        "slug": "bay-of-islands",
+        "name": "Bay of Islands, New Zealand",
+        "description": "First-person logbook guide to Bay of Islands, New Zealand — Waitangi Treaty Grounds, Hole in the Rock boat trips, Russell whaling heritage, wild dolphin swimming, Haruru Falls, and 144 subtropical islands where modern New Zealand began.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/bay-of-islands.html"
+      },
+      {
+        "slug": "bora-bora",
+        "name": "Bora Bora",
+        "description": "First-person logbook guide to Bora Bora — the Pearl of the Pacific.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/bora-bora.html"
+      },
+      {
+        "slug": "bordeaux",
+        "name": "Bordeaux",
+        "description": "Bordeaux is golden stone, grand boulevards, and the wine capital of the world – with the stunning Cité du Vin museum shaped like a wine decanter.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/bordeaux.html"
+      },
+      {
+        "slug": "buenos-aires",
+        "name": "Buenos Aires",
+        "description": "First-person logbook guide to Buenos Aires — La Boca's colorful shipyard houses painted with leftover ship paint, Recoleta Cemetery where flowers always cover Evita's tomb, passionate tango born in immigrant milongas, and 13 million Porteños who made the Paris of South America distinctly Argentine.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/buenos-aires.html"
+      },
+      {
+        "slug": "cabo-san-lucas",
+        "name": "Cabo San Lucas",
+        "description": "Cabo San Lucas is where desert cliffs plunge into two seas at the iconic Land's End arch.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/cabo-san-lucas.html"
+      },
+      {
+        "slug": "callao",
+        "name": "Callao",
+        "description": "Callao is the port for Lima, Peru's capital and a UNESCO World Heritage Site.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/callao.html"
+      },
+      {
+        "slug": "cape-liberty",
+        "name": "Cape Liberty",
+        "description": "New York's smart cruiser alternative — stunning Statue of Liberty sailaway views, easier parking than Manhattan, and the entire city just across the harbor.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/cape-liberty.html"
+      },
+      {
+        "slug": "cape-town",
+        "name": "Cape Town",
+        "description": "First-person logbook guide to Cape Town — Table Mountain cable car since 1929, Robben Island tours with former prisoners, historic Constantia wine estates from 1685, Cape of Good Hope, and South Africa's legislative capital where two oceans meet.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/cape-town.html"
+      },
+      {
+        "slug": "casablanca",
+        "name": "Casablanca",
+        "description": "Casablanca is the massive Hassan II Mosque rising from the Atlantic – one of the few mosques non-Muslims can enter – plus art-deco architecture and real Moroccan city energy.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/casablanca.html"
+      },
+      {
+        "slug": "charleston",
+        "name": "Charleston",
+        "description": "Charleston is America's most charming cruise homeport — where Fort Sumter guards the harbor, Rainbow Row lines the waterfront, and Lowcountry hospitality makes arriving a day early absolutely essential.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/charleston.html"
+      },
+      {
+        "slug": "christchurch",
+        "name": "Christchurch (Lyttelton)",
+        "description": "Discover Christchurch and Lyttelton Port: New Zealand's oldest established city, the Garden City rebuilt after devastating 2011 earthquakes.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/christchurch.html"
+      },
+      {
+        "slug": "colon",
+        "name": "Colón",
+        "description": "First-person logbook guide to Colón, Panama — witnessing the Panama Canal's Agua Clara Locks, Fort San Lorenzo UNESCO World Heritage site, Portobelo Spanish colonial history, Gamboa Rainforest adventures, and experiencing one of the world's great engineering wonders.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/colon.html"
+      },
+      {
+        "slug": "corinto",
+        "name": "Corinto",
+        "description": "First-person logbook guide to Corinto, Nicaragua — exploring colonial León's UNESCO heritage churches and cathedral, volcano boarding down Cerro Negro's black slopes, visiting Las Peñitas beach, experiencing Nicaragua's revolutionary history, authentic local markets, and discovering Central America's most authentic and least-touristed destination.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/corinto.html"
+      },
+      {
+        "slug": "dakar",
+        "name": "Dakar, Senegal",
+        "description": "First-person logbook guide to Dakar, Senegal — Gorée Island UNESCO World Heritage site, African Renaissance Monument, Lac Rose Pink Lake, Sandaga Market, Grand Mosque, and experiencing Senegal's legendary Teranga hospitality at Africa's westernmost point.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/dakar.html"
+      },
+      {
+        "slug": "doha",
+        "name": "Doha, Qatar",
+        "description": "First-person logbook guide to Doha, Qatar — Museum of Islamic Art, Souq Waqif traditional market, Corniche waterfront promenade, Katara Cultural Village, and discovering where ancient Arabian traditions flourish beneath gleaming skyscrapers.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/doha.html"
+      },
+      {
+        "slug": "doubtful-sound",
+        "name": "Doubtful Sound Guide — New Zealand's Deepest Fjord Scenic Cruising",
+        "description": "Doubtful Sound is New Zealand's largest and deepest fjord — 40 kilometers of pristine wilderness where cruise ships glide through dramatic scenery featuring hundreds of waterfalls, resident dolphins, and the unforgettable \"Sound of Silence\" tradition.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/doubtful-sound.html"
+      },
+      {
+        "slug": "dravuni",
+        "name": "Dravuni Island",
+        "description": "First-person logbook guide to Dravuni Island, Fiji — authentic village life, traditional kava ceremony welcomes, pristine coral beach snorkeling, and experiencing genuine Fijian hospitality on an island of 100 souls.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/dravuni.html"
+      },
+      {
+        "slug": "dubai",
+        "name": "Dubai",
+        "description": "First-person logbook guide to Dubai—Mina Rashid terminal, Burj Khalifa's soaring heights, Palm Jumeirah, historic Al Fahidi quarter, Gold Souk, and a city that tells two stories at once: heritage trading port and modern global hub.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/dubai.html"
+      },
+      {
+        "slug": "durban",
+        "name": "Durban, South Africa - Sunny Beaches and Zulu Heritage",
+        "description": "Discover Durban's Golden Mile beaches, rich Indian heritage, and Zulu culture.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/durban.html"
+      },
+      {
+        "slug": "easter-island",
+        "name": "Easter Island (Rapa Nui)",
+        "description": "First-person logbook guide to Easter Island (Rapa Nui), Chile — 887 moai statues at Rano Raraku quarry, Ahu Tongariki's 15 restored moai, Polynesian culture, volcanic landscapes, and discovering the world's most remote inhabited island in the South Pacific.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/easter-island.html"
+      },
+      {
+        "slug": "ensenada",
+        "name": "Ensenada",
+        "description": "Ensenada cruise port guide featuring Valle de Guadalupe wine country, La Bufadora blowhole, legendary fish tacos, and Hussong's Cantina birthplace of the margarita.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/ensenada.html"
+      },
+      {
+        "slug": "falkland-islands",
+        "name": "Falkland Islands (Port Stanley)",
+        "description": "Falkland Islands cruise port guide featuring King penguin colonies at Volunteer Point, windswept Stanley town, 1982 war memorials, and wildlife encounters at the edge of the South Atlantic.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/falkland-islands.html"
+      },
+      {
+        "slug": "fiji",
+        "name": "Fiji (Lautoka)",
+        "description": "First-person logbook guide to Lautoka, Fiji — 333 islands with 3,500 years of Melanesian heritage, kava ceremonies, firewalking traditions, Sigatoka Sand Dunes archaeology, world-class diving in the Soft Coral Capital, and experiencing authentic Fijian bula hospitality.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/fiji.html"
+      },
+      {
+        "slug": "ft-lauderdale",
+        "name": "Fort Lauderdale",
+        "description": "Florida's second-busiest cruise port with 4M+ passengers annually — easier logistics than Miami, 7 miles of pristine Atlantic coastline, Las Olas Boulevard dining, and Water Taxi tours through 300+ miles of canals.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/ft-lauderdale.html"
+      },
+      {
+        "slug": "fortaleza",
+        "name": "Fortaleza",
+        "description": "First-person logbook guide to Fortaleza, Brazil — exploring Beach Park's legendary waterslides, Praia do Futuro's lobster barracas, the historic center's colonial architecture, traditional jangada sailboats, and the laid-back beach culture of Ceará's capital.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/fortaleza.html"
+      },
+      {
+        "slug": "funchal",
+        "name": "Funchal, Madeira",
+        "description": "First-person logbook guide to Funchal, Madeira — capital of this volcanic Atlantic island for five centuries.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/funchal.html"
+      },
+      {
+        "slug": "galveston",
+        "name": "Galveston",
+        "description": "America's fourth busiest cruise port and Texas's gateway to the Western Caribbean.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/galveston.html"
+      },
+      {
+        "slug": "gatun-lake",
+        "name": "Gatun Lake Guide — Panama Canal Transit Experience",
+        "description": "Gatun Lake is the massive man-made freshwater lake at the heart of the Panama Canal.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/gatun-lake.html"
+      },
+      {
+        "slug": "gijon",
+        "name": "Gijón",
+        "description": "Gijón is Asturias' soul on the Bay of Biscay — Celtic Green Coast, Eduardo Chillida's horizon sculpture, Roman baths, and cider culture.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/gijon.html"
+      },
+      {
+        "slug": "gran-canaria",
+        "name": "Gran Canaria (Las Palmas)",
+        "description": "First-person logbook guide to Las Palmas, Gran Canaria — stunning Maspalomas Dunes, colonial Vegueta quarter, Casa de Colón, Playa de las Canteras beach, and discovering the Canary Islands' most diverse landscape.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/gran-canaria.html"
+      },
+      {
+        "slug": "guam",
+        "name": "Guam",
+        "description": "Guam delivers profound WWII history at War in the Pacific National Historical Park, 4,000 years of Chamorro culture, world-class diving on sunken wrecks, and Tumon Bay's pristine beaches — America's furthest west territory, where the day begins.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/guam.html"
+      },
+      {
+        "slug": "guayaquil",
+        "name": "Guayaquil",
+        "description": "Guayaquil is Ecuador's largest city and main Galápagos gateway, featuring Malecón 2000 riverfront, Las Peñas historic hillside district (444 steps), iguana-filled parks, coastal cuisine, and vibrant urban renewal.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/guayaquil.html"
+      },
+      {
+        "slug": "huatulco",
+        "name": "Huatulco",
+        "description": "Huatulco is Mexico's eco-planned coastal paradise—nine protected bays with pristine national park snorkeling, authentic Oaxacan cuisine in La Crucecita, and coffee plantation tours into the Sierra Madre.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/huatulco.html"
+      },
+      {
+        "slug": "hurghada",
+        "name": "Hurghada, Egypt: Red Sea Resort and Marine Life Haven -",
+        "description": "Discover Hurghada's vibrant coral reefs, Giftun Islands marine park, desert adventures, and the gateway to ancient Luxor.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/hurghada.html"
+      },
+      {
+        "slug": "jacksonville",
+        "name": "Jacksonville",
+        "description": "Jacksonville offers a low-key Florida cruise experience with beautiful Atlantic beaches, manageable parking, and easy access for Southeast cruisers.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/jacksonville.html"
+      },
+      {
+        "slug": "la-coruna",
+        "name": "La Coruña",
+        "description": "La Coruña is the City of Glass – Roman lighthouse still working after 1,900 years, galleries in glazed balconies, and beaches right in the city center.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/la-coruna.html"
+      },
+      {
+        "slug": "lanzarote",
+        "name": "Lanzarote (Arrecife)",
+        "description": "First-person logbook guide to Arrecife, Lanzarote — stunning Timanfaya National Park volcanic landscape, Jameos del Agua caves, César Manrique's architectural legacy, La Geria wine region, and discovering the Canary Islands' most dramatic scenery.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/lanzarote.html"
+      },
+      {
+        "slug": "lautoka",
+        "name": "Lautoka, Fiji: Sugar City and Gateway to Paradise",
+        "description": "Discover Lautoka, Fiji's Sugar City on western Viti Levu.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/lautoka.html"
+      },
+      {
+        "slug": "lifou",
+        "name": "Lifou, Loyalty Islands",
+        "description": "First-person logbook guide to Lifou, Loyalty Islands, New Caledonia — Jinek Bay snorkeling, Jokin Cliffs limestone formations, Notre-Dame de Lourdes Chapel, Kanak cultural villages, vanilla plantations, pristine coral reefs, and experiencing authentic Melanesian island life.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/lifou.html"
+      },
+      {
+        "slug": "los-angeles",
+        "name": "Los Angeles",
+        "description": "Southern California's cruise gateway serves Mexican Riviera and Hawaii itineraries from two terminals.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/los-angeles.html"
+      },
+      {
+        "slug": "luanda",
+        "name": "Luanda, Angola: A Maritime Guide to Africa's Oil Capital",
+        "description": "A sailor's guide to Luanda, Angola - exploring the Portuguese colonial fortress, Ilha peninsula, and the stark contrasts of Africa's third-largest city.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/luanda.html"
+      },
+      {
+        "slug": "maldives",
+        "name": "Maldives (Malé)",
+        "description": "First-person logbook guide to Malé, Maldives — whale shark diving, coral stone mosques, fish markets, pristine atolls, and swimming in the impossible turquoise of the Indian Ocean's 1,200-island paradise.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/maldives.html"
+      },
+      {
+        "slug": "manaus",
+        "name": "Manaus, Brazil",
+        "description": "First-person logbook guide to Manaus, Brazil — Teatro Amazonas opera house, Meeting of the Waters, swimming with pink dolphins, piranha fishing, indigenous villages, and discovering the heart of the Amazon rainforest.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/manaus.html"
+      },
+      {
+        "slug": "manta",
+        "name": "Manta",
+        "description": "Manta is Ecuador's largest seaport and the world's tuna capital.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/manta.html"
+      },
+      {
+        "slug": "manzanillo",
+        "name": "Manzanillo",
+        "description": "Manzanillo is Mexico's authentic Pacific coast experience—world-class sailfish sportfishing, twin golden bays, the iconic Las Hadas resort from \"10,\" and real working-city character.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/manzanillo.html"
+      },
+      {
+        "slug": "maputo",
+        "name": "Maputo",
+        "description": "First-person logbook guide to Maputo — Eiffel-designed railway station, Portuguese colonial architecture, Inhaca Island marine reserve, piri piri prawns, and discovering Mozambique's coastal capital.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/maputo.html"
+      },
+      {
+        "slug": "mauritius",
+        "name": "Mauritius (Port Louis)",
+        "description": "First-person logbook guide to Port Louis, Mauritius — Aapravasi Ghat indentured labor history, vibrant Central Market, Blue Penny Museum, Black River Gorges National Park, and discovering Mark Twain's island paradise.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/mauritius.html"
+      },
+      {
+        "slug": "mazatlan",
+        "name": "Mazatlan",
+        "description": "Mazatlan—the \"Pearl of the Pacific\"—offers both Golden Zone beach resort vibes and an authentically restored Centro Historico with 500-year-old buildings.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/mazatlan.html"
+      },
+      {
+        "slug": "miami",
+        "name": "Miami",
+        "description": "Miami is the Cruise Capital of the World — PortMiami handles 8M+ passengers annually.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/miami.html"
+      },
+      {
+        "slug": "milford-sound",
+        "name": "Milford Sound Guide — Eighth Wonder of the World",
+        "description": "Milford Sound is a dramatic 15km fjord in Fiordland National Park — scenic cruising only with Mitre Peak rising 1,692m straight from the sea, cascading waterfalls, ancient rainforest, and UNESCO World Heritage wilderness that earns its title as the eighth wonder of the world.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/milford-sound.html"
+      },
+      {
+        "slug": "mindelo",
+        "name": "Mindelo, Cape Verde: Cultural Heart of the Atlantic",
+        "description": "Experience Mindelo, São Vicente - birthplace of Cesária Évora, cultural capital of Cape Verde, where morna music fills colonial streets and Porto Grande welcomes sailors to Africa's soulful archipelago.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/mindelo.html"
+      },
+      {
+        "slug": "mobile",
+        "name": "Mobile",
+        "description": "Alabama's charming cruise port where Southern hospitality meets the birthplace of Mardi Gras — the USS Alabama, historic district, and Gulf Coast warmth await.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/mobile.html"
+      },
+      {
+        "slug": "mombasa",
+        "name": "Mombasa",
+        "description": "Your complete guide to Mombasa, Kenya - explore Fort Jesus, Old Town's Swahili architecture, pristine Diani Beach, and gateway to Tsavo safari adventures.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/mombasa.html"
+      },
+      {
+        "slug": "montevideo",
+        "name": "Montevideo",
+        "description": "First-person logbook guide to Montevideo — historic Ciudad Vieja walkable from the cruise terminal, legendary Mercado del Puerto grilled meats, Teatro Solís opera house, and discovering Uruguay's surprisingly charming capital.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/montevideo.html"
+      },
+      {
+        "slug": "moorea",
+        "name": "Moorea (French Polynesia)",
+        "description": "First-person logbook guide to Moorea, French Polynesia — Belvedere Lookout over Cook's Bay and Ōpūnohu Bay, lagoon tours with stingrays and blacktip reef sharks, black pearl shopping, Tiki Village cultural experiences, and exploring the heart-shaped volcanic island.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/moorea.html"
+      },
+      {
+        "slug": "muscat",
+        "name": "Muscat",
+        "description": "First-person logbook guide to Muscat — Sultan Qaboos Grand Mosque, the legendary Mutrah Souq, frankincense heritage, and discovering Oman's graceful Arabian capital.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/muscat.html"
+      },
+      {
+        "slug": "mystery-island",
+        "name": "Mystery Island (Vanuatu)",
+        "description": "First-person logbook guide to Mystery Island, Vanuatu — pristine white sand beaches, crystal-clear snorkeling, local Aneityumese vendors arriving by boat, and experiencing an uninhabited South Pacific island where nature remains untouched.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/mystery-island.html"
+      },
+      {
+        "slug": "napier",
+        "name": "Napier",
+        "description": "First-person logbook guide to Napier—Art Deco capital rebuilt after 1931 earthquake, Hawke's Bay wineries, Cape Kidnappers gannets, and New Zealand's oldest wine region under endless sunshine.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/napier.html"
+      },
+      {
+        "slug": "new-orleans",
+        "name": "New Orleans",
+        "description": "America's most captivating cruise homeport — powdered sugar beignets, authentic jazz on Frenchmen Street, Creole cuisine, and centuries of culture in walkable neighborhoods.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/new-orleans.html"
+      },
+      {
+        "slug": "nosy-be",
+        "name": "Nosy Be, Madagascar",
+        "description": "First-person logbook guide to Nosy Be, Madagascar — ylang-ylang plantations on Perfume Island, Lokobe Reserve lemurs, pristine coral reefs, sacred banyan tree, and discovering Madagascar's fragrant island escape.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/nosy-be.html"
+      },
+      {
+        "slug": "noumea",
+        "name": "Noumea, New Caledonia",
+        "description": "First-person logbook guide to Noumea, New Caledonia — UNESCO lagoons, Amedee Island lighthouse, swimming with turtles at Signal Island, Tjibaou Cultural Centre, French cuisine, and exploring where Melanesian culture meets Parisian charm.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/noumea.html"
+      },
+      {
+        "slug": "palau",
+        "name": "Palau / Koror",
+        "description": "First-person guide to Palau cruise port in Koror: Jellyfish Lake with stingless golden jellies, Rock Islands UNESCO site, world-class diving at Blue Corner, Milky Way lagoon, and WWII history at Peleliu.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/palau.html"
+      },
+      {
+        "slug": "panama-canal",
+        "name": "Panama Canal Transit Guide — Locks & Engineering Marvel",
+        "description": "Transiting the Panama Canal is the single most fascinating \"port\" day you will ever have on a cruise — a man-made wonder that still blows minds 110 years later.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/panama-canal.html"
+      },
+      {
+        "slug": "papeete",
+        "name": "Papeete",
+        "description": "First-person logbook guide to Papeete, Tahiti — birthplace of overwater bungalows, home to Gauguin's finest works (1891-1901), Le Marché market, black pearls, vanilla, and French Polynesia's vibrant capital where 118 islands converge.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/papeete.html"
+      },
+      {
+        "slug": "picton",
+        "name": "Picton",
+        "description": "First-person logbook guide to Picton — gateway to the Marlborough Sounds' ancient flooded valleys, Queen Charlotte Track hiking from Ship Cove, world-renowned Marlborough wine country, and New Zealand's serene South Island harbor where wilderness meets working port.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/picton.html"
+      },
+      {
+        "slug": "pitcairn",
+        "name": "Pitcairn Island",
+        "description": "First-person logbook guide to Pitcairn Island — HMS Bounty mutineer descendants, world's most remote inhabited island, longboat landing only, population of 50, Christian's Cave, Bounty Bay, and experiencing the world's smallest democracy in the South Pacific.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/pitcairn.html"
+      },
+      {
+        "slug": "ponta-delgada",
+        "name": "Ponta Delgada",
+        "description": "First-person logbook guide to Ponta Delgada, Azores — stunning Sete Cidades twin lakes, year-round whale watching, volcanic Furnas Valley, geothermal wonders, and the mid-Atlantic crossing everyone should experience.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/ponta-delgada.html"
+      },
+      {
+        "slug": "port-elizabeth",
+        "name": "Port Elizabeth (Gqeberha)",
+        "description": "First-person logbook guide to Port Elizabeth (Gqeberha) — malaria-free elephant encounters at Addo, stunning Garden Route drives, pristine beaches, friendly city atmosphere, and exploring South Africa's Eastern Cape Province.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/port-elizabeth.html"
+      },
+      {
+        "slug": "port-moresby",
+        "name": "Port Moresby, Papua New Guinea - Gateway to Tribal Cultures & WWII History",
+        "description": "Explore Port Moresby, PNG's vibrant capital on the Coral Sea.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/port-moresby.html"
+      },
+      {
+        "slug": "portimao",
+        "name": "Portimão",
+        "description": "Portimão is golden Algarve cliffs tumbling into turquoise water, Benagil Cave's cathedral of light, sardine fishing heritage, and 300 days of sunshine a year on Portugal's southern coast.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/portimao.html"
+      },
+      {
+        "slug": "portland",
+        "name": "Portland",
+        "description": "Portland is the Jurassic Coast – Chesil Beach's 18-mile pebble ridge, Portland Bill lighthouse, and fossils literally falling out of the cliffs.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/portland.html"
+      },
+      {
+        "slug": "porto",
+        "name": "Porto",
+        "description": "Porto is terracotta roofs cascading down to the Douro, port wine lodges, and the most beautiful train station in Europe covered in azulejos.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/porto.html"
+      },
+      {
+        "slug": "praia",
+        "name": "Praia, Cape Verde:",
+        "description": "First-hand guide to visiting Praia, Cape Verde by cruise ship.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/praia.html"
+      },
+      {
+        "slug": "puerto-caldera",
+        "name": "Puerto Caldera",
+        "description": "First-person logbook guide to Puerto Caldera, Costa Rica — exploring the modern cruise terminal closer to San José, Carara National Park's scarlet macaw colonies, Tárcoles River's massive crocodiles, rainforest canopy adventures, sloth sanctuaries, coffee plantations, and immersive eco-tourism experiences in Central America's biodiversity jewel.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/puerto-caldera.html"
+      },
+      {
+        "slug": "puerto-limon",
+        "name": "Puerto Limón",
+        "description": "Puerto Limón is your gateway to Costa Rica's Caribbean rainforest — sloths, monkeys, jungle canals, zip-lines, and the kind of wild that makes you remember what alive means.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/puerto-limon.html"
+      },
+      {
+        "slug": "puerto-madryn",
+        "name": "Puerto Madryn, Argentina",
+        "description": "First-person logbook guide to Puerto Madryn, Argentina — Southern Right Whale watching from shore and boat, Valdés Peninsula UNESCO World Heritage Site, penguin colonies, orca hunting grounds, and discovering Patagonia's wild beauty.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/puerto-madryn.html"
+      },
+      {
+        "slug": "puerto-vallarta",
+        "name": "Puerto Vallarta",
+        "description": "Puerto Vallarta is Pacific Mexico's most walkable and culturally rich cruise port—the Malecon boardwalk, bronze sculptures, art galleries, Our Lady of Guadalupe church, Zona Romantica's intimate restaurants, and Sierra Madre mountain backdrop.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/puerto-vallarta.html"
+      },
+      {
+        "slug": "punta-arenas",
+        "name": "Punta Arenas",
+        "description": "First-person logbook guide to Punta Arenas — Strait of Magellan crossing, Magdalena Island penguin colonies, Fort Bulnes historical site, Torres del Paine National Park gateway, and navigating Chile's southernmost continental city.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/punta-arenas.html"
+      },
+      {
+        "slug": "puntarenas",
+        "name": "Puntarenas",
+        "description": "First-person logbook guide to Puntarenas, Costa Rica — exploring Carara National Park's scarlet macaw sanctuary, Manuel Antonio beaches and wildlife, Monteverde cloud forest, thrilling zip-line canopy tours, sloth encounters, and embracing the Pura Vida spirit of Costa Rica's Pacific coast.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/puntarenas.html"
+      },
+      {
+        "slug": "recife",
+        "name": "Recife",
+        "description": "First-person logbook guide to Recife, Brazil — exploring the Venice of Brazil's bridges and canals, Olinda's UNESCO colonial streets, vibrant frevo rhythms, and the Dutch colonial heritage of Pernambuco's capital.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/recife.html"
+      },
+      {
+        "slug": "rio-de-janeiro",
+        "name": "Rio de Janeiro",
+        "description": "First-person logbook guide to Rio de Janeiro cruise port — Christ the Redeemer atop Corcovado, Sugarloaf's cable car to 1,296-foot summit, Copacabana's golden sands, Carnival's samba heartbeat, and why Cariocas call it Cidade Maravilhosa since 1565.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/rio-de-janeiro.html"
+      },
+      {
+        "slug": "safaga",
+        "name": "Safaga",
+        "description": "First-person logbook guide to Safaga — gateway to Luxor's Valley of the Kings, world-class Red Sea diving, and therapeutic mineral waters along Egypt's eastern shore.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/safaga.html"
+      },
+      {
+        "slug": "saipan",
+        "name": "Saipan",
+        "description": "First-person logbook guide to Saipan — exploring WWII memorials, diving The Grotto, Managaha Island beaches, and discovering the largest island of the Northern Mariana Islands.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/saipan.html"
+      },
+      {
+        "slug": "salalah",
+        "name": "Salalah",
+        "description": "First-person logbook guide to Salalah — the perfume capital of Arabia, UNESCO frankincense sites, Al Baleed archaeological park, and the magical khareef monsoon season.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/salalah.html"
+      },
+      {
+        "slug": "salvador",
+        "name": "Salvador, Brazil",
+        "description": "First-person logbook guide to Salvador, Brazil — Pelourinho UNESCO World Heritage site, baroque São Francisco Church, Afro-Brazilian culture, capoeira performances, colonial architecture, and discovering Brazil's first capital.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/salvador.html"
+      },
+      {
+        "slug": "san-diego",
+        "name": "San Diego",
+        "description": "America's Finest City with perfect weather year-round — the USS Midway, San Diego Zoo, Gaslamp Quarter, and one of the closest airport-to-port connections anywhere.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/san-diego.html"
+      },
+      {
+        "slug": "san-francisco",
+        "name": "San Francisco, USA",
+        "description": "First-person logbook guide to San Francisco — walking the Golden Gate Bridge, touring Alcatraz, riding cable cars, tasting clam chowder at Fisherman's Wharf, and discovering the neighborhoods that make this California city unforgettable.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/san-francisco.html"
+      },
+      {
+        "slug": "santos",
+        "name": "Santos",
+        "description": "First-person logbook guide to Santos — Brazil's largest port, Coffee Museum, beachfront gardens, and gateway to São Paulo.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/santos.html"
+      },
+      {
+        "slug": "seattle",
+        "name": "Seattle",
+        "description": "America's premier gateway to Alaska — Pike Place Market fish throwers, the Space Needle, world-class coffee, and stunning mountain views make arriving early essential.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/seattle.html"
+      },
+      {
+        "slug": "seychelles",
+        "name": "Seychelles (Victoria, Mahé)",
+        "description": "First-person logbook guide to Victoria, Mahé — pristine beaches, giant tortoises at Botanical Gardens, Sainte Anne Marine National Park, Hindu temples, and exploring the Seychelles' granite island paradise.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/seychelles.html"
+      },
+      {
+        "slug": "sharm-el-sheikh",
+        "name": "Sharm el-Sheikh",
+        "description": "First-person logbook guide to Sharm el-Sheikh — world-class diving at Ras Mohammed and Tiran Island, St.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/sharm-el-sheikh.html"
+      },
+      {
+        "slug": "south-georgia",
+        "name": "South Georgia Island",
+        "description": "First-person logbook guide to South Georgia Island — 200,000+ King penguins at Salisbury Plain, Ernest Shackleton's grave at Grytviken, abandoned whaling stations, elephant seals, wandering albatross, and sub-Antarctic wilderness where ice meets ocean.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/south-georgia.html"
+      },
+      {
+        "slug": "south-pacific",
+        "name": "South Pacific Islands",
+        "description": "First-person guide to South Pacific cruise ports: Bora Bora, Tahiti, Moorea, Fiji, Vanuatu, and Nouméa – turquoise lagoons and paradise islands.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/south-pacific.html"
+      },
+      {
+        "slug": "st-helena",
+        "name": "St. Helena",
+        "description": "First-person logbook guide to St.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/st-helena.html"
+      },
+      {
+        "slug": "suva",
+        "name": "Suva",
+        "description": "First-person logbook guide to Suva, Fiji — Kings Wharf downtown access, Fiji Museum cannibal forks and Pacific artifacts, largest South Pacific market, colonial Government Buildings, Colo-i-Suva Forest Park waterfalls, kava ceremonies, and discovering multi-ethnic Fijian warmth.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/suva.html"
+      },
+      {
+        "slug": "tampa",
+        "name": "Tampa",
+        "description": "Florida's underrated Gulf Coast gem — Ybor City Cuban sandwiches, free TECO streetcar, Busch Gardens coasters, and some of the best parking rates among major cruise ports.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/tampa.html"
+      },
+      {
+        "slug": "tangier",
+        "name": "Tangier",
+        "description": "Tangier is the gateway where Europe and Africa kiss – a swirling medina, Atlantic beaches, and the smell of mint tea and spices that hits you the moment you step off.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/tangier.html"
+      },
+      {
+        "slug": "tenerife",
+        "name": "Tenerife",
+        "description": "First-person logbook guide to Tenerife — ascending Spain's highest peak Mount Teide, UNESCO colonial La Laguna, volcanic landscapes, Loro Parque, world-class stargazing, and discovering the Canary Islands' largest island.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/tenerife.html"
+      },
+      {
+        "slug": "tonga",
+        "name": "Tonga (Nuku'alofa)",
+        "description": "First-person logbook guide to Nuku'alofa, Tonga — the Royal Palace, Mapu'a'a Vaea Blowholes shooting ocean spray skyward, Ha'amonga 'a Maui Trilithon, island snorkeling, and exploring the Pacific's only remaining Polynesian kingdom.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/tonga.html"
+      },
+      {
+        "slug": "tristan-da-cunha",
+        "name": "Tristan da Cunha",
+        "description": "First-person logbook guide to Tristan da Cunha — the world's most remote inhabited island, 1,750 miles from the nearest land, Edinburgh of the Seven Seas settlement, volcanic Queen Mary's Peak, rockhopper penguins, and the extraordinary resilience of 250 souls living at the edge of the world.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/tristan-da-cunha.html"
+      },
+      {
+        "slug": "ushuaia",
+        "name": "Ushuaia",
+        "description": "First-person logbook guide to Ushuaia — world's southernmost city, Tierra del Fuego National Park, Beagle Channel wildlife, End of the World Train, Antarctica expeditions, and standing at the edge of civilization.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/ushuaia.html"
+      },
+      {
+        "slug": "valparaiso",
+        "name": "Valparaíso",
+        "description": "First-person logbook guide to Valparaíso — UNESCO World Heritage hillside neighborhoods, historic ascensores funiculars, Pablo Neruda's La Sebastiana house, vibrant street art, and discovering Chile's wonderfully chaotic cultural capital.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/valparaiso.html"
+      },
+      {
+        "slug": "vancouver",
+        "name": "Vancouver",
+        "description": "Vancouver is the premier Alaska cruise gateway — Canada Place terminal sits beneath five iconic white sails, with Stanley Park, Granville Island, and world-class Asian cuisine making extra pre-cruise days essential.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/vancouver.html"
+      },
+      {
+        "slug": "vanuatu",
+        "name": "Vanuatu (Port Vila)",
+        "description": "First-person logbook guide to Port Vila, Vanuatu — Melanesian cultural villages, world's only underwater post office at Hideaway Island, Mele Cascades waterfalls, Blue Lagoon natural pool, and exploring this culturally diverse South Pacific nation.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/vanuatu.html"
+      },
+      {
+        "slug": "vigo",
+        "name": "Vigo",
+        "description": "Vigo is the gateway to the Cíes Islands – Atlantic paradise with beaches that regularly top \"best in the world\" lists and only 2,200 visitors a day.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/vigo.html"
+      },
+      {
+        "slug": "walvis-bay",
+        "name": "Walvis Bay (Namibia)",
+        "description": "First-person logbook guide to Walvis Bay, Namibia — thousands of pink flamingos, gateway to Sossusvlei's red dunes and Deadvlei, Sandwich Harbour's surreal desert-ocean collision, seal kayaking, and Skeleton Coast mystique.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/walvis-bay.html"
+      },
+      {
+        "slug": "zanzibar",
+        "name": "Zanzibar, Tanzania",
+        "description": "First-person logbook guide to Zanzibar, Tanzania — Stone Town UNESCO World Heritage Site, historic carved doors, spice island tours, Prison Island tortoises, and exploring the cultural crossroads of Africa and Arabia.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/zanzibar.html"
+      },
+      {
+        "slug": "zihuatanejo",
+        "name": "Zihuatanejo",
+        "description": "Zihuatanejo is the authentic Mexican fishing village Andy Dufresne dreamed about in Shawshank Redemption—tender landings, golden beaches at Playa La Ropa and Las Gatas, fresh seafood, and an unhurried pace that modern resorts can't replicate.",
+        "region": "other",
+        "tier": 2,
+        "url": "/ports/zihuatanejo.html"
+      }
+    ],
+    "pacific": [
+      {
+        "slug": "auckland",
+        "name": "Auckland",
+        "description": "Auckland cruise port guide featuring Sky Tower views, Waiheke Island wine tours, Maori cultural performances, volcanic landscapes, and New Zealand's City of Sails adventure.",
+        "region": "pacific",
+        "tier": 1,
+        "url": "/ports/auckland.html"
+      },
+      {
+        "slug": "honolulu",
+        "name": "Honolulu",
+        "description": "Honolulu gives you Waikiki's iconic golden sand, Pearl Harbor's solemn memorials, and Diamond Head's panoramic payoff — the one Hawaiian port where you can actually do it all in a single day.",
+        "region": "pacific",
+        "tier": 1,
+        "url": "/ports/honolulu.html"
+      },
+      {
+        "slug": "sydney",
+        "name": "Sydney",
+        "description": "Sydney features Opera House, Harbour Bridge, Bondi Beach, and spectacular harbour entrance.",
+        "region": "pacific",
+        "tier": 1,
+        "url": "/ports/sydney.html"
+      },
+      {
+        "slug": "adelaide",
+        "name": "Adelaide",
+        "description": "Adelaide is Australia's wine capital — gateway to 200+ cellar doors including legendary Barossa Valley ($150-250 tours).",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/adelaide.html"
+      },
+      {
+        "slug": "brisbane",
+        "name": "Brisbane",
+        "description": "First-person logbook: Brisbane's Portside Wharf, South Bank riverside, scenic river cruises to Lone Pine Koala Sanctuary with 130+ koalas, and why Queensland's subtropical warmth makes this Australia's most welcoming port.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/brisbane.html"
+      },
+      {
+        "slug": "cairns",
+        "name": "Cairns",
+        "description": "First-person logbook guide to Cairns — 1876 gold port, gateway to the 2,300km Great Barrier Reef and 180-million-year-old Daintree Rainforest, where two UNESCO sites meet at Cape Tribulation.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/cairns.html"
+      },
+      {
+        "slug": "darwin",
+        "name": "Darwin",
+        "description": "First-person logbook guide to Darwin, Australia — gateway to the Top End, saltwater crocodile territory, Kakadu's UNESCO wetlands and Aboriginal rock art, WWII bombing history, Adelaide River cruises, and Mindil Beach sunset traditions.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/darwin.html"
+      },
+      {
+        "slug": "dunedin",
+        "name": "Dunedin",
+        "description": "First-person logbook guide to Dunedin's Scottish soul — 1848 founding, gold rush prosperity, ornate Railway Station 'Gingerbread House', Larnach Castle on Otago Peninsula, royal albatross colony, hoiho penguins, and Victorian grandeur at the end of the world.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/dunedin.html"
+      },
+      {
+        "slug": "fremantle",
+        "name": "Fremantle",
+        "description": "First-person logbook guide to Fremantle — UNESCO World Heritage convict prison with haunting tunnel tours, markets trading since 1897, bohemian 'Freo' atmosphere, and Perth's historic gateway at the Swan River mouth.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/fremantle.html"
+      },
+      {
+        "slug": "hilo",
+        "name": "Hilo",
+        "description": "Hilo is waterfalls every five minutes, active volcanoes, and the greenest, rainiest, most authentic side of the Big Island.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/hilo.html"
+      },
+      {
+        "slug": "hobart",
+        "name": "Hobart",
+        "description": "First-person logbook guide to Hobart — founded 1804 as penal colony, transformed by MONA (Australia's largest private museum), Salamanca's Georgian warehouses, Mount Wellington's 1,271m summit, gateway to Antarctica, Cascade Brewery (1824), and Tasmania's wild beauty.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/hobart.html"
+      },
+      {
+        "slug": "kona",
+        "name": "Kailua-Kona",
+        "description": "Kailua-Kona is historic villages, world-famous coffee, and one of the planet's best night manta experiences – all from a walkable/tender port.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/kona.html"
+      },
+      {
+        "slug": "lyttelton",
+        "name": "Lyttelton",
+        "description": "First-person logbook guide to Lyttelton — port of Canterbury pilgrims, Antarctic expedition history, earthquake recovery story, and gateway to Christchurch's gardens and resilience.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/lyttelton.html"
+      },
+      {
+        "slug": "maui",
+        "name": "Maui",
+        "description": "Ships dock at Kahului on the Valley Isle.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/maui.html"
+      },
+      {
+        "slug": "melbourne",
+        "name": "Melbourne",
+        "description": "Australia's cultural capital and cruise gateway to New Zealand and the South Pacific — Victorian-era laneways transformed into street art galleries, legendary coffee culture crafted by passionate baristas, and a constantly evolving urban canvas that has earned Melbourne its reputation as one of the world's most liveable cities.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/melbourne.html"
+      },
+      {
+        "slug": "nawiliwili",
+        "name": "Nawiliwili",
+        "description": "Nawiliwili is Kauai's only cruise port – Waimea Canyon, the Na Pali coast, and more chickens than people on the Garden Isle.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/nawiliwili.html"
+      },
+      {
+        "slug": "tauranga",
+        "name": "Tauranga",
+        "description": "Reflective logbook guide to Tauranga — where Captain Cook's 'Bay of Plenty' meets ancient Māori heritage, geothermal valleys bubble beside redwood forests, and hobbit holes nestle among kiwifruit orchards in New Zealand's fertile heartland.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/tauranga.html"
+      },
+      {
+        "slug": "wellington",
+        "name": "Wellington",
+        "description": "First-person logbook guide to Wellington — Te Papa's colossal squid and Māori treasures, Cuba Street's creative spirit, Zealandia ecosanctuary, and experiencing New Zealand's windswept southern capital.",
+        "region": "pacific",
+        "tier": 2,
+        "url": "/ports/wellington.html"
+      }
+    ],
+    "mediterranean": [
+      {
+        "slug": "barcelona",
+        "name": "Barcelona",
+        "description": "Barcelona is a major embarkation port and Mediterranean highlight.",
+        "region": "mediterranean",
+        "tier": 1,
+        "url": "/ports/barcelona.html"
+      },
+      {
+        "slug": "civitavecchia",
+        "name": "Civitavecchia (Rome)",
+        "description": "Civitavecchia is Rome's cruise port, 80km and 90 minutes from the city.",
+        "region": "mediterranean",
+        "tier": 1,
+        "url": "/ports/civitavecchia.html"
+      },
+      {
+        "slug": "dubrovnik",
+        "name": "Dubrovnik",
+        "description": "Dubrovnik is Lord Byron's \"Pearl of the Adriatic\"—a UNESCO-listed city with 2km of 13th-century walls encircling 700 years of maritime republic legacy, where red roofs cascade down to the impossibly blue Adriatic and every stone tells a story of independence and resilience.",
+        "region": "mediterranean",
+        "tier": 1,
+        "url": "/ports/dubrovnik.html"
+      },
+      {
+        "slug": "marseille",
+        "name": "Marseille",
+        "description": "Marseille is France's oldest city (founded 600 BCE) and a gritty, authentic Mediterranean port.",
+        "region": "mediterranean",
+        "tier": 1,
+        "url": "/ports/marseille.html"
+      },
+      {
+        "slug": "mykonos",
+        "name": "Mykonos",
+        "description": "Mykonos is the quintessential Greek island—a maze of white-washed buildings, iconic windmills, and Little Venice waterfront, plus day trips to sacred Delos and world-famous shores.",
+        "region": "mediterranean",
+        "tier": 1,
+        "url": "/ports/mykonos.html"
+      },
+      {
+        "slug": "naples",
+        "name": "Naples",
+        "description": "Naples serves as gateway to Pompeii (35 min by train), Herculaneum, Mount Vesuvius, and the Amalfi Coast.",
+        "region": "mediterranean",
+        "tier": 1,
+        "url": "/ports/naples.html"
+      },
+      {
+        "slug": "santorini",
+        "name": "Santorini",
+        "description": "Santorini means sailing into the collapsed heart of a volcano that exploded around 1600 BC—a flooded caldera with white-washed villages clinging to 300-meter cliffs, iconic blue-domed churches, Bronze Age ruins at Akrotiri, and some of the most dramatic sunsets in the Mediterranean.",
+        "region": "mediterranean",
+        "tier": 1,
+        "url": "/ports/santorini.html"
+      },
+      {
+        "slug": "venice",
+        "name": "Venice",
+        "description": "Large ships now dock at Marghera on the mainland (20-30 min transfer to Venice).",
+        "region": "mediterranean",
+        "tier": 1,
+        "url": "/ports/venice.html"
+      },
+      {
+        "slug": "ajaccio",
+        "name": "Ajaccio (Corsica)",
+        "description": "Ajaccio is Napoleon's birthplace, rich with history, art, and Corsican charm.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/ajaccio.html"
+      },
+      {
+        "slug": "amalfi",
+        "name": "Amalfi (Salerno)",
+        "description": "Salerno is the smart gateway to the Amalfi Coast – Positano, Amalfi, and Ravello without the insane tender crowds of Sorrento.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/amalfi.html"
+      },
+      {
+        "slug": "athens",
+        "name": "Athens (Piraeus)",
+        "description": "Athens cruise port guide featuring the Acropolis, Parthenon, Ancient Agora, Plaka neighborhood, and the birthplace of Western democracy and philosophy.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/athens.html"
+      },
+      {
+        "slug": "bodrum",
+        "name": "Bodrum, Turkey",
+        "description": "First-person logbook guide to Bodrum, Turkey — ancient Halicarnassus, the Mausoleum (Seven Wonders of the Ancient World), Castle of St.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/bodrum.html"
+      },
+      {
+        "slug": "cadiz",
+        "name": "Cadiz",
+        "description": "Cádiz is the oldest continuously inhabited city in Western Europe, founded by Phoenicians in 1100 BC.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/cadiz.html"
+      },
+      {
+        "slug": "cagliari",
+        "name": "Cagliari (Sardinia)",
+        "description": "Cagliari is Sardinia's ancient capital (154,000 souls) built on Neolithic foundations—just 800m from your ship to medieval Castello towers, Bastione di Saint Remy panoramas, the 13th-century Cathedral, and 8km Poetto Beach that rivals the Caribbean.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/cagliari.html"
+      },
+      {
+        "slug": "cannes",
+        "name": "Cannes",
+        "description": "Cannes is red carpets, rosé on the beach, and the Croisette promenade that makes you feel like you're in a French movie – even without the film festival.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/cannes.html"
+      },
+      {
+        "slug": "capri",
+        "name": "Capri, Italy",
+        "description": "First-person logbook guide to Capri — Blue Grotto sea cave with glowing azure water, Monte Solaro panoramas, La Piazzetta's dolce vita lifestyle, Faraglioni rock formations, and the island paradise that captivated emperors and artists.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/capri.html"
+      },
+      {
+        "slug": "cartagena-spain",
+        "name": "Cartagena, Spain",
+        "description": "Cartagena is a perfectly preserved Roman theater, Art Nouveau buildings, and a harbor full of history – Spain's most surprising cruise port.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/cartagena-spain.html"
+      },
+      {
+        "slug": "catania",
+        "name": "Catania",
+        "description": "Catania is the \"Black Baroque\" city — born Greek in 729 BC, destroyed by Etna and earthquake, rebuilt in dark lava stone as a UNESCO World Heritage masterpiece.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/catania.html"
+      },
+      {
+        "slug": "cephalonia",
+        "name": "Cephalonia (Kefalonia), Greece - Largest Ionian Island",
+        "description": "First-person logbook entry from Cephalonia: Greece's largest Ionian island with 50,000 years of history, Melissani Cave's crystal waters, Myrtos Beach, ancient castles, Drogarati Cave, and resilience after the 1953 earthquake.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/cephalonia.html"
+      },
+      {
+        "slug": "corfu",
+        "name": "Corfu",
+        "description": "Corfu Old Town is Venetian charm with British and French twists, surrounded by emerald hills and some of the prettiest beaches in the Ionian.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/corfu.html"
+      },
+      {
+        "slug": "genoa",
+        "name": "Genoa",
+        "description": "Genoa is the underrated grand old lady of the Italian Riviera – massive palazzi, Europe's biggest medieval center, and the best focaccia you'll ever taste.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/genoa.html"
+      },
+      {
+        "slug": "gibraltar",
+        "name": "Gibraltar",
+        "description": "Gibraltar is a British Overseas Territory since 1704, home to the legendary Rock—one of Hercules' Pillars—rising 1,400 ft above the Strait.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/gibraltar.html"
+      },
+      {
+        "slug": "haifa",
+        "name": "Haifa, Israel",
+        "description": "First-person logbook guide to Haifa, Israel — UNESCO Bahá'í Gardens, day tours to Jerusalem and Bethlehem, Nazareth and the Sea of Galilee, ancient Caesarea, and the profound experience of walking where biblical history unfolded.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/haifa.html"
+      },
+      {
+        "slug": "heraklion",
+        "name": "Heraklion (Crete)",
+        "description": "Heraklion is the gateway to Knossos — Europe's oldest palace, birthplace of the Minotaur myth, and the only place you'll see 4,000-year-old frescoes still glowing with color.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/heraklion.html"
+      },
+      {
+        "slug": "hvar",
+        "name": "Hvar, Croatia",
+        "description": "First-person logbook guide to Hvar, Croatia — lavender fields, Stari Grad Plain UNESCO site, Fortica fortress, Europe's first public theater, Pakleni Islands, and exploring the sunniest place in Croatia.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/hvar.html"
+      },
+      {
+        "slug": "ibiza",
+        "name": "Ibiza",
+        "description": "Ibiza reveals 2,600+ years of history: Phoenician Ibossim (654 BCE), Puig des Molins necropolis (best-preserved ancient cemetery in Mediterranean), UNESCO-listed Renaissance Dalt Vila (1999), mythic Es Vedrà island, Formentera's turquoise beaches (30-minute ferry), and legendary club scene.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/ibiza.html"
+      },
+      {
+        "slug": "istanbul",
+        "name": "Istanbul",
+        "description": "First-person logbook guide to Istanbul — Hagia Sophia, Blue Mosque, Grand Bazaar, Bosphorus cruise, and the ancient meeting point of Europe and Asia.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/istanbul.html"
+      },
+      {
+        "slug": "koper",
+        "name": "Koper",
+        "description": "Koper is a miniature Venice with Slovenian prices – Venetian palaces, Tito Square, and the entire Istrian coast waiting 20 minutes away.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/koper.html"
+      },
+      {
+        "slug": "kotor",
+        "name": "Kotor",
+        "description": "Kotor is a medieval town tucked into Europe's southernmost fjord with mountains plunging straight into the sea — dramatic doesn't begin to describe it.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/kotor.html"
+      },
+      {
+        "slug": "kusadasi",
+        "name": "Kusadasi &amp; Ephesus — Turkey's Ancient Wonder",
+        "description": "Kusadasi is Turkey's gateway to Ephesus — one of the best-preserved ancient cities in the world.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/kusadasi.html"
+      },
+      {
+        "slug": "la-spezia",
+        "name": "La Spezia",
+        "description": "First-person logbook guide to La Spezia in Italy's Gulf of Poets — gateway to UNESCO Cinque Terre's five painted villages, Byron's Romantic coastline, naval heritage, and Ligurian focaccia traditions.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/la-spezia.html"
+      },
+      {
+        "slug": "limassol",
+        "name": "Limassol, Cyprus",
+        "description": "First-person logbook guide to Limassol, Cyprus — ancient Greek amphitheaters at Kourion, Crusader castles where Richard the Lionheart married, Temple of Apollo, Commandaria wine, and walking through 4,000 years of Mediterranean history.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/limassol.html"
+      },
+      {
+        "slug": "lisbon",
+        "name": "Lisbon",
+        "description": "Lisbon is seven hills of colorful tiles, melancholy fado music, and pastel de nata still warm from the oven – one of Europe's most soulful capitals.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/lisbon.html"
+      },
+      {
+        "slug": "livorno",
+        "name": "Livorno (Florence & Pisa)",
+        "description": "Livorno is one of Italy's busiest cruise ports and your gateway to Tuscany's greatest treasures — Renaissance Florence and Pisa's Leaning Tower.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/livorno.html"
+      },
+      {
+        "slug": "malaga",
+        "name": "Málaga",
+        "description": "Málaga was founded by Phoenicians around 1000 BC and is Picasso's birthplace (1881).",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/malaga.html"
+      },
+      {
+        "slug": "messina",
+        "name": "Messina",
+        "description": "Messina is the gateway to Taormina – Greek theater with an active volcano backdrop and the prettiest town on the Ionian coast.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/messina.html"
+      },
+      {
+        "slug": "monte-carlo",
+        "name": "Monte Carlo (Monaco)",
+        "description": "Monaco is pure glamour on steroids – supercars, yachts the size of cruise ships, and the Casino that looks exactly like the movies promised.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/monte-carlo.html"
+      },
+      {
+        "slug": "palma",
+        "name": "Palma de Mallorca",
+        "description": "Palma de Mallorca is a top-rated Mediterranean port with a stunning Gothic cathedral, charming old town, and easy beach access.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/palma.html"
+      },
+      {
+        "slug": "patmos",
+        "name": "Patmos",
+        "description": "First-person logbook guide to Patmos, Greece — the Cave of the Apocalypse, Monastery of St.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/patmos.html"
+      },
+      {
+        "slug": "portofino",
+        "name": "Portofino, Italy",
+        "description": "First-person logbook guide to Portofino — ancient Roman harbor transformed into luxury destination.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/portofino.html"
+      },
+      {
+        "slug": "ravenna",
+        "name": "Ravenna",
+        "description": "Ravenna is the world capital of Byzantine mosaics – eight UNESCO sites glowing with gold and color that haven't faded in 1,500 years.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/ravenna.html"
+      },
+      {
+        "slug": "rhodes",
+        "name": "Rhodes",
+        "description": "Rhodes is the best-preserved medieval city in Europe — a living fortress with 4 km of walls, palaces, mosques, and a street where knights actually rode horses down.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/rhodes.html"
+      },
+      {
+        "slug": "sorrento",
+        "name": "Sorrento, Italy",
+        "description": "First-person logbook guide to Sorrento, Italy — perched at the northern gateway to the Amalfi Coast, where ships tender to Marina Piccola, Sfusato Amalfitano lemons perfume the air, and centuries of limoncello tradition meet Pompeii's ruins and Capri's azure waters.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/sorrento.html"
+      },
+      {
+        "slug": "split",
+        "name": "Split",
+        "description": "Split is Diocletian's retirement palace turned living city — Romans, Venetians, and modern Croatians all sharing the same marble streets.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/split.html"
+      },
+      {
+        "slug": "taormina",
+        "name": "Taormina",
+        "description": "Taormina is the jewel of Sicily — perched on a cliff above the Ionian Sea with the legendary Teatro Greco framing views of Mount Etna, centuries of layered history from Greeks to Grand Tour aristocrats, and the kind of beauty that has captivated travelers for over two thousand years.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/taormina.html"
+      },
+      {
+        "slug": "trieste",
+        "name": "Trieste",
+        "description": "Trieste is elegant Habsburg cafés, the largest sea-facing piazza in Italy, and a literary soul that feels like Vienna and Venice had a baby on the Adriatic.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/trieste.html"
+      },
+      {
+        "slug": "tunis",
+        "name": "Tunis (La Goulette)",
+        "description": "La Goulette is your gateway to Carthage, Sidi Bou Said's blue-and-white perfection, and Tunis medina – three UNESCO sites in one day.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/tunis.html"
+      },
+      {
+        "slug": "valencia",
+        "name": "Valencia",
+        "description": "Valencia was founded 138 BC as Roman Valentia, meaning \"strength.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/valencia.html"
+      },
+      {
+        "slug": "valletta",
+        "name": "Valletta (Malta)",
+        "description": "Valletta is Europe's smallest capital and a UNESCO World Heritage Site (since 1980) — a fortress city founded March 28, 1566 by Grand Master Jean de Valette after the Knights of St. John survived the Great Siege of 1565.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/valletta.html"
+      },
+      {
+        "slug": "villefranche",
+        "name": "Villefranche-sur-Mer (Nice & Monaco)",
+        "description": "Villefranche-sur-Mer is a tender port with one of the Mediterranean's deepest natural harbors, dating to 130 BC.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/villefranche.html"
+      },
+      {
+        "slug": "zadar",
+        "name": "Zadar",
+        "description": "Zadar is Roman ruins, a Sea Organ that plays music with the waves, and a Greeting to the Sun light show – the coolest small city on the Adriatic.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/zadar.html"
+      },
+      {
+        "slug": "zakynthos",
+        "name": "Zakynthos (Zante), Greece",
+        "description": "First-person logbook guide to Zakynthos (Zante), Greece — Navagio Shipwreck Beach, Blue Caves, loggerhead sea turtles, Venetian fortress, St.",
+        "region": "mediterranean",
+        "tier": 2,
+        "url": "/ports/zakynthos.html"
+      }
+    ],
+    "northern-europe": [
+      {
+        "slug": "amsterdam",
+        "name": "Amsterdam",
+        "description": "Amsterdam's cruise terminal is right behind Centraal Station — you step off and you're instantly in one of the most beautiful cities on earth.",
+        "region": "northern-europe",
+        "tier": 1,
+        "url": "/ports/amsterdam.html"
+      },
+      {
+        "slug": "copenhagen",
+        "name": "Copenhagen",
+        "description": "Copenhagen is consistently voted the #1 Northern Europe port — colorful Nyhavn, magical Tivoli Gardens, the Little Mermaid, and smørrebrød sandwiches.",
+        "region": "northern-europe",
+        "tier": 1,
+        "url": "/ports/copenhagen.html"
+      },
+      {
+        "slug": "reykjavik",
+        "name": "Reykjavik",
+        "description": "Reykjavik is gateway to Iceland's otherworldly landscapes.",
+        "region": "northern-europe",
+        "tier": 1,
+        "url": "/ports/reykjavik.html"
+      },
+      {
+        "slug": "akureyri",
+        "name": "Akureyri, Iceland",
+        "description": "Akureyri offers world-class whale watching from the pier (€85-150), Goðafoss waterfall 30 minutes away (€80-120 tours), and Lake Mývatn geothermal wonders (€150-200 full-day).",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/akureyri.html"
+      },
+      {
+        "slug": "alesund",
+        "name": "Ålesund",
+        "description": "Ålesund is pure Art Nouveau fairy tale rebuilt after a 1904 fire – pastel buildings, turrets, and islands scattered like confetti in the fjord.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/alesund.html"
+      },
+      {
+        "slug": "belfast",
+        "name": "Belfast",
+        "description": "Belfast has completely transformed and now scores 4.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/belfast.html"
+      },
+      {
+        "slug": "bergen",
+        "name": "Bergen",
+        "description": "Bergen is seven mountains, colorful Hanseatic wharf houses, and rain that somehow makes everything more beautiful – the gateway to the fjords.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/bergen.html"
+      },
+      {
+        "slug": "bilbao",
+        "name": "Bilbao",
+        "description": "Bilbao is living proof that architecture can save a city.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/bilbao.html"
+      },
+      {
+        "slug": "cherbourg",
+        "name": "Cherbourg",
+        "description": "Cherbourg is umbrellas on the promenade, the largest artificial harbor in the world, and perfect Normandy charm with D-Day beaches an easy drive away.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/cherbourg.html"
+      },
+      {
+        "slug": "cork",
+        "name": "Cork/Cobh",
+        "description": "Cobh is the heartbreakingly beautiful last port of call for the Titanic and a million Irish emigrants, with the world's steepest streets and a cathedral that towers over everything.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/cork.html"
+      },
+      {
+        "slug": "dover",
+        "name": "Dover",
+        "description": "Dover is white cliffs, a massive medieval castle, and the gateway to London or Canterbury – England's front door.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/dover.html"
+      },
+      {
+        "slug": "dublin",
+        "name": "Dublin & Cobh",
+        "description": "Ireland is where cruisers report the friendliest people on the planet (4.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/dublin.html"
+      },
+      {
+        "slug": "scotland",
+        "name": "Edinburgh & Glasgow",
+        "description": "South Queensferry (Edinburgh) and Greenock (Glasgow) are both 4.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/scotland.html"
+      },
+      {
+        "slug": "edinburgh",
+        "name": "Edinburgh/Leith",
+        "description": "First-person logbook guide to Edinburgh via Leith, South Queensferry, Newhaven, or Rosyth — Edinburgh Castle commanding from volcanic Castle Rock since the 2nd century, the Royal Mile's 1.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/edinburgh.html"
+      },
+      {
+        "slug": "flam",
+        "name": "Flåm",
+        "description": "First-person logbook guide to Flåm — the legendary Flåmsbana Railway (20 years in the making), Stegastein viewpoint 650m above Aurlandsfjord, UNESCO Nærøyfjord cruises, and Norway's most dramatic fjord scenery in the heart of Sognefjord country.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/flam.html"
+      },
+      {
+        "slug": "gdansk",
+        "name": "Gdansk",
+        "description": "Gdansk is amber, solidarity, and perfectly rebuilt Hanseatic façades along the Motława River – the phoenix city that rose from ashes.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/gdansk.html"
+      },
+      {
+        "slug": "geiranger",
+        "name": "Geiranger Fjord",
+        "description": "Logbook reflections from Geirangerfjord — UNESCO World Heritage site sculpted 120,000 years ago, where Seven Sisters waterfall plunges 410m and abandoned farms tell stories of resilience and loss.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/geiranger.html"
+      },
+      {
+        "slug": "gothenburg",
+        "name": "Gothenburg",
+        "description": "Gothenburg is trams, seafood, and Scandinavian cool – the friendliest big city in Sweden with an archipelago of car-free islands 20 minutes away.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/gothenburg.html"
+      },
+      {
+        "slug": "greenock",
+        "name": "Greenock",
+        "description": "First-person logbook guide to Greenock — Scotland's gateway port for Glasgow Cathedral, Kelvingrove Museum, Loch Lomond, Stirling Castle, and discovering the heart of Scotland from this Clyde estuary port.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/greenock.html"
+      },
+      {
+        "slug": "hamburg",
+        "name": "Hamburg",
+        "description": "Explore Hamburg's UNESCO Speicherstadt warehouses, architectural marvel Elbphilharmonie, and maritime heritage through a sailor's reflective lens.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/hamburg.html"
+      },
+      {
+        "slug": "helsinki",
+        "name": "Helsinki",
+        "description": "Helsinki is the underrated Nordic gem — clean, friendly, and packed with design.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/helsinki.html"
+      },
+      {
+        "slug": "holyhead",
+        "name": "Holyhead",
+        "description": "Holyhead is the gateway to Snowdonia and Anglesey – mountains, castles, and the Welsh village with the longest name in Europe.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/holyhead.html"
+      },
+      {
+        "slug": "honfleur",
+        "name": "Honfleur",
+        "description": "Honfleur is the prettiest harbor in Normandy – colorful tall houses reflected in the Vieux Bassin and the birthplace of Impressionism.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/honfleur.html"
+      },
+      {
+        "slug": "invergordon",
+        "name": "Invergordon",
+        "description": "Invergordon is the gateway to Loch Ness, Inverness, and the Highlands – dramatic glens, castles, and the best chance for Nessie sightings from a cruise ship.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/invergordon.html"
+      },
+      {
+        "slug": "kiel",
+        "name": "Kiel",
+        "description": "Kiel is the sailing capital of Germany – Olympic harbor, massive locks, and the world's busiest canal right at your gangway.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/kiel.html"
+      },
+      {
+        "slug": "kirkwall",
+        "name": "Kirkwall",
+        "description": "Kirkwall is 5,000 years of continuous history – Neolithic villages older than the pyramids, Viking cathedrals, and the best whisky in Scotland.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/kirkwall.html"
+      },
+      {
+        "slug": "klaipeda",
+        "name": "Klaipeda",
+        "description": "First-person logbook guide to Klaipeda, Lithuania — UNESCO Curonian Spit sand dunes, Hill of Witches sculpture trail, German half-timbered Old Town, Baltic beaches at Smiltynė, and discovering Lithuania's only seaport.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/klaipeda.html"
+      },
+      {
+        "slug": "le-havre",
+        "name": "Le Havre",
+        "description": "Le Havre is the realistic gateway to Paris – six hours round-trip on excellent trains for the City of Light in a single (very full) day.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/le-havre.html"
+      },
+      {
+        "slug": "lerwick",
+        "name": "Lerwick",
+        "description": "Lerwick is Britain's northernmost town – ponies the size of dogs, Viking fire festivals, and cliffs full of puffins closer to Norway than London.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/lerwick.html"
+      },
+      {
+        "slug": "liverpool",
+        "name": "Liverpool",
+        "description": "Liverpool is The Beatles, two cathedrals, the best maritime museum in Britain, and the friendliest Scouse welcome you'll ever get.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/liverpool.html"
+      },
+      {
+        "slug": "newcastle",
+        "name": "Newcastle",
+        "description": "Newcastle is seven bridges, proper Geordie warmth, the Angel of the North watching over everything, and the best nightlife in Britain.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/newcastle.html"
+      },
+      {
+        "slug": "norwegian-fjords",
+        "name": "Norwegian Fjords",
+        "description": "Norwegian fjord ports (Geiranger, Flam, Olden, Ålesund) offer the most spectacular scenery in cruising.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/norwegian-fjords.html"
+      },
+      {
+        "slug": "olden",
+        "name": "Olden — Norway's Briksdal Glacier Village",
+        "description": "Olden is a tiny Norwegian fjord village beneath Briksdal Glacier — troll cars ascend to mainland Europe's largest glacier, Oldedalen valley waterfalls cascade from mountains, and Olden's white church stands in profound mountain silence.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/olden.html"
+      },
+      {
+        "slug": "oslo",
+        "name": "Oslo",
+        "description": "Oslo's Oslofjord sail-in past islands and red cabins is stunning.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/oslo.html"
+      },
+      {
+        "slug": "riga",
+        "name": "Riga",
+        "description": "Riga is the Art Nouveau capital of the world wrapped in a Hanseatic old town with the biggest market halls in Europe.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/riga.html"
+      },
+      {
+        "slug": "rostock",
+        "name": "Rostock (Warnemünde)",
+        "description": "First-person logbook guide to Rostock/Warnemünde, Germany — Hanseatic League history, gateway to Berlin, St.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/rostock.html"
+      },
+      {
+        "slug": "southampton",
+        "name": "Southampton",
+        "description": "Southampton is the UK's busiest cruise port (3M+ passengers, £1B economy impact) and Titanic's home port — she departed Berth 44 on April 10, 1912.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/southampton.html"
+      },
+      {
+        "slug": "st-petersburg",
+        "name": "St. Petersburg",
+        "description": "St. Petersburg is imperial excess on steroids – golden spires, canals, and palaces that make Versailles look modest.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/st-petersburg.html"
+      },
+      {
+        "slug": "stavanger",
+        "name": "Stavanger",
+        "description": "Stavanger is white wooden houses, street art, and the gateway to Pulpit Rock and Lysefjord – Norway's adventure capital with surprising charm.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/stavanger.html"
+      },
+      {
+        "slug": "stockholm",
+        "name": "Stockholm",
+        "description": "Stockholm spans 14 islands connected by bridges and ferries.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/stockholm.html"
+      },
+      {
+        "slug": "tallinn",
+        "name": "Tallinn",
+        "description": "Tallinn is a perfectly preserved Hanseatic fairy tale – orange roofs, church spires, and medieval walls that make you feel like you've time-traveled to 1450.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/tallinn.html"
+      },
+      {
+        "slug": "tromso",
+        "name": "Tromsø",
+        "description": "Tromsø is the Arctic capital – midnight sun or northern lights, reindeer sledding, and the stunning Arctic Cathedral glowing across the fjord.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/tromso.html"
+      },
+      {
+        "slug": "warnemunde",
+        "name": "Warnemünde",
+        "description": "Warnemünde is a perfect German beach town, but everyone uses it as the gateway to Berlin – three hours each way for the German capital experience.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/warnemunde.html"
+      },
+      {
+        "slug": "waterford",
+        "name": "Waterford",
+        "description": "Waterford is Viking triangles, the finest crystal in the world, and the oldest city in Ireland with a medieval museum shaped like a Viking longship.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/waterford.html"
+      },
+      {
+        "slug": "zeebrugge",
+        "name": "Zeebrugge/Bruges",
+        "description": "Zeebrugge is the gateway to Bruges – a perfectly preserved medieval fairy-tale city of canals, swans, and more chocolate shops per square meter than anywhere on Earth.",
+        "region": "northern-europe",
+        "tier": 2,
+        "url": "/ports/zeebrugge.html"
+      }
+    ],
+    "caribbean": [
+      {
+        "slug": "aruba",
+        "name": "Aruba",
+        "description": "Aruba cruise port guide featuring Eagle Beach, Oranjestad Dutch colonial downtown, Arikok National Park desert landscapes, and Caribbean sunshine outside the hurricane belt.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/aruba.html"
+      },
+      {
+        "slug": "bermuda",
+        "name": "Bermuda",
+        "description": "Bermuda delivers pink sand shores at Horseshoe Bay, British-Caribbean charm, rum swizzles, and exceptional safety—all wrapped in mid-Atlantic beauty.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/bermuda.html"
+      },
+      {
+        "slug": "costa-maya",
+        "name": "Costa Maya",
+        "description": "Costa Maya is the perfect \"Mayan Riviera meets chill beach town\" day—crystal-clear snorkeling on the Mesoamerican Reef, authentic (less-touristy) ruins at Chacchoben, and the laid-back fishing village of Mahahual make it one of Mexico's best cruise stops.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/costa-maya.html"
+      },
+      {
+        "slug": "cozumel",
+        "name": "Cozumel — Mexico's Premier",
+        "description": "First-person logbook guide to Cozumel — snorkeling, beach clubs, Mayan culture, and why it's the Caribbean's most visited cruise destination.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/cozumel.html"
+      },
+      {
+        "slug": "curacao",
+        "name": "Curaçao",
+        "description": "Curaçao has the prettiest port entrance in the Caribbean with Handelskade's rainbow buildings reflecting in the water.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/curacao.html"
+      },
+      {
+        "slug": "grand-cayman",
+        "name": "Grand Cayman",
+        "description": "Grand Cayman delivers Stingray City sandbar (bucket list!",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/grand-cayman.html"
+      },
+      {
+        "slug": "key-west",
+        "name": "Key West",
+        "description": "Key West is quirky, colorful, and 100% unfiltered America with roosters roaming free, six-toed cats, and the best key lime pie on the planet.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/key-west.html"
+      },
+      {
+        "slug": "nassau",
+        "name": "Nassau",
+        "description": "Nassau delivers Atlantis Aquaventure thrills, gorgeous Cabbage Beach, duty-free shopping, the famous Straw Market, and life-changing cracked conch at Potter's Cay — all within easy reach of the cruise port.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/nassau.html"
+      },
+      {
+        "slug": "roatan",
+        "name": "Roatán",
+        "description": "Roatán is the port everyone underestimates and falls in love with — West Bay Beach has world-class snorkeling right off shore, Gumbalimba Park has monkeys that climb on you, and it's the cheapest perfect beach day in the Caribbean.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/roatan.html"
+      },
+      {
+        "slug": "san-juan",
+        "name": "San Juan",
+        "description": "San Juan is my favorite walkable port — step off the ship into a 500-year-old UNESCO city with El Morro fortress, blue cobblestone streets, incredible mofongo, and the birthplace of the piña colada.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/san-juan.html"
+      },
+      {
+        "slug": "st-maarten",
+        "name": "St. Maarten",
+        "description": "St. Maarten is a dual-nation island with Maho Beach jet-blast plane spotting on the Dutch side and Orient Beach rosé on the French side — two countries, one perfect day.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/st-maarten.html"
+      },
+      {
+        "slug": "st-thomas",
+        "name": "St. Thomas",
+        "description": "St. Thomas is my absolute favorite Caribbean day — Magens Bay (top-10 beach in the world), Paradise Point Bushwackers with 360° views, duty-free shopping, and the convenience of US territory.",
+        "region": "caribbean",
+        "tier": 1,
+        "url": "/ports/st-thomas.html"
+      },
+      {
+        "slug": "amber-cove",
+        "name": "Amber Cove",
+        "description": "Amber Cove is Carnival's purpose-built Dominican Republic port with a massive complimentary pool complex, zip lines ($49-89), and easy access to authentic Puerto Plata.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/amber-cove.html"
+      },
+      {
+        "slug": "antigua",
+        "name": "Antigua",
+        "description": "Antigua cruise port guide featuring Nelson's Dockyard UNESCO site, 365 beaches, English Harbour, Shirley Heights lookout, and Caribbean naval traditions.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/antigua.html"
+      },
+      {
+        "slug": "barbados",
+        "name": "Barbados",
+        "description": "First-person logbook guide to Barbados — UNESCO World Heritage Bridgetown, Mount Gay distillery (1703), St Nicholas Abbey, Carlisle Bay beaches, and the birthplace of rum punch.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/barbados.html"
+      },
+      {
+        "slug": "belize",
+        "name": "Belize City",
+        "description": "Belize is the port where you skip the city and go full adventure – cave tubing through bat-filled caves, Great Blue Hole scenic flights, and Mayan ruins.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/belize.html"
+      },
+      {
+        "slug": "bonaire",
+        "name": "Bonaire",
+        "description": "Bonaire is the Caribbean's diver's paradise – 85+ dive sites with 100+ feet visibility, entire coastline protected as marine park since 1979 (470+ fish species, 57 coral types).",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/bonaire.html"
+      },
+      {
+        "slug": "cartagena",
+        "name": "Cartagena",
+        "description": "Cartagena's walled city is a UNESCO jewel box of colonial architecture, colorful balconies dripping with bougainvillea, emerald museums, and street life that makes you want to dance salsa at 3 p.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/cartagena.html"
+      },
+      {
+        "slug": "dominica",
+        "name": "Dominica (Waitukubuli)",
+        "description": "Waitukubuli – \"tall is her body\" – Dominica is the Nature Island with 9 active volcanoes, 365 rivers, and rainforests covering 2/3 of the island.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/dominica.html"
+      },
+      {
+        "slug": "freeport",
+        "name": "Freeport (Grand Bahama)",
+        "description": "Freeport on Grand Bahama offers pristine Gold Rock Beach, excellent snorkeling at Deadman's Reef near Port Lucaya Marketplace, and laid-back Bahamian vibes.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/freeport.html"
+      },
+      {
+        "slug": "grand-turk",
+        "name": "Grand Turk",
+        "description": "Grand Turk delivers the postcard Caribbean fantasy: turquoise water so clear you can see starfish from the ship, perfect Governor's Beach, and some of the best wall-diving/snorkeling in the hemisphere.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/grand-turk.html"
+      },
+      {
+        "slug": "grenada",
+        "name": "Grenada",
+        "description": "Grenada produces 1/3 of the world's nutmeg and is the true Spice Isle.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/grenada.html"
+      },
+      {
+        "slug": "guadeloupe",
+        "name": "Guadeloupe",
+        "description": "Guadeloupe is a butterfly-shaped island paradise where an active volcano meets pristine beaches, French boulangeries serve pain au chocolat steps from turquoise water, and the island Columbus called \"Karukéra\" (Island of Beautiful Waters) delivers authentic French-Caribbean flair.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/guadeloupe.html"
+      },
+      {
+        "slug": "harvest-caye",
+        "name": "Harvest Caye",
+        "description": "Harvest Caye port guide — Norwegian Cruise Line's 75-acre private island in Belize with lagoon beach, zipline tours, wildlife sanctuary, pool complex, and Caribbean island relaxation.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/harvest-caye.html"
+      },
+      {
+        "slug": "jamaica",
+        "name": "Jamaica (Falmouth)",
+        "description": "Jamaica is all about Dunn's River Falls climbing, Blue Hole cliff jumping, and the best jerk chicken you'll ever eat at Scotchies.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/jamaica.html"
+      },
+      {
+        "slug": "labadee",
+        "name": "Labadee — Royal Caribbean's Private Haiti Destination",
+        "description": "Labadee is Royal Caribbean's original private destination on Haiti's secluded north coast — dramatic mountains dropping to pristine beaches, the world's longest zip line over water (2,600 feet!",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/labadee.html"
+      },
+      {
+        "slug": "martinique",
+        "name": "Martinique",
+        "description": "Martinique is France in the Caribbean – use euros, speak French, and explore Les Salines beach, Saint-Pierre ruins (once the \"Paris of the Caribbean\" until Mount Pelée's 1902 eruption), rhum agricole tasting, and pain au chocolat that rivals Paris.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/martinique.html"
+      },
+      {
+        "slug": "montego-bay",
+        "name": "Montego Bay",
+        "description": "First-person logbook guide to Montego Bay — legendary Doctor's Cave Beach healing waters, Hip Strip tourist hub, Rose Hall haunted great house, and discovering Jamaica's vibrant cruise capital with its beaches, culture, and Caribbean warmth.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/montego-bay.html"
+      },
+      {
+        "slug": "ocho-rios",
+        "name": "Ocho Rios",
+        "description": "First-person logbook guide to Ocho Rios, Jamaica — climbing the iconic 180-foot Dunn's River Falls, Mystic Mountain bobsled thrills, Blue Hole jungle swimming, dolphin encounters, and experiencing authentic Jamaican warmth.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/ocho-rios.html"
+      },
+      {
+        "slug": "cococay",
+        "name": "Perfect Day at CocoCay — Royal Caribbean's Private Island",
+        "description": "Perfect Day at CocoCay is Royal Caribbean's $250 million private island paradise in the Bahamas — featuring the tallest waterslides in North America, the Caribbean's largest freshwater pool, and pristine beaches.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/cococay.html"
+      },
+      {
+        "slug": "philipsburg",
+        "name": "Philipsburg / St. Maarten",
+        "description": "Complete cruise guide to Philipsburg, St.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/philipsburg.html"
+      },
+      {
+        "slug": "port-canaveral",
+        "name": "Port Canaveral",
+        "description": "Port Canaveral is where America's space program meets the sea — 15 miles from Kennedy Space Center, with SpaceX launches lighting the sky.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/port-canaveral.html"
+      },
+      {
+        "slug": "port-everglades",
+        "name": "Port Everglades",
+        "description": "Fort Lauderdale's world-class cruise hub with one of cruising's best airport-to-port connections — beaches, Las Olas Boulevard, and the water taxi \"Venice of America\" experience await.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/port-everglades.html"
+      },
+      {
+        "slug": "port-miami",
+        "name": "PortMiami",
+        "description": "The Cruise Capital of the World with stunning new terminals — South Beach, Little Havana, Wynwood Walls, and Miami's vibrant culture make pre-cruise days unforgettable.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/port-miami.html"
+      },
+      {
+        "slug": "progreso",
+        "name": "Progreso",
+        "description": "Progreso is your gateway to Chichen Itza—one of the New Seven Wonders of the World—via the world's longest pier.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/progreso.html"
+      },
+      {
+        "slug": "royal-beach-club-nassau",
+        "name": "Royal Beach Club Paradise Island Guide — Royal Caribbean's Nassau Beach Club",
+        "description": "Royal Beach Club Paradise Island is Royal Caribbean's premium private beach destination in Nassau — think pristine powder-sand beaches, swim-up bars, overwater cabanas, and Bahamian cultural experiences without the cruise port crowds.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/royal-beach-club-nassau.html"
+      },
+      {
+        "slug": "samana",
+        "name": "Samaná",
+        "description": "Samaná Bay in whale season (mid-January to late March) offers the most reliable, jaw-dropping humpback whale encounters in the entire Caribbean — with a 95% success rate, you'll witness 1,500-2,000 humpbacks that journey 5,000+ miles from the North Atlantic to the warm, shallow waters of this protected Marine Mammals Sanctuary (est.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/samana.html"
+      },
+      {
+        "slug": "st-barts",
+        "name": "St. Barts",
+        "description": "First-person logbook guide to St.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/st-barts.html"
+      },
+      {
+        "slug": "st-kitts",
+        "name": "St. Kitts",
+        "description": "The first West Indian island colonized by Europeans (1623), St. Kitts offers Cockleshell Beach with Killer Bee rum punch, the \"Gibraltar of the West Indies\" Brimstone Hill Fortress (UNESCO 1999), and a historic 1912 sugar railway now carrying passengers on a three-hour island tour with rum punch and choir singing.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/st-kitts.html"
+      },
+      {
+        "slug": "st-lucia",
+        "name": "St. Lucia",
+        "description": "First-person logbook guide to St.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/st-lucia.html"
+      },
+      {
+        "slug": "tortola",
+        "name": "Tortola",
+        "description": "Tortola – \"Land of the Turtle Dove\" and the Sailing Capital of the Caribbean – is your gateway to the BVI.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/tortola.html"
+      },
+      {
+        "slug": "virgin-gorda",
+        "name": "Virgin Gorda",
+        "description": "The Baths at Virgin Gorda is the single most spectacular beach formation in the entire Caribbean — gigantic granite boulders creating grottoes, secret pools, and tunnels that lead to Devil's Bay, one of the world's most beautiful beaches.",
+        "region": "caribbean",
+        "tier": 2,
+        "url": "/ports/virgin-gorda.html"
+      }
+    ],
+    "alaska": [
+      {
+        "slug": "glacier-bay",
+        "name": "Glacier Bay — Alaska's Crown Jewel Scenic Cruising",
+        "description": "Glacier Bay is the crown jewel of Alaska cruising — 65 miles of fjord, 15 tidewater glaciers, park rangers narrating from the bow, and the 250-foot Margerie Glacier wall calving thunder into the sea.",
+        "region": "alaska",
+        "tier": 1,
+        "url": "/ports/glacier-bay.html"
+      },
+      {
+        "slug": "juneau",
+        "name": "Juneau — Alaska's Adventure Capital",
+        "description": "Juneau is Alaska's capital and adventure heart — Mendenhall Glacier, legendary whale watching, and stunning fjord scenery make it consistently the highest-rated Alaska port among cruisers, scoring 4.",
+        "region": "alaska",
+        "tier": 1,
+        "url": "/ports/juneau.html"
+      },
+      {
+        "slug": "ketchikan",
+        "name": "Ketchikan — Alaska's First City",
+        "description": "Ketchikan is Alaska's First City and most walkable cruise port — Creek Street's colorful boardwalks, world-class totem poles, and Misty Fjords flightseeing that makes you believe in something bigger than yourself.",
+        "region": "alaska",
+        "tier": 1,
+        "url": "/ports/ketchikan.html"
+      },
+      {
+        "slug": "sitka",
+        "name": "Sitka — Russian America & Wildlife",
+        "description": "Sitka blends Russian onion domes with Tlingit totems, sea otters floating in kelp beds, and Mount Edgecumbe watching over everything like Alaska's Fuji.",
+        "region": "alaska",
+        "tier": 1,
+        "url": "/ports/sitka.html"
+      },
+      {
+        "slug": "skagway",
+        "name": "Skagway — Gold Rush Gateway",
+        "description": "Skagway is pure 1898 Gold Rush fever frozen in time — the legendary White Pass Railway, wooden boardwalks, and trails where thousands once hauled a ton of supplies toward Klondike gold.",
+        "region": "alaska",
+        "tier": 1,
+        "url": "/ports/skagway.html"
+      },
+      {
+        "slug": "anchorage",
+        "name": "Anchorage",
+        "description": "Anchorage is Alaska's gateway city — ships dock at Seward (2.",
+        "region": "alaska",
+        "tier": 2,
+        "url": "/ports/anchorage.html"
+      },
+      {
+        "slug": "endicott-arm",
+        "name": "Endicott Arm & Dawes Glacier Guide — Alaska",
+        "description": "Endicott Arm is a spectacular 30-mile Alaskan fjord ending at Dawes Glacier—often used as a Tracy Arm alternative, but many passengers prefer it for its intimate glacier views, abundant seal colonies, and fewer crowds.",
+        "region": "alaska",
+        "tier": 2,
+        "url": "/ports/endicott-arm.html"
+      },
+      {
+        "slug": "haines",
+        "name": "Haines — Alaska's Hidden Gem for Eagles & Wilderness",
+        "description": "Haines is Alaska's hidden gem — home to the world's largest bald eagle gathering, authentic small-town charm, stunning mountain scenery, and a genuine frontier atmosphere without the cruise-ship crowds.",
+        "region": "alaska",
+        "tier": 2,
+        "url": "/ports/haines.html"
+      },
+      {
+        "slug": "hubbard-glacier",
+        "name": "Hubbard Glacier — North America's Largest Tidewater Glacier",
+        "description": "Hubbard Glacier is North America's largest tidewater glacier — a 6-mile wall of ancient ice rising 400 feet above Yakutat Bay.",
+        "region": "alaska",
+        "tier": 2,
+        "url": "/ports/hubbard-glacier.html"
+      },
+      {
+        "slug": "icy-strait-point",
+        "name": "Icy Strait Point — Alaska's Authentic Tlingit Port",
+        "description": "Icy Strait Point is Alaska's most authentic cruise experience — 100% Huna Tlingit-owned, world-class whale watching, the world's longest zipline, and all profits stay with the local Indigenous community.",
+        "region": "alaska",
+        "tier": 2,
+        "url": "/ports/icy-strait-point.html"
+      },
+      {
+        "slug": "seward",
+        "name": "Seward — Gateway to Kenai Fjords & Alaska's Best Wildlife",
+        "description": "Seward is the gateway to Kenai Fjords National Park — offering what many call the best single-day wildlife experience in Alaska.",
+        "region": "alaska",
+        "tier": 2,
+        "url": "/ports/seward.html"
+      },
+      {
+        "slug": "tracy-arm",
+        "name": "Tracy Arm Fjord Guide — Alaska's Narrow Glacier Wonder",
+        "description": "Tracy Arm is a stunning alternative to Glacier Bay—a narrow 30-mile fjord with 4,000-foot granite walls, twin Sawyer Glaciers actively calving, and icebergs packed with lounging harbor seals.",
+        "region": "alaska",
+        "tier": 2,
+        "url": "/ports/tracy-arm.html"
+      },
+      {
+        "slug": "victoria-bc",
+        "name": "Victoria BC",
+        "description": "Victoria is the perfect civilized bookend — Butchart Gardens in full bloom, high tea at the Empress, Parliament lit like a fairy tale, and harbor seals begging for popcorn.",
+        "region": "alaska",
+        "tier": 2,
+        "url": "/ports/victoria-bc.html"
+      },
+      {
+        "slug": "whittier",
+        "name": "Whittier",
+        "description": "Whittier is bizarre (everyone lives in one Soviet-looking building) but Prince William Sound's 26 Glaciers cruise is arguably the best glacier day in Alaska—more calving than Glacier Bay, wildlife everywhere, and glacier ice cocktails on deck.",
+        "region": "alaska",
+        "tier": 2,
+        "url": "/ports/whittier.html"
+      }
+    ],
+    "asia": [
+      {
+        "slug": "hong-kong",
+        "name": "Hong Kong",
+        "description": "First-person guide to Hong Kong cruise port: Victoria Harbour's colonial history, historic Star Ferry (1888), Victoria Peak tram, Temple Street Night Market, and the contrast between ancient fishing villages and modern skyscrapers.",
+        "region": "asia",
+        "tier": 1,
+        "url": "/ports/hong-kong.html"
+      },
+      {
+        "slug": "singapore",
+        "name": "Singapore",
+        "description": "First-person guide to Singapore cruise port: Gardens by the Bay, Marina Bay Sands, hawker centers, and why it's Asia's top-rated port.",
+        "region": "asia",
+        "tier": 1,
+        "url": "/ports/singapore.html"
+      },
+      {
+        "slug": "bali",
+        "name": "Bali (Benoa)",
+        "description": "Bali cruise port guide featuring Uluwatu temple kecak fire dance, Ubud rice terraces and monkey forest, Tanah Lot sunset temple, and Hindu spirituality on Indonesia's Island of the Gods.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/bali.html"
+      },
+      {
+        "slug": "bangkok",
+        "name": "Bangkok / Laem Chabang",
+        "description": "First-person Bangkok cruise guide: Grand Palace's royal history, Temple of the Emerald Buddha, Wat Arun's porcelain-encrusted tower, Wat Pho's golden Reclining Buddha, street food crawls, and sunset rooftop bars.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/bangkok.html"
+      },
+      {
+        "slug": "brunei",
+        "name": "Brunei",
+        "description": "First-person logbook guide to Bandar Seri Begawan, Brunei — golden mosques, stilted water villages, royal splendor, and navigating this serene sultanate.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/brunei.html"
+      },
+      {
+        "slug": "busan",
+        "name": "Busan",
+        "description": "First-person logbook: Busan, South Korea's largest port — cliff-perched temples, colorful Gamcheon art village, legendary Jagalchi fish market, mountain monasteries, and the warmth of a city that never forgot the sea.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/busan.html"
+      },
+      {
+        "slug": "cochin",
+        "name": "Cochin (Kochi), India",
+        "description": "First-person logbook guide to Cochin (Kochi), India — Chinese fishing nets, Fort Kochi colonial heritage, Mattancherry Palace, Jewish synagogue, Kathakali dance, Kerala backwaters, and discovering where spice trade history meets living tradition.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/cochin.html"
+      },
+      {
+        "slug": "colombo",
+        "name": "Colombo, Sri Lanka",
+        "description": "First-person logbook guide to Colombo, Sri Lanka — Gangaramaya Temple, elephant orphanages, Ceylon tea country, Pettah Market, and exploring the island where ancient wisdom meets tropical beauty.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/colombo.html"
+      },
+      {
+        "slug": "da-nang",
+        "name": "Da Nang",
+        "description": "First-person logbook guide to Da Nang — where a 666-meter dragon breathes fire over the Han River, three UNESCO World Heritage sites await within an hour's drive, and the spirit of the ancient Champa kingdom still whispers through marble caves and jungle-shrouded temples.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/da-nang.html"
+      },
+      {
+        "slug": "fukuoka",
+        "name": "Fukuoka",
+        "description": "First-person logbook guide to Fukuoka — Hakata Port's rich trading history with China and Korea, authentic tonkotsu ramen with kaedama noodle refills, yatai food stalls on Nakasu Island, Kushida Shrine's Yamakasa festival, and Sumiyoshi's ancient Shinto heritage.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/fukuoka.html"
+      },
+      {
+        "slug": "goa",
+        "name": "Goa (Mormugao)",
+        "description": "First-person logbook guide to Mormugao Port, Goa — UNESCO World Heritage churches in Old Goa, Portuguese colonial architecture, golden beaches from Anjuna to Benaulim, vindaloo and feni, exploring India's smallest state shaped by 451 years of Portuguese rule.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/goa.html"
+      },
+      {
+        "slug": "ha-long-bay",
+        "name": "Ha Long Bay, Vietnam",
+        "description": "First-person logbook guide to Ha Long Bay, Vietnam — UNESCO World Heritage limestone karsts, Sung Sot Cave exploration, kayaking hidden lagoons, Cua Van floating village, and sailing through Vietnam's emerald dreamscape.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/ha-long-bay.html"
+      },
+      {
+        "slug": "hakodate",
+        "name": "Hakodate",
+        "description": "Hakodate is where Japan opened to the world — climb Mount Hakodate for million-dollar night views, feast on uni and ikura at the 5am market, wander Western-style streets where Russian churches meet Buddhist temples, and ride vintage streetcars through history.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/hakodate.html"
+      },
+      {
+        "slug": "hiroshima",
+        "name": "Hiroshima",
+        "description": "First-person logbook guide to Hiroshima — where August 6, 1945 transformed a city into a messenger of peace.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/hiroshima.html"
+      },
+      {
+        "slug": "ho-chi-minh-city",
+        "name": "Ho Chi Minh City",
+        "description": "First-person logbook guide to Ho Chi Minh City via Phu My port — Cu Chi Tunnels' underground war history, French colonial architecture by Gustave Eiffel, Reunification Palace, and the irrepressible energy of Vietnam's largest city.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/ho-chi-minh-city.html"
+      },
+      {
+        "slug": "ho-chi-minh",
+        "name": "Ho Chi Minh City (Saigon)",
+        "description": "First-person guide to Ho Chi Minh City cruise port: War Remnants Museum, Cu Chi Tunnels, Notre-Dame Cathedral, vibrant markets, and iconic street food.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/ho-chi-minh.html"
+      },
+      {
+        "slug": "incheon",
+        "name": "Incheon, South Korea - Gateway Port & Historic Landing Site",
+        "description": "First-hand account of Incheon, South Korea - gateway to Seoul, historic treaty port, and site of the pivotal Korean War landing.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/incheon.html"
+      },
+      {
+        "slug": "jeju",
+        "name": "Jeju Island, South Korea",
+        "description": "First-person logbook guide to Jeju Island, South Korea — UNESCO triple crown volcanic landscapes, Manjanggul lava tubes, Seongsan Sunrise Peak, Hallasan Mountain, haenyeo sea women divers, and exploring Korea's mystical island paradise.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/jeju.html"
+      },
+      {
+        "slug": "kobe",
+        "name": "Kobe, Japan",
+        "description": "First-person logbook guide to Kobe, Japan — rebuilt after the 1995 earthquake, gateway opened to foreign trade in the 1860s, featuring Kitano's Meiji-era mansions, Nada's seven-century sake tradition, Kyoto's golden temples, Osaka's neon energy, world-famous Kobe beef, and the resilient spirit of a harbor city that welcomed the world.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/kobe.html"
+      },
+      {
+        "slug": "koh-samui",
+        "name": "Koh Samui, Thailand",
+        "description": "First-person logbook guide to Koh Samui tender port — Big Buddha Temple, Wat Plai Laem, Chaweng Beach, Na Muang Waterfalls, and exploring Thailand's tropical island of golden statues and gentle hospitality.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/koh-samui.html"
+      },
+      {
+        "slug": "komodo",
+        "name": "Komodo (Indonesia)",
+        "description": "First-person logbook guide to Komodo, Indonesia — tender port to Komodo National Park, face-to-face encounters with prehistoric dragons on Rinca and Komodo islands, volcanic landscapes, and trekking through one of Earth's last untamed wilderness areas.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/komodo.html"
+      },
+      {
+        "slug": "kota-kinabalu",
+        "name": "Kota Kinabalu, Malaysia: Borneo Gateway & Mount Kinabalu Views",
+        "description": "A reflective cruise port guide to Kota Kinabalu, Sabah - where Borneo's highest peak meets turquoise marine parks, indigenous cultures, and the vibrant heart of Malaysian Borneo.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/kota-kinabalu.html"
+      },
+      {
+        "slug": "langkawi",
+        "name": "Langkawi",
+        "description": "First-person logbook guide to Langkawi, Malaysia — UNESCO Global Geopark archipelago with ancient limestone karsts, SkyCab cable car to Gunung Mat Chinchang, curved SkyBridge, Kilim mangrove forests, and 99 islands in the Andaman Sea.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/langkawi.html"
+      },
+      {
+        "slug": "lombok",
+        "name": "Lombok",
+        "description": "First-person logbook guide to Lombok, Indonesia — Mount Rinjani volcano, Gili Islands without cars, traditional Sasak villages, pink coral beaches, and experiencing authentic Indonesian culture beyond Bali's crowds.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/lombok.html"
+      },
+      {
+        "slug": "manila",
+        "name": "Manila",
+        "description": "First-person guide to Manila cruise port: Intramuros walled city, Fort Santiago, colonial churches, vibrant jeepney culture, and world-class museums.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/manila.html"
+      },
+      {
+        "slug": "mumbai",
+        "name": "Mumbai",
+        "description": "First-person guide to Mumbai cruise port: Gateway of India, Taj Mahal Palace Hotel, Elephanta Caves, Bollywood, and why this vibrant megacity captivates every visitor.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/mumbai.html"
+      },
+      {
+        "slug": "nagasaki",
+        "name": "Nagasaki",
+        "description": "First-person logbook guide to Nagasaki — the Peace Memorial, Dejima's fan-shaped island of isolation, Thomas Glover's Scottish legacy, and Japan's profound window to the world.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/nagasaki.html"
+      },
+      {
+        "slug": "nha-trang",
+        "name": "Nha Trang, Vietnam",
+        "description": "First-person logbook guide to Nha Trang, Vietnam — ancient Po Nagar Cham Towers, pristine beaches, Vinpearl Island cable car, Hon Mun Marine Protected Area snorkeling, Ba Ho Waterfalls, and exploring Vietnam's most beautiful bay.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/nha-trang.html"
+      },
+      {
+        "slug": "osaka",
+        "name": "Osaka",
+        "description": "First-person logbook guide to Osaka — exploring Dotonbori's historic 1612 canal, tasting takoyaki where it was invented, discovering Osaka Castle's resilient history, embracing kuidaore culture, and venturing to Kyoto, Nara, and Himeji.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/osaka.html"
+      },
+      {
+        "slug": "penang",
+        "name": "Penang",
+        "description": "First-person logbook guide to Penang — exploring Georgetown's UNESCO heritage architecture, Ernest Zacharevic's iconic street art, Khoo Kongsi clan temple, Kek Lok Si's Buddhist grandeur, and discovering where four cultures paint one astonishing canvas through legendary street food.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/penang.html"
+      },
+      {
+        "slug": "phuket",
+        "name": "Phuket",
+        "description": "First-person logbook guide to Phuket — the gleaming Big Buddha, colorful Sino-Portuguese shophouses of Old Town, Patong's water sports and nightlife, tranquil family beaches, and Sirinat's coral gardens where turtles nest.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/phuket.html"
+      },
+      {
+        "slug": "shanghai",
+        "name": "Shanghai",
+        "description": "First-person guide to Shanghai cruise port: The Bund's colonial architecture, futuristic Pudong, Ming Dynasty Yu Garden, French Concession history, and the city where past meets future.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/shanghai.html"
+      },
+      {
+        "slug": "sihanoukville",
+        "name": "Sihanoukville, Cambodia - Beach Resort & Island Gateway",
+        "description": "A cruise guide to Sihanoukville, Cambodia's premier beach destination and gateway to pristine Gulf of Thailand islands.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/sihanoukville.html"
+      },
+      {
+        "slug": "taipei",
+        "name": "Taipei (Keelung)",
+        "description": "First-person logbook guide to Taipei via historic Keelung Port — from Spanish traders to night market treasures, Jiufen's mining village magic, ancient temples, and Taiwan's extraordinary food culture.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/taipei.html"
+      },
+      {
+        "slug": "tianjin",
+        "name": "Tianjin",
+        "description": "First-person guide to Tianjin cruise port: Beijing gateway with Great Wall, Forbidden City, Temple of Heaven, and Tianjin's Italian Concession streets.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/tianjin.html"
+      },
+      {
+        "slug": "tokyo",
+        "name": "Tokyo / Yokohama",
+        "description": "First-person guide to Tokyo and Yokohama cruise ports: Historic Osanbashi Pier since 1894, Mount Fuji views, ancient temples, Shibuya Crossing, TeamLab art, and the contrast of tradition meeting ultra-modern technology.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/tokyo.html"
+      },
+      {
+        "slug": "yangon",
+        "name": "Yangon (Rangoon), Myanmar: Golden Spires and Colonial Echoes - In the Wake",
+        "description": "A cruise port guide to Yangon, Myanmar - from the shimmering Shwedagon Pagoda to British colonial architecture, tea shop culture, and the complex beauty of Burma's former capital.",
+        "region": "asia",
+        "tier": 2,
+        "url": "/ports/yangon.html"
+      }
+    ],
+    "new-england": [
+      {
+        "slug": "boston",
+        "name": "Boston",
+        "description": "Boston is history you can touch — Freedom Trail, Fenway (if in season), North End cannoli, and clam chowder that ruins all other chowder forever.",
+        "region": "new-england",
+        "tier": 1,
+        "url": "/ports/boston.html"
+      },
+      {
+        "slug": "halifax",
+        "name": "Halifax",
+        "description": "Halifax is friendly, walkable, and has the best waterfront boardwalk in Atlantic Canada.",
+        "region": "new-england",
+        "tier": 1,
+        "url": "/ports/halifax.html"
+      },
+      {
+        "slug": "quebec-city",
+        "name": "Quebec City",
+        "description": "Quebec City is the only walled city in North America north of Mexico and a UNESCO World Heritage Site since 1985.",
+        "region": "new-england",
+        "tier": 1,
+        "url": "/ports/quebec-city.html"
+      },
+      {
+        "slug": "bar-harbor",
+        "name": "Bar Harbor",
+        "description": "Bar Harbor is your gateway to Acadia National Park — rugged coastline, Cadillac Mountain sunrises, and lobster so fresh it's still mad about it.",
+        "region": "new-england",
+        "tier": 2,
+        "url": "/ports/bar-harbor.html"
+      },
+      {
+        "slug": "charlottetown",
+        "name": "Charlottetown",
+        "description": "Birthplace of Canada, Anne of Green Gables, red sand beaches, and Cows ice cream that ruins you for all other ice cream.",
+        "region": "new-england",
+        "tier": 2,
+        "url": "/ports/charlottetown.html"
+      },
+      {
+        "slug": "newport",
+        "name": "Newport",
+        "description": "Gilded Age mansions, Cliff Walk, and sailboats everywhere — America's sailing capital feels like the Hamptons in 1890.",
+        "region": "new-england",
+        "tier": 2,
+        "url": "/ports/newport.html"
+      },
+      {
+        "slug": "portland-maine",
+        "name": "Portland, Maine",
+        "description": "Portland, Maine is six lighthouses including George Washington's Portland Head Light, working lobster boat tours hauling traps in season, cobblestone Old Port streets, and lobster rolls that taste like they came from the trap an hour ago.",
+        "region": "new-england",
+        "tier": 2,
+        "url": "/ports/portland-maine.html"
+      },
+      {
+        "slug": "saguenay",
+        "name": "Saguenay",
+        "description": "Saguenay Fjord is jaw-dropping — steep cliffs, beluga whales, and fall colors that look photoshopped.",
+        "region": "new-england",
+        "tier": 2,
+        "url": "/ports/saguenay.html"
+      },
+      {
+        "slug": "saint-john",
+        "name": "Saint John",
+        "description": "Saint John (Bay of Fundy) has the world's highest tides, Reversing Falls, and the best coastal scenery in the Maritimes.",
+        "region": "new-england",
+        "tier": 2,
+        "url": "/ports/saint-john.html"
+      },
+      {
+        "slug": "sydney-ns",
+        "name": "Sydney",
+        "description": "Sydney is the gateway to Cape Breton — biggest fiddle, friendliest people, and Cabot Trail if overnight.",
+        "region": "new-england",
+        "tier": 2,
+        "url": "/ports/sydney-ns.html"
+      }
+    ]
+  }
+}

--- a/ports.html
+++ b/ports.html
@@ -1006,169 +1006,427 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <p class="tiny">Tip: Always arrive the day before embarkation when possible. Weather, flight delays, and traffic can turn a same-day arrival into a missed ship.</p>
       </article>
 
-      <!-- Additional Port Destinations -->
-      <article class="card">
-        <h2>Additional Port Destinations</h2>
-        <p>Royal Caribbean visits hundreds more ports worldwide. Below are additional destinations organized by region — use the search above to find specific ports quickly.</p>
+      <!-- Complete Port Directory -->
+      <article class="card" id="port-directory">
+        <h2>Complete Port Directory — All 333 Destinations</h2>
+        <p>Every Royal Caribbean cruise port with destination highlights. All ports link to detailed guides with local tips, accessibility information, and insider recommendations.</p>
 
-        <h3>Additional Caribbean & Latin America Ports</h3>
-        <ul class="cols-2 tiny">
-          <li><a href="/ports/amber-cove.html">Amber Cove, Dominican Republic</a></li>
-          <li><a href="/ports/antigua.html">Antigua</a></li>
-          <li><a href="/ports/cabo-san-lucas.html">Cabo San Lucas, Mexico</a></li>
-          <li><a href="/ports/callao.html">Callao (Lima), Peru</a></li>
-          <li><a href="/ports/colon.html">Colón, Panama</a></li>
-          <li><a href="/ports/corinto.html">Corinto, Nicaragua</a></li>
-          <li><a href="/ports/barbados.html">Barbados</a></li>
-        </ul>
 
-        <h3>Additional Mediterranean & Europe Ports</h3>
-        <ul class="cols-2 tiny">
-          <li><a href="/ports/ajaccio.html">Ajaccio, Corsica</a></li>
-          <li><a href="/ports/amsterdam.html">Amsterdam, Netherlands</a></li>
-          <li><a href="/ports/antwerp.html">Antwerp, Belgium</a></li>
-          <li><a href="/ports/bilbao.html">Bilbao, Spain</a></li>
-          <li><a href="/ports/bodrum.html">Bodrum, Turkey</a></li>
-          <li><a href="/ports/bordeaux.html">Bordeaux, France</a></li>
-          <li><a href="/ports/capri.html">Capri, Italy</a></li>
-          <li><a href="/ports/catania.html">Catania, Sicily</a></li>
-          <li><a href="/ports/cephalonia.html">Cephalonia, Greece</a></li>
-          <li><a href="/ports/cherbourg.html">Cherbourg, France</a></li>
-          <li><a href="/ports/edinburgh.html">Edinburgh/Leith, Scotland</a></li>
-          <li><a href="/ports/funchal.html">Funchal, Madeira</a></li>
-          <li><a href="/ports/gijon.html">Gijón, Spain</a></li>
-          <li><a href="/ports/gran-canaria.html">Gran Canaria, Canary Islands</a></li>
-          <li><a href="/ports/le-havre.html">Le Havre, France</a></li>
-          <li><a href="/ports/lisbon.html">Lisbon, Portugal</a></li>
-          <li><a href="/ports/monte-carlo.html">Monte Carlo, Monaco</a></li>
-          <li><a href="/ports/nice.html">Nice, France</a></li>
-          <li><a href="/ports/portofino.html">Portofino, Italy</a></li>
-          <li><a href="/ports/seville.html">Seville, Spain</a></li>
-          <li><a href="/ports/tallinn.html">Tallinn, Estonia</a></li>
-          <li><a href="/ports/valletta.html">Valletta, Malta</a></li>
-        </ul>
 
-        <h3>Additional Northern Europe & Scandinavia Ports</h3>
-        <ul class="cols-2 tiny">
-          <li><a href="/ports/aalborg.html">Aalborg, Denmark</a></li>
-          <li><a href="/ports/akureyri.html">Akureyri, Iceland</a></li>
-          <li><a href="/ports/alesund.html">Ålesund, Norway</a></li>
-          <li><a href="/ports/belfast.html">Belfast, Northern Ireland</a></li>
-          <li><a href="/ports/cork.html">Cork, Ireland</a></li>
-          <li><a href="/ports/dublin.html">Dublin, Ireland</a></li>
-          <li><a href="/ports/flam.html">Flåm, Norway</a></li>
-          <li><a href="/ports/geiranger.html">Geiranger, Norway</a></li>
-          <li><a href="/ports/gdansk.html">Gdańsk, Poland</a></li>
-          <li><a href="/ports/gothenburg.html">Gothenburg, Sweden</a></li>
-          <li><a href="/ports/greenock.html">Greenock (Glasgow), Scotland</a></li>
-          <li><a href="/ports/helsinki.html">Helsinki, Finland</a></li>
-          <li><a href="/ports/holyhead.html">Holyhead, Wales</a></li>
-          <li><a href="/ports/invergordon.html">Invergordon, Scotland</a></li>
-          <li><a href="/ports/kirkwall.html">Kirkwall, Orkney Islands</a></li>
-          <li><a href="/ports/lerwick.html">Lerwick, Shetland Islands</a></li>
-          <li><a href="/ports/molde.html">Molde, Norway</a></li>
-          <li><a href="/ports/oslo.html">Oslo, Norway</a></li>
-          <li><a href="/ports/riga.html">Riga, Latvia</a></li>
-          <li><a href="/ports/stavanger.html">Stavanger, Norway</a></li>
-          <li><a href="/ports/stockholm.html">Stockholm, Sweden</a></li>
-          <li><a href="/ports/warnemunde.html">Warnemünde (Berlin), Germany</a></li>
-        </ul>
+<h3>Caribbean & Bahamas (42 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/amber-cove.html">Amber Cove</a></strong> — Amber Cove is Carnival's purpose-built Dominican Republic port with a massive...</li>
+  <li><strong><a href="/ports/antigua.html">Antigua</a></strong> — Antigua cruise port guide featuring Nelson's Dockyard UNESCO site, 365 beache...</li>
+  <li><strong><a href="/ports/aruba.html">Aruba</a></strong> — Aruba cruise port guide featuring Eagle Beach, Oranjestad Dutch colonial down...</li>
+  <li><strong><a href="/ports/barbados.html">Barbados</a></strong> — Barbados — UNESCO World Heritage Bridgetown, Mount Gay distillery (1703), St ...</li>
+  <li><strong><a href="/ports/belize.html">Belize City</a></strong> — Belize is the port where you skip the city and go full adventure – cave tubin...</li>
+  <li><strong><a href="/ports/bermuda.html">Bermuda</a></strong> — Bermuda delivers pink sand shores at Horseshoe Bay, British-Caribbean charm, ...</li>
+  <li><strong><a href="/ports/bonaire.html">Bonaire</a></strong> — Bonaire is the Caribbean's diver's paradise – 85+ dive sites with 100+ feet v...</li>
+  <li><strong><a href="/ports/cartagena.html">Cartagena</a></strong> — Cartagena's walled city is a UNESCO jewel box of colonial architecture, color...</li>
+  <li><strong><a href="/ports/costa-maya.html">Costa Maya</a></strong> — Costa Maya is the perfect "Mayan Riviera meets chill beach town" day—crystal-...</li>
+  <li><strong><a href="/ports/cozumel.html">Cozumel — Mexico's Premier</a></strong> — Cozumel — snorkeling, beach clubs, Mayan culture, and why it's the Caribbean'...</li>
+  <li><strong><a href="/ports/curacao.html">Curaçao</a></strong> — Curaçao has the prettiest port entrance in the Caribbean with Handelskade's r...</li>
+  <li><strong><a href="/ports/dominica.html">Dominica (Waitukubuli)</a></strong> — Waitukubuli – "tall is her body" – Dominica is the Nature Island with 9 activ...</li>
+  <li><strong><a href="/ports/freeport.html">Freeport (Grand Bahama)</a></strong> — Freeport on Grand Bahama offers pristine Gold Rock Beach, excellent snorkelin...</li>
+  <li><strong><a href="/ports/grand-cayman.html">Grand Cayman</a></strong> — Grand Cayman delivers Stingray City sandbar (bucket list!</li>
+  <li><strong><a href="/ports/grand-turk.html">Grand Turk</a></strong> — Grand Turk delivers the postcard Caribbean fantasy: turquoise water so clear ...</li>
+  <li><strong><a href="/ports/grenada.html">Grenada</a></strong> — Grenada produces 1/3 of the world's nutmeg and is the true Spice Isle.</li>
+  <li><strong><a href="/ports/guadeloupe.html">Guadeloupe</a></strong> — Guadeloupe is a butterfly-shaped island paradise where an active volcano meet...</li>
+  <li><strong><a href="/ports/harvest-caye.html">Harvest Caye</a></strong> — Harvest Caye port guide — Norwegian Cruise Line's 75-acre private island in B...</li>
+  <li><strong><a href="/ports/jamaica.html">Jamaica (Falmouth)</a></strong> — Jamaica is all about Dunn's River Falls climbing, Blue Hole cliff jumping, an...</li>
+  <li><strong><a href="/ports/key-west.html">Key West</a></strong> — Key West is quirky, colorful, and 100% unfiltered America with roosters roami...</li>
+  <li><strong><a href="/ports/labadee.html">Labadee — Royal Caribbean's Private Haiti Destination</a></strong> — Labadee is Royal Caribbean's original private destination on Haiti's secluded...</li>
+  <li><strong><a href="/ports/martinique.html">Martinique</a></strong> — Martinique is France in the Caribbean – use euros, speak French, and explore ...</li>
+  <li><strong><a href="/ports/montego-bay.html">Montego Bay</a></strong> — Montego Bay — legendary Doctor's Cave Beach healing waters, Hip Strip tourist...</li>
+  <li><strong><a href="/ports/nassau.html">Nassau</a></strong> — Nassau delivers Atlantis Aquaventure thrills, gorgeous Cabbage Beach, duty-fr...</li>
+  <li><strong><a href="/ports/ocho-rios.html">Ocho Rios</a></strong> — Ocho Rios, Jamaica — climbing the iconic 180-foot Dunn's River Falls, Mystic ...</li>
+  <li><strong><a href="/ports/cococay.html">Perfect Day at CocoCay — Royal Caribbean's Private Island</a></strong> — Perfect Day at CocoCay is Royal Caribbean's $250 million private island parad...</li>
+  <li><strong><a href="/ports/philipsburg.html">Philipsburg / St. Maarten</a></strong> — Complete cruise guide to Philipsburg, St.</li>
+  <li><strong><a href="/ports/port-canaveral.html">Port Canaveral</a></strong> — Port Canaveral is where America's space program meets the sea — 15 miles from...</li>
+  <li><strong><a href="/ports/port-everglades.html">Port Everglades</a></strong> — Fort Lauderdale's world-class cruise hub with one of cruising's best airport-...</li>
+  <li><strong><a href="/ports/port-miami.html">PortMiami</a></strong> — The Cruise Capital of the World with stunning new terminals — South Beach, Li...</li>
+  <li><strong><a href="/ports/progreso.html">Progreso</a></strong> — Progreso is your gateway to Chichen Itza—one of the New Seven Wonders of the ...</li>
+  <li><strong><a href="/ports/roatan.html">Roatán</a></strong> — Roatán is the port everyone underestimates and falls in love with — West Bay ...</li>
+  <li><strong><a href="/ports/royal-beach-club-nassau.html">Royal Beach Club Paradise Island Guide — Royal Caribbean's Nassau Beach Club</a></strong> — Royal Beach Club Paradise Island is Royal Caribbean's premium private beach d...</li>
+  <li><strong><a href="/ports/samana.html">Samaná</a></strong> — Samaná Bay in whale season (mid-January to late March) offers the most reliab...</li>
+  <li><strong><a href="/ports/san-juan.html">San Juan</a></strong> — San Juan is my favorite walkable port — step off the ship into a 500-year-old...</li>
+  <li><strong><a href="/ports/st-barts.html">St. Barts</a></strong> — St.</li>
+  <li><strong><a href="/ports/st-kitts.html">St. Kitts</a></strong> — The first West Indian island colonized by Europeans (1623), St. Kitts offers ...</li>
+  <li><strong><a href="/ports/st-lucia.html">St. Lucia</a></strong> — St.</li>
+  <li><strong><a href="/ports/st-maarten.html">St. Maarten</a></strong> — St. Maarten is a dual-nation island with Maho Beach jet-blast plane spotting ...</li>
+  <li><strong><a href="/ports/st-thomas.html">St. Thomas</a></strong> — St. Thomas is my absolute favorite Caribbean day — Magens Bay (top-10 beach i...</li>
+  <li><strong><a href="/ports/tortola.html">Tortola</a></strong> — Tortola – "Land of the Turtle Dove" and the Sailing Capital of the Caribbean ...</li>
+  <li><strong><a href="/ports/virgin-gorda.html">Virgin Gorda</a></strong> — The Baths at Virgin Gorda is the single most spectacular beach formation in t...</li>
+</ul>
 
-        <h3>Additional Asia-Pacific Ports</h3>
-        <ul class="cols-2 tiny">
-          <li><a href="/ports/bali.html">Bali (Benoa), Indonesia</a></li>
-          <li><a href="/ports/bangkok.html">Bangkok (Laem Chabang), Thailand</a></li>
-          <li><a href="/ports/brunei.html">Brunei</a></li>
-          <li><a href="/ports/busan.html">Busan, South Korea</a></li>
-          <li><a href="/ports/da-nang.html">Da Nang, Vietnam</a></li>
-          <li><a href="/ports/dubai.html">Dubai, UAE</a></li>
-          <li><a href="/ports/abu-dhabi.html">Abu Dhabi, UAE</a></li>
-          <li><a href="/ports/doha.html">Doha, Qatar</a></li>
-          <li><a href="/ports/fukuoka.html">Fukuoka, Japan</a></li>
-          <li><a href="/ports/hakodate.html">Hakodate, Japan</a></li>
-          <li><a href="/ports/haifa.html">Haifa, Israel</a></li>
-          <li><a href="/ports/ha-long-bay.html">Ha Long Bay, Vietnam</a></li>
-          <li><a href="/ports/ho-chi-minh.html">Ho Chi Minh City, Vietnam</a></li>
-          <li><a href="/ports/hong-kong.html">Hong Kong</a></li>
-          <li><a href="/ports/istanbul.html">Istanbul, Turkey</a></li>
-          <li><a href="/ports/kagoshima.html">Kagoshima, Japan</a></li>
-          <li><a href="/ports/manila.html">Manila, Philippines</a></li>
-          <li><a href="/ports/mumbai.html">Mumbai, India</a></li>
-          <li><a href="/ports/muscat.html">Muscat, Oman</a></li>
-          <li><a href="/ports/okinawa.html">Okinawa, Japan</a></li>
-          <li><a href="/ports/phuket.html">Phuket, Thailand</a></li>
-          <li><a href="/ports/seoul.html">Seoul (Incheon), South Korea</a></li>
-          <li><a href="/ports/taipei.html">Taipei (Keelung), Taiwan</a></li>
-          <li><a href="/ports/tokyo.html">Tokyo (Yokohama), Japan</a></li>
-        </ul>
+<h3>Alaska (14 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/anchorage.html">Anchorage</a></strong> — Anchorage is Alaska's gateway city — ships dock at Seward (2.</li>
+  <li><strong><a href="/ports/endicott-arm.html">Endicott Arm & Dawes Glacier Guide — Alaska</a></strong> — Endicott Arm is a spectacular 30-mile Alaskan fjord ending at Dawes Glacier—o...</li>
+  <li><strong><a href="/ports/glacier-bay.html">Glacier Bay — Alaska's Crown Jewel Scenic Cruising</a></strong> — Glacier Bay is the crown jewel of Alaska cruising — 65 miles of fjord, 15 tid...</li>
+  <li><strong><a href="/ports/haines.html">Haines — Alaska's Hidden Gem for Eagles & Wilderness</a></strong> — Haines is Alaska's hidden gem — home to the world's largest bald eagle gather...</li>
+  <li><strong><a href="/ports/hubbard-glacier.html">Hubbard Glacier — North America's Largest Tidewater Glacier</a></strong> — Hubbard Glacier is North America's largest tidewater glacier — a 6-mile wall ...</li>
+  <li><strong><a href="/ports/icy-strait-point.html">Icy Strait Point — Alaska's Authentic Tlingit Port</a></strong> — Icy Strait Point is Alaska's most authentic cruise experience — 100% Huna Tli...</li>
+  <li><strong><a href="/ports/juneau.html">Juneau — Alaska's Adventure Capital</a></strong> — Juneau is Alaska's capital and adventure heart — Mendenhall Glacier, legendar...</li>
+  <li><strong><a href="/ports/ketchikan.html">Ketchikan — Alaska's First City</a></strong> — Ketchikan is Alaska's First City and most walkable cruise port — Creek Street...</li>
+  <li><strong><a href="/ports/seward.html">Seward — Gateway to Kenai Fjords & Alaska's Best Wildlife</a></strong> — Seward is the gateway to Kenai Fjords National Park — offering what many call...</li>
+  <li><strong><a href="/ports/sitka.html">Sitka — Russian America & Wildlife</a></strong> — Sitka blends Russian onion domes with Tlingit totems, sea otters floating in ...</li>
+  <li><strong><a href="/ports/skagway.html">Skagway — Gold Rush Gateway</a></strong> — Skagway is pure 1898 Gold Rush fever frozen in time — the legendary White Pas...</li>
+  <li><strong><a href="/ports/tracy-arm.html">Tracy Arm Fjord Guide — Alaska's Narrow Glacier Wonder</a></strong> — Tracy Arm is a stunning alternative to Glacier Bay—a narrow 30-mile fjord wit...</li>
+  <li><strong><a href="/ports/victoria-bc.html">Victoria BC</a></strong> — Victoria is the perfect civilized bookend — Butchart Gardens in full bloom, h...</li>
+  <li><strong><a href="/ports/whittier.html">Whittier</a></strong> — Whittier is bizarre (everyone lives in one Soviet-looking building) but Princ...</li>
+</ul>
 
-        <h3>Additional Australia & New Zealand Ports</h3>
-        <ul class="cols-2 tiny">
-          <li><a href="/ports/adelaide.html">Adelaide, Australia</a></li>
-          <li><a href="/ports/auckland.html">Auckland, New Zealand</a></li>
-          <li><a href="/ports/bay-of-islands.html">Bay of Islands, New Zealand</a></li>
-          <li><a href="/ports/cairns.html">Cairns, Australia</a></li>
-          <li><a href="/ports/christchurch.html">Christchurch (Lyttelton), New Zealand</a></li>
-          <li><a href="/ports/darwin.html">Darwin, Australia</a></li>
-          <li><a href="/ports/doubtful-sound.html">Doubtful Sound, New Zealand</a></li>
-          <li><a href="/ports/dunedin.html">Dunedin, New Zealand</a></li>
-          <li><a href="/ports/fremantle.html">Fremantle (Perth), Australia</a></li>
-          <li><a href="/ports/hobart.html">Hobart, Tasmania</a></li>
-          <li><a href="/ports/milford-sound.html">Milford Sound, New Zealand</a></li>
-          <li><a href="/ports/napier.html">Napier, New Zealand</a></li>
-          <li><a href="/ports/picton.html">Picton, New Zealand</a></li>
-          <li><a href="/ports/port-douglas.html">Port Douglas, Australia</a></li>
-          <li><a href="/ports/tauranga.html">Tauranga, New Zealand</a></li>
-          <li><a href="/ports/wellington.html">Wellington, New Zealand</a></li>
-          <li><a href="/ports/whitsundays.html">Whitsundays, Australia</a></li>
-        </ul>
+<h3>Mexican Riviera (8 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/acapulco.html">Acapulco</a></strong> — Acapulco is Mexico's legendary Pacific resort — don't miss the iconic La Queb...</li>
+  <li><strong><a href="/ports/cabo-san-lucas.html">Cabo San Lucas</a></strong> — Cabo San Lucas is where desert cliffs plunge into two seas at the iconic Land...</li>
+  <li><strong><a href="/ports/ensenada.html">Ensenada</a></strong> — Ensenada cruise port guide featuring Valle de Guadalupe wine country, La Bufa...</li>
+  <li><strong><a href="/ports/huatulco.html">Huatulco</a></strong> — Huatulco is Mexico's eco-planned coastal paradise—nine protected bays with pr...</li>
+  <li><strong><a href="/ports/manzanillo.html">Manzanillo</a></strong> — Manzanillo is Mexico's authentic Pacific coast experience—world-class sailfis...</li>
+  <li><strong><a href="/ports/mazatlan.html">Mazatlan</a></strong> — Mazatlan—the "Pearl of the Pacific"—offers both Golden Zone beach resort vibe...</li>
+  <li><strong><a href="/ports/puerto-vallarta.html">Puerto Vallarta</a></strong> — Puerto Vallarta is Pacific Mexico's most walkable and culturally rich cruise ...</li>
+  <li><strong><a href="/ports/zihuatanejo.html">Zihuatanejo</a></strong> — Zihuatanejo is the authentic Mexican fishing village Andy Dufresne dreamed ab...</li>
+</ul>
 
-        <h3>Additional South Pacific & Indian Ocean Ports</h3>
-        <ul class="cols-2 tiny">
-          <li><a href="/ports/apia.html">Apia, Samoa</a></li>
-          <li><a href="/ports/bora-bora.html">Bora Bora, French Polynesia</a></li>
-          <li><a href="/ports/cochin.html">Cochin (Kochi), India</a></li>
-          <li><a href="/ports/colombo.html">Colombo, Sri Lanka</a></li>
-          <li><a href="/ports/dravuni.html">Dravuni Island, Fiji</a></li>
-          <li><a href="/ports/easter-island.html">Easter Island, Chile</a></li>
-          <li><a href="/ports/fiji.html">Fiji (Suva/Lautoka)</a></li>
-          <li><a href="/ports/goa.html">Goa, India</a></li>
-          <li><a href="/ports/guam.html">Guam</a></li>
-          <li><a href="/ports/lifou.html">Lifou, New Caledonia</a></li>
-          <li><a href="/ports/moorea.html">Moorea, French Polynesia</a></li>
-          <li><a href="/ports/noumea.html">Nouméa, New Caledonia</a></li>
-          <li><a href="/ports/pago-pago.html">Pago Pago, American Samoa</a></li>
-          <li><a href="/ports/papeete.html">Papeete, Tahiti</a></li>
-          <li><a href="/ports/rarotonga.html">Rarotonga, Cook Islands</a></li>
-        </ul>
+<h3>Mediterranean (59 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/ajaccio.html">Ajaccio (Corsica)</a></strong> — Ajaccio is Napoleon's birthplace, rich with history, art, and Corsican charm.</li>
+  <li><strong><a href="/ports/amalfi.html">Amalfi (Salerno)</a></strong> — Salerno is the smart gateway to the Amalfi Coast – Positano, Amalfi, and Rave...</li>
+  <li><strong><a href="/ports/athens.html">Athens (Piraeus)</a></strong> — Athens cruise port guide featuring the Acropolis, Parthenon, Ancient Agora, P...</li>
+  <li><strong><a href="/ports/barcelona.html">Barcelona</a></strong> — Barcelona is a major embarkation port and Mediterranean highlight.</li>
+  <li><strong><a href="/ports/bodrum.html">Bodrum, Turkey</a></strong> — Bodrum, Turkey — ancient Halicarnassus, the Mausoleum (Seven Wonders of the A...</li>
+  <li><strong><a href="/ports/bordeaux.html">Bordeaux</a></strong> — Bordeaux is golden stone, grand boulevards, and the wine capital of the world...</li>
+  <li><strong><a href="/ports/cadiz.html">Cadiz</a></strong> — Cádiz is the oldest continuously inhabited city in Western Europe, founded by...</li>
+  <li><strong><a href="/ports/cagliari.html">Cagliari (Sardinia)</a></strong> — Cagliari is Sardinia's ancient capital (154,000 souls) built on Neolithic fou...</li>
+  <li><strong><a href="/ports/cannes.html">Cannes</a></strong> — Cannes is red carpets, rosé on the beach, and the Croisette promenade that ma...</li>
+  <li><strong><a href="/ports/capri.html">Capri, Italy</a></strong> — Capri — Blue Grotto sea cave with glowing azure water, Monte Solaro panoramas...</li>
+  <li><strong><a href="/ports/cartagena-spain.html">Cartagena, Spain</a></strong> — Cartagena is a perfectly preserved Roman theater, Art Nouveau buildings, and ...</li>
+  <li><strong><a href="/ports/catania.html">Catania</a></strong> — Catania is the "Black Baroque" city — born Greek in 729 BC, destroyed by Etna...</li>
+  <li><strong><a href="/ports/cephalonia.html">Cephalonia (Kefalonia), Greece - Largest Ionian Island</a></strong> — First-person logbook entry from Cephalonia: Greece's largest Ionian island wi...</li>
+  <li><strong><a href="/ports/civitavecchia.html">Civitavecchia (Rome)</a></strong> — Civitavecchia is Rome's cruise port, 80km and 90 minutes from the city.</li>
+  <li><strong><a href="/ports/corfu.html">Corfu</a></strong> — Corfu Old Town is Venetian charm with British and French twists, surrounded b...</li>
+  <li><strong><a href="/ports/dubrovnik.html">Dubrovnik</a></strong> — Dubrovnik is Lord Byron's "Pearl of the Adriatic"—a UNESCO-listed city with 2...</li>
+  <li><strong><a href="/ports/funchal.html">Funchal, Madeira</a></strong> — Funchal, Madeira — capital of this volcanic Atlantic island for five centuries.</li>
+  <li><strong><a href="/ports/genoa.html">Genoa</a></strong> — Genoa is the underrated grand old lady of the Italian Riviera – massive palaz...</li>
+  <li><strong><a href="/ports/gibraltar.html">Gibraltar</a></strong> — Gibraltar is a British Overseas Territory since 1704, home to the legendary R...</li>
+  <li><strong><a href="/ports/gijon.html">Gijón</a></strong> — Gijón is Asturias' soul on the Bay of Biscay — Celtic Green Coast, Eduardo Ch...</li>
+  <li><strong><a href="/ports/haifa.html">Haifa, Israel</a></strong> — Haifa, Israel — UNESCO Bahá'í Gardens, day tours to Jerusalem and Bethlehem, ...</li>
+  <li><strong><a href="/ports/heraklion.html">Heraklion (Crete)</a></strong> — Heraklion is the gateway to Knossos — Europe's oldest palace, birthplace of t...</li>
+  <li><strong><a href="/ports/hvar.html">Hvar, Croatia</a></strong> — Hvar, Croatia — lavender fields, Stari Grad Plain UNESCO site, Fortica fortre...</li>
+  <li><strong><a href="/ports/ibiza.html">Ibiza</a></strong> — Ibiza reveals 2,600+ years of history: Phoenician Ibossim (654 BCE), Puig des...</li>
+  <li><strong><a href="/ports/istanbul.html">Istanbul</a></strong> — Istanbul — Hagia Sophia, Blue Mosque, Grand Bazaar, Bosphorus cruise, and the...</li>
+  <li><strong><a href="/ports/koper.html">Koper</a></strong> — Koper is a miniature Venice with Slovenian prices – Venetian palaces, Tito Sq...</li>
+  <li><strong><a href="/ports/kotor.html">Kotor</a></strong> — Kotor is a medieval town tucked into Europe's southernmost fjord with mountai...</li>
+  <li><strong><a href="/ports/kusadasi.html">Kusadasi &amp; Ephesus — Turkey's Ancient Wonder</a></strong> — Kusadasi is Turkey's gateway to Ephesus — one of the best-preserved ancient c...</li>
+  <li><strong><a href="/ports/la-coruna.html">La Coruña</a></strong> — La Coruña is the City of Glass – Roman lighthouse still working after 1,900 y...</li>
+  <li><strong><a href="/ports/la-spezia.html">La Spezia</a></strong> — La Spezia in Italy's Gulf of Poets — gateway to UNESCO Cinque Terre's five pa...</li>
+  <li><strong><a href="/ports/limassol.html">Limassol, Cyprus</a></strong> — Limassol, Cyprus — ancient Greek amphitheaters at Kourion, Crusader castles w...</li>
+  <li><strong><a href="/ports/lisbon.html">Lisbon</a></strong> — Lisbon is seven hills of colorful tiles, melancholy fado music, and pastel de...</li>
+  <li><strong><a href="/ports/livorno.html">Livorno (Florence & Pisa)</a></strong> — Livorno is one of Italy's busiest cruise ports and your gateway to Tuscany's ...</li>
+  <li><strong><a href="/ports/malaga.html">Málaga</a></strong> — Málaga was founded by Phoenicians around 1000 BC and is Picasso's birthplace ...</li>
+  <li><strong><a href="/ports/marseille.html">Marseille</a></strong> — Marseille is France's oldest city (founded 600 BCE) and a gritty, authentic M...</li>
+  <li><strong><a href="/ports/messina.html">Messina</a></strong> — Messina is the gateway to Taormina – Greek theater with an active volcano bac...</li>
+  <li><strong><a href="/ports/monte-carlo.html">Monte Carlo (Monaco)</a></strong> — Monaco is pure glamour on steroids – supercars, yachts the size of cruise shi...</li>
+  <li><strong><a href="/ports/mykonos.html">Mykonos</a></strong> — Mykonos is the quintessential Greek island—a maze of white-washed buildings, ...</li>
+  <li><strong><a href="/ports/naples.html">Naples</a></strong> — Naples serves as gateway to Pompeii (35 min by train), Herculaneum, Mount Ves...</li>
+  <li><strong><a href="/ports/palma.html">Palma de Mallorca</a></strong> — Palma de Mallorca is a top-rated Mediterranean port with a stunning Gothic ca...</li>
+  <li><strong><a href="/ports/patmos.html">Patmos</a></strong> — Patmos, Greece — the Cave of the Apocalypse, Monastery of St.</li>
+  <li><strong><a href="/ports/portimao.html">Portimão</a></strong> — Portimão is golden Algarve cliffs tumbling into turquoise water, Benagil Cave...</li>
+  <li><strong><a href="/ports/porto.html">Porto</a></strong> — Porto is terracotta roofs cascading down to the Douro, port wine lodges, and ...</li>
+  <li><strong><a href="/ports/portofino.html">Portofino, Italy</a></strong> — Portofino — ancient Roman harbor transformed into luxury destination.</li>
+  <li><strong><a href="/ports/ravenna.html">Ravenna</a></strong> — Ravenna is the world capital of Byzantine mosaics – eight UNESCO sites glowin...</li>
+  <li><strong><a href="/ports/rhodes.html">Rhodes</a></strong> — Rhodes is the best-preserved medieval city in Europe — a living fortress with...</li>
+  <li><strong><a href="/ports/santorini.html">Santorini</a></strong> — Santorini means sailing into the collapsed heart of a volcano that exploded a...</li>
+  <li><strong><a href="/ports/sorrento.html">Sorrento, Italy</a></strong> — Sorrento, Italy — perched at the northern gateway to the Amalfi Coast, where ...</li>
+  <li><strong><a href="/ports/split.html">Split</a></strong> — Split is Diocletian's retirement palace turned living city — Romans, Venetian...</li>
+  <li><strong><a href="/ports/taormina.html">Taormina</a></strong> — Taormina is the jewel of Sicily — perched on a cliff above the Ionian Sea wit...</li>
+  <li><strong><a href="/ports/trieste.html">Trieste</a></strong> — Trieste is elegant Habsburg cafés, the largest sea-facing piazza in Italy, an...</li>
+  <li><strong><a href="/ports/tunis.html">Tunis (La Goulette)</a></strong> — La Goulette is your gateway to Carthage, Sidi Bou Said's blue-and-white perfe...</li>
+  <li><strong><a href="/ports/valencia.html">Valencia</a></strong> — Valencia was founded 138 BC as Roman Valentia, meaning "strength.</li>
+  <li><strong><a href="/ports/valletta.html">Valletta (Malta)</a></strong> — Valletta is Europe's smallest capital and a UNESCO World Heritage Site (since...</li>
+  <li><strong><a href="/ports/venice.html">Venice</a></strong> — Large ships now dock at Marghera on the mainland (20-30 min transfer to Venice).</li>
+  <li><strong><a href="/ports/vigo.html">Vigo</a></strong> — Vigo is the gateway to the Cíes Islands – Atlantic paradise with beaches that...</li>
+  <li><strong><a href="/ports/villefranche.html">Villefranche-sur-Mer (Nice & Monaco)</a></strong> — Villefranche-sur-Mer is a tender port with one of the Mediterranean's deepest...</li>
+  <li><strong><a href="/ports/zadar.html">Zadar</a></strong> — Zadar is Roman ruins, a Sea Organ that plays music with the waves, and a Gree...</li>
+  <li><strong><a href="/ports/zakynthos.html">Zakynthos (Zante), Greece</a></strong> — Zakynthos (Zante), Greece — Navagio Shipwreck Beach, Blue Caves, loggerhead s...</li>
+</ul>
 
-        <h3>Additional Africa & Atlantic Islands Ports</h3>
-        <ul class="cols-2 tiny">
-          <li><a href="/ports/agadir.html">Agadir, Morocco</a></li>
-          <li><a href="/ports/ascension.html">Ascension Island</a></li>
-          <li><a href="/ports/cape-town.html">Cape Town, South Africa</a></li>
-          <li><a href="/ports/casablanca.html">Casablanca, Morocco</a></li>
-          <li><a href="/ports/dakar.html">Dakar, Senegal</a></li>
-          <li><a href="/ports/durban.html">Durban, South Africa</a></li>
-          <li><a href="/ports/lanzarote.html">Lanzarote, Canary Islands</a></li>
-          <li><a href="/ports/port-elizabeth.html">Port Elizabeth, South Africa</a></li>
-          <li><a href="/ports/sao-tome.html">São Tomé and Príncipe</a></li>
-          <li><a href="/ports/tenerife.html">Tenerife, Canary Islands</a></li>
-        </ul>
+<h3>Northern Europe & British Isles (45 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/akureyri.html">Akureyri, Iceland</a></strong> — Akureyri offers world-class whale watching from the pier (€85-150), Goðafoss ...</li>
+  <li><strong><a href="/ports/alesund.html">Ålesund</a></strong> — Ålesund is pure Art Nouveau fairy tale rebuilt after a 1904 fire – pastel bui...</li>
+  <li><strong><a href="/ports/amsterdam.html">Amsterdam</a></strong> — Amsterdam's cruise terminal is right behind Centraal Station — you step off a...</li>
+  <li><strong><a href="/ports/belfast.html">Belfast</a></strong> — Belfast has completely transformed and now scores 4.</li>
+  <li><strong><a href="/ports/bergen.html">Bergen</a></strong> — Bergen is seven mountains, colorful Hanseatic wharf houses, and rain that som...</li>
+  <li><strong><a href="/ports/bilbao.html">Bilbao</a></strong> — Bilbao is living proof that architecture can save a city.</li>
+  <li><strong><a href="/ports/cherbourg.html">Cherbourg</a></strong> — Cherbourg is umbrellas on the promenade, the largest artificial harbor in the...</li>
+  <li><strong><a href="/ports/copenhagen.html">Copenhagen</a></strong> — Copenhagen is consistently voted the #1 Northern Europe port — colorful Nyhav...</li>
+  <li><strong><a href="/ports/cork.html">Cork/Cobh</a></strong> — Cobh is the heartbreakingly beautiful last port of call for the Titanic and a...</li>
+  <li><strong><a href="/ports/dover.html">Dover</a></strong> — Dover is white cliffs, a massive medieval castle, and the gateway to London o...</li>
+  <li><strong><a href="/ports/dublin.html">Dublin & Cobh</a></strong> — Ireland is where cruisers report the friendliest people on the planet (4.</li>
+  <li><strong><a href="/ports/scotland.html">Edinburgh & Glasgow</a></strong> — South Queensferry (Edinburgh) and Greenock (Glasgow) are both 4.</li>
+  <li><strong><a href="/ports/edinburgh.html">Edinburgh/Leith</a></strong> — Edinburgh via Leith, South Queensferry, Newhaven, or Rosyth — Edinburgh Castl...</li>
+  <li><strong><a href="/ports/flam.html">Flåm</a></strong> — Flåm — the legendary Flåmsbana Railway (20 years in the making), Stegastein v...</li>
+  <li><strong><a href="/ports/gdansk.html">Gdansk</a></strong> — Gdansk is amber, solidarity, and perfectly rebuilt Hanseatic façades along th...</li>
+  <li><strong><a href="/ports/geiranger.html">Geiranger Fjord</a></strong> — Logbook reflections from Geirangerfjord — UNESCO World Heritage site sculpted...</li>
+  <li><strong><a href="/ports/gothenburg.html">Gothenburg</a></strong> — Gothenburg is trams, seafood, and Scandinavian cool – the friendliest big cit...</li>
+  <li><strong><a href="/ports/greenock.html">Greenock</a></strong> — Greenock — Scotland's gateway port for Glasgow Cathedral, Kelvingrove Museum,...</li>
+  <li><strong><a href="/ports/hamburg.html">Hamburg</a></strong> — Explore Hamburg's UNESCO Speicherstadt warehouses, architectural marvel Elbph...</li>
+  <li><strong><a href="/ports/helsinki.html">Helsinki</a></strong> — Helsinki is the underrated Nordic gem — clean, friendly, and packed with design.</li>
+  <li><strong><a href="/ports/holyhead.html">Holyhead</a></strong> — Holyhead is the gateway to Snowdonia and Anglesey – mountains, castles, and t...</li>
+  <li><strong><a href="/ports/honfleur.html">Honfleur</a></strong> — Honfleur is the prettiest harbor in Normandy – colorful tall houses reflected...</li>
+  <li><strong><a href="/ports/invergordon.html">Invergordon</a></strong> — Invergordon is the gateway to Loch Ness, Inverness, and the Highlands – drama...</li>
+  <li><strong><a href="/ports/kiel.html">Kiel</a></strong> — Kiel is the sailing capital of Germany – Olympic harbor, massive locks, and t...</li>
+  <li><strong><a href="/ports/kirkwall.html">Kirkwall</a></strong> — Kirkwall is 5,000 years of continuous history – Neolithic villages older than...</li>
+  <li><strong><a href="/ports/klaipeda.html">Klaipeda</a></strong> — Klaipeda, Lithuania — UNESCO Curonian Spit sand dunes, Hill of Witches sculpt...</li>
+  <li><strong><a href="/ports/le-havre.html">Le Havre</a></strong> — Le Havre is the realistic gateway to Paris – six hours round-trip on excellen...</li>
+  <li><strong><a href="/ports/lerwick.html">Lerwick</a></strong> — Lerwick is Britain's northernmost town – ponies the size of dogs, Viking fire...</li>
+  <li><strong><a href="/ports/liverpool.html">Liverpool</a></strong> — Liverpool is The Beatles, two cathedrals, the best maritime museum in Britain...</li>
+  <li><strong><a href="/ports/newcastle.html">Newcastle</a></strong> — Newcastle is seven bridges, proper Geordie warmth, the Angel of the North wat...</li>
+  <li><strong><a href="/ports/norwegian-fjords.html">Norwegian Fjords</a></strong> — Norwegian fjord ports (Geiranger, Flam, Olden, Ålesund) offer the most specta...</li>
+  <li><strong><a href="/ports/olden.html">Olden — Norway's Briksdal Glacier Village</a></strong> — Olden is a tiny Norwegian fjord village beneath Briksdal Glacier — troll cars...</li>
+  <li><strong><a href="/ports/oslo.html">Oslo</a></strong> — Oslo's Oslofjord sail-in past islands and red cabins is stunning.</li>
+  <li><strong><a href="/ports/reykjavik.html">Reykjavik</a></strong> — Reykjavik is gateway to Iceland's otherworldly landscapes.</li>
+  <li><strong><a href="/ports/riga.html">Riga</a></strong> — Riga is the Art Nouveau capital of the world wrapped in a Hanseatic old town ...</li>
+  <li><strong><a href="/ports/rostock.html">Rostock (Warnemünde)</a></strong> — Rostock/Warnemünde, Germany — Hanseatic League history, gateway to Berlin, St.</li>
+  <li><strong><a href="/ports/southampton.html">Southampton</a></strong> — Southampton is the UK's busiest cruise port (3M+ passengers, £1B economy impa...</li>
+  <li><strong><a href="/ports/st-petersburg.html">St. Petersburg</a></strong> — St. Petersburg is imperial excess on steroids – golden spires, canals, and pa...</li>
+  <li><strong><a href="/ports/stavanger.html">Stavanger</a></strong> — Stavanger is white wooden houses, street art, and the gateway to Pulpit Rock ...</li>
+  <li><strong><a href="/ports/stockholm.html">Stockholm</a></strong> — Stockholm spans 14 islands connected by bridges and ferries.</li>
+  <li><strong><a href="/ports/tallinn.html">Tallinn</a></strong> — Tallinn is a perfectly preserved Hanseatic fairy tale – orange roofs, church ...</li>
+  <li><strong><a href="/ports/tromso.html">Tromsø</a></strong> — Tromsø is the Arctic capital – midnight sun or northern lights, reindeer sled...</li>
+  <li><strong><a href="/ports/warnemunde.html">Warnemünde</a></strong> — Warnemünde is a perfect German beach town, but everyone uses it as the gatewa...</li>
+  <li><strong><a href="/ports/waterford.html">Waterford</a></strong> — Waterford is Viking triangles, the finest crystal in the world, and the oldes...</li>
+  <li><strong><a href="/ports/zeebrugge.html">Zeebrugge/Bruges</a></strong> — Zeebrugge is the gateway to Bruges – a perfectly preserved medieval fairy-tal...</li>
+</ul>
 
-        <h3>Additional Remote & Expedition Ports</h3>
-        <ul class="cols-2 tiny">
-          <li><a href="/ports/aitutaki.html">Aitutaki, Cook Islands</a></li>
-          <li><a href="/ports/aqaba.html">Aqaba, Jordan</a></li>
-          <li><a href="/ports/falkland-islands.html">Falkland Islands</a></li>
-          <li><a href="/ports/greenland.html">Greenland (Qaqortoq)</a></li>
-          <li><a href="/ports/iceland.html">Iceland (Reykjavik)</a></li>
-          <li><a href="/ports/mauritius.html">Mauritius</a></li>
-          <li><a href="/ports/seychelles.html">Seychelles</a></li>
-          <li><a href="/ports/st-helena.html">St. Helena</a></li>
-          <li><a href="/ports/svalbard.html">Svalbard, Norway</a></li>
-          <li><a href="/ports/tristan-da-cunha.html">Tristan da Cunha</a></li>
-        </ul>
+<h3>Canary Islands & Atlantic (3 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/gran-canaria.html">Gran Canaria (Las Palmas)</a></strong> — Las Palmas, Gran Canaria — stunning Maspalomas Dunes, colonial Vegueta quarte...</li>
+  <li><strong><a href="/ports/lanzarote.html">Lanzarote (Arrecife)</a></strong> — Arrecife, Lanzarote — stunning Timanfaya National Park volcanic landscape, Ja...</li>
+  <li><strong><a href="/ports/tenerife.html">Tenerife</a></strong> — Tenerife — ascending Spain's highest peak Mount Teide, UNESCO colonial La Lag...</li>
+</ul>
+
+<h3>Canada & New England (10 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/bar-harbor.html">Bar Harbor</a></strong> — Bar Harbor is your gateway to Acadia National Park — rugged coastline, Cadill...</li>
+  <li><strong><a href="/ports/boston.html">Boston</a></strong> — Boston is history you can touch — Freedom Trail, Fenway (if in season), North...</li>
+  <li><strong><a href="/ports/charlottetown.html">Charlottetown</a></strong> — Birthplace of Canada, Anne of Green Gables, red sand beaches, and Cows ice cr...</li>
+  <li><strong><a href="/ports/halifax.html">Halifax</a></strong> — Halifax is friendly, walkable, and has the best waterfront boardwalk in Atlan...</li>
+  <li><strong><a href="/ports/newport.html">Newport</a></strong> — Gilded Age mansions, Cliff Walk, and sailboats everywhere — America's sailing...</li>
+  <li><strong><a href="/ports/portland-maine.html">Portland, Maine</a></strong> — Portland, Maine is six lighthouses including George Washington's Portland Hea...</li>
+  <li><strong><a href="/ports/quebec-city.html">Quebec City</a></strong> — Quebec City is the only walled city in North America north of Mexico and a UN...</li>
+  <li><strong><a href="/ports/saguenay.html">Saguenay</a></strong> — Saguenay Fjord is jaw-dropping — steep cliffs, beluga whales, and fall colors...</li>
+  <li><strong><a href="/ports/saint-john.html">Saint John</a></strong> — Saint John (Bay of Fundy) has the world's highest tides, Reversing Falls, and...</li>
+  <li><strong><a href="/ports/sydney-ns.html">Sydney</a></strong> — Sydney is the gateway to Cape Breton — biggest fiddle, friendliest people, an...</li>
+</ul>
+
+<h3>Hawaii & Pacific (18 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/adelaide.html">Adelaide</a></strong> — Adelaide is Australia's wine capital — gateway to 200+ cellar doors including...</li>
+  <li><strong><a href="/ports/auckland.html">Auckland</a></strong> — Auckland cruise port guide featuring Sky Tower views, Waiheke Island wine tou...</li>
+  <li><strong><a href="/ports/brisbane.html">Brisbane</a></strong> — First-person logbook: Brisbane's Portside Wharf, South Bank riverside, scenic...</li>
+  <li><strong><a href="/ports/cairns.html">Cairns</a></strong> — Cairns — 1876 gold port, gateway to the 2,300km Great Barrier Reef and 180-mi...</li>
+  <li><strong><a href="/ports/darwin.html">Darwin</a></strong> — Darwin, Australia — gateway to the Top End, saltwater crocodile territory, Ka...</li>
+  <li><strong><a href="/ports/dunedin.html">Dunedin</a></strong> — Dunedin's Scottish soul — 1848 founding, gold rush prosperity, ornate Railway...</li>
+  <li><strong><a href="/ports/fremantle.html">Fremantle</a></strong> — Fremantle — UNESCO World Heritage convict prison with haunting tunnel tours, ...</li>
+  <li><strong><a href="/ports/hilo.html">Hilo</a></strong> — Hilo is waterfalls every five minutes, active volcanoes, and the greenest, ra...</li>
+  <li><strong><a href="/ports/hobart.html">Hobart</a></strong> — Hobart — founded 1804 as penal colony, transformed by MONA (Australia's large...</li>
+  <li><strong><a href="/ports/honolulu.html">Honolulu</a></strong> — Honolulu gives you Waikiki's iconic golden sand, Pearl Harbor's solemn memori...</li>
+  <li><strong><a href="/ports/kona.html">Kailua-Kona</a></strong> — Kailua-Kona is historic villages, world-famous coffee, and one of the planet'...</li>
+  <li><strong><a href="/ports/lyttelton.html">Lyttelton</a></strong> — Lyttelton — port of Canterbury pilgrims, Antarctic expedition history, earthq...</li>
+  <li><strong><a href="/ports/maui.html">Maui</a></strong> — Ships dock at Kahului on the Valley Isle.</li>
+  <li><strong><a href="/ports/melbourne.html">Melbourne</a></strong> — Australia's cultural capital and cruise gateway to New Zealand and the South ...</li>
+  <li><strong><a href="/ports/nawiliwili.html">Nawiliwili</a></strong> — Nawiliwili is Kauai's only cruise port – Waimea Canyon, the Na Pali coast, an...</li>
+  <li><strong><a href="/ports/sydney.html">Sydney</a></strong> — Sydney features Opera House, Harbour Bridge, Bondi Beach, and spectacular har...</li>
+  <li><strong><a href="/ports/tauranga.html">Tauranga</a></strong> — Reflective logbook guide to Tauranga — where Captain Cook's 'Bay of Plenty' m...</li>
+  <li><strong><a href="/ports/wellington.html">Wellington</a></strong> — Wellington — Te Papa's colossal squid and Māori treasures, Cuba Street's crea...</li>
+</ul>
+
+<h3>Australia & New Zealand (4 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/bay-of-islands.html">Bay of Islands, New Zealand</a></strong> — Bay of Islands, New Zealand — Waitangi Treaty Grounds, Hole in the Rock boat ...</li>
+  <li><strong><a href="/ports/christchurch.html">Christchurch (Lyttelton)</a></strong> — Discover Christchurch and Lyttelton Port: New Zealand's oldest established ci...</li>
+  <li><strong><a href="/ports/doubtful-sound.html">Doubtful Sound Guide — New Zealand's Deepest Fjord Scenic Cruising</a></strong> — Doubtful Sound is New Zealand's largest and deepest fjord — 40 kilometers of ...</li>
+  <li><strong><a href="/ports/milford-sound.html">Milford Sound Guide — Eighth Wonder of the World</a></strong> — Milford Sound is a dramatic 15km fjord in Fiordland National Park — scenic cr...</li>
+</ul>
+
+<h3>South Pacific Islands (13 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/apia.html">Apia, Samoa</a></strong> — Apia cruise port guide featuring Robert Louis Stevenson Museum, To Sua Ocean ...</li>
+  <li><strong><a href="/ports/bora-bora.html">Bora Bora</a></strong> — Bora Bora — the Pearl of the Pacific.</li>
+  <li><strong><a href="/ports/dravuni.html">Dravuni Island</a></strong> — Dravuni Island, Fiji — authentic village life, traditional kava ceremony welc...</li>
+  <li><strong><a href="/ports/fiji.html">Fiji (Lautoka)</a></strong> — Lautoka, Fiji — 333 islands with 3,500 years of Melanesian heritage, kava cer...</li>
+  <li><strong><a href="/ports/guam.html">Guam</a></strong> — Guam delivers profound WWII history at War in the Pacific National Historical...</li>
+  <li><strong><a href="/ports/lautoka.html">Lautoka, Fiji: Sugar City and Gateway to Paradise</a></strong> — Discover Lautoka, Fiji's Sugar City on western Viti Levu.</li>
+  <li><strong><a href="/ports/lifou.html">Lifou, Loyalty Islands</a></strong> — Lifou, Loyalty Islands, New Caledonia — Jinek Bay snorkeling, Jokin Cliffs li...</li>
+  <li><strong><a href="/ports/moorea.html">Moorea (French Polynesia)</a></strong> — Moorea, French Polynesia — Belvedere Lookout over Cook's Bay and Ōpūnohu Bay,...</li>
+  <li><strong><a href="/ports/noumea.html">Noumea, New Caledonia</a></strong> — Noumea, New Caledonia — UNESCO lagoons, Amedee Island lighthouse, swimming wi...</li>
+  <li><strong><a href="/ports/papeete.html">Papeete</a></strong> — Papeete, Tahiti — birthplace of overwater bungalows, home to Gauguin's finest...</li>
+  <li><strong><a href="/ports/suva.html">Suva</a></strong> — Suva, Fiji — Kings Wharf downtown access, Fiji Museum cannibal forks and Paci...</li>
+  <li><strong><a href="/ports/tonga.html">Tonga (Nuku'alofa)</a></strong> — Nuku'alofa, Tonga — the Royal Palace, Mapu'a'a Vaea Blowholes shooting ocean ...</li>
+  <li><strong><a href="/ports/vanuatu.html">Vanuatu (Port Vila)</a></strong> — Port Vila, Vanuatu — Melanesian cultural villages, world's only underwater po...</li>
+</ul>
+
+<h3>Asia (37 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/bali.html">Bali (Benoa)</a></strong> — Bali cruise port guide featuring Uluwatu temple kecak fire dance, Ubud rice t...</li>
+  <li><strong><a href="/ports/bangkok.html">Bangkok / Laem Chabang</a></strong> — First-person Bangkok cruise guide: Grand Palace's royal history, Temple of th...</li>
+  <li><strong><a href="/ports/brunei.html">Brunei</a></strong> — Bandar Seri Begawan, Brunei — golden mosques, stilted water villages, royal s...</li>
+  <li><strong><a href="/ports/busan.html">Busan</a></strong> — First-person logbook: Busan, South Korea's largest port — cliff-perched templ...</li>
+  <li><strong><a href="/ports/cochin.html">Cochin (Kochi), India</a></strong> — Cochin (Kochi), India — Chinese fishing nets, Fort Kochi colonial heritage, M...</li>
+  <li><strong><a href="/ports/colombo.html">Colombo, Sri Lanka</a></strong> — Colombo, Sri Lanka — Gangaramaya Temple, elephant orphanages, Ceylon tea coun...</li>
+  <li><strong><a href="/ports/da-nang.html">Da Nang</a></strong> — Da Nang — where a 666-meter dragon breathes fire over the Han River, three UN...</li>
+  <li><strong><a href="/ports/fukuoka.html">Fukuoka</a></strong> — Fukuoka — Hakata Port's rich trading history with China and Korea, authentic ...</li>
+  <li><strong><a href="/ports/goa.html">Goa (Mormugao)</a></strong> — Mormugao Port, Goa — UNESCO World Heritage churches in Old Goa, Portuguese co...</li>
+  <li><strong><a href="/ports/ha-long-bay.html">Ha Long Bay, Vietnam</a></strong> — Ha Long Bay, Vietnam — UNESCO World Heritage limestone karsts, Sung Sot Cave ...</li>
+  <li><strong><a href="/ports/hakodate.html">Hakodate</a></strong> — Hakodate is where Japan opened to the world — climb Mount Hakodate for millio...</li>
+  <li><strong><a href="/ports/hiroshima.html">Hiroshima</a></strong> — Hiroshima — where August 6, 1945 transformed a city into a messenger of peace.</li>
+  <li><strong><a href="/ports/ho-chi-minh-city.html">Ho Chi Minh City</a></strong> — Ho Chi Minh City via Phu My port — Cu Chi Tunnels' underground war history, F...</li>
+  <li><strong><a href="/ports/ho-chi-minh.html">Ho Chi Minh City (Saigon)</a></strong> — Ho Chi Minh City cruise port: War Remnants Museum, Cu Chi Tunnels, Notre-Dame...</li>
+  <li><strong><a href="/ports/hong-kong.html">Hong Kong</a></strong> — Hong Kong cruise port: Victoria Harbour's colonial history, historic Star Fer...</li>
+  <li><strong><a href="/ports/incheon.html">Incheon, South Korea - Gateway Port & Historic Landing Site</a></strong> — First-hand account of Incheon, South Korea - gateway to Seoul, historic treat...</li>
+  <li><strong><a href="/ports/jeju.html">Jeju Island, South Korea</a></strong> — Jeju Island, South Korea — UNESCO triple crown volcanic landscapes, Manjanggu...</li>
+  <li><strong><a href="/ports/kobe.html">Kobe, Japan</a></strong> — Kobe, Japan — rebuilt after the 1995 earthquake, gateway opened to foreign tr...</li>
+  <li><strong><a href="/ports/koh-samui.html">Koh Samui, Thailand</a></strong> — Koh Samui tender port — Big Buddha Temple, Wat Plai Laem, Chaweng Beach, Na M...</li>
+  <li><strong><a href="/ports/komodo.html">Komodo (Indonesia)</a></strong> — Komodo, Indonesia — tender port to Komodo National Park, face-to-face encount...</li>
+  <li><strong><a href="/ports/kota-kinabalu.html">Kota Kinabalu, Malaysia: Borneo Gateway & Mount Kinabalu Views</a></strong> — A reflective cruise port guide to Kota Kinabalu, Sabah - where Borneo's highe...</li>
+  <li><strong><a href="/ports/langkawi.html">Langkawi</a></strong> — Langkawi, Malaysia — UNESCO Global Geopark archipelago with ancient limestone...</li>
+  <li><strong><a href="/ports/lombok.html">Lombok</a></strong> — Lombok, Indonesia — Mount Rinjani volcano, Gili Islands without cars, traditi...</li>
+  <li><strong><a href="/ports/manila.html">Manila</a></strong> — Manila cruise port: Intramuros walled city, Fort Santiago, colonial churches,...</li>
+  <li><strong><a href="/ports/mumbai.html">Mumbai</a></strong> — Mumbai cruise port: Gateway of India, Taj Mahal Palace Hotel, Elephanta Caves...</li>
+  <li><strong><a href="/ports/nagasaki.html">Nagasaki</a></strong> — Nagasaki — the Peace Memorial, Dejima's fan-shaped island of isolation, Thoma...</li>
+  <li><strong><a href="/ports/nha-trang.html">Nha Trang, Vietnam</a></strong> — Nha Trang, Vietnam — ancient Po Nagar Cham Towers, pristine beaches, Vinpearl...</li>
+  <li><strong><a href="/ports/osaka.html">Osaka</a></strong> — Osaka — exploring Dotonbori's historic 1612 canal, tasting takoyaki where it ...</li>
+  <li><strong><a href="/ports/penang.html">Penang</a></strong> — Penang — exploring Georgetown's UNESCO heritage architecture, Ernest Zacharev...</li>
+  <li><strong><a href="/ports/phuket.html">Phuket</a></strong> — Phuket — the gleaming Big Buddha, colorful Sino-Portuguese shophouses of Old ...</li>
+  <li><strong><a href="/ports/shanghai.html">Shanghai</a></strong> — Shanghai cruise port: The Bund's colonial architecture, futuristic Pudong, Mi...</li>
+  <li><strong><a href="/ports/sihanoukville.html">Sihanoukville, Cambodia - Beach Resort & Island Gateway</a></strong> — A cruise guide to Sihanoukville, Cambodia's premier beach destination and gat...</li>
+  <li><strong><a href="/ports/singapore.html">Singapore</a></strong> — Singapore cruise port: Gardens by the Bay, Marina Bay Sands, hawker centers, ...</li>
+  <li><strong><a href="/ports/taipei.html">Taipei (Keelung)</a></strong> — Taipei via historic Keelung Port — from Spanish traders to night market treas...</li>
+  <li><strong><a href="/ports/tianjin.html">Tianjin</a></strong> — Tianjin cruise port: Beijing gateway with Great Wall, Forbidden City, Temple ...</li>
+  <li><strong><a href="/ports/tokyo.html">Tokyo / Yokohama</a></strong> — Tokyo and Yokohama cruise ports: Historic Osanbashi Pier since 1894, Mount Fu...</li>
+  <li><strong><a href="/ports/yangon.html">Yangon (Rangoon), Myanmar: Golden Spires and Colonial Echoes - In the Wake</a></strong> — A cruise port guide to Yangon, Myanmar - from the shimmering Shwedagon Pagoda...</li>
+</ul>
+
+<h3>Middle East & Red Sea (8 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/abu-dhabi.html">Abu Dhabi</a></strong> — Abu Dhabi is the UAE's elegant capital — visit the awe-inspiring Sheikh Zayed...</li>
+  <li><strong><a href="/ports/aqaba.html">Aqaba</a></strong> — Aqaba cruise port guide featuring Petra day trips, Wadi Rum desert, Red Sea d...</li>
+  <li><strong><a href="/ports/doha.html">Doha, Qatar</a></strong> — Doha, Qatar — Museum of Islamic Art, Souq Waqif traditional market, Corniche ...</li>
+  <li><strong><a href="/ports/dubai.html">Dubai</a></strong> — Dubai—Mina Rashid terminal, Burj Khalifa's soaring heights, Palm Jumeirah, hi...</li>
+  <li><strong><a href="/ports/hurghada.html">Hurghada, Egypt: Red Sea Resort and Marine Life Haven -</a></strong> — Discover Hurghada's vibrant coral reefs, Giftun Islands marine park, desert a...</li>
+  <li><strong><a href="/ports/muscat.html">Muscat</a></strong> — Muscat — Sultan Qaboos Grand Mosque, the legendary Mutrah Souq, frankincense ...</li>
+  <li><strong><a href="/ports/safaga.html">Safaga</a></strong> — Safaga — gateway to Luxor's Valley of the Kings, world-class Red Sea diving, ...</li>
+  <li><strong><a href="/ports/salalah.html">Salalah</a></strong> — Salalah — the perfume capital of Arabia, UNESCO frankincense sites, Al Baleed...</li>
+</ul>
+
+<h3>Indian Ocean (3 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/maldives.html">Maldives (Malé)</a></strong> — Malé, Maldives — whale shark diving, coral stone mosques, fish markets, prist...</li>
+  <li><strong><a href="/ports/mauritius.html">Mauritius (Port Louis)</a></strong> — Port Louis, Mauritius — Aapravasi Ghat indentured labor history, vibrant Cent...</li>
+  <li><strong><a href="/ports/seychelles.html">Seychelles (Victoria, Mahé)</a></strong> — Victoria, Mahé — pristine beaches, giant tortoises at Botanical Gardens, Sain...</li>
+</ul>
+
+<h3>Africa (15 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/agadir.html">Agadir</a></strong> — Agadir is Morocco's modern beach resort — 10 km of Atlantic sand, Paradise Va...</li>
+  <li><strong><a href="/ports/ascension.html">Ascension Island</a></strong> — Ascension Island cruise port guide featuring Green Mountain cloud forest, sea...</li>
+  <li><strong><a href="/ports/cape-town.html">Cape Town</a></strong> — Cape Town — Table Mountain cable car since 1929, Robben Island tours with for...</li>
+  <li><strong><a href="/ports/casablanca.html">Casablanca</a></strong> — Casablanca is the massive Hassan II Mosque rising from the Atlantic – one of ...</li>
+  <li><strong><a href="/ports/dakar.html">Dakar, Senegal</a></strong> — Dakar, Senegal — Gorée Island UNESCO World Heritage site, African Renaissance...</li>
+  <li><strong><a href="/ports/durban.html">Durban, South Africa - Sunny Beaches and Zulu Heritage</a></strong> — Discover Durban's Golden Mile beaches, rich Indian heritage, and Zulu culture.</li>
+  <li><strong><a href="/ports/luanda.html">Luanda, Angola: A Maritime Guide to Africa's Oil Capital</a></strong> — A sailor's guide to Luanda, Angola - exploring the Portuguese colonial fortre...</li>
+  <li><strong><a href="/ports/maputo.html">Maputo</a></strong> — Maputo — Eiffel-designed railway station, Portuguese colonial architecture, I...</li>
+  <li><strong><a href="/ports/mindelo.html">Mindelo, Cape Verde: Cultural Heart of the Atlantic</a></strong> — Experience Mindelo, São Vicente - birthplace of Cesária Évora, cultural capit...</li>
+  <li><strong><a href="/ports/mombasa.html">Mombasa</a></strong> — Your complete guide to Mombasa, Kenya - explore Fort Jesus, Old Town's Swahil...</li>
+  <li><strong><a href="/ports/port-elizabeth.html">Port Elizabeth (Gqeberha)</a></strong> — Port Elizabeth (Gqeberha) — malaria-free elephant encounters at Addo, stunnin...</li>
+  <li><strong><a href="/ports/praia.html">Praia, Cape Verde:</a></strong> — First-hand guide to visiting Praia, Cape Verde by cruise ship.</li>
+  <li><strong><a href="/ports/st-helena.html">St. Helena</a></strong> — St.</li>
+  <li><strong><a href="/ports/tangier.html">Tangier</a></strong> — Tangier is the gateway where Europe and Africa kiss – a swirling medina, Atla...</li>
+  <li><strong><a href="/ports/walvis-bay.html">Walvis Bay (Namibia)</a></strong> — Walvis Bay, Namibia — thousands of pink flamingos, gateway to Sossusvlei's re...</li>
+</ul>
+
+<h3>South America (17 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/buenos-aires.html">Buenos Aires</a></strong> — Buenos Aires — La Boca's colorful shipyard houses painted with leftover ship ...</li>
+  <li><strong><a href="/ports/callao.html">Callao</a></strong> — Callao is the port for Lima, Peru's capital and a UNESCO World Heritage Site.</li>
+  <li><strong><a href="/ports/easter-island.html">Easter Island (Rapa Nui)</a></strong> — Easter Island (Rapa Nui), Chile — 887 moai statues at Rano Raraku quarry, Ahu...</li>
+  <li><strong><a href="/ports/falkland-islands.html">Falkland Islands (Port Stanley)</a></strong> — Falkland Islands cruise port guide featuring King penguin colonies at Volunte...</li>
+  <li><strong><a href="/ports/fortaleza.html">Fortaleza</a></strong> — Fortaleza, Brazil — exploring Beach Park's legendary waterslides, Praia do Fu...</li>
+  <li><strong><a href="/ports/guayaquil.html">Guayaquil</a></strong> — Guayaquil is Ecuador's largest city and main Galápagos gateway, featuring Mal...</li>
+  <li><strong><a href="/ports/manaus.html">Manaus, Brazil</a></strong> — Manaus, Brazil — Teatro Amazonas opera house, Meeting of the Waters, swimming...</li>
+  <li><strong><a href="/ports/manta.html">Manta</a></strong> — Manta is Ecuador's largest seaport and the world's tuna capital.</li>
+  <li><strong><a href="/ports/montevideo.html">Montevideo</a></strong> — Montevideo — historic Ciudad Vieja walkable from the cruise terminal, legenda...</li>
+  <li><strong><a href="/ports/puerto-madryn.html">Puerto Madryn, Argentina</a></strong> — Puerto Madryn, Argentina — Southern Right Whale watching from shore and boat,...</li>
+  <li><strong><a href="/ports/punta-arenas.html">Punta Arenas</a></strong> — Punta Arenas — Strait of Magellan crossing, Magdalena Island penguin colonies...</li>
+  <li><strong><a href="/ports/recife.html">Recife</a></strong> — Recife, Brazil — exploring the Venice of Brazil's bridges and canals, Olinda'...</li>
+  <li><strong><a href="/ports/rio-de-janeiro.html">Rio de Janeiro</a></strong> — Rio de Janeiro cruise port — Christ the Redeemer atop Corcovado, Sugarloaf's ...</li>
+  <li><strong><a href="/ports/salvador.html">Salvador, Brazil</a></strong> — Salvador, Brazil — Pelourinho UNESCO World Heritage site, baroque São Francis...</li>
+  <li><strong><a href="/ports/santos.html">Santos</a></strong> — Santos — Brazil's largest port, Coffee Museum, beachfront gardens, and gatewa...</li>
+  <li><strong><a href="/ports/ushuaia.html">Ushuaia</a></strong> — Ushuaia — world's southernmost city, Tierra del Fuego National Park, Beagle C...</li>
+  <li><strong><a href="/ports/valparaiso.html">Valparaíso</a></strong> — Valparaíso — UNESCO World Heritage hillside neighborhoods, historic ascensore...</li>
+</ul>
+
+<h3>Central America & Panama (4 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/colon.html">Colón</a></strong> — Colón, Panama — witnessing the Panama Canal's Agua Clara Locks, Fort San Lore...</li>
+  <li><strong><a href="/ports/corinto.html">Corinto</a></strong> — Corinto, Nicaragua — exploring colonial León's UNESCO heritage churches and c...</li>
+  <li><strong><a href="/ports/puerto-limon.html">Puerto Limón</a></strong> — Puerto Limón is your gateway to Costa Rica's Caribbean rainforest — sloths, m...</li>
+  <li><strong><a href="/ports/puntarenas.html">Puntarenas</a></strong> — Puntarenas, Costa Rica — exploring Carara National Park's scarlet macaw sanct...</li>
+</ul>
+
+<h3>Panama Canal (1 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/gatun-lake.html">Gatun Lake Guide — Panama Canal Transit Experience</a></strong> — Gatun Lake is the massive man-made freshwater lake at the heart of the Panama...</li>
+</ul>
+
+<h3>US Embarkation Ports (13 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/baltimore.html">Baltimore</a></strong> — Baltimore is more than a cruise gateway — it's where the Star-Spangled Banner...</li>
+  <li><strong><a href="/ports/cape-liberty.html">Cape Liberty</a></strong> — New York's smart cruiser alternative — stunning Statue of Liberty sailaway vi...</li>
+  <li><strong><a href="/ports/charleston.html">Charleston</a></strong> — Charleston is America's most charming cruise homeport — where Fort Sumter gua...</li>
+  <li><strong><a href="/ports/ft-lauderdale.html">Fort Lauderdale</a></strong> — Florida's second-busiest cruise port with 4M+ passengers annually — easier lo...</li>
+  <li><strong><a href="/ports/galveston.html">Galveston</a></strong> — America's fourth busiest cruise port and Texas's gateway to the Western Carib...</li>
+  <li><strong><a href="/ports/jacksonville.html">Jacksonville</a></strong> — Jacksonville offers a low-key Florida cruise experience with beautiful Atlant...</li>
+  <li><strong><a href="/ports/los-angeles.html">Los Angeles</a></strong> — Southern California's cruise gateway serves Mexican Riviera and Hawaii itiner...</li>
+  <li><strong><a href="/ports/miami.html">Miami</a></strong> — Miami is the Cruise Capital of the World — PortMiami handles 8M+ passengers a...</li>
+  <li><strong><a href="/ports/mobile.html">Mobile</a></strong> — Alabama's charming cruise port where Southern hospitality meets the birthplac...</li>
+  <li><strong><a href="/ports/new-orleans.html">New Orleans</a></strong> — America's most captivating cruise homeport — powdered sugar beignets, authent...</li>
+  <li><strong><a href="/ports/san-diego.html">San Diego</a></strong> — America's Finest City with perfect weather year-round — the USS Midway, San D...</li>
+  <li><strong><a href="/ports/san-francisco.html">San Francisco, USA</a></strong> — San Francisco — walking the Golden Gate Bridge, touring Alcatraz, riding cabl...</li>
+  <li><strong><a href="/ports/tampa.html">Tampa</a></strong> — Florida's underrated Gulf Coast gem — Ybor City Cuban sandwiches, free TECO s...</li>
+</ul>
+
+<h3>Expedition & Remote Ports (1 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/tristan-da-cunha.html">Tristan da Cunha</a></strong> — Tristan da Cunha — the world's most remote inhabited island, 1,750 miles from...</li>
+</ul>
+
+<h3>Other Destinations (18 ports)</h3>
+<ul class="cols-2">
+  <li><strong><a href="/ports/mystery-island.html">Mystery Island (Vanuatu)</a></strong> — Mystery Island, Vanuatu — pristine white sand beaches, crystal-clear snorkeli...</li>
+  <li><strong><a href="/ports/napier.html">Napier</a></strong> — Napier—Art Deco capital rebuilt after 1931 earthquake, Hawke's Bay wineries, ...</li>
+  <li><strong><a href="/ports/nosy-be.html">Nosy Be, Madagascar</a></strong> — Nosy Be, Madagascar — ylang-ylang plantations on Perfume Island, Lokobe Reser...</li>
+  <li><strong><a href="/ports/palau.html">Palau / Koror</a></strong> — Palau cruise port in Koror: Jellyfish Lake with stingless golden jellies, Roc...</li>
+  <li><strong><a href="/ports/panama-canal.html">Panama Canal Transit Guide — Locks & Engineering Marvel</a></strong> — Transiting the Panama Canal is the single most fascinating "port" day you wil...</li>
+  <li><strong><a href="/ports/picton.html">Picton</a></strong> — Picton — gateway to the Marlborough Sounds' ancient flooded valleys, Queen Ch...</li>
+  <li><strong><a href="/ports/pitcairn.html">Pitcairn Island</a></strong> — Pitcairn Island — HMS Bounty mutineer descendants, world's most remote inhabi...</li>
+  <li><strong><a href="/ports/ponta-delgada.html">Ponta Delgada</a></strong> — Ponta Delgada, Azores — stunning Sete Cidades twin lakes, year-round whale wa...</li>
+  <li><strong><a href="/ports/port-moresby.html">Port Moresby, Papua New Guinea - Gateway to Tribal Cultures & WWII History</a></strong> — Explore Port Moresby, PNG's vibrant capital on the Coral Sea.</li>
+  <li><strong><a href="/ports/portland.html">Portland</a></strong> — Portland is the Jurassic Coast – Chesil Beach's 18-mile pebble ridge, Portlan...</li>
+  <li><strong><a href="/ports/puerto-caldera.html">Puerto Caldera</a></strong> — Puerto Caldera, Costa Rica — exploring the modern cruise terminal closer to S...</li>
+  <li><strong><a href="/ports/saipan.html">Saipan</a></strong> — Saipan — exploring WWII memorials, diving The Grotto, Managaha Island beaches...</li>
+  <li><strong><a href="/ports/seattle.html">Seattle</a></strong> — America's premier gateway to Alaska — Pike Place Market fish throwers, the Sp...</li>
+  <li><strong><a href="/ports/sharm-el-sheikh.html">Sharm el-Sheikh</a></strong> — Sharm el-Sheikh — world-class diving at Ras Mohammed and Tiran Island, St.</li>
+  <li><strong><a href="/ports/south-georgia.html">South Georgia Island</a></strong> — South Georgia Island — 200,000+ King penguins at Salisbury Plain, Ernest Shac...</li>
+  <li><strong><a href="/ports/south-pacific.html">South Pacific Islands</a></strong> — South Pacific cruise ports: Bora Bora, Tahiti, Moorea, Fiji, Vanuatu, and Nou...</li>
+  <li><strong><a href="/ports/vancouver.html">Vancouver</a></strong> — Vancouver is the premier Alaska cruise gateway — Canada Place terminal sits b...</li>
+  <li><strong><a href="/ports/zanzibar.html">Zanzibar, Tanzania</a></strong> — Zanzibar, Tanzania — Stone Town UNESCO World Heritage Site, historic carved d...</li>
+</ul>
+
+<!-- Total: 333 ports -->
       </article>
 
       <!-- What We Cover -->
@@ -1276,37 +1534,88 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   // Port metadata for enhanced search (keywords, countries, tags)
   const portMetadata = {
-    'labadee': { country: 'Haiti', keywords: ['private island', 'zip line', 'beach', 'exclusive', 'private', 'haiti'], tags: ['caribbean', 'haiti', 'private'] },
-    'cococay': { country: 'Bahamas', keywords: ['perfect day', 'private island', 'water park', 'beach', 'private', 'bahamas'], tags: ['caribbean', 'bahamas', 'private'] },
-    'roatan': { country: 'Honduras', keywords: ['honduras', 'diving', 'snorkeling', 'mahogany bay'], tags: ['caribbean', 'honduras'] },
-    'cozumel': { country: 'Mexico', keywords: ['mexico', 'diving', 'mayan ruins', 'playa del carmen'], tags: ['caribbean', 'mexico'] },
-    'nassau': { country: 'Bahamas', keywords: ['bahamas', 'atlantis', 'paradise island', 'capital'], tags: ['caribbean', 'bahamas'] },
-    'grand-cayman': { country: 'Cayman Islands', keywords: ['stingray city', 'seven mile beach', 'diving', 'cayman'], tags: ['caribbean', 'cayman'] },
-    'st-thomas': { country: 'US Virgin Islands', keywords: ['usvi', 'virgin islands', 'magens bay', 'shopping', 'charlotte amalie'], tags: ['caribbean', 'usvi'] },
-    'st-maarten': { country: 'Sint Maarten', keywords: ['st martin', 'maho beach', 'philipsburg', 'dutch', 'french'], tags: ['caribbean'] },
-    'aruba': { country: 'Aruba', keywords: ['abc islands', 'eagle beach', 'oranjestad', 'dutch'], tags: ['caribbean', 'aruba'] },
-    'curacao': { country: 'Curaçao', keywords: ['abc islands', 'willemstad', 'dutch', 'colorful'], tags: ['caribbean', 'curacao'] },
-    'bonaire': { country: 'Bonaire', keywords: ['abc islands', 'diving', 'dutch', 'flamingos'], tags: ['caribbean', 'bonaire'] },
-    'san-juan': { country: 'Puerto Rico', keywords: ['puerto rico', 'old san juan', 'el morro', 'capital'], tags: ['caribbean', 'puerto rico'] },
-    'barcelona': { country: 'Spain', keywords: ['spain', 'gaudi', 'sagrada familia', 'catalonia'], tags: ['mediterranean', 'spain'] },
-    'rome-civitavecchia': { country: 'Italy', keywords: ['rome', 'vatican', 'colosseum', 'italy'], tags: ['mediterranean', 'italy'] },
-    'venice': { country: 'Italy', keywords: ['italy', 'canals', 'gondola', 'st marks'], tags: ['mediterranean', 'italy'] },
-    'santorini': { country: 'Greece', keywords: ['greece', 'oia', 'caldera', 'whitewashed', 'cyclades'], tags: ['mediterranean', 'greece'] },
-    'mykonos': { country: 'Greece', keywords: ['greece', 'party', 'windmills', 'cyclades'], tags: ['mediterranean', 'greece'] },
-    'dubrovnik': { country: 'Croatia', keywords: ['croatia', 'game of thrones', 'old town', 'kings landing'], tags: ['mediterranean', 'croatia'] },
-    'juneau': { country: 'USA', keywords: ['alaska', 'mendenhall glacier', 'whale watching', 'capital'], tags: ['alaska', 'usa'] },
-    'skagway': { country: 'USA', keywords: ['alaska', 'white pass', 'yukon', 'gold rush'], tags: ['alaska', 'usa'] },
-    'ketchikan': { country: 'USA', keywords: ['alaska', 'salmon', 'totem poles', 'misty fjords'], tags: ['alaska', 'usa'] },
-    'sitka': { country: 'USA', keywords: ['alaska', 'russian', 'bears', 'wildlife'], tags: ['alaska', 'usa'] },
-    'icy-strait-point': { country: 'USA', keywords: ['alaska', 'hoonah', 'whale watching', 'zip line'], tags: ['alaska', 'usa'] },
-    'sydney': { country: 'Australia', keywords: ['australia', 'opera house', 'harbour bridge', 'bondi'], tags: ['australia', 'south pacific'] },
-    'auckland': { country: 'New Zealand', keywords: ['new zealand', 'sky tower', 'harbour'], tags: ['new zealand', 'south pacific'] },
-    'bora-bora': { country: 'French Polynesia', keywords: ['tahiti', 'overwater bungalows', 'lagoon', 'paradise'], tags: ['south pacific', 'french polynesia'] },
-    'papeete': { country: 'French Polynesia', keywords: ['tahiti', 'capital', 'market'], tags: ['south pacific', 'french polynesia'] },
-    'dubai': { country: 'UAE', keywords: ['united arab emirates', 'burj khalifa', 'desert', 'luxury'], tags: ['middle east', 'uae'] },
-    'singapore': { country: 'Singapore', keywords: ['gardens by the bay', 'marina bay sands', 'asia'], tags: ['asia', 'singapore'] },
-    'hong-kong': { country: 'Hong Kong', keywords: ['victoria peak', 'harbor', 'dim sum', 'china'], tags: ['asia', 'hong kong'] },
-    'tokyo': { country: 'Japan', keywords: ['japan', 'shibuya', 'mount fuji', 'yokohama'], tags: ['asia', 'japan'] }
+    // Caribbean & Bahamas
+    'labadee': { country: 'Haiti', keywords: ['private island', 'zip line', 'beach', 'exclusive', 'private', 'haiti', 'dragons breath'], tags: ['caribbean', 'haiti', 'private'] },
+    'cococay': { country: 'Bahamas', keywords: ['perfect day', 'private island', 'water park', 'beach', 'private', 'bahamas', 'thrill waterpark'], tags: ['caribbean', 'bahamas', 'private'] },
+    'roatan': { country: 'Honduras', keywords: ['honduras', 'diving', 'snorkeling', 'mahogany bay', 'west bay beach'], tags: ['caribbean', 'honduras'] },
+    'cozumel': { country: 'Mexico', keywords: ['mexico', 'diving', 'mayan ruins', 'playa del carmen', 'snorkeling'], tags: ['caribbean', 'mexico'] },
+    'costa-maya': { country: 'Mexico', keywords: ['mexico', 'mayan ruins', 'beach club', 'quiet'], tags: ['caribbean', 'mexico'] },
+    'nassau': { country: 'Bahamas', keywords: ['bahamas', 'atlantis', 'paradise island', 'capital', 'junkanoo'], tags: ['caribbean', 'bahamas'] },
+    'grand-cayman': { country: 'Cayman Islands', keywords: ['stingray city', 'seven mile beach', 'diving', 'cayman', 'george town'], tags: ['caribbean', 'cayman'] },
+    'st-thomas': { country: 'US Virgin Islands', keywords: ['usvi', 'virgin islands', 'magens bay', 'shopping', 'charlotte amalie', 'duty free'], tags: ['caribbean', 'usvi'] },
+    'st-maarten': { country: 'Sint Maarten', keywords: ['st martin', 'maho beach', 'philipsburg', 'dutch', 'french', 'planes'], tags: ['caribbean'] },
+    'aruba': { country: 'Aruba', keywords: ['abc islands', 'eagle beach', 'oranjestad', 'dutch', 'one happy island'], tags: ['caribbean', 'aruba'] },
+    'curacao': { country: 'Curaçao', keywords: ['abc islands', 'willemstad', 'dutch', 'colorful', 'handelskade'], tags: ['caribbean', 'curacao'] },
+    'bonaire': { country: 'Bonaire', keywords: ['abc islands', 'diving', 'dutch', 'flamingos', 'shore diving'], tags: ['caribbean', 'bonaire'] },
+    'san-juan': { country: 'Puerto Rico', keywords: ['puerto rico', 'old san juan', 'el morro', 'capital', 'castillo'], tags: ['caribbean', 'puerto rico'] },
+    'jamaica': { country: 'Jamaica', keywords: ['jamaica', 'falmouth', 'dunns river falls', 'ocho rios', 'reggae'], tags: ['caribbean', 'jamaica'] },
+    'bermuda': { country: 'Bermuda', keywords: ['pink sand', 'horseshoe bay', 'british', 'kings wharf'], tags: ['caribbean', 'bermuda'] },
+    'key-west': { country: 'USA', keywords: ['florida keys', 'hemingway', 'duval street', 'sunset', 'conch'], tags: ['caribbean', 'usa', 'florida'] },
+    'barbados': { country: 'Barbados', keywords: ['bridgetown', 'mount gay rum', 'harrisons cave'], tags: ['caribbean', 'barbados'] },
+    'st-lucia': { country: 'St. Lucia', keywords: ['pitons', 'volcano', 'mud baths', 'soufriere'], tags: ['caribbean', 'st lucia'] },
+    'antigua': { country: 'Antigua', keywords: ['nelsons dockyard', '365 beaches', 'shirley heights'], tags: ['caribbean', 'antigua'] },
+    'grenada': { country: 'Grenada', keywords: ['spice island', 'nutmeg', 'grand anse beach'], tags: ['caribbean', 'grenada'] },
+    'martinique': { country: 'Martinique', keywords: ['french', 'mount pelee', 'rum', 'france'], tags: ['caribbean', 'martinique', 'french'] },
+    'dominica': { country: 'Dominica', keywords: ['nature island', 'waterfalls', 'hiking', 'boiling lake'], tags: ['caribbean', 'dominica'] },
+
+    // Alaska
+    'juneau': { country: 'USA', keywords: ['alaska', 'mendenhall glacier', 'whale watching', 'capital', 'glaciers'], tags: ['alaska', 'usa'] },
+    'skagway': { country: 'USA', keywords: ['alaska', 'white pass', 'yukon', 'gold rush', 'railway'], tags: ['alaska', 'usa'] },
+    'ketchikan': { country: 'USA', keywords: ['alaska', 'salmon', 'totem poles', 'misty fjords', 'creek street'], tags: ['alaska', 'usa'] },
+    'sitka': { country: 'USA', keywords: ['alaska', 'russian', 'bears', 'wildlife', 'raptor center'], tags: ['alaska', 'usa'] },
+    'icy-strait-point': { country: 'USA', keywords: ['alaska', 'hoonah', 'whale watching', 'zip line', 'tlingit'], tags: ['alaska', 'usa'] },
+    'glacier-bay': { country: 'USA', keywords: ['alaska', 'glacier', 'national park', 'calving', 'margerie'], tags: ['alaska', 'usa'] },
+    'victoria-bc': { country: 'Canada', keywords: ['british columbia', 'butchart gardens', 'afternoon tea', 'vancouver island'], tags: ['alaska', 'canada'] },
+
+    // Mediterranean
+    'barcelona': { country: 'Spain', keywords: ['spain', 'gaudi', 'sagrada familia', 'catalonia', 'la rambla'], tags: ['mediterranean', 'spain'] },
+    'civitavecchia': { country: 'Italy', keywords: ['rome', 'vatican', 'colosseum', 'italy', 'sistine chapel'], tags: ['mediterranean', 'italy'] },
+    'naples': { country: 'Italy', keywords: ['italy', 'pompeii', 'vesuvius', 'amalfi', 'pizza'], tags: ['mediterranean', 'italy'] },
+    'venice': { country: 'Italy', keywords: ['italy', 'canals', 'gondola', 'st marks', 'murano'], tags: ['mediterranean', 'italy'] },
+    'santorini': { country: 'Greece', keywords: ['greece', 'oia', 'caldera', 'whitewashed', 'cyclades', 'sunset'], tags: ['mediterranean', 'greece'] },
+    'mykonos': { country: 'Greece', keywords: ['greece', 'party', 'windmills', 'cyclades', 'beaches'], tags: ['mediterranean', 'greece'] },
+    'athens': { country: 'Greece', keywords: ['greece', 'acropolis', 'parthenon', 'piraeus', 'plaka'], tags: ['mediterranean', 'greece'] },
+    'dubrovnik': { country: 'Croatia', keywords: ['croatia', 'game of thrones', 'old town', 'kings landing', 'walls'], tags: ['mediterranean', 'croatia'] },
+    'kotor': { country: 'Montenegro', keywords: ['montenegro', 'fjord', 'medieval', 'bay'], tags: ['mediterranean', 'montenegro'] },
+    'marseille': { country: 'France', keywords: ['france', 'bouillabaisse', 'provence', 'notre dame de la garde'], tags: ['mediterranean', 'france'] },
+
+    // Northern Europe
+    'copenhagen': { country: 'Denmark', keywords: ['denmark', 'tivoli', 'nyhavn', 'little mermaid', 'scandinavian'], tags: ['northern europe', 'denmark'] },
+    'amsterdam': { country: 'Netherlands', keywords: ['netherlands', 'canals', 'anne frank', 'rijksmuseum', 'dutch'], tags: ['northern europe', 'netherlands'] },
+    'reykjavik': { country: 'Iceland', keywords: ['iceland', 'golden circle', 'northern lights', 'geysers', 'blue lagoon'], tags: ['northern europe', 'iceland'] },
+    'bergen': { country: 'Norway', keywords: ['norway', 'bryggen', 'fjords', 'hanseatic', 'fish market'], tags: ['northern europe', 'norway'] },
+    'oslo': { country: 'Norway', keywords: ['norway', 'viking', 'munch', 'opera house'], tags: ['northern europe', 'norway'] },
+    'stockholm': { country: 'Sweden', keywords: ['sweden', 'gamla stan', 'vasa', 'archipelago'], tags: ['northern europe', 'sweden'] },
+    'helsinki': { country: 'Finland', keywords: ['finland', 'suomenlinna', 'design', 'sauna'], tags: ['northern europe', 'finland'] },
+    'st-petersburg': { country: 'Russia', keywords: ['russia', 'hermitage', 'winter palace', 'peterhof', 'catherine'], tags: ['northern europe', 'russia'] },
+    'tallinn': { country: 'Estonia', keywords: ['estonia', 'old town', 'medieval', 'baltic'], tags: ['northern europe', 'estonia'] },
+
+    // Australia & Pacific
+    'sydney': { country: 'Australia', keywords: ['australia', 'opera house', 'harbour bridge', 'bondi', 'rocks'], tags: ['australia', 'south pacific'] },
+    'auckland': { country: 'New Zealand', keywords: ['new zealand', 'sky tower', 'harbour', 'hobbiton'], tags: ['new zealand', 'south pacific'] },
+    'bora-bora': { country: 'French Polynesia', keywords: ['tahiti', 'overwater bungalows', 'lagoon', 'paradise', 'french polynesia'], tags: ['south pacific', 'french polynesia'] },
+    'papeete': { country: 'French Polynesia', keywords: ['tahiti', 'capital', 'market', 'french polynesia'], tags: ['south pacific', 'french polynesia'] },
+    'fiji': { country: 'Fiji', keywords: ['fiji', 'bula', 'islands', 'pacific'], tags: ['south pacific', 'fiji'] },
+
+    // Asia
+    'dubai': { country: 'UAE', keywords: ['united arab emirates', 'burj khalifa', 'desert', 'luxury', 'mall'], tags: ['middle east', 'uae'] },
+    'singapore': { country: 'Singapore', keywords: ['gardens by the bay', 'marina bay sands', 'asia', 'sentosa', 'hawker'], tags: ['asia', 'singapore'] },
+    'hong-kong': { country: 'Hong Kong', keywords: ['victoria peak', 'harbor', 'dim sum', 'china', 'star ferry'], tags: ['asia', 'hong kong'] },
+    'tokyo': { country: 'Japan', keywords: ['japan', 'shibuya', 'mount fuji', 'yokohama', 'sushi', 'anime'], tags: ['asia', 'japan'] },
+    'shanghai': { country: 'China', keywords: ['china', 'bund', 'pudong', 'yu garden'], tags: ['asia', 'china'] },
+    'bali': { country: 'Indonesia', keywords: ['indonesia', 'temples', 'ubud', 'rice terraces', 'benoa'], tags: ['asia', 'indonesia'] },
+
+    // US Homeports
+    'port-miami': { country: 'USA', keywords: ['miami', 'florida', 'south beach', 'embarkation', 'homeport'], tags: ['homeport', 'usa', 'florida'] },
+    'port-canaveral': { country: 'USA', keywords: ['florida', 'orlando', 'kennedy space center', 'nasa', 'embarkation'], tags: ['homeport', 'usa', 'florida'] },
+    'galveston': { country: 'USA', keywords: ['texas', 'houston', 'embarkation', 'homeport'], tags: ['homeport', 'usa', 'texas'] },
+    'seattle': { country: 'USA', keywords: ['washington', 'pike place', 'space needle', 'alaska', 'embarkation'], tags: ['homeport', 'usa', 'alaska'] },
+    'los-angeles': { country: 'USA', keywords: ['california', 'san pedro', 'long beach', 'hollywood', 'embarkation'], tags: ['homeport', 'usa', 'california'] },
+
+    // Canada/New England
+    'boston': { country: 'USA', keywords: ['massachusetts', 'freedom trail', 'fenway', 'new england', 'fall foliage'], tags: ['new england', 'usa'] },
+    'halifax': { country: 'Canada', keywords: ['nova scotia', 'peggys cove', 'titanic', 'maritime'], tags: ['new england', 'canada'] },
+    'quebec-city': { country: 'Canada', keywords: ['quebec', 'chateau frontenac', 'french canada', 'old town'], tags: ['new england', 'canada'] }
   };
 
   // Build search index from page content

--- a/scripts/extract-port-summaries.js
+++ b/scripts/extract-port-summaries.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Extracts port summaries and metadata from all port HTML files
+ * Used to generate comprehensive ports.html content
+ */
+const fs = require('fs');
+const path = require('path');
+
+const portsDir = path.join(__dirname, '..', 'ports');
+const registryPath = path.join(__dirname, '..', 'assets', 'data', 'ports', 'port-registry.json');
+
+// Load registry for region info
+const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+
+// Get all port files
+const portFiles = fs.readdirSync(portsDir)
+  .filter(f => f.endsWith('.html'))
+  .sort();
+
+const ports = [];
+
+for (const file of portFiles) {
+  const slug = file.replace('.html', '');
+  const filePath = path.join(portsDir, file);
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  // Extract port name from title
+  const titleMatch = content.match(/<title>([^|<]+)/);
+  let name = titleMatch ? titleMatch[1].replace(/\s+Cruise Port.*$|Port Guide.*$/i, '').trim() : slug;
+
+  // Extract short description from meta description or Quick Answer
+  let description = '';
+
+  // Try Quick Answer first
+  const quickAnswerMatch = content.match(/<strong>Quick Answer:<\/strong>\s*([^<]+)/);
+  if (quickAnswerMatch) {
+    description = quickAnswerMatch[1].trim();
+    // Truncate to first sentence but handle "St." and similar abbreviations
+    if (description.length > 100) {
+      // Don't truncate at "St." or "Dr." or numbers with periods
+      const safeSentence = description.match(/^(?:(?!(?:St\.|Dr\.|Mt\.|Ft\.|Mr\.|Mrs\.|Ms\.|Jr\.|Sr\.|vs\.|etc\.|i\.e\.|e\.g\.))[^.!?]|St\.|Dr\.|Mt\.|Ft\.|Mr\.|Mrs\.|Ms\.|Jr\.|Sr\.|vs\.|etc\.|i\.e\.|e\.g\.)+[.!?]/);
+      description = safeSentence ? safeSentence[0] : description.substring(0, 100) + '...';
+    }
+  }
+
+  // Fallback to meta description
+  if (!description) {
+    const metaMatch = content.match(/<meta name="description" content="([^"]+)"/);
+    if (metaMatch) {
+      description = metaMatch[1].trim();
+      if (description.length > 100) {
+        const firstSentence = description.match(/^[^.!?]+[.!?]/);
+        description = firstSentence ? firstSentence[0] : description.substring(0, 100) + '...';
+      }
+    }
+  }
+
+  // Get region from registry
+  const regData = registry.ports[slug];
+  const region = regData ? regData.region : 'other';
+  const tier = regData ? regData.tier : 3;
+
+  ports.push({
+    slug,
+    name,
+    description: description || 'Cruise port destination',
+    region,
+    tier,
+    url: `/ports/${slug}.html`
+  });
+}
+
+// Group by region
+const regionGroups = {};
+for (const port of ports) {
+  if (!regionGroups[port.region]) {
+    regionGroups[port.region] = [];
+  }
+  regionGroups[port.region].push(port);
+}
+
+// Sort ports within each region by tier then name
+for (const region of Object.keys(regionGroups)) {
+  regionGroups[region].sort((a, b) => {
+    if (a.tier !== b.tier) return a.tier - b.tier;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+// Output summary
+console.log('=== PORT SUMMARY ===');
+console.log(`Total ports: ${ports.length}`);
+console.log('');
+console.log('By region:');
+for (const [region, portList] of Object.entries(regionGroups)) {
+  console.log(`  ${region}: ${portList.length} ports`);
+}
+console.log('');
+
+// Output as JSON for further processing
+const outputPath = path.join(__dirname, '..', 'assets', 'data', 'ports', 'port-summaries.json');
+fs.writeFileSync(outputPath, JSON.stringify({
+  generated: new Date().toISOString(),
+  totalPorts: ports.length,
+  ports: ports,
+  byRegion: regionGroups
+}, null, 2));
+
+console.log(`Summaries written to: ${outputPath}`);
+
+// Also output ports without good descriptions for review
+const needsDescription = ports.filter(p =>
+  !p.description ||
+  p.description === 'Cruise port destination' ||
+  p.description.length < 20
+);
+
+if (needsDescription.length > 0) {
+  console.log('');
+  console.log(`=== PORTS NEEDING BETTER DESCRIPTIONS (${needsDescription.length}) ===`);
+  needsDescription.forEach(p => console.log(`  ${p.slug}: "${p.description}"`));
+}

--- a/scripts/generate-ports-content.js
+++ b/scripts/generate-ports-content.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Generates updated port list content for ports.html
+ * Organizes all 333 ports by region with descriptions
+ */
+const fs = require('fs');
+const path = require('path');
+
+// Load port summaries
+const summaries = require('../assets/data/ports/port-summaries.json');
+
+// Define region mappings for "other" ports
+const regionOverrides = {
+  // Middle East & Red Sea
+  'abu-dhabi': 'middle-east', 'doha': 'middle-east', 'dubai': 'middle-east',
+  'aqaba': 'middle-east', 'hurghada': 'middle-east', 'safaga': 'middle-east',
+  'muscat': 'middle-east', 'salalah': 'middle-east', 'suez': 'middle-east',
+
+  // Africa
+  'agadir': 'africa', 'casablanca': 'africa', 'tangier': 'africa', 'tunis': 'africa',
+  'dakar': 'africa', 'durban': 'africa', 'cape-town': 'africa', 'luanda': 'africa',
+  'port-elizabeth': 'africa', 'maputo': 'africa', 'mombasa': 'africa',
+  'walvis-bay': 'africa', 'mindelo': 'africa', 'praia': 'africa',
+  'sao-tome': 'africa', 'st-helena': 'africa', 'ascension': 'africa',
+
+  // Canary Islands
+  'gran-canaria': 'canary-islands', 'lanzarote': 'canary-islands',
+  'tenerife': 'canary-islands', 'santa-cruz-de-la-palma': 'canary-islands',
+
+  // Mexican Pacific & Central America
+  'acapulco': 'mexico-pacific', 'cabo-san-lucas': 'mexico-pacific',
+  'ensenada': 'mexico-pacific', 'huatulco': 'mexico-pacific',
+  'manzanillo': 'mexico-pacific', 'mazatlan': 'mexico-pacific',
+  'puerto-vallarta': 'mexico-pacific', 'zihuatanejo': 'mexico-pacific',
+  'colon': 'central-america', 'corinto': 'central-america',
+  'puerto-limon': 'central-america', 'puntarenas': 'central-america',
+  'gatun-lake': 'panama-canal',
+
+  // South America
+  'buenos-aires': 'south-america', 'callao': 'south-america',
+  'fortaleza': 'south-america', 'guayaquil': 'south-america',
+  'manta': 'south-america', 'manaus': 'south-america',
+  'montevideo': 'south-america', 'rio-de-janeiro': 'south-america',
+  'santos': 'south-america', 'valparaiso': 'south-america',
+  'ushuaia': 'south-america', 'punta-arenas': 'south-america',
+  'punta-del-este': 'south-america', 'recife': 'south-america',
+  'salvador': 'south-america', 'falkland-islands': 'south-america',
+  'puerto-madryn': 'south-america', 'easter-island': 'south-america',
+
+  // US Homeports
+  'baltimore': 'us-homeports', 'cape-liberty': 'us-homeports',
+  'charleston': 'us-homeports', 'ft-lauderdale': 'us-homeports',
+  'galveston': 'us-homeports', 'jacksonville': 'us-homeports',
+  'los-angeles': 'us-homeports', 'miami': 'us-homeports',
+  'mobile': 'us-homeports', 'new-orleans': 'us-homeports',
+  'new-york': 'us-homeports', 'port-canaveral': 'us-homeports',
+  'port-everglades': 'us-homeports', 'port-miami': 'us-homeports',
+  'san-diego': 'us-homeports', 'san-francisco': 'us-homeports',
+  'san-pedro': 'us-homeports', 'tampa': 'us-homeports',
+
+  // South Pacific
+  'bora-bora': 'south-pacific', 'fiji': 'south-pacific', 'lautoka': 'south-pacific',
+  'guam': 'south-pacific', 'papeete': 'south-pacific', 'moorea': 'south-pacific',
+  'noumea': 'south-pacific', 'lifou': 'south-pacific', 'dravuni': 'south-pacific',
+  'rarotonga': 'south-pacific', 'apia': 'south-pacific', 'tonga': 'south-pacific',
+  'vanuatu': 'south-pacific', 'pago-pago': 'south-pacific', 'port-vila': 'south-pacific',
+  'suva': 'south-pacific',
+
+  // Indian Ocean
+  'maldives': 'indian-ocean', 'mauritius': 'indian-ocean',
+  'seychelles': 'indian-ocean', 'reunion': 'indian-ocean',
+  'cochin': 'indian-ocean', 'goa': 'indian-ocean', 'mumbai': 'indian-ocean',
+  'colombo': 'indian-ocean', 'port-louis': 'indian-ocean',
+
+  // Australia/New Zealand (already in pacific, move to separate)
+  'bay-of-islands': 'australia-nz', 'christchurch': 'australia-nz',
+  'doubtful-sound': 'australia-nz', 'milford-sound': 'australia-nz',
+
+  // Mediterranean additions
+  'bordeaux': 'mediterranean', 'funchal': 'mediterranean', 'gijon': 'mediterranean',
+  'la-coruna': 'mediterranean', 'portimao': 'mediterranean', 'porto': 'mediterranean',
+  'vigo': 'mediterranean',
+
+  // Northern Europe
+  'hamburg': 'northern-europe', 'southampton': 'northern-europe',
+  'ijmuiden': 'northern-europe', 'rotterdam': 'northern-europe',
+  'zeebrugge': 'northern-europe',
+
+  // Expedition/Remote
+  'tristan-da-cunha': 'expedition', 'svalbard': 'expedition',
+  'greenland': 'expedition', 'longyearbyen': 'expedition'
+};
+
+// Region display names and order
+const regionConfig = {
+  'caribbean': { name: 'Caribbean & Bahamas', order: 1 },
+  'alaska': { name: 'Alaska', order: 2 },
+  'mexico-pacific': { name: 'Mexican Riviera', order: 3 },
+  'mediterranean': { name: 'Mediterranean', order: 4 },
+  'northern-europe': { name: 'Northern Europe & British Isles', order: 5 },
+  'canary-islands': { name: 'Canary Islands & Atlantic', order: 6 },
+  'new-england': { name: 'Canada & New England', order: 7 },
+  'pacific': { name: 'Hawaii & Pacific', order: 8 },
+  'australia-nz': { name: 'Australia & New Zealand', order: 9 },
+  'south-pacific': { name: 'South Pacific Islands', order: 10 },
+  'asia': { name: 'Asia', order: 11 },
+  'middle-east': { name: 'Middle East & Red Sea', order: 12 },
+  'indian-ocean': { name: 'Indian Ocean', order: 13 },
+  'africa': { name: 'Africa', order: 14 },
+  'south-america': { name: 'South America', order: 15 },
+  'central-america': { name: 'Central America & Panama', order: 16 },
+  'panama-canal': { name: 'Panama Canal', order: 17 },
+  'us-homeports': { name: 'US Embarkation Ports', order: 18 },
+  'expedition': { name: 'Expedition & Remote Ports', order: 19 },
+  'other': { name: 'Other Destinations', order: 20 }
+};
+
+// Organize ports by region
+const portsByRegion = {};
+
+for (const port of summaries.ports) {
+  // Determine region
+  let region = port.region;
+  if (region === 'other' && regionOverrides[port.slug]) {
+    region = regionOverrides[port.slug];
+  }
+
+  if (!portsByRegion[region]) {
+    portsByRegion[region] = [];
+  }
+
+  // Clean up description
+  let desc = port.description;
+  if (desc.startsWith('First-person')) {
+    desc = desc.replace(/^First-person (?:logbook )?guide (?:to )?/i, '');
+  }
+  if (desc.length > 80) {
+    desc = desc.substring(0, 77) + '...';
+  }
+
+  portsByRegion[region].push({
+    ...port,
+    cleanDesc: desc
+  });
+}
+
+// Sort ports within each region alphabetically
+for (const region of Object.keys(portsByRegion)) {
+  portsByRegion[region].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Generate HTML output
+console.log('<!-- GENERATED PORT LISTS BY REGION -->');
+console.log('');
+
+const sortedRegions = Object.entries(portsByRegion)
+  .map(([key, ports]) => ({
+    key,
+    ports,
+    config: regionConfig[key] || { name: key, order: 99 }
+  }))
+  .sort((a, b) => a.config.order - b.config.order);
+
+for (const { key, ports, config } of sortedRegions) {
+  console.log(`<h3>${config.name} (${ports.length} ports)</h3>`);
+  console.log('<ul class="cols-2">');
+  for (const port of ports) {
+    console.log(`  <li><strong><a href="${port.url}">${port.name}</a></strong> — ${port.cleanDesc}</li>`);
+  }
+  console.log('</ul>');
+  console.log('');
+}
+
+console.log('<!-- Total: ' + summaries.ports.length + ' ports -->');


### PR DESCRIPTION
…search

Major changes:
- Replace "Additional Port Destinations" section with comprehensive "Complete Port Directory" featuring all 333 ports organized by region
- Each port now has link AND short description extracted from Quick Answer
- Ports organized into: Caribbean, Alaska, Mexican Riviera, Mediterranean, Northern Europe, Canary Islands, Canada/New England, Hawaii/Pacific, Australia/NZ, South Pacific, Asia, Middle East, Indian Ocean, Africa, South America, Central America, Panama Canal, US Homeports, Expedition
- Expanded port search metadata from 32 to 64 key destinations with enhanced keywords for better fuzzy search matching
- Add utility scripts for port summary extraction and content generation

Search now covers all 333 ports with country, region, and keyword matching.