### PR TITLE
Implement multi-cruise-line ship quiz V2

### DIFF
--- a/assets/data/ship-quiz-data-v2.json
+++ b/assets/data/ship-quiz-data-v2.json
@@ -1,0 +1,1933 @@
+{
+  "model_version": "2.0",
+  "as_of_date": "2026-01-02",
+  "supported_lines": ["rcl", "carnival", "ncl", "msc"],
+
+  "cruise_lines": {
+    "rcl": {
+      "name": "Royal Caribbean",
+      "short_name": "RCL",
+      "colors": {
+        "primary": "#1a3d7c",
+        "accent": "#ffd700"
+      },
+      "food_modifier": 6
+    },
+    "carnival": {
+      "name": "Carnival Cruise Line",
+      "short_name": "Carnival",
+      "colors": {
+        "primary": "#e31837",
+        "accent": "#0033a0"
+      },
+      "food_modifier": -3,
+      "casual_food_modifier": 6
+    },
+    "ncl": {
+      "name": "Norwegian Cruise Line",
+      "short_name": "NCL",
+      "colors": {
+        "primary": "#00205b",
+        "accent": "#ffffff"
+      },
+      "food_modifier": 2
+    },
+    "msc": {
+      "name": "MSC Cruises",
+      "short_name": "MSC",
+      "colors": {
+        "primary": "#003366",
+        "accent": "#b8860b"
+      },
+      "food_modifier": -5
+    }
+  },
+
+  "classes": {
+    "rcl": {
+      "icon": {
+        "name": "Icon Class",
+        "intensity": 10,
+        "vibe": "max_resort_family",
+        "description": "The largest cruise ships ever built. Floating cities with neighborhoods, waterparks, and endless possibilities.",
+        "best_for": ["Families with kids", "First-timers who want it all", "High-energy seekers"],
+        "not_ideal_for": ["Low crowd tolerance", "Port-focused travelers", "Value seekers"],
+        "dining_modifier": 2,
+        "avg_gt": 250000,
+        "avg_capacity": 5610
+      },
+      "oasis": {
+        "name": "Oasis Class",
+        "intensity": 9,
+        "vibe": "mega_variety_social",
+        "description": "Neighborhood-style mega-ships with Central Park, Boardwalk, and incredible variety. The original game-changers.",
+        "best_for": ["Multi-generational groups", "Teens and tweens", "Those wanting variety"],
+        "not_ideal_for": ["Low crowd tolerance", "Intimate ship seekers", "Sanctuary seekers"],
+        "dining_modifier": 1,
+        "avg_gt": 227000,
+        "avg_capacity": 5500
+      },
+      "quantum": {
+        "name": "Quantum Class",
+        "intensity": 7,
+        "vibe": "modern_innovative_balanced",
+        "description": "Tech-forward ships with North Star, RipCord, and innovative dining. Modern without being overwhelming.",
+        "best_for": ["Couples", "Tech enthusiasts", "Balanced travelers"],
+        "not_ideal_for": ["Waterpark-first families", "Traditional dining lovers"],
+        "dining_modifier": 1,
+        "avg_gt": 168000,
+        "avg_capacity": 4180
+      },
+      "freedom": {
+        "name": "Freedom Class",
+        "intensity": 7,
+        "vibe": "big_fun_value_balanced",
+        "description": "Classic big-ship fun with FlowRider and solid amenities. Great value for the experience.",
+        "best_for": ["Value seekers", "First-timers", "Friend groups"],
+        "not_ideal_for": ["Must-have-newest seekers", "Ultra-premium seekers"],
+        "dining_modifier": 0,
+        "avg_gt": 155000,
+        "avg_capacity": 3634
+      },
+      "voyager": {
+        "name": "Voyager Class",
+        "intensity": 6,
+        "vibe": "classic_goldilocks_value",
+        "description": "The original revolutionaries. Still deliver a great Royal Caribbean experience at excellent value.",
+        "best_for": ["Value-first travelers", "Short getaways", "First-timers"],
+        "not_ideal_for": ["Must-feel-modern travelers", "Maximum variety seekers"],
+        "dining_modifier": 0,
+        "avg_gt": 138000,
+        "avg_capacity": 3200
+      },
+      "radiance": {
+        "name": "Radiance Class",
+        "intensity": 4,
+        "vibe": "scenic_calm_ports",
+        "description": "Elegant mid-size ships with floor-to-ceiling glass. Perfect for scenic destinations and relaxed cruising.",
+        "best_for": ["Couples", "Port-focused travelers", "Alaska cruisers"],
+        "not_ideal_for": ["Families with young kids", "Nightlife seekers", "Thrill seekers"],
+        "dining_modifier": -1,
+        "avg_gt": 90000,
+        "avg_capacity": 2142
+      },
+      "vision": {
+        "name": "Vision Class",
+        "intensity": 3,
+        "vibe": "simple_classic_ports_value",
+        "description": "Classic, intimate ships focused on the destination. Simple cruising done well.",
+        "best_for": ["Port-intensive itineraries", "Value seekers", "Traditional cruisers"],
+        "not_ideal_for": ["Families with young kids", "Ship-as-destination travelers", "Modern-feel seekers"],
+        "dining_modifier": -1,
+        "avg_gt": 78000,
+        "avg_capacity": 2200
+      }
+    },
+    "carnival": {
+      "excel": {
+        "name": "Excel Class",
+        "intensity": 9,
+        "vibe": "party_flagship_mega",
+        "description": "Carnival's largest ships with 6,400+ guests. BOLT roller coaster, 20+ dining venues, themed zones. First LNG-powered Carnival ships.",
+        "best_for": ["Families with kids", "Thrill-seekers", "First-timers wanting everything"],
+        "not_ideal_for": ["Low crowd tolerance", "Value-first budgets", "Quiet atmosphere seekers"],
+        "dining_modifier": 3,
+        "avg_gt": 183000,
+        "avg_capacity": 6400
+      },
+      "vista": {
+        "name": "Vista Class",
+        "intensity": 8,
+        "vibe": "modern_family_fun",
+        "description": "The most family-friendly Carnival class. SkyRide, IMAX theater, Family Harbor zone, Havana section for adults.",
+        "best_for": ["Families with kids of all ages", "Couples wanting Havana perks", "West Coast cruisers"],
+        "not_ideal_for": ["Those seeking newest/flashiest", "Very budget-conscious travelers"],
+        "dining_modifier": 1,
+        "avg_gt": 133500,
+        "avg_capacity": 3934
+      },
+      "dream": {
+        "name": "Dream Class",
+        "intensity": 7,
+        "vibe": "balanced_mainstream",
+        "description": "Sweet spot between features and price. WaterWorks water park, comedy clubs, piano bars. Great for families and friend groups.",
+        "best_for": ["Families with water-park-loving kids", "Friend groups", "Couples seeking value"],
+        "not_ideal_for": ["Those wanting flagship experience", "Ultra-quiet seekers"],
+        "dining_modifier": 1,
+        "avg_gt": 130000,
+        "avg_capacity": 3646
+      },
+      "conquest": {
+        "name": "Conquest Class",
+        "intensity": 6,
+        "vibe": "classic_workhorse",
+        "description": "Carnival's budget workhorses. 3,000 guests, solid core Carnival experience. Some have enhanced waterparks.",
+        "best_for": ["Value-first travelers", "First-timers on a budget", "Short getaway cruisers"],
+        "not_ideal_for": ["Must-have-modern seekers", "Extensive specialty dining seekers"],
+        "dining_modifier": 0,
+        "avg_gt": 110000,
+        "avg_capacity": 2974
+      },
+      "spirit": {
+        "name": "Spirit Class",
+        "intensity": 5,
+        "vibe": "intimate_elegant",
+        "description": "Mid-size ships (2,100 guests) with highest percentage of balcony cabins. More intimate, can transit Panama Canal.",
+        "best_for": ["Couples seeking intimacy", "Destination-focused cruisers", "Panama Canal/Alaska itineraries"],
+        "not_ideal_for": ["Families with young kids", "Thrill-seekers", "Nightlife-first travelers"],
+        "dining_modifier": -1,
+        "avg_gt": 88000,
+        "avg_capacity": 2124
+      },
+      "venice": {
+        "name": "Venice Class",
+        "intensity": 7,
+        "vibe": "eurozone_premium",
+        "description": "Costa ships transferred to Carnival with European flair. Italian design touches, refined atmosphere.",
+        "best_for": ["Couples", "Travelers wanting European feel", "NYC-based cruisers"],
+        "not_ideal_for": ["Families wanting traditional Carnival vibe", "Waterpark enthusiasts"],
+        "dining_modifier": 1,
+        "avg_gt": 135000,
+        "avg_capacity": 4072
+      },
+      "splendor": {
+        "name": "Splendor Class",
+        "intensity": 6,
+        "vibe": "solo_workhorse",
+        "description": "Solo ship bridging Dream and Conquest classes. Good variety without mega-ship scale.",
+        "best_for": ["Balanced travelers", "Those wanting mid-size experience", "Value seekers"],
+        "not_ideal_for": ["Those wanting newest features", "Families needing extensive kids programming"],
+        "dining_modifier": 0,
+        "avg_gt": 113300,
+        "avg_capacity": 3006
+      },
+      "sunshine": {
+        "name": "Sunshine Class",
+        "intensity": 5,
+        "vibe": "refreshed_classic",
+        "description": "Refreshed older ships with modern Carnival touches. Serenity adult-only area, Guy's Burger Joint, RedFrog Pub.",
+        "best_for": ["Value seekers", "Short getaway cruisers", "Adults seeking Serenity deck"],
+        "not_ideal_for": ["Families wanting big waterparks", "Must-feel-modern travelers"],
+        "dining_modifier": 0,
+        "avg_gt": 102000,
+        "avg_capacity": 2974
+      },
+      "fantasy": {
+        "name": "Fantasy Class",
+        "intensity": 3,
+        "vibe": "budget_short_getaway",
+        "description": "Carnival's oldest and smallest active ships. Simple, no-frills cruising. Great value for short getaways.",
+        "best_for": ["Budget-first travelers", "Short 3-4 night getaways", "First-timers testing the waters"],
+        "not_ideal_for": ["Families with young kids", "Those wanting activities", "Ship-as-destination travelers"],
+        "dining_modifier": -2,
+        "avg_gt": 70000,
+        "avg_capacity": 2056
+      }
+    },
+    "ncl": {
+      "prima": {
+        "name": "Prima Class",
+        "intensity": 9,
+        "vibe": "modern_innovative_flagship",
+        "description": "NCL's newest, most upscale ships. Highest space-to-passenger ratio, 8-deck Haven complex, Indulge Food Hall, Ocean Boulevard.",
+        "best_for": ["Couples seeking luxury", "Adults-only groups", "Haven suite guests"],
+        "not_ideal_for": ["Families with young kids", "Budget travelers"],
+        "dining_modifier": 1,
+        "avg_gt": 142500,
+        "avg_capacity": 3215
+      },
+      "breakaway_plus": {
+        "name": "Breakaway Plus Class",
+        "intensity": 8,
+        "vibe": "mega_variety",
+        "description": "NCL's largest ships packed with activities. Go-karts, laser tag, Galaxy Pavilion VR, Broadway shows. Best dining variety in fleet.",
+        "best_for": ["High-energy travelers", "Families with teens", "Entertainment lovers"],
+        "not_ideal_for": ["Those seeking quiet/intimate", "Budget-first travelers"],
+        "dining_modifier": 2,
+        "avg_gt": 168000,
+        "avg_capacity": 4000
+      },
+      "breakaway": {
+        "name": "Breakaway Class",
+        "intensity": 7,
+        "vibe": "mainstream_balanced",
+        "description": "Foundation for Breakaway Plus with slightly fewer features. Ropes course, Aqua Park, good nightlife.",
+        "best_for": ["Families", "First-time NCL cruisers", "Balance of features and value"],
+        "not_ideal_for": ["Must-have-newest seekers", "Those wanting go-karts/laser tag"],
+        "dining_modifier": 1,
+        "avg_gt": 145000,
+        "avg_capacity": 3963
+      },
+      "epic": {
+        "name": "Epic Class",
+        "intensity": 7,
+        "vibe": "solo_friendly_mega",
+        "description": "Unique solo-focused ship with 128 Studio Staterooms and exclusive Studio Lounge. Large ship with ice bar, Cirque shows.",
+        "best_for": ["Solo travelers", "Singles wanting social atmosphere", "Adults seeking variety"],
+        "not_ideal_for": ["Families", "Couples wanting privacy", "Those wanting modern design"],
+        "dining_modifier": 0,
+        "avg_gt": 155000,
+        "avg_capacity": 4100
+      },
+      "jewel": {
+        "name": "Jewel Class",
+        "intensity": 6,
+        "vibe": "mid_size_classic",
+        "description": "Mid-size classics (2,400 guests) beloved by NCL loyalists. Relaxed resort feel, good specialty dining.",
+        "best_for": ["Couples", "Experienced cruisers", "Freestyle purists"],
+        "not_ideal_for": ["Families wanting waterparks", "Thrill-seekers", "First-timers wanting wow"],
+        "dining_modifier": 0,
+        "avg_gt": 93000,
+        "avg_capacity": 2376
+      },
+      "pride_of_america": {
+        "name": "Pride of America",
+        "intensity": 5,
+        "vibe": "hawaii_specialist",
+        "description": "Hawaii specialist - the only cruise ship sailing year-round inter-island Hawaii itineraries. US-flagged, American crew.",
+        "best_for": ["Hawaii-focused travelers", "Inter-island experience seekers", "US travelers preferring American crew"],
+        "not_ideal_for": ["Caribbean/Europe seekers", "Budget travelers", "Families wanting activities"],
+        "dining_modifier": 0,
+        "avg_gt": 81000,
+        "avg_capacity": 2186
+      },
+      "dawn": {
+        "name": "Dawn Class",
+        "intensity": 5,
+        "vibe": "classic_mid_size",
+        "description": "Early Freestyle Cruising ships (2001-2002). Quirky layouts, solid service. Good for destination-focused cruising.",
+        "best_for": ["Destination-focused cruisers", "Experienced travelers", "Those prioritizing itinerary over ship"],
+        "not_ideal_for": ["Ship-as-destination travelers", "Families with young kids", "First-timers"],
+        "dining_modifier": -1,
+        "avg_gt": 92000,
+        "avg_capacity": 2340
+      },
+      "sun": {
+        "name": "Sun Class",
+        "intensity": 4,
+        "vibe": "intimate_value",
+        "description": "Oldest active NCL ships. Smaller, more intimate, often all-inclusive deals. Sky specializes in short cruises.",
+        "best_for": ["Value seekers", "Short getaway cruisers", "Adults wanting quiet"],
+        "not_ideal_for": ["Families", "Those wanting activities", "Long cruises"],
+        "dining_modifier": -1,
+        "avg_gt": 77000,
+        "avg_capacity": 2002
+      },
+      "spirit": {
+        "name": "Spirit Class",
+        "intensity": 4,
+        "vibe": "intimate_classic",
+        "description": "Fleet's oldest ship (1998 build). Well-maintained but lacking modern features. Classic cruising.",
+        "best_for": ["Nostalgic cruisers", "Value seekers", "Destination-focused travelers"],
+        "not_ideal_for": ["Families", "Those wanting activities", "Ship-as-destination travelers"],
+        "dining_modifier": -2,
+        "avg_gt": 75000,
+        "avg_capacity": 1966
+      }
+    },
+    "msc": {
+      "world": {
+        "name": "World Class",
+        "intensity": 9,
+        "vibe": "mega_flagship",
+        "description": "MSC's largest, newest flagships (~216,000 GT). Eataly restaurant, The Harbour family zone, bumper cars, Cliffhanger swing. LNG-powered.",
+        "best_for": ["Families wanting megaship variety", "Couples seeking European flair", "Budget-conscious megaship seekers"],
+        "not_ideal_for": ["Those wanting intimate experience", "Crowd-averse travelers", "Those wanting American-style service"],
+        "dining_modifier": 4,
+        "avg_gt": 216000,
+        "avg_capacity": 6762
+      },
+      "meraviglia_plus": {
+        "name": "Meraviglia-Plus Class",
+        "intensity": 8,
+        "vibe": "large_modern",
+        "description": "Large ships with covered LED promenade, Cirque shows, extensive dining. Indoor-focused design works well for varied weather.",
+        "best_for": ["Families wanting entertainment", "Foodies", "Mediterranean cruisers"],
+        "not_ideal_for": ["Those wanting outdoor focus", "Intimate experience seekers"],
+        "dining_modifier": 1,
+        "avg_gt": 181000,
+        "avg_capacity": 5700
+      },
+      "seaside_evo": {
+        "name": "Seaside EVO Class",
+        "intensity": 8,
+        "vibe": "beach_resort_style",
+        "description": "Enhanced Seaside design with more outdoor space. Resort-style living, outdoor promenade, designed for warm-weather cruising.",
+        "best_for": ["Caribbean cruisers", "Families wanting water features", "Sun lovers"],
+        "not_ideal_for": ["Cold-weather itinerary seekers", "Indoor-focused travelers"],
+        "dining_modifier": 1,
+        "avg_gt": 170000,
+        "avg_capacity": 5632
+      },
+      "meraviglia": {
+        "name": "Meraviglia Class",
+        "intensity": 7,
+        "vibe": "mainstream_modern",
+        "description": "High-tech entertainment, stunning LED promenade, modern European city feel at sea. Strong Cirque shows.",
+        "best_for": ["Entertainment lovers", "Families", "Those wanting modern design"],
+        "not_ideal_for": ["Outdoor-focused travelers", "Intimacy seekers"],
+        "dining_modifier": 0,
+        "avg_gt": 171000,
+        "avg_capacity": 5700
+      },
+      "seaside": {
+        "name": "Seaside Class",
+        "intensity": 7,
+        "vibe": "outdoor_focused",
+        "description": "First MSC ships designed for warm-weather/outdoor cruising. Broad outdoor promenade, zipline, outdoor spa.",
+        "best_for": ["Warm-weather cruisers", "Couples seeking sun", "Families wanting water slides"],
+        "not_ideal_for": ["Mediterranean winter sailings", "Those wanting extensive indoor options"],
+        "dining_modifier": 0,
+        "avg_gt": 160000,
+        "avg_capacity": 5179
+      },
+      "fantasia": {
+        "name": "Fantasia Class",
+        "intensity": 6,
+        "vibe": "classic_euro",
+        "description": "MSC's classic big ship class (130,000+ GT). European elegance, Yacht Club suites, showing age but well-maintained.",
+        "best_for": ["European-style experience lovers", "Yacht Club guests", "Destination-focused travelers"],
+        "not_ideal_for": ["Must-feel-modern travelers", "Families wanting extensive activities"],
+        "dining_modifier": -1,
+        "avg_gt": 138000,
+        "avg_capacity": 4363
+      },
+      "musica": {
+        "name": "Musica Class",
+        "intensity": 5,
+        "vibe": "mid_size_euro",
+        "description": "Mid-size ships with classic MSC décor. Relaxed, international atmosphere. Good for itinerary-focused cruising.",
+        "best_for": ["Experienced cruisers", "Destination-focused travelers", "Value seekers"],
+        "not_ideal_for": ["Activity seekers", "Families with young kids", "First-timers wanting wow"],
+        "dining_modifier": -1,
+        "avg_gt": 92000,
+        "avg_capacity": 3013
+      },
+      "lirica": {
+        "name": "Lirica Class",
+        "intensity": 4,
+        "vibe": "intimate_euro",
+        "description": "MSC's oldest ships (2003-2004, refurbished 2015). Smallest in fleet, intimate feel. Classic character retained.",
+        "best_for": ["Budget travelers", "Destination-focused cruisers", "European traditionalists"],
+        "not_ideal_for": ["Families wanting activities", "Ship-as-destination travelers", "Those wanting modern amenities"],
+        "dining_modifier": -2,
+        "avg_gt": 65000,
+        "avg_capacity": 2069
+      }
+    }
+  },
+
+  "ships": {
+    "rcl": {
+      "icon-of-the-seas": {
+        "name": "Icon of the Seas",
+        "class": "icon",
+        "year": 2024,
+        "gt": 250800,
+        "capacity": 5610,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Category 6 waterpark", "7 pools", "40+ restaurants & bars", "Surfside family neighborhood"],
+        "image": "/assets/social/icon-of-the-seas.jpg",
+        "page": "/ships/rcl/icon-of-the-seas.html"
+      },
+      "star-of-the-seas": {
+        "name": "Star of the Seas",
+        "class": "icon",
+        "year": 2025,
+        "gt": 250800,
+        "capacity": 5610,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Icon's sister ship", "Category 6 waterpark", "Debuting 2025"],
+        "image": "/assets/social/star-of-the-seas.jpg",
+        "page": "/ships/rcl/star-of-the-seas.html"
+      },
+      "wonder-of-the-seas": {
+        "name": "Wonder of the Seas",
+        "class": "oasis",
+        "year": 2022,
+        "gt": 236857,
+        "capacity": 5734,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 95,
+        "highlights": ["Largest Oasis-class", "8 neighborhoods", "Wonder Playscape"],
+        "image": "/assets/social/wonder-of-the-seas.jpg",
+        "page": "/ships/rcl/wonder-of-the-seas.html"
+      },
+      "utopia-of-the-seas": {
+        "name": "Utopia of the Seas",
+        "class": "oasis",
+        "year": 2024,
+        "gt": 236860,
+        "capacity": 5668,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Newest Oasis-class", "Short getaway focused", "Weekend party positioning"],
+        "image": "/assets/social/utopia-of-the-seas.jpg",
+        "page": "/ships/rcl/utopia-of-the-seas.html"
+      },
+      "symphony-of-the-seas": {
+        "name": "Symphony of the Seas",
+        "class": "oasis",
+        "year": 2018,
+        "gt": 228081,
+        "capacity": 5518,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Ultimate Abyss slide", "Laser tag", "Glow-in-dark mini golf"],
+        "image": "/assets/social/symphony-of-the-seas.jpg",
+        "page": "/ships/rcl/symphony-of-the-seas.html"
+      },
+      "harmony-of-the-seas": {
+        "name": "Harmony of the Seas",
+        "class": "oasis",
+        "year": 2016,
+        "gt": 226963,
+        "capacity": 5479,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Ultimate Abyss debut ship", "Bionic Bar", "Perfect Day sailings"],
+        "image": "/assets/social/harmony-of-the-seas.jpg",
+        "page": "/ships/rcl/harmony-of-the-seas.html"
+      },
+      "allure-of-the-seas": {
+        "name": "Allure of the Seas",
+        "class": "oasis",
+        "year": 2010,
+        "gt": 225282,
+        "capacity": 5400,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2020,
+        "cdc_score": 100,
+        "highlights": ["Amplified 2020", "The Mason Jar", "El Loco Fresh", "Playmakers"],
+        "image": "/assets/social/allure-of-the-seas.jpg",
+        "page": "/ships/rcl/allure-of-the-seas.html"
+      },
+      "oasis-of-the-seas": {
+        "name": "Oasis of the Seas",
+        "class": "oasis",
+        "year": 2009,
+        "gt": 225282,
+        "capacity": 5400,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2019,
+        "cdc_score": 92,
+        "highlights": ["The original mega-ship", "Amplified 2019", "Central Park", "Boardwalk"],
+        "image": "/assets/social/oasis-of-the-seas.jpg",
+        "page": "/ships/rcl/oasis-of-the-seas.html"
+      },
+      "odyssey-of-the-seas": {
+        "name": "Odyssey of the Seas",
+        "class": "quantum",
+        "year": 2021,
+        "gt": 167704,
+        "capacity": 4180,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["Newest Quantum Ultra", "SeaPlex", "Sky Pad", "Playmakers"],
+        "image": "/assets/social/odyssey-of-the-seas.jpg",
+        "page": "/ships/rcl/odyssey-of-the-seas.html"
+      },
+      "spectrum-of-the-seas": {
+        "name": "Spectrum of the Seas",
+        "class": "quantum",
+        "year": 2019,
+        "gt": 169379,
+        "capacity": 4240,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Asia-Pacific flagship", "North Star", "Ultimate Family Suite"],
+        "image": "/assets/social/spectrum-of-the-seas.jpg",
+        "page": "/ships/rcl/spectrum-of-the-seas.html"
+      },
+      "ovation-of-the-seas": {
+        "name": "Ovation of the Seas",
+        "class": "quantum",
+        "year": 2016,
+        "gt": 167800,
+        "capacity": 4180,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Alaska favorite", "North Star", "RipCord by iFLY", "Two70"],
+        "image": "/assets/social/ovation-of-the-seas.jpg",
+        "page": "/ships/rcl/ovation-of-the-seas.html"
+      },
+      "anthem-of-the-seas": {
+        "name": "Anthem of the Seas",
+        "class": "quantum",
+        "year": 2015,
+        "gt": 167800,
+        "capacity": 4180,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 99,
+        "highlights": ["East Coast based", "North Star", "Bumper cars", "SeaPlex"],
+        "image": "/assets/social/anthem-of-the-seas.jpg",
+        "page": "/ships/rcl/anthem-of-the-seas.html"
+      },
+      "quantum-of-the-seas": {
+        "name": "Quantum of the Seas",
+        "class": "quantum",
+        "year": 2014,
+        "gt": 168666,
+        "capacity": 4180,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["Original Quantum", "First North Star", "Asia-based"],
+        "image": "/assets/social/quantum-of-the-seas.jpg",
+        "page": "/ships/rcl/quantum-of-the-seas.html"
+      },
+      "independence-of-the-seas": {
+        "name": "Independence of the Seas",
+        "class": "freedom",
+        "year": 2008,
+        "gt": 156080,
+        "capacity": 3634,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2018,
+        "cdc_score": 93,
+        "highlights": ["Amplified 2018", "Sky Pad", "Splashaway Bay", "El Loco Fresh"],
+        "image": "/assets/social/independence-of-the-seas.jpg",
+        "page": "/ships/rcl/independence-of-the-seas.html"
+      },
+      "liberty-of-the-seas": {
+        "name": "Liberty of the Seas",
+        "class": "freedom",
+        "year": 2007,
+        "gt": 154407,
+        "capacity": 3634,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2016,
+        "cdc_score": 99,
+        "highlights": ["Amplified 2016", "Tidal Wave slide", "Splashaway Bay"],
+        "image": "/assets/social/liberty-of-the-seas.jpg",
+        "page": "/ships/rcl/liberty-of-the-seas.html"
+      },
+      "freedom-of-the-seas": {
+        "name": "Freedom of the Seas",
+        "class": "freedom",
+        "year": 2006,
+        "gt": 156271,
+        "capacity": 3634,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2020,
+        "cdc_score": 96,
+        "highlights": ["Amplified 2020", "Perfect Storm slides", "Splashaway Bay", "Playmakers"],
+        "image": "/assets/social/freedom-of-the-seas.jpg",
+        "page": "/ships/rcl/freedom-of-the-seas.html"
+      },
+      "mariner-of-the-seas": {
+        "name": "Mariner of the Seas",
+        "class": "voyager",
+        "year": 2003,
+        "gt": 139863,
+        "capacity": 3388,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2018,
+        "cdc_score": 100,
+        "highlights": ["Amplified 2018", "Sky Pad", "FlowRider", "Short getaways from LA"],
+        "image": "/assets/social/mariner-of-the-seas.jpg",
+        "page": "/ships/rcl/mariner-of-the-seas.html"
+      },
+      "navigator-of-the-seas": {
+        "name": "Navigator of the Seas",
+        "class": "voyager",
+        "year": 2002,
+        "gt": 139570,
+        "capacity": 3388,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2019,
+        "cdc_score": 96,
+        "highlights": ["Amplified 2019", "Blaster aqua coaster", "To Dry For bar"],
+        "image": "/assets/social/navigator-of-the-seas.jpg",
+        "page": "/ships/rcl/navigator-of-the-seas.html"
+      },
+      "adventure-of-the-seas": {
+        "name": "Adventure of the Seas",
+        "class": "voyager",
+        "year": 2001,
+        "gt": 137276,
+        "capacity": 3114,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Ice skating rink", "Rock climbing wall", "FlowRider"],
+        "image": "/assets/social/adventure-of-the-seas.jpg",
+        "page": "/ships/rcl/adventure-of-the-seas.html"
+      },
+      "explorer-of-the-seas": {
+        "name": "Explorer of the Seas",
+        "class": "voyager",
+        "year": 2000,
+        "gt": 137308,
+        "capacity": 3114,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 93,
+        "highlights": ["Classic Voyager experience", "Ice skating", "Rock climbing"],
+        "image": "/assets/social/explorer-of-the-seas.jpg",
+        "page": "/ships/rcl/explorer-of-the-seas.html"
+      },
+      "voyager-of-the-seas": {
+        "name": "Voyager of the Seas",
+        "class": "voyager",
+        "year": 1999,
+        "gt": 137276,
+        "capacity": 3114,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["The original revolutionary", "Started the mega-ship era"],
+        "image": "/assets/social/voyager-of-the-seas.jpg",
+        "page": "/ships/rcl/voyager-of-the-seas.html"
+      },
+      "brilliance-of-the-seas": {
+        "name": "Brilliance of the Seas",
+        "class": "radiance",
+        "year": 2002,
+        "gt": 90090,
+        "capacity": 2142,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Floor-to-ceiling glass", "Outdoor pool deck", "Adults-focused"],
+        "image": "/assets/social/brilliance-of-the-seas.jpg",
+        "page": "/ships/rcl/brilliance-of-the-seas.html"
+      },
+      "jewel-of-the-seas": {
+        "name": "Jewel of the Seas",
+        "class": "radiance",
+        "year": 2004,
+        "gt": 90090,
+        "capacity": 2142,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["European itineraries", "Scenic cruising", "Intimate size"],
+        "image": "/assets/social/jewel-of-the-seas.jpg",
+        "page": "/ships/rcl/jewel-of-the-seas.html"
+      },
+      "radiance-of-the-seas": {
+        "name": "Radiance of the Seas",
+        "class": "radiance",
+        "year": 2001,
+        "gt": 90090,
+        "capacity": 2142,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Alaska specialist", "Glass elevators", "Panoramic views"],
+        "image": "/assets/social/radiance-of-the-seas.jpg",
+        "page": "/ships/rcl/radiance-of-the-seas.html"
+      },
+      "serenade-of-the-seas": {
+        "name": "Serenade of the Seas",
+        "class": "radiance",
+        "year": 2003,
+        "gt": 90090,
+        "capacity": 2142,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Panama Canal specialist", "Scenic routes", "Elegant atmosphere"],
+        "image": "/assets/social/serenade-of-the-seas.jpg",
+        "page": "/ships/rcl/serenade-of-the-seas.html"
+      },
+      "enchantment-of-the-seas": {
+        "name": "Enchantment of the Seas",
+        "class": "vision",
+        "year": 1997,
+        "gt": 82910,
+        "capacity": 2730,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["Stretched in 2005", "Short getaways", "Value-focused"],
+        "image": "/assets/social/enchantment-of-the-seas.jpg",
+        "page": "/ships/rcl/enchantment-of-the-seas.html"
+      },
+      "grandeur-of-the-seas": {
+        "name": "Grandeur of the Seas",
+        "class": "vision",
+        "year": 1996,
+        "gt": 73817,
+        "capacity": 1992,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Most intimate RCL ship", "Classic cruising", "Excellent value"],
+        "image": "/assets/social/grandeur-of-the-seas.jpg",
+        "page": "/ships/rcl/grandeur-of-the-seas.html"
+      },
+      "rhapsody-of-the-seas": {
+        "name": "Rhapsody of the Seas",
+        "class": "vision",
+        "year": 1997,
+        "gt": 78491,
+        "capacity": 2109,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Refreshed 2012", "Smaller ship experience", "Destination-focused"],
+        "image": "/assets/social/rhapsody-of-the-seas.jpg",
+        "page": "/ships/rcl/rhapsody-of-the-seas.html"
+      },
+      "vision-of-the-seas": {
+        "name": "Vision of the Seas",
+        "class": "vision",
+        "year": 1998,
+        "gt": 78340,
+        "capacity": 2050,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 99,
+        "highlights": ["Classic Vision class", "Traditional experience", "Intimate atmosphere"],
+        "image": "/assets/social/vision-of-the-seas.jpg",
+        "page": "/ships/rcl/vision-of-the-seas.html"
+      }
+    },
+    "carnival": {
+      "mardi-gras": {
+        "name": "Mardi Gras",
+        "class": "excel",
+        "year": 2021,
+        "gt": 180800,
+        "capacity": 5282,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["BOLT roller coaster", "Zone-based design", "Guy Fieri's venues"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/mardi-gras.html"
+      },
+      "carnival-celebration": {
+        "name": "Carnival Celebration",
+        "class": "excel",
+        "year": 2022,
+        "gt": 183521,
+        "capacity": 5374,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["BOLT coaster", "Miami-themed zones", "Newest Excel ship"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/celebration.html"
+      },
+      "carnival-jubilee": {
+        "name": "Carnival Jubilee",
+        "class": "excel",
+        "year": 2023,
+        "gt": 183521,
+        "capacity": 5374,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["BOLT coaster", "Texas-themed zones", "Galveston homeport"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/jubilee.html"
+      },
+      "carnival-vista": {
+        "name": "Carnival Vista",
+        "class": "vista",
+        "year": 2016,
+        "gt": 133500,
+        "capacity": 3934,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 93,
+        "highlights": ["SkyRide", "IMAX theater", "Havana section"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/vista.html"
+      },
+      "carnival-horizon": {
+        "name": "Carnival Horizon",
+        "class": "vista",
+        "year": 2018,
+        "gt": 133500,
+        "capacity": 3954,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 95,
+        "highlights": ["SkyRide", "Dr. Seuss WaterWorks", "Family Harbor"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/horizon.html"
+      },
+      "carnival-panorama": {
+        "name": "Carnival Panorama",
+        "class": "vista",
+        "year": 2019,
+        "gt": 133500,
+        "capacity": 3954,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["West Coast flagship", "Sky Zone trampoline", "Havana section"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/panorama.html"
+      },
+      "carnival-dream": {
+        "name": "Carnival Dream",
+        "class": "dream",
+        "year": 2009,
+        "gt": 128251,
+        "capacity": 3646,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 94,
+        "highlights": ["WaterWorks", "Limelight Lounge", "Ocean Plaza"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/dream.html"
+      },
+      "carnival-magic": {
+        "name": "Carnival Magic",
+        "class": "dream",
+        "year": 2011,
+        "gt": 128048,
+        "capacity": 3690,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["WaterWorks", "SportSquare", "RedFrog Pub"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/magic.html"
+      },
+      "carnival-breeze": {
+        "name": "Carnival Breeze",
+        "class": "dream",
+        "year": 2012,
+        "gt": 128052,
+        "capacity": 3690,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["WaterWorks", "Cucina del Capitano", "Guy's Burger Joint"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/breeze.html"
+      },
+      "carnival-conquest": {
+        "name": "Carnival Conquest",
+        "class": "conquest",
+        "year": 2002,
+        "gt": 110000,
+        "capacity": 2974,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Classic Carnival experience", "Impressionist art theme"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/conquest.html"
+      },
+      "carnival-glory": {
+        "name": "Carnival Glory",
+        "class": "conquest",
+        "year": 2003,
+        "gt": 110000,
+        "capacity": 2974,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 96,
+        "highlights": ["Colors theme", "Guy's Burger Joint added"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/glory.html"
+      },
+      "carnival-valor": {
+        "name": "Carnival Valor",
+        "class": "conquest",
+        "year": 2004,
+        "gt": 110000,
+        "capacity": 2974,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 96,
+        "highlights": ["New Orleans homeport", "Valor-themed décor"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/valor.html"
+      },
+      "carnival-liberty": {
+        "name": "Carnival Liberty",
+        "class": "conquest",
+        "year": 2005,
+        "gt": 110000,
+        "capacity": 2974,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 93,
+        "highlights": ["Victorian theme", "Port Canaveral based"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/liberty.html"
+      },
+      "carnival-freedom": {
+        "name": "Carnival Freedom",
+        "class": "conquest",
+        "year": 2007,
+        "gt": 110000,
+        "capacity": 2974,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 96,
+        "highlights": ["American theme", "Recently refreshed"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/freedom.html"
+      },
+      "carnival-spirit": {
+        "name": "Carnival Spirit",
+        "class": "spirit",
+        "year": 2001,
+        "gt": 88500,
+        "capacity": 2124,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 99,
+        "highlights": ["Australia homeport", "Intimate atmosphere"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/spirit.html"
+      },
+      "carnival-pride": {
+        "name": "Carnival Pride",
+        "class": "spirit",
+        "year": 2002,
+        "gt": 88500,
+        "capacity": 2124,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 86,
+        "highlights": ["Baltimore homeport", "Renaissance art theme"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/pride.html"
+      },
+      "carnival-legend": {
+        "name": "Carnival Legend",
+        "class": "spirit",
+        "year": 2002,
+        "gt": 88500,
+        "capacity": 2124,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 90,
+        "highlights": ["Mythology theme", "Tampa homeport"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/legend.html"
+      },
+      "carnival-miracle": {
+        "name": "Carnival Miracle",
+        "class": "spirit",
+        "year": 2004,
+        "gt": 88500,
+        "capacity": 2124,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 99,
+        "highlights": ["Superheroes theme", "Long Beach based"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/miracle.html"
+      },
+      "carnival-luminosa": {
+        "name": "Carnival Luminosa",
+        "class": "spirit",
+        "year": 2009,
+        "gt": 92720,
+        "capacity": 2260,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["Former Costa ship", "Seattle homeport", "European flair"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/luminosa.html"
+      },
+      "carnival-venezia": {
+        "name": "Carnival Venezia",
+        "class": "venice",
+        "year": 2019,
+        "gt": 135500,
+        "capacity": 4072,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Former Costa ship", "NYC homeport", "Italian design"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/venezia.html"
+      },
+      "carnival-firenze": {
+        "name": "Carnival Firenze",
+        "class": "venice",
+        "year": 2020,
+        "gt": 135500,
+        "capacity": 4072,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Former Costa ship", "Long Beach based", "European atmosphere"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/firenze.html"
+      },
+      "carnival-splendor": {
+        "name": "Carnival Splendor",
+        "class": "splendor",
+        "year": 2008,
+        "gt": 113300,
+        "capacity": 3006,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 93,
+        "highlights": ["Solo ship in class", "Good mid-size option"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/splendor.html"
+      },
+      "carnival-sunshine": {
+        "name": "Carnival Sunshine",
+        "class": "sunshine",
+        "year": 1996,
+        "gt": 102853,
+        "capacity": 2974,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2013,
+        "cdc_score": null,
+        "highlights": ["Major 2013 refit", "Guy's Burger Joint", "Charleston based"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/sunshine.html"
+      },
+      "carnival-sunrise": {
+        "name": "Carnival Sunrise",
+        "class": "sunshine",
+        "year": 1999,
+        "gt": 101509,
+        "capacity": 2984,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2019,
+        "cdc_score": 97,
+        "highlights": ["Major 2019 refit", "Miami homeport"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/sunrise.html"
+      },
+      "carnival-radiance": {
+        "name": "Carnival Radiance",
+        "class": "sunshine",
+        "year": 2000,
+        "gt": 101353,
+        "capacity": 2984,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2022,
+        "cdc_score": 98,
+        "highlights": ["Major 2022 refit", "Long Beach based"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/radiance.html"
+      },
+      "carnival-paradise": {
+        "name": "Carnival Paradise",
+        "class": "fantasy",
+        "year": 1998,
+        "gt": 70367,
+        "capacity": 2056,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["Budget-friendly", "Short getaways"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/paradise.html"
+      },
+      "carnival-elation": {
+        "name": "Carnival Elation",
+        "class": "fantasy",
+        "year": 1998,
+        "gt": 70367,
+        "capacity": 2056,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 93,
+        "highlights": ["Budget-friendly", "Jacksonville based"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/carnival/elation.html"
+      }
+    },
+    "ncl": {
+      "norwegian-aqua": {
+        "name": "Norwegian Aqua",
+        "class": "prima",
+        "year": 2025,
+        "gt": 142500,
+        "capacity": 3571,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Newest Prima", "Enhanced family features", "Aqua Slidecoaster"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/aqua.html"
+      },
+      "norwegian-viva": {
+        "name": "Norwegian Viva",
+        "class": "prima",
+        "year": 2023,
+        "gt": 142500,
+        "capacity": 3215,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Prima-class ship", "Ocean Boulevard", "Indulge Food Hall"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/viva.html"
+      },
+      "norwegian-prima": {
+        "name": "Norwegian Prima",
+        "class": "prima",
+        "year": 2022,
+        "gt": 142500,
+        "capacity": 3215,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["First Prima-class", "Ocean Boulevard", "The Drop slide"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/prima.html"
+      },
+      "norwegian-encore": {
+        "name": "Norwegian Encore",
+        "class": "breakaway_plus",
+        "year": 2019,
+        "gt": 169116,
+        "capacity": 3998,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Go-karts", "Laser tag", "Galaxy Pavilion VR"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/encore.html"
+      },
+      "norwegian-bliss": {
+        "name": "Norwegian Bliss",
+        "class": "breakaway_plus",
+        "year": 2018,
+        "gt": 168028,
+        "capacity": 4004,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Go-karts", "Alaska flagship", "Observation Lounge"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/bliss.html"
+      },
+      "norwegian-joy": {
+        "name": "Norwegian Joy",
+        "class": "breakaway_plus",
+        "year": 2017,
+        "gt": 167725,
+        "capacity": 3804,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Go-karts", "Galaxy Pavilion", "Refitted for Western market"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/joy.html"
+      },
+      "norwegian-escape": {
+        "name": "Norwegian Escape",
+        "class": "breakaway_plus",
+        "year": 2015,
+        "gt": 164600,
+        "capacity": 4266,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Ropes course", "The Waterfront", "Jimmy Buffett's Margaritaville"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/escape.html"
+      },
+      "norwegian-getaway": {
+        "name": "Norwegian Getaway",
+        "class": "breakaway",
+        "year": 2014,
+        "gt": 145655,
+        "capacity": 3963,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 95,
+        "highlights": ["Ropes course", "Aqua Park", "The Waterfront"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/getaway.html"
+      },
+      "norwegian-breakaway": {
+        "name": "Norwegian Breakaway",
+        "class": "breakaway",
+        "year": 2013,
+        "gt": 144017,
+        "capacity": 3963,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["First Breakaway", "Ropes course", "NYC homeport"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/breakaway.html"
+      },
+      "norwegian-epic": {
+        "name": "Norwegian Epic",
+        "class": "epic",
+        "year": 2010,
+        "gt": 155873,
+        "capacity": 4100,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 89,
+        "highlights": ["128 Studio cabins", "Studio Lounge", "Ice bar"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/epic.html"
+      },
+      "norwegian-gem": {
+        "name": "Norwegian Gem",
+        "class": "jewel",
+        "year": 2007,
+        "gt": 93530,
+        "capacity": 2394,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Jewel-class ship", "NYC homeport", "Relaxed vibe"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/gem.html"
+      },
+      "norwegian-pearl": {
+        "name": "Norwegian Pearl",
+        "class": "jewel",
+        "year": 2006,
+        "gt": 93530,
+        "capacity": 2394,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Jewel-class ship", "Bowling alley", "10 dining options"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/pearl.html"
+      },
+      "norwegian-jade": {
+        "name": "Norwegian Jade",
+        "class": "jewel",
+        "year": 2006,
+        "gt": 93558,
+        "capacity": 2402,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Jewel-class ship", "Europe specialist", "Yin & Yang spa"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/jade.html"
+      },
+      "norwegian-jewel": {
+        "name": "Norwegian Jewel",
+        "class": "jewel",
+        "year": 2005,
+        "gt": 93502,
+        "capacity": 2376,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["First Jewel-class", "Asia deployments", "Classic NCL"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/jewel.html"
+      },
+      "pride-of-america": {
+        "name": "Pride of America",
+        "class": "pride_of_america",
+        "year": 2005,
+        "gt": 80439,
+        "capacity": 2186,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Hawaii inter-island", "US-flagged", "Only overnight at ports"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/pride-of-america.html"
+      },
+      "norwegian-dawn": {
+        "name": "Norwegian Dawn",
+        "class": "dawn",
+        "year": 2002,
+        "gt": 92250,
+        "capacity": 2340,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 98,
+        "highlights": ["Early Freestyle ship", "Bermuda specialist"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/dawn.html"
+      },
+      "norwegian-star": {
+        "name": "Norwegian Star",
+        "class": "dawn",
+        "year": 2001,
+        "gt": 91740,
+        "capacity": 2348,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 94,
+        "highlights": ["First Freestyle ship", "Good itineraries"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/star.html"
+      },
+      "norwegian-sun": {
+        "name": "Norwegian Sun",
+        "class": "sun",
+        "year": 2001,
+        "gt": 78309,
+        "capacity": 1936,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Intimate ship", "Cuba specialist", "Value pricing"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/sun.html"
+      },
+      "norwegian-sky": {
+        "name": "Norwegian Sky",
+        "class": "sun",
+        "year": 1999,
+        "gt": 77104,
+        "capacity": 2002,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Short cruises", "All-inclusive pricing", "Miami based"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/sky.html"
+      },
+      "norwegian-spirit": {
+        "name": "Norwegian Spirit",
+        "class": "spirit",
+        "year": 1998,
+        "gt": 75338,
+        "capacity": 1966,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 97,
+        "highlights": ["Fleet's oldest", "Refurbished 2020", "Classic cruising"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/ncl/spirit.html"
+      }
+    },
+    "msc": {
+      "msc-world-america": {
+        "name": "MSC World America",
+        "class": "world",
+        "year": 2025,
+        "gt": 215863,
+        "capacity": 6762,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Newest flagship", "Eataly at sea", "The Harbour family zone"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/world-america.html"
+      },
+      "msc-world-europa": {
+        "name": "MSC World Europa",
+        "class": "world",
+        "year": 2022,
+        "gt": 215863,
+        "capacity": 6762,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["First World-class", "LNG-powered", "11-deck promenade"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/world-europa.html"
+      },
+      "msc-euribia": {
+        "name": "MSC Euribia",
+        "class": "meraviglia_plus",
+        "year": 2023,
+        "gt": 181541,
+        "capacity": 6327,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["LNG-powered", "LED promenade", "Cirque shows"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/euribia.html"
+      },
+      "msc-virtuosa": {
+        "name": "MSC Virtuosa",
+        "class": "meraviglia_plus",
+        "year": 2021,
+        "gt": 181541,
+        "capacity": 6334,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Rob the Robot bartender", "LED promenade", "Cirque du Soleil"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/virtuosa.html"
+      },
+      "msc-grandiosa": {
+        "name": "MSC Grandiosa",
+        "class": "meraviglia_plus",
+        "year": 2019,
+        "gt": 181541,
+        "capacity": 6334,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["First Meraviglia-Plus", "LED promenade", "Cirque du Soleil"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/grandiosa.html"
+      },
+      "msc-seascape": {
+        "name": "MSC Seascape",
+        "class": "seaside_evo",
+        "year": 2022,
+        "gt": 170412,
+        "capacity": 5632,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["Caribbean flagship", "Robot bartenders", "Outdoor promenade"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/seascape.html"
+      },
+      "msc-seashore": {
+        "name": "MSC Seashore",
+        "class": "seaside_evo",
+        "year": 2021,
+        "gt": 169400,
+        "capacity": 5632,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["First Seaside EVO", "Extended outdoor deck", "Miami homeport"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/seashore.html"
+      },
+      "msc-meraviglia": {
+        "name": "MSC Meraviglia",
+        "class": "meraviglia",
+        "year": 2017,
+        "gt": 171598,
+        "capacity": 5714,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 100,
+        "highlights": ["First Meraviglia", "LED promenade", "Cirque du Soleil"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/meraviglia.html"
+      },
+      "msc-bellissima": {
+        "name": "MSC Bellissima",
+        "class": "meraviglia",
+        "year": 2019,
+        "gt": 171598,
+        "capacity": 5714,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Highest-rated MSC ship", "LED promenade", "Cirque du Soleil"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/bellissima.html"
+      },
+      "msc-seaside": {
+        "name": "MSC Seaside",
+        "class": "seaside",
+        "year": 2017,
+        "gt": 160000,
+        "capacity": 5179,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["First Seaside", "Outdoor promenade", "Miami homeport"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/seaside.html"
+      },
+      "msc-seaview": {
+        "name": "MSC Seaview",
+        "class": "seaside",
+        "year": 2018,
+        "gt": 160000,
+        "capacity": 5179,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Seaside-class ship", "Outdoor focus", "European deployments"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/seaview.html"
+      },
+      "msc-preziosa": {
+        "name": "MSC Preziosa",
+        "class": "fantasia",
+        "year": 2013,
+        "gt": 139072,
+        "capacity": 4363,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Newest Fantasia", "Infinity pool", "Yacht Club"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/preziosa.html"
+      },
+      "msc-divina": {
+        "name": "MSC Divina",
+        "class": "fantasia",
+        "year": 2012,
+        "gt": 139072,
+        "capacity": 4345,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Sophia Loren godmother", "Yacht Club", "Caribbean based"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/divina.html"
+      },
+      "msc-magnifica": {
+        "name": "MSC Magnifica",
+        "class": "fantasia",
+        "year": 2010,
+        "gt": 137936,
+        "capacity": 3223,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": 86,
+        "highlights": ["World cruise specialist", "Top Sail Lounge", "Classic MSC"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/magnifica.html"
+      },
+      "msc-splendida": {
+        "name": "MSC Splendida",
+        "class": "fantasia",
+        "year": 2009,
+        "gt": 137936,
+        "capacity": 4363,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Yacht Club", "Mediterranean specialist"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/splendida.html"
+      },
+      "msc-fantasia": {
+        "name": "MSC Fantasia",
+        "class": "fantasia",
+        "year": 2008,
+        "gt": 137936,
+        "capacity": 4363,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["First Fantasia-class", "First Yacht Club", "Mediterranean based"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/fantasia.html"
+      },
+      "msc-poesia": {
+        "name": "MSC Poesia",
+        "class": "musica",
+        "year": 2008,
+        "gt": 92627,
+        "capacity": 3013,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Musica-class ship", "European itineraries"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/poesia.html"
+      },
+      "msc-orchestra": {
+        "name": "MSC Orchestra",
+        "class": "musica",
+        "year": 2007,
+        "gt": 92409,
+        "capacity": 3013,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["Musica-class ship", "South America cruises"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/orchestra.html"
+      },
+      "msc-musica": {
+        "name": "MSC Musica",
+        "class": "musica",
+        "year": 2006,
+        "gt": 92409,
+        "capacity": 3013,
+        "status": "active",
+        "amplified": false,
+        "cdc_score": null,
+        "highlights": ["First Musica-class", "Mediterranean specialist"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/musica.html"
+      },
+      "msc-lirica": {
+        "name": "MSC Lirica",
+        "class": "lirica",
+        "year": 2003,
+        "gt": 65591,
+        "capacity": 2069,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2015,
+        "cdc_score": 100,
+        "highlights": ["First Lirica-class", "Refurbished 2015", "Intimate size"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/lirica.html"
+      },
+      "msc-opera": {
+        "name": "MSC Opera",
+        "class": "lirica",
+        "year": 2004,
+        "gt": 65591,
+        "capacity": 2069,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2015,
+        "cdc_score": null,
+        "highlights": ["Lirica-class ship", "Refurbished 2015", "European sailings"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/opera.html"
+      },
+      "msc-sinfonia": {
+        "name": "MSC Sinfonia",
+        "class": "lirica",
+        "year": 2002,
+        "gt": 65542,
+        "capacity": 2069,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2015,
+        "cdc_score": null,
+        "highlights": ["Lirica-class ship", "Refurbished 2015", "Budget-friendly"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/sinfonia.html"
+      },
+      "msc-armonia": {
+        "name": "MSC Armonia",
+        "class": "lirica",
+        "year": 2001,
+        "gt": 65542,
+        "capacity": 2069,
+        "status": "active",
+        "amplified": true,
+        "amplified_year": 2014,
+        "cdc_score": null,
+        "highlights": ["Oldest MSC ship", "Refurbished 2014", "Cuba specialist"],
+        "image": "/assets/social/ships-hero.jpg",
+        "page": "/ships/msc/armonia.html"
+      }
+    }
+  },
+
+  "scoring_weights": {
+    "rcl": {
+      "energy_level": {
+        "go_go_go": { "icon": 18, "oasis": 16, "freedom": 10, "voyager": 8, "quantum": 8, "radiance": 0, "vision": 0 },
+        "balanced": { "freedom": 14, "quantum": 12, "voyager": 10, "oasis": 8, "icon": 0, "radiance": 0, "vision": 0 },
+        "relax": { "radiance": 18, "vision": 14, "quantum": 6, "voyager": 4, "icon": -12, "oasis": -10, "freedom": 0 }
+      },
+      "crowd_tolerance": {
+        "high": { "icon": 14, "oasis": 12 },
+        "medium": { "freedom": 8, "quantum": 8, "voyager": 6 },
+        "low": { "radiance": 14, "vision": 12, "voyager": 8, "icon": -14, "oasis": -12 }
+      },
+      "budget_mindset": {
+        "premium": { "icon": 12, "oasis": 10, "quantum": 8 },
+        "balanced": { "freedom": 10, "voyager": 8, "quantum": 8, "oasis": 6 },
+        "value": { "voyager": 14, "freedom": 12, "vision": 10, "radiance": 6, "icon": -10 }
+      },
+      "sailing_length": {
+        "short": { "voyager": 10, "freedom": 10, "oasis": 8 },
+        "standard": { "freedom": 10, "voyager": 10, "oasis": 8, "quantum": 8 },
+        "long": { "radiance": 12, "vision": 10, "quantum": 10, "voyager": 6, "icon": -8 }
+      },
+      "group_type": {
+        "solo": { "radiance": 8, "vision": 8, "quantum": 6, "voyager": 6 },
+        "couple": { "quantum": 10, "radiance": 10, "oasis": 6, "voyager": 6 },
+        "friends": { "oasis": 12, "freedom": 10, "voyager": 10, "icon": 6 },
+        "family_young": { "icon": 16, "oasis": 10, "freedom": 10, "voyager": 8 },
+        "family_teens": { "oasis": 14, "icon": 12, "quantum": 10, "freedom": 8 },
+        "multigen": { "oasis": 12, "icon": 10, "freedom": 10, "voyager": 8, "radiance": 6 }
+      },
+      "ship_vs_ports": {
+        "ship": { "icon": 12, "oasis": 10, "quantum": 6, "freedom": 6 },
+        "balanced": { "freedom": 8, "quantum": 8, "voyager": 6, "oasis": 4 },
+        "ports": { "radiance": 18, "vision": 18, "voyager": 8, "icon": -15, "oasis": -12 }
+      },
+      "cruise_experience": {
+        "first_time": { "freedom": 6, "voyager": 6, "oasis": 4 },
+        "a_few": { "oasis": 4, "quantum": 4, "freedom": 2 },
+        "seasoned": { "icon": 4, "radiance": 4, "vision": 4 }
+      }
+    },
+    "carnival": {
+      "energy_level": {
+        "go_go_go": { "excel": 18, "vista": 14, "dream": 12, "conquest": 8, "venice": 6, "splendor": 6, "sunshine": 4, "spirit": 0, "fantasy": 0 },
+        "balanced": { "dream": 14, "vista": 12, "conquest": 10, "splendor": 10, "venice": 8, "excel": 6, "sunshine": 6, "spirit": 4, "fantasy": 0 },
+        "relax": { "spirit": 16, "fantasy": 12, "sunshine": 10, "venice": 8, "splendor": 6, "conquest": 4, "excel": -10, "vista": -6, "dream": 0 }
+      },
+      "crowd_tolerance": {
+        "high": { "excel": 14, "vista": 10, "dream": 8 },
+        "medium": { "dream": 8, "conquest": 8, "splendor": 6, "vista": 6, "venice": 6 },
+        "low": { "spirit": 14, "fantasy": 12, "sunshine": 10, "venice": 8, "excel": -14, "vista": -10 }
+      },
+      "budget_mindset": {
+        "premium": { "excel": 12, "vista": 8, "venice": 8, "dream": 6 },
+        "balanced": { "dream": 10, "conquest": 10, "vista": 8, "splendor": 8, "spirit": 6 },
+        "value": { "fantasy": 14, "conquest": 12, "sunshine": 12, "splendor": 10, "spirit": 8, "excel": -8 }
+      },
+      "sailing_length": {
+        "short": { "fantasy": 12, "conquest": 10, "sunshine": 10, "dream": 6, "excel": 4 },
+        "standard": { "dream": 10, "conquest": 10, "vista": 8, "excel": 8, "splendor": 8 },
+        "long": { "spirit": 12, "venice": 10, "vista": 8, "dream": 6, "excel": -6 }
+      },
+      "group_type": {
+        "solo": { "spirit": 10, "venice": 8, "sunshine": 6, "splendor": 6 },
+        "couple": { "spirit": 12, "venice": 10, "dream": 8, "vista": 6 },
+        "friends": { "excel": 12, "dream": 10, "conquest": 10, "vista": 8 },
+        "family_young": { "excel": 16, "vista": 14, "dream": 12, "conquest": 8, "spirit": -12, "fantasy": -14 },
+        "family_teens": { "excel": 14, "vista": 12, "dream": 10, "conquest": 8 },
+        "multigen": { "vista": 12, "excel": 10, "dream": 10, "conquest": 8, "spirit": 6 }
+      },
+      "ship_vs_ports": {
+        "ship": { "excel": 14, "vista": 10, "dream": 8, "conquest": 4 },
+        "balanced": { "dream": 8, "conquest": 8, "vista": 6, "splendor": 6 },
+        "ports": { "spirit": 16, "fantasy": 14, "sunshine": 10, "venice": 8, "excel": -12, "vista": -8 }
+      },
+      "cruise_experience": {
+        "first_time": { "conquest": 6, "dream": 6, "vista": 4 },
+        "a_few": { "vista": 4, "dream": 4, "excel": 2 },
+        "seasoned": { "excel": 4, "spirit": 4, "venice": 4 }
+      }
+    },
+    "ncl": {
+      "energy_level": {
+        "go_go_go": { "breakaway_plus": 18, "prima": 12, "breakaway": 12, "epic": 10, "jewel": 4, "dawn": 0, "sun": 0, "spirit": 0, "pride_of_america": 0 },
+        "balanced": { "jewel": 12, "breakaway": 12, "prima": 10, "epic": 8, "breakaway_plus": 6, "dawn": 6, "pride_of_america": 6, "sun": 0, "spirit": 0 },
+        "relax": { "sun": 16, "spirit": 14, "jewel": 12, "dawn": 10, "pride_of_america": 8, "breakaway_plus": -10, "prima": -6, "breakaway": 0, "epic": 0 }
+      },
+      "crowd_tolerance": {
+        "high": { "breakaway_plus": 14, "prima": 10, "epic": 8, "breakaway": 8 },
+        "medium": { "breakaway": 8, "jewel": 8, "epic": 6, "prima": 6 },
+        "low": { "sun": 14, "spirit": 14, "jewel": 10, "dawn": 10, "breakaway_plus": -14, "epic": -10 }
+      },
+      "budget_mindset": {
+        "premium": { "prima": 14, "breakaway_plus": 10, "epic": 6 },
+        "balanced": { "breakaway": 10, "jewel": 10, "breakaway_plus": 8, "epic": 8, "dawn": 6 },
+        "value": { "sun": 14, "spirit": 12, "dawn": 10, "jewel": 8, "prima": -10, "breakaway_plus": -6 }
+      },
+      "sailing_length": {
+        "short": { "sun": 12, "spirit": 8, "breakaway": 6 },
+        "standard": { "breakaway_plus": 10, "breakaway": 10, "jewel": 8, "prima": 8, "epic": 8 },
+        "long": { "pride_of_america": 14, "dawn": 10, "jewel": 8, "prima": 6, "sun": -8 }
+      },
+      "group_type": {
+        "solo": { "epic": 16, "prima": 8, "jewel": 6, "sun": 6 },
+        "couple": { "prima": 14, "jewel": 12, "breakaway_plus": 8, "dawn": 6 },
+        "friends": { "breakaway_plus": 14, "breakaway": 12, "epic": 10, "prima": 8 },
+        "family_young": { "breakaway_plus": 14, "breakaway": 12, "epic": -10, "sun": -14, "spirit": -14 },
+        "family_teens": { "breakaway_plus": 16, "breakaway": 12, "prima": 8, "jewel": 6 },
+        "multigen": { "breakaway_plus": 10, "jewel": 10, "breakaway": 8, "prima": 6 }
+      },
+      "ship_vs_ports": {
+        "ship": { "breakaway_plus": 14, "prima": 12, "epic": 8, "breakaway": 6 },
+        "balanced": { "breakaway": 8, "jewel": 8, "prima": 6, "breakaway_plus": 6 },
+        "ports": { "pride_of_america": 16, "dawn": 14, "spirit": 12, "sun": 10, "jewel": 8, "breakaway_plus": -10 }
+      },
+      "cruise_experience": {
+        "first_time": { "breakaway": 6, "jewel": 6, "breakaway_plus": 4 },
+        "a_few": { "breakaway_plus": 4, "breakaway": 4, "prima": 2 },
+        "seasoned": { "prima": 4, "epic": 4, "sun": 4 }
+      }
+    },
+    "msc": {
+      "energy_level": {
+        "go_go_go": { "world": 18, "meraviglia_plus": 14, "seaside_evo": 12, "meraviglia": 10, "seaside": 8, "fantasia": 4, "musica": 0, "lirica": 0 },
+        "balanced": { "meraviglia": 12, "seaside": 10, "seaside_evo": 10, "fantasia": 8, "meraviglia_plus": 6, "world": 6, "musica": 6, "lirica": 0 },
+        "relax": { "lirica": 16, "musica": 14, "fantasia": 10, "seaside": 6, "world": -10, "meraviglia_plus": -8, "meraviglia": 0, "seaside_evo": 0 }
+      },
+      "crowd_tolerance": {
+        "high": { "world": 14, "meraviglia_plus": 10, "seaside_evo": 8, "meraviglia": 8 },
+        "medium": { "seaside": 8, "meraviglia": 8, "fantasia": 6, "seaside_evo": 6 },
+        "low": { "lirica": 14, "musica": 14, "fantasia": 8, "world": -14, "meraviglia_plus": -10 }
+      },
+      "budget_mindset": {
+        "premium": { "world": 12, "meraviglia_plus": 8, "seaside_evo": 6 },
+        "balanced": { "seaside": 10, "meraviglia": 10, "fantasia": 8, "seaside_evo": 8 },
+        "value": { "lirica": 14, "musica": 12, "fantasia": 10, "world": -6, "meraviglia_plus": -4 }
+      },
+      "sailing_length": {
+        "short": { "lirica": 10, "seaside": 8, "musica": 6 },
+        "standard": { "world": 10, "seaside_evo": 10, "meraviglia": 8, "seaside": 8, "meraviglia_plus": 8 },
+        "long": { "fantasia": 12, "musica": 10, "lirica": 8, "meraviglia_plus": 6 }
+      },
+      "group_type": {
+        "solo": { "musica": 8, "lirica": 8, "fantasia": 6 },
+        "couple": { "seaside_evo": 12, "seaside": 12, "world": 8, "fantasia": 8, "musica": 6 },
+        "friends": { "world": 12, "meraviglia_plus": 10, "meraviglia": 10, "seaside_evo": 8 },
+        "family_young": { "world": 16, "meraviglia_plus": 14, "seaside_evo": 12, "meraviglia": 10, "lirica": -12, "musica": -10 },
+        "family_teens": { "world": 14, "meraviglia_plus": 12, "seaside_evo": 10, "meraviglia": 8 },
+        "multigen": { "fantasia": 10, "world": 10, "meraviglia_plus": 8, "seaside_evo": 8 }
+      },
+      "ship_vs_ports": {
+        "ship": { "world": 14, "meraviglia_plus": 10, "seaside_evo": 8, "meraviglia": 6 },
+        "balanced": { "seaside": 8, "meraviglia": 8, "fantasia": 6, "seaside_evo": 6 },
+        "ports": { "lirica": 16, "musica": 14, "fantasia": 10, "world": -10, "meraviglia_plus": -8 }
+      },
+      "cruise_experience": {
+        "first_time": { "meraviglia": 6, "fantasia": 6, "seaside": 4 },
+        "a_few": { "meraviglia_plus": 4, "seaside_evo": 4, "world": 2 },
+        "seasoned": { "world": 4, "lirica": 4, "musica": 4 }
+      }
+    }
+  },
+
+  "must_have_bonuses": {
+    "waterpark": {
+      "rcl": { "icon": 15, "oasis": 10, "freedom": 8 },
+      "carnival": { "excel": 15, "vista": 12, "dream": 8 },
+      "ncl": { "breakaway_plus": 12, "breakaway": 10, "prima": 6 },
+      "msc": { "world": 12, "seaside_evo": 10, "meraviglia_plus": 8 }
+    },
+    "dining": {
+      "rcl": { "icon": 10, "oasis": 12, "quantum": 8 },
+      "carnival": { "excel": 12, "vista": 8, "venice": 8 },
+      "ncl": { "prima": 12, "breakaway_plus": 10, "jewel": 6 },
+      "msc": { "world": 14, "meraviglia_plus": 8, "seaside_evo": 6 }
+    },
+    "shows": {
+      "rcl": { "oasis": 12, "quantum": 10, "icon": 8 },
+      "carnival": { "excel": 10, "vista": 8, "dream": 8 },
+      "ncl": { "breakaway_plus": 12, "breakaway": 10, "epic": 8 },
+      "msc": { "meraviglia_plus": 12, "meraviglia": 12, "world": 8 }
+    },
+    "tech": {
+      "rcl": { "quantum": 15, "icon": 10, "oasis": 6 },
+      "carnival": { "excel": 12, "vista": 8 },
+      "ncl": { "prima": 14, "breakaway_plus": 10 },
+      "msc": { "world": 12, "meraviglia_plus": 10, "seaside_evo": 8 }
+    },
+    "scenic": {
+      "rcl": { "radiance": 15, "vision": 12, "quantum": 6 },
+      "carnival": { "spirit": 12, "venice": 10, "fantasy": 8 },
+      "ncl": { "jewel": 12, "dawn": 10, "pride_of_america": 14 },
+      "msc": { "fantasia": 10, "musica": 10, "lirica": 8 }
+    },
+    "family": {
+      "rcl": { "icon": 14, "oasis": 12, "freedom": 10 },
+      "carnival": { "excel": 14, "vista": 14, "dream": 10 },
+      "ncl": { "breakaway_plus": 12, "breakaway": 10 },
+      "msc": { "world": 14, "meraviglia_plus": 12, "seaside_evo": 10 }
+    }
+  }
+}

--- a/ships/allshipquiz.html
+++ b/ships/allshipquiz.html
@@ -1,0 +1,1846 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+
+<!-- ai-breadcrumbs
+     entity: Multi-Line Ship Selection Quiz
+     type: Interactive Tool
+     parent: /ships.html
+     category: Planning Tool
+     updated: 2026-01-02
+     expertise: Cruise planning, ship selection, personalized recommendations
+     target-audience: Cruise travelers seeking ship recommendations across multiple lines
+     answer-first: Take this quick quiz to find your perfect cruise ship across Royal Caribbean, Carnival, NCL, and MSC based on your travel style.
+     -->
+  <!-- ======================================================
+       In the Wake — All Ship Quiz V2
+       Version: 2.0.0  |  Soli Deo Gloria
+       ====================================================== -->
+
+  <!-- Consent (autoblocking) -->
+  <script type="text/javascript" data-cmp-ab="1"
+    src="https://cdn.consentmanager.net/delivery/autoblocking/e11a25480244a.js"
+    data-cmp-host="a.delivery.consentmanager.net"
+    data-cmp-cdn="cdn.consentmanager.net"
+    data-cmp-codesrc="16"></script>
+
+  <!-- Analytics -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-WZP891PZXJ',{anonymize_ip:true});</script>
+
+  <!-- ICP-Lite v1.4 Meta Tags -->
+  <meta name="ai-summary" content="Interactive quiz to help cruise travelers find their perfect ship across Royal Caribbean, Carnival, Norwegian, and MSC. Answer 8 simple questions about your travel party, pace, budget, and preferences to get personalized ship recommendations." />
+  <meta name="last-reviewed" content="2026-01-02" />
+  <meta name="content-protocol" content="ICP-Lite v1.4" />
+
+  <!-- Core -->
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer-when-downgrade"/>
+
+  <!-- SEO -->
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="author" content="In the Wake"/>
+
+  <!-- Title & Description -->
+  <title>Find Your Perfect Cruise Ship — Quiz | In the Wake</title>
+  <meta name="description" content="Not sure which cruise ship is right for you? Take our quick quiz to get personalized recommendations from Royal Caribbean, Carnival, Norwegian, and MSC." />
+  <link rel="canonical" href="https://cruisinginthewake.com/ships/allshipquiz.html"/>
+
+  <!-- OpenGraph -->
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/allshipquiz.html"/>
+  <meta property="og:title" content="Find Your Perfect Cruise Ship — Quiz"/>
+  <meta property="og:description" content="Answer a few quick questions and we'll recommend the best ships for your cruise style across 4 major cruise lines."/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Find Your Perfect Cruise Ship — Quiz"/>
+  <meta name="twitter:description" content="Answer a few quick questions and we'll recommend the best ships for your cruise style."/>
+
+  <!-- JSON-LD: BreadcrumbList -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://cruisinginthewake.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Ships", "item": "https://cruisinginthewake.com/ships.html" },
+      { "@type": "ListItem", "position": 3, "name": "Ship Quiz", "item": "https://cruisinginthewake.com/ships/allshipquiz.html" }
+    ]
+  }
+  </script>
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/css/item-cards.css?v=1.0.0">
+
+  <style>
+    /* Quiz-specific styles */
+    .quiz-container {
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    /* Cruise line pill selector */
+    .cruise-line-selector {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      justify-content: center;
+      margin-bottom: 1.5rem;
+      padding: 1rem;
+      background: var(--sky);
+      border-radius: 14px;
+    }
+    .line-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.6rem 1.2rem;
+      border: 2px solid var(--rope);
+      border-radius: 999px;
+      background: #fff;
+      color: var(--ink);
+      font-weight: 600;
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      min-height: 44px;
+    }
+    .line-pill:hover {
+      border-color: var(--accent);
+      background: var(--foam);
+    }
+    .line-pill.active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+    .line-pill .line-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      display: inline-block;
+    }
+    .line-pill[data-line="all"] .line-dot { background: linear-gradient(135deg, #1a3d7c, #e31837, #00205b, #003366); }
+    .line-pill[data-line="rcl"] .line-dot { background: #1a3d7c; }
+    .line-pill[data-line="carnival"] .line-dot { background: #e31837; }
+    .line-pill[data-line="ncl"] .line-dot { background: #00205b; }
+    .line-pill[data-line="msc"] .line-dot { background: #003366; }
+
+    /* Mobile hamburger for pills */
+    .line-selector-mobile {
+      display: none;
+    }
+    @media (max-width: 600px) {
+      .cruise-line-selector {
+        display: none;
+      }
+      .line-selector-mobile {
+        display: block;
+        margin-bottom: 1.5rem;
+      }
+      .line-selector-trigger {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+        padding: 1rem;
+        background: var(--sky);
+        border: 2px solid var(--rope);
+        border-radius: 14px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      .line-selector-trigger .current-line {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .line-selector-dropdown {
+        display: none;
+        position: absolute;
+        left: 0;
+        right: 0;
+        background: #fff;
+        border: 2px solid var(--rope);
+        border-radius: 14px;
+        margin-top: 0.5rem;
+        padding: 0.5rem;
+        z-index: 100;
+        box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+      }
+      .line-selector-dropdown.open {
+        display: block;
+      }
+      .line-selector-dropdown .line-option {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 1rem;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+      .line-selector-dropdown .line-option:hover {
+        background: var(--foam);
+      }
+      .line-selector-dropdown .line-option.active {
+        background: var(--foam);
+        font-weight: 600;
+      }
+      .line-selector-dropdown .escape-rope {
+        border-top: 1px solid var(--rope);
+        margin-top: 0.5rem;
+        padding-top: 0.5rem;
+      }
+    }
+
+    /* Progress indicator */
+    .quiz-progress {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      background: linear-gradient(135deg, rgba(14, 110, 142, 0.95) 0%, rgba(10, 61, 98, 0.95) 100%);
+      color: #fff;
+      padding: 0.5rem 1rem;
+      border-radius: 999px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      box-shadow: 0 4px 12px rgba(8, 48, 65, 0.2);
+      z-index: 1000;
+      backdrop-filter: blur(8px);
+      display: none;
+    }
+    .quiz-progress.visible {
+      display: block;
+    }
+
+    /* Quiz intro */
+    .quiz-intro {
+      text-align: center;
+      padding: 2rem 1rem;
+    }
+    .quiz-intro h1 {
+      font-size: 2rem;
+      color: var(--sea);
+      margin-bottom: 1rem;
+    }
+    .quiz-intro p {
+      font-size: 1.1rem;
+      color: var(--ink-mid);
+      max-width: 600px;
+      margin: 0 auto 1.5rem;
+    }
+    .btn-start {
+      display: inline-block;
+      padding: 1rem 2.5rem;
+      background: linear-gradient(135deg, #0e6e8e 0%, #0a3d62 100%);
+      color: #fff;
+      font-size: 1.2rem;
+      font-weight: 600;
+      border: none;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: transform 0.2s, box-shadow 0.2s;
+      box-shadow: 0 4px 12px rgba(14, 110, 142, 0.3);
+    }
+    .btn-start:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 6px 20px rgba(14, 110, 142, 0.4);
+    }
+
+    /* Question screen */
+    .quiz-question {
+      display: none;
+      animation: fadeIn 0.3s ease;
+    }
+    .quiz-question.active {
+      display: block;
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .question-header {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    .question-header h2 {
+      font-size: 1.6rem;
+      color: var(--sea);
+      margin-bottom: 0.5rem;
+    }
+    .question-subtitle {
+      color: var(--ink-mid);
+      font-size: 1rem;
+    }
+
+    /* Option cards */
+    .options-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+    .options-grid.two-col {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .options-grid.three-col {
+      grid-template-columns: repeat(3, 1fr);
+    }
+    @media (max-width: 600px) {
+      .options-grid.two-col,
+      .options-grid.three-col {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .option-card {
+      background: #fff;
+      border: 2px solid var(--rope);
+      border-radius: 14px;
+      padding: 1.25rem;
+      cursor: pointer;
+      transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+      text-align: center;
+    }
+    .option-card:hover {
+      border-color: var(--accent);
+      transform: translateY(-4px);
+      box-shadow: 0 8px 24px rgba(14, 110, 142, 0.15);
+    }
+    .option-card.selected {
+      border-color: var(--accent);
+      background: linear-gradient(135deg, rgba(14, 110, 142, 0.08) 0%, rgba(14, 110, 142, 0.04) 100%);
+      box-shadow: 0 4px 16px rgba(14, 110, 142, 0.2);
+    }
+    .option-card.selected .option-icon {
+      transform: scale(1.1);
+    }
+
+    .option-icon {
+      font-size: 2.5rem;
+      margin-bottom: 0.75rem;
+      transition: transform 0.2s;
+    }
+    .option-label {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: var(--sea);
+      margin-bottom: 0.25rem;
+    }
+    .option-desc {
+      font-size: 0.85rem;
+      color: var(--ink-mid);
+    }
+
+    /* Navigation */
+    .quiz-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 2rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid #e0f0f5;
+    }
+    .btn-back {
+      padding: 0.75rem 1.5rem;
+      background: transparent;
+      color: var(--accent);
+      border: 2px solid var(--accent);
+      border-radius: 999px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+    .btn-back:hover {
+      background: var(--foam);
+    }
+    .btn-back:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .btn-next {
+      padding: 0.75rem 2rem;
+      background: linear-gradient(135deg, #0e6e8e 0%, #0a3d62 100%);
+      color: #fff;
+      border: none;
+      border-radius: 999px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+      box-shadow: 0 4px 12px rgba(14, 110, 142, 0.25);
+    }
+    .btn-next:hover:not(:disabled) {
+      transform: translateY(-2px);
+      box-shadow: 0 6px 16px rgba(14, 110, 142, 0.35);
+    }
+    .btn-next:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    /* Results screen */
+    .quiz-results {
+      display: none;
+      animation: fadeIn 0.4s ease;
+    }
+    .quiz-results.active {
+      display: block;
+    }
+
+    .results-header {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    .results-header h2 {
+      font-size: 1.8rem;
+      color: var(--sea);
+      margin-bottom: 0.5rem;
+    }
+    .results-header p {
+      color: var(--ink-mid);
+    }
+
+    /* Ship result cards with brand colors */
+    .result-card {
+      background: #fff;
+      border: 2px solid var(--rope);
+      border-radius: 14px;
+      overflow: hidden;
+      margin-bottom: 1.5rem;
+      transition: all 0.25s;
+    }
+    .result-card:hover {
+      box-shadow: 0 8px 24px rgba(14, 110, 142, 0.12);
+    }
+    .result-card.top-pick {
+      border-color: var(--accent);
+      box-shadow: 0 6px 20px rgba(14, 110, 142, 0.15);
+    }
+    .result-card.top-pick .result-badge {
+      display: block;
+    }
+
+    /* Brand color bar */
+    .result-brand-bar {
+      height: 6px;
+      width: 100%;
+    }
+    .result-brand-bar.rcl { background: linear-gradient(90deg, #1a3d7c, #ffd700); }
+    .result-brand-bar.carnival { background: linear-gradient(90deg, #e31837, #0033a0); }
+    .result-brand-bar.ncl { background: linear-gradient(90deg, #00205b, #ffffff); }
+    .result-brand-bar.msc { background: linear-gradient(90deg, #003366, #b8860b); }
+
+    .result-image {
+      position: relative;
+      aspect-ratio: 16 / 9;
+      overflow: hidden;
+      background: linear-gradient(135deg, #eaf6f6 0%, #d4eeee 100%);
+    }
+    .result-image img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      transition: transform 0.3s;
+    }
+    .result-card:hover .result-image img {
+      transform: scale(1.05);
+    }
+    .result-badge {
+      display: none;
+      position: absolute;
+      top: 1rem;
+      left: 1rem;
+      background: linear-gradient(135deg, #fbbf24 0%, #d97706 100%);
+      color: #fff;
+      padding: 0.4rem 0.85rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .result-match {
+      position: absolute;
+      bottom: 1rem;
+      right: 1rem;
+      background: rgba(14, 110, 142, 0.9);
+      color: #fff;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      font-weight: 600;
+      backdrop-filter: blur(4px);
+    }
+
+    .result-content {
+      padding: 1.25rem;
+    }
+    .result-title {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 0.75rem;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    .result-title h3 {
+      font-size: 1.3rem;
+      color: var(--sea);
+      margin: 0;
+    }
+    .result-badges {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .result-class {
+      background: var(--foam);
+      color: var(--accent);
+      padding: 0.25rem 0.6rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .result-line {
+      padding: 0.25rem 0.6rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #fff;
+    }
+    .result-line.rcl { background: #1a3d7c; }
+    .result-line.carnival { background: #e31837; }
+    .result-line.ncl { background: #00205b; }
+    .result-line.msc { background: #003366; }
+
+    .result-narrative {
+      color: var(--ink-mid);
+      margin-bottom: 1rem;
+      line-height: 1.6;
+    }
+
+    .result-specs {
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+      padding: 0.75rem;
+      background: var(--sky);
+      border-radius: 8px;
+    }
+    .spec-item {
+      display: flex;
+      flex-direction: column;
+    }
+    .spec-label {
+      font-size: 0.7rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .spec-value {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--sea);
+    }
+
+    .result-highlights {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    .highlight-tag {
+      background: linear-gradient(135deg, rgba(14, 110, 142, 0.1) 0%, rgba(14, 110, 142, 0.05) 100%);
+      color: var(--accent);
+      padding: 0.3rem 0.6rem;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      font-weight: 500;
+    }
+
+    /* Why this ship section */
+    .result-why {
+      margin-top: 0.75rem;
+      padding: 0.75rem;
+      background: linear-gradient(135deg, rgba(251, 191, 36, 0.1) 0%, rgba(251, 191, 36, 0.05) 100%);
+      border-radius: 8px;
+      border-left: 3px solid #fbbf24;
+    }
+    .result-why-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      cursor: pointer;
+    }
+    .result-why-title {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #b45309;
+      margin-bottom: 0;
+    }
+    .result-why-toggle {
+      font-size: 0.75rem;
+      color: #b45309;
+      text-decoration: underline;
+    }
+    .result-why-text {
+      font-size: 0.85rem;
+      color: var(--ink-mid);
+      margin: 0.5rem 0 0;
+    }
+    .result-why-details {
+      display: none;
+      margin-top: 0.75rem;
+      padding-top: 0.75rem;
+      border-top: 1px solid rgba(251, 191, 36, 0.3);
+    }
+    .result-why-details.open {
+      display: block;
+    }
+    .score-breakdown {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+    .score-row {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.8rem;
+    }
+    .score-row .label {
+      color: var(--ink-mid);
+    }
+    .score-row .points {
+      font-weight: 600;
+      color: #b45309;
+    }
+
+    .result-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1.25rem;
+      background: linear-gradient(135deg, #0e6e8e 0%, #0a3d62 100%);
+      color: #fff;
+      text-decoration: none;
+      border-radius: 999px;
+      font-weight: 600;
+      transition: all 0.2s;
+    }
+    .result-cta:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(14, 110, 142, 0.3);
+    }
+
+    /* You Might Also Like section */
+    .also-like-section {
+      margin-top: 2rem;
+      padding: 1.5rem;
+      background: linear-gradient(135deg, rgba(14, 110, 142, 0.04) 0%, rgba(14, 110, 142, 0.02) 100%);
+      border-radius: 14px;
+      border: 1px solid rgba(14, 110, 142, 0.1);
+    }
+    .also-like-section h3 {
+      font-size: 1.1rem;
+      color: var(--sea);
+      margin-bottom: 0.5rem;
+    }
+    .also-like-section p {
+      color: var(--ink-mid);
+      font-size: 0.9rem;
+      margin-bottom: 1rem;
+    }
+    .also-like-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+    }
+    .also-like-card {
+      background: #fff;
+      border: 2px solid var(--rope);
+      border-radius: 10px;
+      padding: 1rem;
+      text-align: center;
+      transition: all 0.2s;
+      text-decoration: none;
+    }
+    .also-like-card:hover {
+      border-color: var(--accent);
+      transform: translateY(-2px);
+    }
+    .also-like-card .ship-name {
+      font-weight: 600;
+      color: var(--sea);
+      font-size: 0.95rem;
+      margin-bottom: 0.25rem;
+    }
+    .also-like-card .ship-line {
+      font-size: 0.75rem;
+      color: var(--ink-mid);
+      margin-bottom: 0.5rem;
+    }
+    .also-like-card .ship-match {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--accent);
+    }
+
+    /* Color guide */
+    .color-guide {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      margin-top: 1rem;
+      padding: 0.75rem;
+      background: #fff;
+      border-radius: 8px;
+      font-size: 0.8rem;
+    }
+    .color-item {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+    .color-item .dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+
+    /* Restart button */
+    .quiz-restart {
+      text-align: center;
+      margin-top: 2rem;
+      padding-top: 2rem;
+      border-top: 1px solid #e0f0f5;
+    }
+    .btn-restart {
+      padding: 0.75rem 2rem;
+      background: transparent;
+      color: var(--accent);
+      border: 2px solid var(--accent);
+      border-radius: 999px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+    .btn-restart:hover {
+      background: var(--foam);
+    }
+
+    /* Loading state */
+    .quiz-loading {
+      text-align: center;
+      padding: 3rem;
+      color: var(--ink-mid);
+    }
+
+    /* Hide elements */
+    .hidden {
+      display: none !important;
+    }
+
+    /* Share section */
+    .share-section {
+      margin-top: 2rem;
+      padding: 1.5rem;
+      background: linear-gradient(135deg, rgba(14, 110, 142, 0.06) 0%, rgba(14, 110, 142, 0.02) 100%);
+      border-radius: 14px;
+      border: 2px solid rgba(14, 110, 142, 0.15);
+    }
+    .share-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    .share-header h3 {
+      font-size: 1.1rem;
+      color: var(--sea);
+      margin: 0;
+    }
+    .share-preview {
+      background: #fff;
+      border: 1px solid #e0f0f5;
+      border-radius: 8px;
+      padding: 0.75rem;
+      margin-bottom: 1rem;
+      font-size: 0.9rem;
+      color: var(--ink-mid);
+      line-height: 1.5;
+    }
+    .share-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+    .share-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.6rem 1rem;
+      border-radius: 999px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+      border: none;
+      text-decoration: none;
+    }
+    .share-btn:hover {
+      transform: translateY(-2px);
+    }
+    .share-btn-primary {
+      background: linear-gradient(135deg, #0e6e8e 0%, #0a3d62 100%);
+      color: #fff;
+      box-shadow: 0 4px 12px rgba(14, 110, 142, 0.25);
+    }
+    .share-btn-primary:hover {
+      box-shadow: 0 6px 16px rgba(14, 110, 142, 0.35);
+    }
+    .share-btn-outline {
+      background: #fff;
+      color: var(--accent);
+      border: 2px solid var(--accent);
+    }
+    .share-btn-outline:hover {
+      background: var(--foam);
+    }
+    .share-btn-download {
+      background: linear-gradient(135deg, #fbbf24 0%, #d97706 100%);
+      color: #fff;
+    }
+    .share-btn svg {
+      width: 18px;
+      height: 18px;
+      fill: currentColor;
+    }
+    .share-copied {
+      display: none;
+      color: #10b981;
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-left: 0.5rem;
+    }
+    .share-copied.show {
+      display: inline;
+    }
+
+    /* Canvas for share image (hidden) */
+    #shareCanvas {
+      display: none;
+    }
+  </style>
+</head>
+
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <!-- ARIA Live Regions -->
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+
+  <header class="site-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <a href="/">
+          <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake - Home" decoding="async"/>
+        </a>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <!-- Mobile hamburger button -->
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning (overview)</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
+        <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Progress indicator -->
+  <div class="quiz-progress" id="quizProgress" aria-live="polite">
+    <span id="progressText">1 of 8</span>
+  </div>
+
+  <main id="main-content" class="wrap" role="main">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="/">Home</a></li>
+        <li><a href="/ships.html">Ships</a></li>
+        <li aria-current="page">Ship Quiz</li>
+      </ol>
+    </nav>
+
+    <div class="quiz-container">
+      <!-- Intro Screen -->
+      <div class="quiz-intro card" id="quizIntro">
+        <h1>Find Your Perfect Ship</h1>
+        <p>Not sure which cruise ship is right for you? Answer a few quick questions and we'll recommend the best matches from Royal Caribbean, Carnival, Norwegian, and MSC.</p>
+
+        <!-- Desktop pill selector -->
+        <div class="cruise-line-selector" role="group" aria-label="Select cruise line">
+          <button class="line-pill active" data-line="all" type="button">
+            <span class="line-dot"></span> All Lines
+          </button>
+          <button class="line-pill" data-line="rcl" type="button">
+            <span class="line-dot"></span> Royal Caribbean
+          </button>
+          <button class="line-pill" data-line="carnival" type="button">
+            <span class="line-dot"></span> Carnival
+          </button>
+          <button class="line-pill" data-line="ncl" type="button">
+            <span class="line-dot"></span> NCL
+          </button>
+          <button class="line-pill" data-line="msc" type="button">
+            <span class="line-dot"></span> MSC
+          </button>
+        </div>
+
+        <!-- Mobile dropdown selector -->
+        <div class="line-selector-mobile" style="position: relative;">
+          <button class="line-selector-trigger" type="button" id="mobileSelectorTrigger">
+            <span class="current-line">
+              <span class="line-dot" style="width:10px;height:10px;border-radius:50%;background:linear-gradient(135deg, #1a3d7c, #e31837, #00205b, #003366);"></span>
+              <span id="currentLineName">All Cruise Lines</span>
+            </span>
+            <span>&#9662;</span>
+          </button>
+          <div class="line-selector-dropdown" id="mobileDropdown">
+            <div class="line-option active" data-line="all">
+              <span class="line-dot" style="width:10px;height:10px;border-radius:50%;background:linear-gradient(135deg, #1a3d7c, #e31837, #00205b, #003366);"></span>
+              All Cruise Lines
+            </div>
+            <div class="line-option" data-line="rcl">
+              <span class="line-dot" style="width:10px;height:10px;border-radius:50%;background:#1a3d7c;"></span>
+              Royal Caribbean
+            </div>
+            <div class="line-option" data-line="carnival">
+              <span class="line-dot" style="width:10px;height:10px;border-radius:50%;background:#e31837;"></span>
+              Carnival
+            </div>
+            <div class="line-option" data-line="ncl">
+              <span class="line-dot" style="width:10px;height:10px;border-radius:50%;background:#00205b;"></span>
+              Norwegian Cruise Line
+            </div>
+            <div class="line-option" data-line="msc">
+              <span class="line-dot" style="width:10px;height:10px;border-radius:50%;background:#003366;"></span>
+              MSC Cruises
+            </div>
+            <div class="line-option escape-rope" data-action="close">
+              ← Back to Quiz
+            </div>
+          </div>
+        </div>
+
+        <p class="tiny muted" style="margin-bottom: 1.5rem;">Takes about 2 minutes. No signup required.</p>
+        <button class="btn-start" id="btnStart" type="button">Let's Go</button>
+      </div>
+
+      <!-- Questions Container -->
+      <div id="questionsContainer" class="hidden">
+        <!-- Questions will be injected here -->
+      </div>
+
+      <!-- Results Screen -->
+      <div class="quiz-results card" id="quizResults">
+        <div class="results-header">
+          <h2>Your Perfect Ships</h2>
+          <p>Based on your answers, here are our top recommendations:</p>
+        </div>
+        <div id="resultsContainer">
+          <!-- Results will be injected here -->
+        </div>
+
+        <!-- You Might Also Like Section -->
+        <div class="also-like-section hidden" id="alsoLikeSection">
+          <h3>You Might Also Like</h3>
+          <p>Ships from other cruise lines that match your preferences:</p>
+          <div class="also-like-grid" id="alsoLikeGrid">
+            <!-- Injected dynamically -->
+          </div>
+          <div class="color-guide">
+            <div class="color-item"><span class="dot" style="background:#1a3d7c;"></span> Royal Caribbean</div>
+            <div class="color-item"><span class="dot" style="background:#e31837;"></span> Carnival</div>
+            <div class="color-item"><span class="dot" style="background:#00205b;"></span> NCL</div>
+            <div class="color-item"><span class="dot" style="background:#003366;"></span> MSC</div>
+          </div>
+        </div>
+
+        <!-- Share Section -->
+        <div class="share-section" id="shareSection">
+          <div class="share-header">
+            <span style="font-size: 1.3rem;">📤</span>
+            <h3>Share Your Results</h3>
+          </div>
+          <div class="share-preview" id="sharePreview">
+            <!-- Dynamic share text -->
+          </div>
+          <div class="share-buttons">
+            <button class="share-btn share-btn-primary" id="btnNativeShare" type="button">
+              <svg viewBox="0 0 24 24"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"/></svg>
+              Share
+            </button>
+            <button class="share-btn share-btn-outline" id="btnCopyLink" type="button">
+              <svg viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
+              Copy Link
+              <span class="share-copied" id="copiedMsg">Copied!</span>
+            </button>
+            <button class="share-btn share-btn-download" id="btnDownloadImage" type="button">
+              <svg viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>
+              Save Image
+            </button>
+          </div>
+        </div>
+
+        <!-- Hidden canvas for image generation -->
+        <canvas id="shareCanvas" width="1200" height="630"></canvas>
+
+        <div class="quiz-restart">
+          <button class="btn-restart" id="btnRestart" type="button">Take Quiz Again</button>
+        </div>
+      </div>
+
+      <!-- Loading State -->
+      <div class="quiz-loading hidden" id="quizLoading">
+        <p>Calculating your perfect ships...</p>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer" role="contentinfo">
+    <p class="tiny muted" style="text-align:center; padding: 2rem;">
+      &copy; 2026 In the Wake. Quiz recommendations are suggestions based on general ship characteristics.
+      <br>Always verify current ship features and itineraries before booking.
+    </p>
+    <p class="trust-badge">✓ No ads. No tracking. No affiliate links.</p>
+  </footer>
+
+  <!-- Dropdown nav script -->
+  <script>
+  (function(){
+    document.querySelectorAll('.nav-dropdown').forEach(dd=>{
+      const btn=dd.querySelector('button');
+      const menu=dd.querySelector('.dropdown-menu');
+      if(!btn||!menu)return;
+      let timeout;
+      const show=()=>{clearTimeout(timeout);btn.setAttribute('aria-expanded','true');menu.style.display='block';};
+      const hide=()=>{timeout=setTimeout(()=>{btn.setAttribute('aria-expanded','false');menu.style.display='none';},300);};
+      dd.addEventListener('mouseenter',show);
+      dd.addEventListener('mouseleave',hide);
+      btn.addEventListener('click',()=>{
+        const open=btn.getAttribute('aria-expanded')==='true';
+        open?hide():show();
+      });
+      btn.addEventListener('keydown',e=>{if(e.key==='Escape')hide();});
+    });
+  })();
+  </script>
+
+  <!-- Quiz Logic -->
+  <script>
+  (function() {
+    'use strict';
+
+    // State
+    let quizData = null;
+    let currentQuestion = 0;
+    let answers = {};
+    let selectedLine = 'all';
+
+    // Line display names
+    const lineNames = {
+      'all': 'All Cruise Lines',
+      'rcl': 'Royal Caribbean',
+      'carnival': 'Carnival',
+      'ncl': 'NCL',
+      'msc': 'MSC'
+    };
+
+    // Questions definition
+    const questions = [
+      {
+        id: 'group_type',
+        question: "Who's sailing with you?",
+        subtitle: "This helps us match the right vibe",
+        options: [
+          { value: 'solo', label: 'Just Me', icon: '🧭', desc: 'Solo adventure' },
+          { value: 'couple', label: 'Me + 1', icon: '💑', desc: 'Couples getaway' },
+          { value: 'friends', label: 'Friend Group', icon: '👯', desc: 'Squad goals' },
+          { value: 'family_young', label: 'Family (Kids 12 & Under)', icon: '👨‍👩‍👧‍👦', desc: 'Young explorers' },
+          { value: 'family_teens', label: 'Family (Teens)', icon: '🎮', desc: 'Teen-approved fun' },
+          { value: 'multigen', label: 'Multi-Generational', icon: '👴👶', desc: 'Grandparents to grandkids' }
+        ],
+        gridClass: 'three-col'
+      },
+      {
+        id: 'cruise_experience',
+        question: "How much have you cruised?",
+        subtitle: "No wrong answer here!",
+        options: [
+          { value: 'first_time', label: 'First Time!', icon: '🌟', desc: 'Excited to discover cruising' },
+          { value: 'a_few', label: 'A Few Cruises', icon: '⚓', desc: "I've got the basics down" },
+          { value: 'seasoned', label: 'Seasoned Sailor', icon: '🧭', desc: 'Lost count of my sailings' }
+        ],
+        gridClass: 'three-col'
+      },
+      {
+        id: 'energy_level',
+        question: "What's your ideal vacation pace?",
+        subtitle: "How do you like to spend your days?",
+        options: [
+          { value: 'relax', label: 'Relaxation Mode', icon: '🧘', desc: 'Pool, spa, quiet corners' },
+          { value: 'balanced', label: 'Best of Both', icon: '⚖️', desc: 'Mix of chill and adventure' },
+          { value: 'go_go_go', label: 'Go Go Go!', icon: '🎢', desc: 'Every activity, every show' }
+        ],
+        gridClass: 'three-col'
+      },
+      {
+        id: 'crowd_tolerance',
+        question: "How do you feel about crowds?",
+        subtitle: "Be honest—it matters for ship selection",
+        options: [
+          { value: 'low', label: 'Keep It Intimate', icon: '🤫', desc: 'Smaller, quieter spaces' },
+          { value: 'medium', label: 'Moderate Is Fine', icon: '👥', desc: 'Some bustle is okay' },
+          { value: 'high', label: 'Bring the Energy!', icon: '🎉', desc: 'Love a lively atmosphere' }
+        ],
+        gridClass: 'three-col'
+      },
+      {
+        id: 'ship_vs_ports',
+        question: "Ship or destinations—what matters more?",
+        subtitle: "Where's your focus?",
+        options: [
+          { value: 'ship', label: 'The Ship IS the Destination', icon: '🚢', desc: 'Onboard experience is everything' },
+          { value: 'balanced', label: 'Equal Mix', icon: '🔄', desc: 'Love both ship and ports' },
+          { value: 'ports', label: 'All About the Ports', icon: '🏝️', desc: 'Ship is just transport' }
+        ],
+        gridClass: 'three-col'
+      },
+      {
+        id: 'sailing_length',
+        question: "How long do you want to sail?",
+        subtitle: "Trip duration preference",
+        options: [
+          { value: 'short', label: '3-4 Nights', icon: '⚡', desc: 'Quick getaway' },
+          { value: 'standard', label: '5-7 Nights', icon: '📅', desc: 'Classic cruise length' },
+          { value: 'long', label: '8+ Nights', icon: '🌎', desc: 'Extended voyage' }
+        ],
+        gridClass: 'three-col'
+      },
+      {
+        id: 'budget_mindset',
+        question: "What's your budget philosophy?",
+        subtitle: "All cruises have value—this is about priorities",
+        options: [
+          { value: 'value', label: 'Smart Value', icon: '💰', desc: 'Best bang for the buck' },
+          { value: 'balanced', label: 'Balanced Approach', icon: '⚖️', desc: 'Worth paying for quality' },
+          { value: 'premium', label: 'Go Premium', icon: '✨', desc: 'The best experience matters most' }
+        ],
+        gridClass: 'three-col'
+      },
+      {
+        id: 'must_have',
+        question: "What's a must-have for you?",
+        subtitle: "Pick the one that matters most",
+        options: [
+          { value: 'waterpark', label: 'Water Slides & Pools', icon: '🌊', desc: 'Splash-tastic fun' },
+          { value: 'dining', label: 'Specialty Dining', icon: '🍽️', desc: 'Foodie experiences' },
+          { value: 'shows', label: 'Live Shows', icon: '🎭', desc: 'Entertainment first' },
+          { value: 'tech', label: 'Unique Thrills', icon: '🎢', desc: 'Go-karts, coasters, iFly' },
+          { value: 'scenic', label: 'Scenic & Relaxation', icon: '🌅', desc: 'Glass, vistas, nature' },
+          { value: 'family', label: 'Kids & Family Zones', icon: '👨‍👩‍👧‍👦', desc: 'Family-focused areas' },
+          { value: 'none', label: 'No Dealbreaker', icon: '🤷', desc: 'Open to anything' }
+        ],
+        gridClass: 'three-col'
+      }
+    ];
+
+    // DOM elements
+    const quizIntro = document.getElementById('quizIntro');
+    const questionsContainer = document.getElementById('questionsContainer');
+    const quizResults = document.getElementById('quizResults');
+    const quizProgress = document.getElementById('quizProgress');
+    const progressText = document.getElementById('progressText');
+    const resultsContainer = document.getElementById('resultsContainer');
+    const btnStart = document.getElementById('btnStart');
+    const btnRestart = document.getElementById('btnRestart');
+    const alsoLikeSection = document.getElementById('alsoLikeSection');
+    const alsoLikeGrid = document.getElementById('alsoLikeGrid');
+
+    // Load quiz data
+    async function loadQuizData() {
+      try {
+        const response = await fetch('/assets/data/ship-quiz-data-v2.json');
+        quizData = await response.json();
+      } catch (error) {
+        console.error('Failed to load quiz data:', error);
+      }
+    }
+
+    // Setup cruise line selector
+    function setupLineSelector() {
+      // Desktop pills
+      document.querySelectorAll('.cruise-line-selector .line-pill').forEach(pill => {
+        pill.addEventListener('click', () => {
+          document.querySelectorAll('.cruise-line-selector .line-pill').forEach(p => p.classList.remove('active'));
+          pill.classList.add('active');
+          selectedLine = pill.dataset.line;
+          updateMobileSelector();
+        });
+      });
+
+      // Mobile dropdown
+      const trigger = document.getElementById('mobileSelectorTrigger');
+      const dropdown = document.getElementById('mobileDropdown');
+
+      trigger.addEventListener('click', () => {
+        dropdown.classList.toggle('open');
+      });
+
+      document.querySelectorAll('#mobileDropdown .line-option').forEach(opt => {
+        opt.addEventListener('click', () => {
+          if (opt.dataset.action === 'close') {
+            dropdown.classList.remove('open');
+            return;
+          }
+          document.querySelectorAll('#mobileDropdown .line-option').forEach(o => o.classList.remove('active'));
+          opt.classList.add('active');
+          selectedLine = opt.dataset.line;
+          updateMobileSelector();
+          dropdown.classList.remove('open');
+
+          // Sync desktop pills
+          document.querySelectorAll('.cruise-line-selector .line-pill').forEach(p => {
+            p.classList.toggle('active', p.dataset.line === selectedLine);
+          });
+        });
+      });
+
+      // Close dropdown on outside click
+      document.addEventListener('click', (e) => {
+        if (!e.target.closest('.line-selector-mobile')) {
+          dropdown.classList.remove('open');
+        }
+      });
+    }
+
+    function updateMobileSelector() {
+      document.getElementById('currentLineName').textContent = lineNames[selectedLine];
+    }
+
+    // Render a question
+    function renderQuestion(index) {
+      const q = questions[index];
+      const isLast = index === questions.length - 1;
+
+      const html = `
+        <div class="quiz-question active" data-question="${q.id}">
+          <div class="question-header">
+            <h2>${q.question}</h2>
+            <p class="question-subtitle">${q.subtitle}</p>
+          </div>
+          <div class="options-grid ${q.gridClass || ''}">
+            ${q.options.map(opt => `
+              <div class="option-card" data-value="${opt.value}" role="button" tabindex="0" aria-pressed="false">
+                <div class="option-icon">${opt.icon}</div>
+                <div class="option-label">${opt.label}</div>
+                <div class="option-desc">${opt.desc}</div>
+              </div>
+            `).join('')}
+          </div>
+          <div class="quiz-nav">
+            <button class="btn-back" type="button" ${index === 0 ? 'disabled' : ''}>Back</button>
+            <button class="btn-next" type="button" disabled>${isLast ? 'See Results' : 'Next'}</button>
+          </div>
+        </div>
+      `;
+
+      questionsContainer.innerHTML = html;
+
+      // Add event listeners
+      const optionCards = questionsContainer.querySelectorAll('.option-card');
+      const btnNext = questionsContainer.querySelector('.btn-next');
+      const btnBack = questionsContainer.querySelector('.btn-back');
+
+      optionCards.forEach(card => {
+        card.addEventListener('click', () => selectOption(card, q.id, btnNext));
+        card.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            selectOption(card, q.id, btnNext);
+          }
+        });
+      });
+
+      btnNext.addEventListener('click', () => {
+        if (isLast) {
+          showResults();
+        } else {
+          currentQuestion++;
+          renderQuestion(currentQuestion);
+          updateProgress();
+        }
+      });
+
+      btnBack.addEventListener('click', () => {
+        if (currentQuestion > 0) {
+          currentQuestion--;
+          renderQuestion(currentQuestion);
+          updateProgress();
+        }
+      });
+
+      // Restore previous selection if exists
+      if (answers[q.id]) {
+        const prevSelected = questionsContainer.querySelector(`[data-value="${answers[q.id]}"]`);
+        if (prevSelected) {
+          prevSelected.classList.add('selected');
+          prevSelected.setAttribute('aria-pressed', 'true');
+          btnNext.disabled = false;
+        }
+      }
+    }
+
+    // Select an option
+    function selectOption(card, questionId, btnNext) {
+      const allCards = card.parentElement.querySelectorAll('.option-card');
+      allCards.forEach(c => {
+        c.classList.remove('selected');
+        c.setAttribute('aria-pressed', 'false');
+      });
+      card.classList.add('selected');
+      card.setAttribute('aria-pressed', 'true');
+      answers[questionId] = card.dataset.value;
+      btnNext.disabled = false;
+    }
+
+    // Update progress indicator
+    function updateProgress() {
+      progressText.textContent = `${currentQuestion + 1} of ${questions.length}`;
+    }
+
+    // Calculate scores for a cruise line
+    function calculateScoresForLine(line) {
+      const classScores = {};
+      const classes = quizData.classes[line];
+      const weights = quizData.scoring_weights[line];
+
+      // Initialize scores
+      for (const className of Object.keys(classes)) {
+        classScores[className] = 0;
+      }
+
+      // Apply weights for each answer
+      for (const [questionId, answer] of Object.entries(answers)) {
+        if (weights[questionId] && weights[questionId][answer]) {
+          const scoreAdjustments = weights[questionId][answer];
+          for (const [className, points] of Object.entries(scoreAdjustments)) {
+            if (classScores.hasOwnProperty(className)) {
+              classScores[className] += points;
+            }
+          }
+        }
+      }
+
+      // Apply must_have bonuses
+      const mustHave = answers.must_have;
+      if (mustHave && mustHave !== 'none' && quizData.must_have_bonuses[mustHave]) {
+        const bonuses = quizData.must_have_bonuses[mustHave][line];
+        if (bonuses) {
+          for (const [className, bonus] of Object.entries(bonuses)) {
+            if (classScores.hasOwnProperty(className)) {
+              classScores[className] += bonus;
+            }
+          }
+        }
+      }
+
+      return classScores;
+    }
+
+    // Get top ships for a class
+    function getTopShipsForClass(line, className, count = 2) {
+      const ships = Object.entries(quizData.ships[line])
+        .filter(([_, ship]) => ship.class === className && ship.status === 'active')
+        .sort((a, b) => b[1].year - a[1].year)
+        .slice(0, count);
+
+      return ships.map(([slug, ship]) => ({ slug, ...ship, line }));
+    }
+
+    // Generate narrative for a ship
+    function generateNarrative(ship, classData, line) {
+      const parts = [classData.description];
+
+      if (answers.group_type === 'family_young' && classData.intensity >= 7) {
+        parts.push(`With kids in tow, you'll love the dedicated family areas.`);
+      }
+      if (answers.energy_level === 'relax' && classData.intensity <= 5) {
+        parts.push(`The more relaxed atmosphere is perfect for your laid-back vacation style.`);
+      }
+      if (ship.amplified) {
+        parts.push(`Recently refreshed with modern amenities.`);
+      }
+
+      return parts.join(' ');
+    }
+
+    // Generate why explanation with score breakdown
+    function generateWhy(ship, classData, line, scoreBreakdown, rank) {
+      const reasons = [];
+
+      if (rank === 1) {
+        reasons.push('Top match for your preferences');
+      }
+
+      const groupMatches = {
+        'solo': { intensity: [3, 6], reason: 'solo travelers' },
+        'couple': { intensity: [4, 8], reason: 'couples' },
+        'family_young': { intensity: [7, 10], reason: 'families with kids' },
+        'family_teens': { intensity: [7, 10], reason: 'families with teens' }
+      };
+
+      if (groupMatches[answers.group_type]) {
+        const match = groupMatches[answers.group_type];
+        if (classData.intensity >= match.intensity[0] && classData.intensity <= match.intensity[1]) {
+          reasons.push(`Great for ${match.reason}`);
+        }
+      }
+
+      if (answers.energy_level === 'relax' && classData.intensity <= 5) {
+        reasons.push('Matches your relaxed pace');
+      }
+      if (answers.energy_level === 'go_go_go' && classData.intensity >= 8) {
+        reasons.push('Endless activities for your go-go-go style');
+      }
+
+      return {
+        summary: reasons.slice(0, 2).join('. ') + (reasons.length > 0 ? '.' : 'A great match based on your preferences.'),
+        breakdown: scoreBreakdown
+      };
+    }
+
+    // Show results
+    function showResults() {
+      questionsContainer.classList.add('hidden');
+      quizProgress.classList.remove('visible');
+
+      const linesToScore = selectedLine === 'all'
+        ? ['rcl', 'carnival', 'ncl', 'msc']
+        : [selectedLine];
+
+      // Calculate scores for all selected lines
+      const allResults = [];
+      const scoresByLine = {};
+
+      for (const line of linesToScore) {
+        const scores = calculateScoresForLine(line);
+        scoresByLine[line] = scores;
+
+        const sortedClasses = Object.entries(scores)
+          .sort((a, b) => b[1] - a[1]);
+
+        for (const [className, score] of sortedClasses) {
+          const ships = getTopShipsForClass(line, className, 2);
+          for (const ship of ships) {
+            allResults.push({
+              ship,
+              classData: quizData.classes[line][className],
+              className,
+              line,
+              score,
+              lineData: quizData.cruise_lines[line]
+            });
+          }
+        }
+      }
+
+      // Sort all results by score and take top 3
+      allResults.sort((a, b) => b.score - a.score);
+      const topResults = allResults.slice(0, 3);
+
+      // Render results
+      resultsContainer.innerHTML = topResults.map((rec, idx) => {
+        const { ship, classData, className, line, score, lineData } = rec;
+        const narrative = generateNarrative(ship, classData, line);
+        const matchPercent = Math.min(99, Math.round(50 + score));
+
+        const scoreBreakdown = [];
+        const weights = quizData.scoring_weights[line];
+        for (const [qId, answer] of Object.entries(answers)) {
+          if (weights[qId] && weights[qId][answer] && weights[qId][answer][className]) {
+            const pts = weights[qId][answer][className];
+            const qLabel = questions.find(q => q.id === qId)?.question || qId;
+            scoreBreakdown.push({ label: qLabel.replace("?", ""), points: pts });
+          }
+        }
+
+        const why = generateWhy(ship, classData, line, scoreBreakdown, idx + 1);
+
+        return `
+          <article class="result-card ${idx === 0 ? 'top-pick' : ''}">
+            <div class="result-brand-bar ${line}"></div>
+            <div class="result-image">
+              <img src="${ship.image}"
+                   alt="${ship.name}"
+                   loading="${idx === 0 ? 'eager' : 'lazy'}"
+                   onerror="this.src='/assets/social/ships-hero.jpg'">
+              <span class="result-badge">Top Pick</span>
+              <span class="result-match">${matchPercent}% Match</span>
+            </div>
+            <div class="result-content">
+              <div class="result-title">
+                <h3>${ship.name}</h3>
+                <div class="result-badges">
+                  <span class="result-line ${line}">${lineData.short_name}</span>
+                  <span class="result-class">${classData.name}</span>
+                </div>
+              </div>
+              <p class="result-narrative">${narrative}</p>
+              <div class="result-specs">
+                <div class="spec-item">
+                  <span class="spec-label">Year</span>
+                  <span class="spec-value">${ship.year}</span>
+                </div>
+                <div class="spec-item">
+                  <span class="spec-label">Size</span>
+                  <span class="spec-value">${(ship.gt / 1000).toFixed(0)}K GT</span>
+                </div>
+                <div class="spec-item">
+                  <span class="spec-label">Guests</span>
+                  <span class="spec-value">${ship.capacity.toLocaleString()}</span>
+                </div>
+              </div>
+              <div class="result-highlights">
+                ${ship.highlights.slice(0, 3).map(h => `<span class="highlight-tag">${h}</span>`).join('')}
+              </div>
+              <div class="result-why">
+                <div class="result-why-header" onclick="this.nextElementSibling.nextElementSibling.classList.toggle('open'); this.querySelector('.result-why-toggle').textContent = this.nextElementSibling.nextElementSibling.classList.contains('open') ? 'Hide details' : 'Show details';">
+                  <span class="result-why-title">Why this ship?</span>
+                  <span class="result-why-toggle">Show details</span>
+                </div>
+                <p class="result-why-text">${why.summary}</p>
+                <div class="result-why-details">
+                  <div class="score-breakdown">
+                    ${why.breakdown.slice(0, 5).map(b => `
+                      <div class="score-row">
+                        <span class="label">${b.label}</span>
+                        <span class="points">${b.points > 0 ? '+' : ''}${b.points} pts</span>
+                      </div>
+                    `).join('')}
+                  </div>
+                </div>
+              </div>
+              <a href="${ship.page}" class="result-cta">
+                Explore ${ship.name.split(' of ')[0]} →
+              </a>
+            </div>
+          </article>
+        `;
+      }).join('');
+
+      // Show "You Might Also Like" if filtered to single line
+      if (selectedLine !== 'all') {
+        const otherLines = ['rcl', 'carnival', 'ncl', 'msc'].filter(l => l !== selectedLine);
+        const otherResults = [];
+
+        for (const line of otherLines) {
+          const scores = calculateScoresForLine(line);
+          const sortedClasses = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+
+          if (sortedClasses.length > 0) {
+            const [topClass, topScore] = sortedClasses[0];
+            const ships = getTopShipsForClass(line, topClass, 1);
+            if (ships.length > 0) {
+              otherResults.push({
+                ship: ships[0],
+                line,
+                score: topScore,
+                lineData: quizData.cruise_lines[line]
+              });
+            }
+          }
+        }
+
+        if (otherResults.length > 0) {
+          otherResults.sort((a, b) => b.score - a.score);
+
+          alsoLikeGrid.innerHTML = otherResults.map(r => {
+            const matchPercent = Math.min(99, Math.round(50 + r.score));
+            return `
+              <a href="${r.ship.page}" class="also-like-card">
+                <div class="ship-name">${r.ship.name}</div>
+                <div class="ship-line" style="color:${r.lineData.colors.primary}">${r.lineData.short_name}</div>
+                <div class="ship-match">${matchPercent}% match</div>
+              </a>
+            `;
+          }).join('');
+
+          alsoLikeSection.classList.remove('hidden');
+        }
+      } else {
+        alsoLikeSection.classList.add('hidden');
+      }
+
+      // Update share section
+      const topRec = topResults[0];
+      const topMatchPercent = Math.min(99, Math.round(50 + topRec.score));
+      updateShareSection(topRec.ship, topMatchPercent, topRec.lineData, topRec.classData);
+
+      quizResults.classList.add('active');
+      quizResults.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
+    // Start quiz
+    function startQuiz() {
+      quizIntro.classList.add('hidden');
+      questionsContainer.classList.remove('hidden');
+      quizProgress.classList.add('visible');
+      currentQuestion = 0;
+      answers = {};
+      renderQuestion(currentQuestion);
+      updateProgress();
+    }
+
+    // Restart quiz
+    function restartQuiz() {
+      quizResults.classList.remove('active');
+      quizIntro.classList.remove('hidden');
+      questionsContainer.classList.add('hidden');
+      quizProgress.classList.remove('visible');
+      alsoLikeSection.classList.add('hidden');
+      currentQuestion = 0;
+      answers = {};
+      history.replaceState({}, '', window.location.pathname);
+    }
+
+    // ==========================================
+    // SHARING FUNCTIONALITY
+    // ==========================================
+
+    let currentTopShip = null;
+    let currentMatchPercent = 0;
+    let currentLineName = '';
+    let currentClassName = '';
+
+    function generateShareURL() {
+      const data = { answers, line: selectedLine };
+      const encoded = btoa(JSON.stringify(data));
+      return `${window.location.origin}${window.location.pathname}?r=${encoded}`;
+    }
+
+    function parseShareURL() {
+      const params = new URLSearchParams(window.location.search);
+      const encoded = params.get('r');
+      const lineParam = params.get('line');
+
+      if (lineParam && ['all', 'rcl', 'carnival', 'ncl', 'msc'].includes(lineParam)) {
+        selectedLine = lineParam;
+        document.querySelectorAll('.cruise-line-selector .line-pill').forEach(p => {
+          p.classList.toggle('active', p.dataset.line === selectedLine);
+        });
+        updateMobileSelector();
+      }
+
+      if (encoded) {
+        try {
+          const data = JSON.parse(atob(encoded));
+          answers = data.answers || {};
+          if (data.line) {
+            selectedLine = data.line;
+            document.querySelectorAll('.cruise-line-selector .line-pill').forEach(p => {
+              p.classList.toggle('active', p.dataset.line === selectedLine);
+            });
+            updateMobileSelector();
+          }
+          return true;
+        } catch (e) {
+          console.error('Invalid share URL');
+        }
+      }
+      return false;
+    }
+
+    function generateShareText(ship, matchPercent, lineName) {
+      return `My perfect cruise ship is ${ship.name}! 🚢\n\n${matchPercent}% match for my travel style (${lineName}).\n\nFind your perfect ship:`;
+    }
+
+    function updateShareSection(ship, matchPercent, lineData, classData) {
+      currentTopShip = ship;
+      currentMatchPercent = matchPercent;
+      currentLineName = lineData.name;
+      currentClassName = classData.name;
+
+      const sharePreview = document.getElementById('sharePreview');
+      sharePreview.innerHTML = `
+        <strong>"My perfect ship is ${ship.name}!"</strong><br>
+        ${matchPercent}% match • ${lineData.short_name} • ${classData.name}
+      `;
+    }
+
+    async function copyShareLink() {
+      const url = generateShareURL();
+      try {
+        await navigator.clipboard.writeText(url);
+        const copiedMsg = document.getElementById('copiedMsg');
+        copiedMsg.classList.add('show');
+        setTimeout(() => copiedMsg.classList.remove('show'), 2000);
+      } catch (err) {
+        const textarea = document.createElement('textarea');
+        textarea.value = url;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+        const copiedMsg = document.getElementById('copiedMsg');
+        copiedMsg.classList.add('show');
+        setTimeout(() => copiedMsg.classList.remove('show'), 2000);
+      }
+    }
+
+    async function nativeShare() {
+      const shareURL = generateShareURL();
+      const shareText = generateShareText(currentTopShip, currentMatchPercent, currentLineName);
+
+      if (navigator.share) {
+        try {
+          await navigator.share({
+            title: `My Perfect Ship: ${currentTopShip.name}`,
+            text: shareText,
+            url: shareURL
+          });
+        } catch (err) {
+          console.error('Share failed:', err);
+        }
+      } else {
+        copyShareLink();
+      }
+    }
+
+    async function downloadShareImage() {
+      const canvas = document.getElementById('shareCanvas');
+      const ctx = canvas.getContext('2d');
+
+      // Draw background
+      const bgGrad = ctx.createLinearGradient(0, 0, 1200, 630);
+      bgGrad.addColorStop(0, '#0a3d62');
+      bgGrad.addColorStop(1, '#083041');
+      ctx.fillStyle = bgGrad;
+      ctx.fillRect(0, 0, 1200, 630);
+
+      // Content
+      ctx.fillStyle = 'rgba(255,255,255,0.7)';
+      ctx.font = '24px system-ui, sans-serif';
+      ctx.fillText('My Perfect Cruise Ship Is', 80, 150);
+
+      ctx.fillStyle = '#ffffff';
+      ctx.font = 'bold 48px system-ui, sans-serif';
+      ctx.fillText(currentTopShip.name, 80, 220);
+
+      ctx.fillStyle = '#d9b382';
+      ctx.font = '600 24px system-ui, sans-serif';
+      ctx.fillText(`${currentMatchPercent}% Match • ${currentLineName}`, 80, 280);
+
+      ctx.fillStyle = 'rgba(255,255,255,0.6)';
+      ctx.font = '20px system-ui, sans-serif';
+      ctx.fillText('Find your perfect ship at', 80, 400);
+
+      ctx.fillStyle = '#d9b382';
+      ctx.font = 'bold 24px system-ui, sans-serif';
+      ctx.fillText('cruisinginthewake.com/ships/allshipquiz.html', 80, 440);
+
+      ctx.fillStyle = 'rgba(255,255,255,0.8)';
+      ctx.font = '600 16px system-ui, sans-serif';
+      ctx.textAlign = 'right';
+      ctx.fillText('In the Wake', 1120, 560);
+      ctx.textAlign = 'left';
+
+      const link = document.createElement('a');
+      link.download = `my-perfect-ship-${currentTopShip.slug || 'result'}.png`;
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+    }
+
+    function setupShareListeners() {
+      document.getElementById('btnNativeShare').addEventListener('click', nativeShare);
+      document.getElementById('btnCopyLink').addEventListener('click', copyShareLink);
+      document.getElementById('btnDownloadImage').addEventListener('click', downloadShareImage);
+
+      if (!navigator.share) {
+        document.getElementById('btnNativeShare').style.display = 'none';
+      }
+    }
+
+    // Initialize
+    async function init() {
+      await loadQuizData();
+      setupLineSelector();
+      btnStart.addEventListener('click', startQuiz);
+      btnRestart.addEventListener('click', restartQuiz);
+      setupShareListeners();
+
+      if (parseShareURL()) {
+        quizIntro.classList.add('hidden');
+        showResults();
+      }
+    }
+
+    init();
+  })();
+  </script>
+
+  <!-- Navigation dropdown/mobile menu -->
+  <script src="/assets/js/dropdown.js"></script>
+</body>
+</html>


### PR DESCRIPTION
- Create ship-quiz-data-v2.json with 4 cruise lines:
  - Royal Caribbean (7 classes, 29 ships)
  - Carnival (9 classes, 27 ships)
  - NCL (9 classes, 21 ships)
  - MSC (8 classes, 24 ships)
- Create allshipquiz.html with:
  - Pill selector UI for cruise line filtering
  - Brand-aware color coding (navy/gold RCL, red/blue Carnival, etc.)
  - Mobile hamburger menu with escape rope
  - "You Might Also Like" cross-line recommendations
  - "Why This Ship?" expandable score breakdown
  - URL sharing with line and result params
  - 3-tier cruise_experience scale (first_time/a_few/seasoned)
- Includes CDC health scores and food modifiers
- Ready for soft launch testing