### PR TITLE
feat(ports): Add 5 Patagonia/Antarctica expedition pages

### DIFF
--- a/ports.html
+++ b/ports.html
@@ -888,17 +888,17 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
         <h3>Chilean Fjords (Scenic Cruising)</h3>
         <ul>
-          <li><strong>Chilean Fjords</strong> — Dramatic scenery comparable to Alaska/Norway</li>
-          <li><strong>Strait of Magellan</strong> — Historic passage between Atlantic and Pacific</li>
-          <li><strong>Glacier Alley</strong> — Multiple glaciers along Beagle Channel</li>
+          <li><strong><a href="/ports/chilean-fjords.html">Chilean Fjords</a></strong> — Dramatic scenery comparable to Alaska/Norway</li>
+          <li><strong><a href="/ports/strait-of-magellan.html">Strait of Magellan</a></strong> — Historic passage between Atlantic and Pacific</li>
+          <li><strong><a href="/ports/glacier-alley.html">Glacier Alley</a></strong> — Multiple glaciers along Beagle Channel</li>
         </ul>
 
         <h3>Antarctica</h3>
         <p>Royal Caribbean offers expedition-style Antarctic cruises from November through February.</p>
         <ul>
-          <li><strong>Antarctic Peninsula</strong> — Icebergs, penguins, seals, whales</li>
+          <li><strong><a href="/ports/antarctic-peninsula.html">Antarctic Peninsula</a></strong> — Icebergs, penguins, seals, whales</li>
           <li><strong><a href="/ports/drake-passage.html">Drake Passage</a></strong> — Notoriously rough crossing from South America</li>
-          <li><strong>South Shetland Islands</strong> — Research stations, wildlife colonies</li>
+          <li><strong><a href="/ports/south-shetland-islands.html">South Shetland Islands</a></strong> — Research stations, wildlife colonies</li>
         </ul>
 
         <p class="tiny">Note: Antarctica is bucket-list cruising. Ships must navigate pack ice, landings depend on weather. Zodiac excursions common. Bring warm, waterproof layers.</p>

--- a/ports/antarctic-peninsula.html
+++ b/ports/antarctic-peninsula.html
@@ -1,0 +1,362 @@
+<!--
+Soli Deo Gloria
+
+"The heavens declare the glory of God;
+the skies proclaim the work of his hands."
+- Psalm 19:1
+
+ITW-Lite v3.010 | ICP-Lite v1.4
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Antarctic Peninsula Cruise Guide 2025 | Expedition Landings | In the Wake</title>
+    <meta
+      name="description"
+      content="Antarctic Peninsula expedition cruise guide. Zodiac landings, penguin colonies, glacier views. The most accessible part of Antarctica for cruise passengers."
+    />
+    <meta
+      name="ai-summary"
+      content="Antarctic Peninsula is most-visited part of Antarctica. 800-mile mountainous stretch extending toward South America. Zodiac landings at research stations, penguin rookeries. Nov-Mar season. Wildlife: gentoo, chinstrap, Adelie penguins, leopard seals, whales."
+    />
+    <meta name="last-reviewed" content="2026-01-03" />
+    <meta name="content-protocol" content="ICP-Lite v1.4" />
+    <meta
+      name="keywords"
+      content="Antarctic Peninsula cruise, expedition landing, penguin colonies, Zodiac excursion, polar expedition, Antarctica wildlife"
+    />
+    <link rel="canonical" href="https://inthewake.io/ports/antarctic-peninsula" />
+
+    <!-- Open Graph -->
+    <meta
+      property="og:title"
+      content="Antarctic Peninsula Cruise Guide 2025 | Expedition Landings"
+    />
+    <meta
+      property="og:description"
+      content="Complete guide to Antarctic Peninsula expedition landings. Penguin colonies, research stations, and pristine wilderness."
+    />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://inthewake.io/ports/antarctic-peninsula" />
+    <meta
+      property="og:image"
+      content="https://inthewake.io/images/ports/antarctic-peninsula-og.jpg"
+    />
+
+    <!-- Structured Data: BreadcrumbList -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://inthewake.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Ports",
+            "item": "https://inthewake.io/ports"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Antarctic Peninsula",
+            "item": "https://inthewake.io/ports/antarctic-peninsula"
+          }
+        ]
+      }
+    </script>
+
+    <!-- Structured Data: WebPage with Place -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Antarctic Peninsula Cruise Guide",
+        "description": "Complete guide to expedition cruising along the Antarctic Peninsula",
+        "mainEntity": {
+          "@type": "Place",
+          "name": "Antarctic Peninsula",
+          "description": "The northernmost part of mainland Antarctica, extending toward South America",
+          "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": -65.5,
+            "longitude": -64.0
+          }
+        }
+      }
+    </script>
+
+    <!-- Structured Data: FAQPage -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "How do you land on the Antarctic Peninsula?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Landings are made via Zodiac inflatable boats. Ships anchor offshore and Zodiacs ferry passengers to shore. IAATO regulations limit landings to 100 passengers at a time. Dry landings on rocks or wet landings through shallow water are typical."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What wildlife can you see on the Antarctic Peninsula?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The Antarctic Peninsula hosts massive penguin colonies (gentoo, chinstrap, Adelie), leopard seals, Weddell seals, humpback whales, orcas, and numerous seabirds including albatross and petrels. Wildlife is remarkably unafraid of humans."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "When is the best time to cruise the Antarctic Peninsula?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "November-March is the Antarctic summer. November-December offers pristine snow and penguin courtship. January-February has warmest temps (up to 40°F) and penguin chicks. March sees whale activity and dramatic lighting."
+            }
+          }
+        ]
+      }
+    </script>
+
+    <link rel="stylesheet" href="/assets/css/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a href="/" class="logo">In The Wake</a>
+        <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+        <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+        <ul class="nav-links">
+          <li><a href="/ships.html">Ships</a></li>
+          <li><a href="/ports.html">Ports</a></li>
+          <li><a href="/tips/">Tips</a></li>
+          <li><a href="/news/">News</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="port-guide">
+      <article class="port-content">
+        <header class="port-header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="/">Home</a></li>
+              <li><a href="/ports.html">Ports</a></li>
+              <li aria-current="page">Antarctic Peninsula</li>
+            </ol>
+          </nav>
+          <h1>Antarctic Peninsula Cruise Guide</h1>
+          <p class="port-intro">
+            The Antarctic Peninsula is Earth's final frontier — an 800-mile spine of mountains, glaciers, and ice shelves extending toward South America. This is where most expedition cruises make their landings, offering intimate encounters with penguin colonies numbering in the hundreds of thousands, curious seals lounging on ice floes, and whales feeding in pristine waters.
+          </p>
+        </header>
+
+        <!-- Logbook Entry -->
+        <section class="logbook-entry">
+          <h2>From the Logbook</h2>
+          <blockquote>
+            <p>
+              "The Zodiac crunched onto the pebble beach at Neko Harbour, and within seconds we were surrounded by gentoo penguins going about their business as if we weren't there. The smell hit first — that unmistakable musky penguin odor that somehow becomes endearing. Behind us, a massive glacier calved with a thunderous crack, sending waves rippling across the bay. We had twenty minutes until the next group arrived. In that moment, standing among thousands of penguins beneath Antarctic peaks, I understood why explorers gave everything to reach this place."
+            </p>
+            <cite>— Expedition landing, Neko Harbour, Antarctic Peninsula</cite>
+          </blockquote>
+          <p class="highlight">
+            <strong>Highlight:</strong> Watching a leopard seal surface just feet from our Zodiac, its spotted coat glistening, eyes tracking us with intelligent curiosity before slipping silently back beneath the ice-blue water.
+          </p>
+        </section>
+
+        <!-- Main Content Sections -->
+        <section class="port-section">
+          <h2>Popular Landing Sites</h2>
+          <p>
+            IAATO (International Association of Antarctica Tour Operators) manages over 200 designated landing sites. Weather and ice conditions determine which sites are accessible on any given day. Popular peninsula landings include:
+          </p>
+          <ul>
+            <li><strong>Neko Harbour</strong> — Mainland Antarctica landing, gentoo colony, dramatic glacier backdrop</li>
+            <li><strong>Paradise Harbour</strong> — Aptly named bay, Argentine research station, Zodiac cruising among icebergs</li>
+            <li><strong>Port Lockroy</strong> — Historic British base, post office, museum, gentoo penguins</li>
+            <li><strong>Cuverville Island</strong> — Massive gentoo penguin colony, iceberg alley approach</li>
+            <li><strong>Deception Island</strong> — Active volcanic caldera, hot springs, abandoned whaling station</li>
+            <li><strong>Lemaire Channel</strong> — Scenic cruising through narrow passage, towering cliffs</li>
+            <li><strong>Petermann Island</strong> — Southernmost gentoo colony, Adelie penguins</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Wildlife Encounters</h2>
+          <p>
+            The Antarctic Peninsula hosts an extraordinary concentration of wildlife during the austral summer:
+          </p>
+          <ul>
+            <li><strong>Penguins</strong> — Gentoo, chinstrap, and Adelie penguins breed in massive colonies. Approach distances are regulated, but penguins often approach visitors</li>
+            <li><strong>Seals</strong> — Leopard seals (apex predators), Weddell seals, crabeater seals, elephant seals on beaches</li>
+            <li><strong>Whales</strong> — Humpback whales are common, often bubble-net feeding. Orcas hunt in pods. Minke whales surface near Zodiacs</li>
+            <li><strong>Seabirds</strong> — Wandering albatross, southern giant petrels, skuas, blue-eyed cormorants</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Expedition Logistics</h2>
+          <p>
+            Antarctic Peninsula landings require proper preparation:
+          </p>
+          <ul>
+            <li><strong>Zodiac boarding</strong> — Wear waterproof boots (often provided). Wet or dry landings depending on site</li>
+            <li><strong>IAATO guidelines</strong> — Maximum 100 passengers ashore at once. Maintain 5-meter distance from wildlife (unless they approach you)</li>
+            <li><strong>Biosecurity</strong> — Vacuum all gear before departure. Boot washing stations before/after each landing</li>
+            <li><strong>Weather dependency</strong> — Landings canceled in high winds, poor visibility, or dangerous swells. Flexibility essential</li>
+            <li><strong>Duration</strong> — Typical landing 1.5-2.5 hours. Often two landings per day when conditions allow</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Research Stations</h2>
+          <p>
+            The Antarctic Peninsula has the highest concentration of research stations in Antarctica. Some welcome cruise visitors:
+          </p>
+          <ul>
+            <li><strong>Port Lockroy (UK)</strong> — Historic base turned museum, operational post office, gentoo colony</li>
+            <li><strong>Vernadsky Station (Ukraine)</strong> — Offers bar visits, vodka, and souvenirs</li>
+            <li><strong>Almirante Brown (Argentina)</strong> — Paradise Bay, limited access</li>
+            <li><strong>Palmer Station (USA)</strong> — Anvers Island, occasional tours for American expedition ships</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Practical Information</h2>
+          <ul>
+            <li><strong>Season</strong> — November through March (Antarctic summer)</li>
+            <li><strong>Temperature</strong> — 20-40°F (-6 to 4°C) typical during landings</li>
+            <li><strong>Daylight</strong> — Near 24-hour daylight in December/January</li>
+            <li><strong>Clothing</strong> — Expedition parka (usually provided), waterproof pants, layers, warm hat, gloves</li>
+            <li><strong>Photography</strong> — Extra batteries (cold drains them fast), waterproof bag for Zodiac rides</li>
+            <li><strong>Motion sickness</strong> — Medication recommended for Drake Passage crossing</li>
+          </ul>
+        </section>
+
+        <!-- Port Map -->
+        <section class="port-section">
+          <h2>Antarctic Peninsula Map</h2>
+          <div id="port-map" style="height: 400px; border-radius: 8px"></div>
+        </section>
+
+        <!-- FAQ Section -->
+        <section class="port-faq">
+          <h2>Frequently Asked Questions</h2>
+          <details>
+            <summary>How do you land on the Antarctic Peninsula?</summary>
+            <p>
+              Landings are made via Zodiac inflatable boats. Ships anchor offshore and Zodiacs ferry passengers to shore. IAATO regulations limit landings to 100 passengers at a time. Dry landings on rocks or wet landings through shallow water are typical. Expedition staff assist with boarding and disembarking.
+            </p>
+          </details>
+          <details>
+            <summary>What wildlife can you see on the Antarctic Peninsula?</summary>
+            <p>
+              The Antarctic Peninsula hosts massive penguin colonies (gentoo, chinstrap, Adelie), leopard seals, Weddell seals, humpback whales, orcas, and numerous seabirds including albatross and petrels. Wildlife is remarkably unafraid of humans due to the absence of land predators.
+            </p>
+          </details>
+          <details>
+            <summary>When is the best time to cruise the Antarctic Peninsula?</summary>
+            <p>
+              November-March is the Antarctic summer. November-December offers pristine snow and penguin courtship rituals. January-February has the warmest temperatures (up to 40°F) and penguin chicks. March sees increased whale activity and dramatic late-season lighting.
+            </p>
+          </details>
+          <details>
+            <summary>Can you set foot on mainland Antarctica?</summary>
+            <p>
+              Yes. Neko Harbour and Paradise Harbour are popular landing sites on the Antarctic continent itself (not just islands). You'll receive a certificate for "setting foot on the 7th continent."
+            </p>
+          </details>
+        </section>
+
+        <!-- Disclaimers -->
+        <aside class="disclaimers">
+          <p>
+            <strong>Landing Conditions:</strong> Antarctic landings are weather-dependent. Expedition leaders make final decisions based on safety. Itineraries are flexible — no specific landing site is guaranteed.
+          </p>
+          <p>
+            <strong>IAATO Compliance:</strong> All reputable operators follow IAATO guidelines. Verify your cruise line is an IAATO member before booking.
+          </p>
+        </aside>
+      </article>
+
+      <!-- Rail Sidebar -->
+      <aside class="port-rail">
+        <div class="rail-section">
+          <h3>Quick Answer</h3>
+          <p>
+            The Antarctic Peninsula is the most accessible part of Antarctica, offering Zodiac landings at penguin colonies, research stations, and pristine wilderness. Massive wildlife concentrations, dramatic ice formations, and genuine expedition adventure.
+          </p>
+        </div>
+
+        <div class="rail-section">
+          <h3>Best For</h3>
+          <ul>
+            <li>Penguin colony visits</li>
+            <li>Wildlife photography</li>
+            <li>Zodiac expeditions</li>
+            <li>Bucket-list adventure</li>
+            <li>Pristine wilderness</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Key Facts</h3>
+          <ul>
+            <li><strong>Length:</strong> ~800 miles</li>
+            <li><strong>Season:</strong> Nov-Mar</li>
+            <li><strong>Temps:</strong> 20-40°F</li>
+            <li><strong>Access:</strong> Zodiac only</li>
+            <li><strong>Gateway:</strong> Ushuaia, Argentina</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Related Pages</h3>
+          <ul>
+            <li><a href="/ports/antarctica.html">Antarctica Overview</a></li>
+            <li><a href="/ports/drake-passage.html">Drake Passage</a></li>
+            <li><a href="/ports/ushuaia.html">Ushuaia</a></li>
+            <li><a href="/ports/south-shetland-islands.html">South Shetland Islands</a></li>
+            <li><a href="/ports/falkland-islands.html">Falkland Islands</a></li>
+          </ul>
+        </div>
+      </aside>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 In The Wake. All rights reserved.</p>
+      <p class="disclaimer">
+        Not affiliated with Royal Caribbean International.
+      </p>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        var map = L.map("port-map").setView([-65.5, -64.0], 5);
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          attribution: "&copy; OpenStreetMap contributors",
+        }).addTo(map);
+        L.marker([-64.83, -62.87]).addTo(map).bindPopup("Neko Harbour");
+        L.marker([-64.85, -62.90]).addTo(map).bindPopup("Paradise Harbour");
+        L.marker([-64.82, -63.48]).addTo(map).bindPopup("Port Lockroy");
+        L.marker([-62.97, -60.55]).addTo(map).bindPopup("Deception Island");
+        L.marker([-64.73, -63.57]).addTo(map).bindPopup("Cuverville Island");
+      });
+    </script>
+  </body>
+</html>

--- a/ports/chilean-fjords.html
+++ b/ports/chilean-fjords.html
@@ -1,0 +1,343 @@
+<!--
+Soli Deo Gloria
+
+"The mountains rose, the valleys sank down
+to the place that you appointed for them."
+- Psalm 104:8
+
+ITW-Lite v3.010 | ICP-Lite v1.4
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chilean Fjords Cruise Guide 2025 | Patagonia Scenic Cruising | In the Wake</title>
+    <meta
+      name="description"
+      content="Chilean Fjords scenic cruising guide. Dramatic Patagonian landscapes rivaling Norway and Alaska. Glaciers, waterfalls, and pristine wilderness by ship."
+    />
+    <meta
+      name="ai-summary"
+      content="Chilean Fjords scenic cruising between Puerto Montt and Punta Arenas. Dramatic landscapes rivaling Norway/Alaska. Glaciers calving into sea, waterfalls, dense forests. No dock stops - scenic cruising only. Best on weather-dependent days."
+    />
+    <meta name="last-reviewed" content="2026-01-03" />
+    <meta name="content-protocol" content="ICP-Lite v1.4" />
+    <meta
+      name="keywords"
+      content="Chilean Fjords, Patagonia cruise, scenic cruising, Chile glaciers, fjord cruise, Patagonian channels"
+    />
+    <link rel="canonical" href="https://inthewake.io/ports/chilean-fjords" />
+
+    <!-- Open Graph -->
+    <meta
+      property="og:title"
+      content="Chilean Fjords Cruise Guide 2025 | Patagonia Scenic Cruising"
+    />
+    <meta
+      property="og:description"
+      content="Complete guide to cruising the Chilean Fjords. Patagonian glaciers, dramatic channels, and pristine wilderness."
+    />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://inthewake.io/ports/chilean-fjords" />
+    <meta
+      property="og:image"
+      content="https://inthewake.io/images/ports/chilean-fjords-og.jpg"
+    />
+
+    <!-- Structured Data: BreadcrumbList -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://inthewake.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Ports",
+            "item": "https://inthewake.io/ports"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Chilean Fjords",
+            "item": "https://inthewake.io/ports/chilean-fjords"
+          }
+        ]
+      }
+    </script>
+
+    <!-- Structured Data: WebPage with Place -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Chilean Fjords Cruise Guide",
+        "description": "Complete guide to scenic cruising through the Chilean Fjords of Patagonia",
+        "mainEntity": {
+          "@type": "Place",
+          "name": "Chilean Fjords",
+          "description": "Network of dramatic fjords, channels, and glaciers in Chilean Patagonia",
+          "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": -48.5,
+            "longitude": -74.5
+          }
+        }
+      }
+    </script>
+
+    <!-- Structured Data: FAQPage -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "How do Chilean Fjords compare to Norway and Alaska?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The Chilean Fjords rival Norway and Alaska in dramatic scenery — steep mountains plunging into narrow channels, glaciers calving into the sea, and dense temperate rainforest. Less developed tourism infrastructure means more pristine wilderness, but also fewer landing opportunities."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "When is the best time to cruise the Chilean Fjords?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "December through March is the Southern Hemisphere summer with longer daylight (18+ hours in December) and milder temperatures. The fjords receive significant rainfall year-round; rain gear is essential regardless of season."
+            }
+          }
+        ]
+      }
+    </script>
+
+    <link rel="stylesheet" href="/assets/css/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a href="/" class="logo">In The Wake</a>
+        <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+        <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+        <ul class="nav-links">
+          <li><a href="/ships.html">Ships</a></li>
+          <li><a href="/ports.html">Ports</a></li>
+          <li><a href="/tips/">Tips</a></li>
+          <li><a href="/news/">News</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="port-guide">
+      <article class="port-content">
+        <header class="port-header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="/">Home</a></li>
+              <li><a href="/ports.html">Ports</a></li>
+              <li aria-current="page">Chilean Fjords</li>
+            </ol>
+          </nav>
+          <p class="port-type"><span class="badge">Scenic Cruising</span></p>
+          <h1>Chilean Fjords Cruise Guide</h1>
+          <p class="port-intro">
+            The Chilean Fjords stretch over 1,000 miles along Patagonia's fragmented coastline — a labyrinth of narrow channels, towering granite peaks, and glaciers spilling into the sea. Often compared to Norway and Alaska, these fjords offer some of South America's most dramatic scenery, witnessed entirely from the ship as you navigate waterways carved by ice over millennia.
+          </p>
+        </header>
+
+        <!-- Logbook Entry -->
+        <section class="logbook-entry">
+          <h2>From the Logbook</h2>
+          <blockquote>
+            <p>
+              "We woke to find the ship gliding silently between walls of rock so close you could almost touch them. Waterfalls cascaded hundreds of feet down moss-covered cliffs, disappearing into mist before reaching the channel below. The captain threaded us through passages barely wider than the ship, the water so still it reflected the peaks like a mirror. No other vessels, no buildings, no signs of humanity — just raw Patagonian wilderness stretching in every direction. This is what cruising must have felt like before the modern world."
+            </p>
+            <cite>— Scenic cruising, Messier Channel, Chilean Fjords</cite>
+          </blockquote>
+          <p class="highlight">
+            <strong>Highlight:</strong> Standing on deck in soft Patagonian rain as the ship passed a glacier calving ice directly into the channel, the thunder of falling ice echoing off the fjord walls.
+          </p>
+        </section>
+
+        <!-- Main Content Sections -->
+        <section class="port-section">
+          <h2>The Route</h2>
+          <p>
+            Ships typically transit the Chilean Fjords when sailing between Puerto Montt (or Puerto Chacabuco) and Punta Arenas, or en route to Antarctica. The journey takes 2-3 days of scenic cruising:
+          </p>
+          <ul>
+            <li><strong>Northern section</strong> — Channels south of Puerto Montt, Chonos Archipelago</li>
+            <li><strong>Aysén Region</strong> — San Rafael Lagoon (some ships), Northern Ice Field views</li>
+            <li><strong>Messier Channel</strong> — Narrow passage through dense rainforest</li>
+            <li><strong>Golfo de Penas</strong> — Open water crossing, rougher conditions</li>
+            <li><strong>Wellington Channel</strong> — Southern section approaching Strait of Magellan</li>
+            <li><strong>Glacier Alley</strong> — Multiple glaciers along Beagle Channel (separate route)</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Scenic Highlights</h2>
+          <ul>
+            <li><strong>Glaciers</strong> — Several tidewater glaciers visible from ship, ice calving into channels</li>
+            <li><strong>Waterfalls</strong> — Hundreds of waterfalls cascade from steep cliffs, especially after rain</li>
+            <li><strong>Narrow channels</strong> — Some passages barely wider than the ship, dramatic navigation</li>
+            <li><strong>Wildlife</strong> — Magellanic penguins, sea lions, Andean condors, dolphins</li>
+            <li><strong>Temperate rainforest</strong> — Dense vegetation, ancient trees clinging to rock faces</li>
+            <li><strong>Granite peaks</strong> — Sheer walls rising thousands of feet from the water</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>What to Expect</h2>
+          <p>
+            Chilean Fjords cruising is scenic-only with no dock stops:
+          </p>
+          <ul>
+            <li><strong>Duration</strong> — 2-3 days depending on route</li>
+            <li><strong>Deck time</strong> — Best experienced on open decks; dress warmly</li>
+            <li><strong>Weather</strong> — Rain is common; fog can limit visibility. Clear days are spectacular</li>
+            <li><strong>Navigation</strong> — Watch from bridge wings if open; pilots board for complex passages</li>
+            <li><strong>Lectures</strong> — Ships typically offer naturalist talks on geology, wildlife, history</li>
+            <li><strong>Photography</strong> — Bring rain protection for camera; telephoto for wildlife</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Regional Geography</h2>
+          <p>
+            The Chilean Fjords are part of a continuous coastal mountain range that fragments into thousands of islands, channels, and inlets:
+          </p>
+          <ul>
+            <li><strong>Patagonian Ice Fields</strong> — Third largest ice mass after Antarctica and Greenland</li>
+            <li><strong>Chonos Archipelago</strong> — Northern island group, transition zone</li>
+            <li><strong>Wellington Island</strong> — Large island, marks passage to Strait of Magellan</li>
+            <li><strong>Climate</strong> — Temperate rainforest; 4,000+ mm annual rainfall in places</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Practical Information</h2>
+          <ul>
+            <li><strong>Season</strong> — Year-round, but Southern Hemisphere summer (Dec-Mar) offers best weather and light</li>
+            <li><strong>Temperature</strong> — 40-60°F (4-15°C) typical, cooler with wind chill</li>
+            <li><strong>Rainfall</strong> — Expect rain; pack waterproof layers</li>
+            <li><strong>Motion</strong> — Channels are protected; Golfo de Penas can be rough</li>
+            <li><strong>Connectivity</strong> — Limited to no cell/internet service throughout fjords</li>
+          </ul>
+        </section>
+
+        <!-- Port Map -->
+        <section class="port-section">
+          <h2>Chilean Fjords Map</h2>
+          <div id="port-map" style="height: 400px; border-radius: 8px"></div>
+        </section>
+
+        <!-- FAQ Section -->
+        <section class="port-faq">
+          <h2>Frequently Asked Questions</h2>
+          <details>
+            <summary>How do Chilean Fjords compare to Norway and Alaska?</summary>
+            <p>
+              The Chilean Fjords rival Norway and Alaska in dramatic scenery — steep mountains plunging into narrow channels, glaciers calving into the sea, and dense temperate rainforest. Less developed tourism infrastructure means more pristine wilderness, but also fewer landing opportunities. The remoteness is part of the appeal.
+            </p>
+          </details>
+          <details>
+            <summary>When is the best time to cruise the Chilean Fjords?</summary>
+            <p>
+              December through March (Southern Hemisphere summer) offers longer daylight (18+ hours in December), milder temperatures, and calmer seas. However, the fjords receive significant rainfall year-round — rain gear is essential regardless of season.
+            </p>
+          </details>
+          <details>
+            <summary>Are there any stops or landings?</summary>
+            <p>
+              Most Chilean Fjords cruising is scenic-only with no landings. Some expedition ships offer Zodiac excursions or stop at remote settlements. Port calls at Puerto Chacabuco or Puerto Natales may bookend the scenic cruising days.
+            </p>
+          </details>
+        </section>
+
+        <!-- Disclaimers -->
+        <aside class="disclaimers">
+          <p>
+            <strong>Weather Dependent:</strong> Visibility in the fjords varies dramatically. Fog and rain are common; spectacular clear days are a bonus, not guaranteed.
+          </p>
+        </aside>
+      </article>
+
+      <!-- Rail Sidebar -->
+      <aside class="port-rail">
+        <div class="rail-section">
+          <h3>Quick Answer</h3>
+          <p>
+            The Chilean Fjords offer 2-3 days of scenic cruising through dramatic Patagonian channels — glaciers, waterfalls, sheer peaks, and pristine wilderness rivaling Norway and Alaska. No landings; bring rain gear and binoculars.
+          </p>
+        </div>
+
+        <div class="rail-section">
+          <h3>Best For</h3>
+          <ul>
+            <li>Dramatic landscapes</li>
+            <li>Glacier viewing</li>
+            <li>Photography</li>
+            <li>Wilderness immersion</li>
+            <li>Quiet contemplation</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Key Facts</h3>
+          <ul>
+            <li><strong>Length:</strong> 1,000+ miles</li>
+            <li><strong>Duration:</strong> 2-3 days</li>
+            <li><strong>Season:</strong> Year-round</li>
+            <li><strong>Weather:</strong> Rainy, variable</li>
+            <li><strong>Type:</strong> Scenic cruising</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Related Pages</h3>
+          <ul>
+            <li><a href="/ports/puerto-montt.html">Puerto Montt</a></li>
+            <li><a href="/ports/punta-arenas.html">Punta Arenas</a></li>
+            <li><a href="/ports/glacier-alley.html">Glacier Alley</a></li>
+            <li><a href="/ports/strait-of-magellan.html">Strait of Magellan</a></li>
+            <li><a href="/ports/ushuaia.html">Ushuaia</a></li>
+          </ul>
+        </div>
+      </aside>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 In The Wake. All rights reserved.</p>
+      <p class="disclaimer">
+        Not affiliated with Royal Caribbean International.
+      </p>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        var map = L.map("port-map").setView([-48.0, -74.5], 5);
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          attribution: "&copy; OpenStreetMap contributors",
+        }).addTo(map);
+        L.marker([-41.47, -72.94]).addTo(map).bindPopup("Puerto Montt");
+        L.marker([-45.40, -72.82]).addTo(map).bindPopup("Puerto Chacabuco");
+        L.marker([-48.0, -74.5]).addTo(map).bindPopup("Messier Channel");
+        L.marker([-53.16, -70.91]).addTo(map).bindPopup("Punta Arenas");
+      });
+    </script>
+  </body>
+</html>

--- a/ports/glacier-alley.html
+++ b/ports/glacier-alley.html
@@ -1,0 +1,348 @@
+<!--
+Soli Deo Gloria
+
+"He gives snow like wool;
+he scatters frost like ashes."
+- Psalm 147:16
+
+ITW-Lite v3.010 | ICP-Lite v1.4
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Glacier Alley Cruise Guide 2025 | Beagle Channel | In the Wake</title>
+    <meta
+      name="description"
+      content="Glacier Alley cruise guide. Seven glaciers along the Beagle Channel in Patagonia. Spectacular ice formations, calving glaciers, pristine Chilean wilderness."
+    />
+    <meta
+      name="ai-summary"
+      content="Glacier Alley features 7 tidewater glaciers along Beagle Channel's Alberto de Agostini National Park. Named for European countries. Dramatic calving, turquoise ice. Transit between Ushuaia and Punta Arenas. Year-round access, best Nov-Mar."
+    />
+    <meta name="last-reviewed" content="2026-01-03" />
+    <meta name="content-protocol" content="ICP-Lite v1.4" />
+    <meta
+      name="keywords"
+      content="Glacier Alley, Beagle Channel, Patagonia glaciers, Chile cruise, tidewater glaciers, Alberto de Agostini"
+    />
+    <link rel="canonical" href="https://inthewake.io/ports/glacier-alley" />
+
+    <!-- Open Graph -->
+    <meta
+      property="og:title"
+      content="Glacier Alley Cruise Guide 2025 | Beagle Channel Glaciers"
+    />
+    <meta
+      property="og:description"
+      content="Cruise past seven spectacular glaciers in Patagonia's Glacier Alley. Dramatic ice formations along the Beagle Channel."
+    />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://inthewake.io/ports/glacier-alley" />
+    <meta
+      property="og:image"
+      content="https://inthewake.io/images/ports/glacier-alley-og.jpg"
+    />
+
+    <!-- Structured Data: BreadcrumbList -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://inthewake.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Ports",
+            "item": "https://inthewake.io/ports"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Glacier Alley",
+            "item": "https://inthewake.io/ports/glacier-alley"
+          }
+        ]
+      }
+    </script>
+
+    <!-- Structured Data: WebPage with Place -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Glacier Alley Cruise Guide",
+        "description": "Complete guide to scenic cruising through Glacier Alley in the Beagle Channel",
+        "mainEntity": {
+          "@type": "Place",
+          "name": "Glacier Alley",
+          "description": "Series of seven tidewater glaciers along the Beagle Channel in Chilean Patagonia",
+          "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": -54.9,
+            "longitude": -69.6
+          }
+        }
+      }
+    </script>
+
+    <!-- Structured Data: FAQPage -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "How many glaciers are in Glacier Alley?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Seven major tidewater glaciers line Glacier Alley: Romanche, Alemania (Germany), Francia (France), Italia (Italy), Holanda (Holland), España (Spain), and Pía. Each is named after European countries that contributed to early Antarctic exploration."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can you get close to the glaciers?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ships cruise slowly past each glacier at a safe distance, with some passages bringing vessels remarkably close to the ice faces. Expedition ships may offer Zodiac excursions for closer approaches. Binoculars enhance the experience."
+            }
+          }
+        ]
+      }
+    </script>
+
+    <link rel="stylesheet" href="/assets/css/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a href="/" class="logo">In The Wake</a>
+        <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+        <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+        <ul class="nav-links">
+          <li><a href="/ships.html">Ships</a></li>
+          <li><a href="/ports.html">Ports</a></li>
+          <li><a href="/tips/">Tips</a></li>
+          <li><a href="/news/">News</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="port-guide">
+      <article class="port-content">
+        <header class="port-header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="/">Home</a></li>
+              <li><a href="/ports.html">Ports</a></li>
+              <li aria-current="page">Glacier Alley</li>
+            </ol>
+          </nav>
+          <p class="port-type"><span class="badge">Scenic Cruising</span></p>
+          <h1>Glacier Alley Cruise Guide</h1>
+          <p class="port-intro">
+            Glacier Alley is one of Patagonia's most spectacular sights — a parade of seven tidewater glaciers cascading from the Darwin Range into the Beagle Channel. Ships transit this natural gallery between Ushuaia and Punta Arenas, passing walls of blue ice, witnessing calving events, and experiencing the raw power of glacial landscapes. Named after European nations that contributed to Antarctic exploration, these glaciers offer a preview of the ice worlds ahead for ships bound for Antarctica.
+          </p>
+        </header>
+
+        <!-- Logbook Entry -->
+        <section class="logbook-entry">
+          <h2>From the Logbook</h2>
+          <blockquote>
+            <p>
+              "The ship slowed as we approached the first glacier — Romanche — its blue-white face rising straight from the dark channel water. The silence was absolute. Then came the crack, like rifle shots echoing off the mountains, followed by a thunderous rumble as a section of ice calved into the sea. Passengers gasped. Over the next hours, we passed six more glaciers, each distinct: the broad sweep of Italia, the fractured seracs of España, the impossibly blue ice of Holanda. The captain positioned the ship for optimal viewing of each. By the time we reached Pía Glacier at the end of the alley, we'd used up three camera batteries."
+            </p>
+            <cite>— Glacier Alley transit, Beagle Channel</cite>
+          </blockquote>
+          <p class="highlight">
+            <strong>Highlight:</strong> The turquoise blue of the glacial ice, more vivid than any photograph can capture, glowing against the grey Patagonian sky.
+          </p>
+        </section>
+
+        <!-- Main Content Sections -->
+        <section class="port-section">
+          <h2>The Seven Glaciers</h2>
+          <p>
+            From east to west, the glaciers of Glacier Alley flow from the Darwin Range into the Beagle Channel:
+          </p>
+          <ul>
+            <li><strong>Romanche Glacier</strong> — First encountered from Ushuaia, dramatic ice cliffs</li>
+            <li><strong>Alemania (Germany) Glacier</strong> — Named for German contributions to polar exploration</li>
+            <li><strong>Francia (France) Glacier</strong> — One of the more active calving glaciers</li>
+            <li><strong>Italia (Italy) Glacier</strong> — Broad glacier face, good for panoramic views</li>
+            <li><strong>Holanda (Holland) Glacier</strong> — Known for its distinctive blue ice</li>
+            <li><strong>España (Spain) Glacier</strong> — Heavily crevassed, dramatic seracs</li>
+            <li><strong>Pía Glacier</strong> — Largest and most visited, Zodiac excursions possible</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Location & Route</h2>
+          <p>
+            Glacier Alley lies within Alberto de Agostini National Park, Chile, along the northern shore of the Beagle Channel:
+          </p>
+          <ul>
+            <li><strong>Western Beagle Channel</strong> — Between Ushuaia (Argentina) and the Darwin Range</li>
+            <li><strong>Protected waters</strong> — Generally calmer than open ocean</li>
+            <li><strong>Common routes</strong> — Cruises between Ushuaia and Punta Arenas transit Glacier Alley</li>
+            <li><strong>Antarctica itineraries</strong> — Some expedition ships include Glacier Alley pre- or post-Antarctica</li>
+            <li><strong>Transit time</strong> — 4-6 hours to pass all seven glaciers with viewing stops</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Viewing Tips</h2>
+          <ul>
+            <li><strong>Deck position</strong> — Starboard (right) side when sailing west from Ushuaia; port side when returning east</li>
+            <li><strong>Dress warmly</strong> — Cold air flows off glaciers; wind chill significant on deck</li>
+            <li><strong>Camera gear</strong> — Telephoto for details, wide angle for scale. Extra batteries (cold drains them)</li>
+            <li><strong>Binoculars</strong> — Essential for spotting calving activity and wildlife on ice</li>
+            <li><strong>Timing</strong> — Ships often slow or stop at each glacier; check announcements</li>
+            <li><strong>Narration</strong> — Most ships provide naturalist commentary during transit</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Wildlife</h2>
+          <ul>
+            <li><strong>Seabirds</strong> — Giant petrels, cormorants, and skuas common near glaciers</li>
+            <li><strong>Seals</strong> — Occasionally spotted on ice floes or along shore</li>
+            <li><strong>Condors</strong> — Andean condors may soar over the Darwin Range</li>
+            <li><strong>Dolphins</strong> — Peale's dolphins and Commerson's dolphins in channel waters</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Practical Information</h2>
+          <ul>
+            <li><strong>Location</strong> — Alberto de Agostini National Park, Chile</li>
+            <li><strong>Access</strong> — Cruise ship only; no road access</li>
+            <li><strong>Duration</strong> — 4-6 hours for full transit</li>
+            <li><strong>Season</strong> — Year-round, but Southern Hemisphere summer (Nov-Mar) offers best conditions</li>
+            <li><strong>Temperature</strong> — 30-50°F (-1 to 10°C) on deck near glaciers</li>
+            <li><strong>Expedition options</strong> — Some ships offer Zodiac landings near Pía Glacier</li>
+          </ul>
+        </section>
+
+        <!-- Port Map -->
+        <section class="port-section">
+          <h2>Glacier Alley Map</h2>
+          <div id="port-map" style="height: 400px; border-radius: 8px"></div>
+        </section>
+
+        <!-- FAQ Section -->
+        <section class="port-faq">
+          <h2>Frequently Asked Questions</h2>
+          <details>
+            <summary>How many glaciers are in Glacier Alley?</summary>
+            <p>
+              Seven major tidewater glaciers line Glacier Alley: Romanche, Alemania (Germany), Francia (France), Italia (Italy), Holanda (Holland), España (Spain), and Pía. Each is named after European countries that contributed to early Antarctic exploration.
+            </p>
+          </details>
+          <details>
+            <summary>Can you get close to the glaciers?</summary>
+            <p>
+              Ships cruise slowly past each glacier at a safe distance, with some passages bringing vessels remarkably close to the ice faces. Expedition ships may offer Zodiac excursions for closer approaches to Pía Glacier. Binoculars enhance the experience for all passengers.
+            </p>
+          </details>
+          <details>
+            <summary>Do the glaciers always calve?</summary>
+            <p>
+              Calving is frequent but not guaranteed. Glaciers continuously crack and groan; visible calving events depend on timing and luck. Even without dramatic calving, the glaciers are spectacular. Listen for the thunderous sounds that precede ice falls.
+            </p>
+          </details>
+          <details>
+            <summary>Which side of the ship is best for viewing?</summary>
+            <p>
+              Sailing westward from Ushuaia, the glaciers are on the starboard (right) side. Sailing eastward toward Ushuaia, they're on the port (left) side. Most ships reposition to give all passengers views; check with cruise staff.
+            </p>
+          </details>
+        </section>
+
+        <!-- Disclaimers -->
+        <aside class="disclaimers">
+          <p>
+            <strong>Weather Dependent:</strong> Visibility can be affected by fog, rain, and low clouds common in this region. Clear days offer spectacular views; overcast days are atmospheric but may limit photography.
+          </p>
+        </aside>
+      </article>
+
+      <!-- Rail Sidebar -->
+      <aside class="port-rail">
+        <div class="rail-section">
+          <h3>Quick Answer</h3>
+          <p>
+            Glacier Alley features seven spectacular tidewater glaciers along the Beagle Channel. Ships cruise past walls of blue ice, witnessing calving events. Named after European countries. Unforgettable scenic cruising between Ushuaia and Punta Arenas.
+          </p>
+        </div>
+
+        <div class="rail-section">
+          <h3>Best For</h3>
+          <ul>
+            <li>Glacier viewing</li>
+            <li>Photography</li>
+            <li>Ice calving</li>
+            <li>Patagonian scenery</li>
+            <li>Wildlife spotting</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Key Facts</h3>
+          <ul>
+            <li><strong>Glaciers:</strong> 7 major</li>
+            <li><strong>Location:</strong> Beagle Channel</li>
+            <li><strong>Duration:</strong> 4-6 hours</li>
+            <li><strong>Largest:</strong> Pía Glacier</li>
+            <li><strong>Park:</strong> Alberto de Agostini</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Related Pages</h3>
+          <ul>
+            <li><a href="/ports/ushuaia.html">Ushuaia</a></li>
+            <li><a href="/ports/punta-arenas.html">Punta Arenas</a></li>
+            <li><a href="/ports/cape-horn.html">Cape Horn</a></li>
+            <li><a href="/ports/chilean-fjords.html">Chilean Fjords</a></li>
+            <li><a href="/ports/antarctica.html">Antarctica</a></li>
+          </ul>
+        </div>
+      </aside>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 In The Wake. All rights reserved.</p>
+      <p class="disclaimer">
+        Not affiliated with Royal Caribbean International.
+      </p>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        var map = L.map("port-map").setView([-54.9, -69.6], 8);
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          attribution: "&copy; OpenStreetMap contributors",
+        }).addTo(map);
+        L.marker([-54.93, -68.48]).addTo(map).bindPopup("Romanche Glacier");
+        L.marker([-54.91, -68.72]).addTo(map).bindPopup("Italia Glacier");
+        L.marker([-54.90, -69.05]).addTo(map).bindPopup("Holanda Glacier");
+        L.marker([-54.88, -69.65]).addTo(map).bindPopup("Pía Glacier");
+        L.marker([-54.81, -68.31]).addTo(map).bindPopup("Ushuaia");
+      });
+    </script>
+  </body>
+</html>

--- a/ports/south-shetland-islands.html
+++ b/ports/south-shetland-islands.html
@@ -1,0 +1,358 @@
+<!--
+Soli Deo Gloria
+
+"He spreads the snow like wool
+and scatters the frost like ashes."
+- Psalm 147:16
+
+ITW-Lite v3.010 | ICP-Lite v1.4
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>South Shetland Islands Cruise Guide 2025 | Antarctica Gateway | In the Wake</title>
+    <meta
+      name="description"
+      content="South Shetland Islands expedition cruise guide. Antarctic wildlife, research stations, volcanic Deception Island. First landfall after Drake Passage crossing."
+    />
+    <meta
+      name="ai-summary"
+      content="South Shetland Islands are first Antarctic landfall after Drake Passage. 11 major islands including volcanic Deception Island. Research stations, chinstrap penguin colonies. Gateway to Antarctic Peninsula. Nov-Mar season."
+    />
+    <meta name="last-reviewed" content="2026-01-03" />
+    <meta name="content-protocol" content="ICP-Lite v1.4" />
+    <meta
+      name="keywords"
+      content="South Shetland Islands, Deception Island, Antarctica cruise, Half Moon Island, penguin colonies, research station"
+    />
+    <link rel="canonical" href="https://inthewake.io/ports/south-shetland-islands" />
+
+    <!-- Open Graph -->
+    <meta
+      property="og:title"
+      content="South Shetland Islands Cruise Guide 2025 | Antarctica Gateway"
+    />
+    <meta
+      property="og:description"
+      content="Complete guide to South Shetland Islands expedition landings. Deception Island volcano, research stations, and Antarctic wildlife."
+    />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://inthewake.io/ports/south-shetland-islands" />
+    <meta
+      property="og:image"
+      content="https://inthewake.io/images/ports/south-shetland-islands-og.jpg"
+    />
+
+    <!-- Structured Data: BreadcrumbList -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://inthewake.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Ports",
+            "item": "https://inthewake.io/ports"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "South Shetland Islands",
+            "item": "https://inthewake.io/ports/south-shetland-islands"
+          }
+        ]
+      }
+    </script>
+
+    <!-- Structured Data: WebPage with Place -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "South Shetland Islands Cruise Guide",
+        "description": "Complete guide to expedition cruising in the South Shetland Islands",
+        "mainEntity": {
+          "@type": "Place",
+          "name": "South Shetland Islands",
+          "description": "Antarctic archipelago between Drake Passage and the Antarctic Peninsula",
+          "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": -62.0,
+            "longitude": -58.5
+          }
+        }
+      }
+    </script>
+
+    <!-- Structured Data: FAQPage -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is Deception Island?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Deception Island is an active volcanic caldera in the South Shetland Islands. Ships sail through Neptune's Bellows into the flooded caldera. Hot springs warm the black sand beaches. Abandoned whaling station remains at Whalers Bay."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Which research stations can you visit in the South Shetlands?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "King George Island has multiple research stations from different countries. Visits depend on prior arrangement and weather. Stations occasionally welcome cruise passengers for brief tours."
+            }
+          }
+        ]
+      }
+    </script>
+
+    <link rel="stylesheet" href="/assets/css/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a href="/" class="logo">In The Wake</a>
+        <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+        <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+        <ul class="nav-links">
+          <li><a href="/ships.html">Ships</a></li>
+          <li><a href="/ports.html">Ports</a></li>
+          <li><a href="/tips/">Tips</a></li>
+          <li><a href="/news/">News</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="port-guide">
+      <article class="port-content">
+        <header class="port-header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="/">Home</a></li>
+              <li><a href="/ports.html">Ports</a></li>
+              <li aria-current="page">South Shetland Islands</li>
+            </ol>
+          </nav>
+          <h1>South Shetland Islands Cruise Guide</h1>
+          <p class="port-intro">
+            The South Shetland Islands are the gateway to Antarctica — an archipelago of 11 major islands stretching 335 miles between the Drake Passage and the Antarctic Peninsula. These volcanic islands host abundant wildlife, active research stations, and one of Antarctica's most unique experiences: sailing into the flooded caldera of Deception Island.
+          </p>
+        </header>
+
+        <!-- Logbook Entry -->
+        <section class="logbook-entry">
+          <h2>From the Logbook</h2>
+          <blockquote>
+            <p>
+              "As we approached Neptune's Bellows — the narrow entrance to Deception Island's caldera — the captain cut engines and the ship went silent. The volcanic cliffs towered on both sides, the passage just wide enough for our hull. Inside, the caldera opened into an otherworldly bay: black sand beaches, rusting whaling tanks, steam rising from the water's edge. Passengers were already stripping to swimsuits, eager to dig trenches in the sand where geothermal heat meets Antarctic cold. You swim in Antarctica at an active volcano. It's as surreal as it sounds."
+            </p>
+            <cite>— Deception Island landing, South Shetland Islands</cite>
+          </blockquote>
+          <p class="highlight">
+            <strong>Highlight:</strong> Digging a hole in the black volcanic sand at Pendulum Cove and sinking into warm geothermal water while snow-capped peaks encircle the caldera.
+          </p>
+        </section>
+
+        <!-- Main Content Sections -->
+        <section class="port-section">
+          <h2>Major Islands & Landing Sites</h2>
+          <ul>
+            <li><strong>Deception Island</strong> — Active volcano, flooded caldera, geothermal beaches, abandoned whaling station at Whalers Bay, chinstrap penguins at Baily Head</li>
+            <li><strong>Half Moon Island</strong> — Crescent-shaped island, chinstrap penguin colony, Antarctic terns, spectacular mountain backdrop</li>
+            <li><strong>Livingston Island</strong> — Second largest island, Hannah Point with gentoo, chinstrap, and elephant seals</li>
+            <li><strong>King George Island</strong> — Largest island, multiple international research stations, Fildes Peninsula</li>
+            <li><strong>Elephant Island</strong> — Historic Shackleton refuge, difficult landings, Point Wild with Pardo bust</li>
+            <li><strong>Aitcho Islands</strong> — Gentoo and chinstrap colonies, often first Antarctic landing after Drake crossing</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Deception Island</h2>
+          <p>
+            Deception Island is one of Antarctica's most extraordinary destinations — an active volcanic caldera you can sail inside:
+          </p>
+          <ul>
+            <li><strong>Neptune's Bellows</strong> — Dramatic 230m-wide entrance passage between volcanic cliffs</li>
+            <li><strong>Whalers Bay</strong> — Abandoned Norwegian whaling station, rusting tanks, haunting industrial ruins</li>
+            <li><strong>Pendulum Cove</strong> — Geothermal beaches where you can "swim" in Antarctica (water temperature varies)</li>
+            <li><strong>Baily Head</strong> — Massive chinstrap penguin colony (100,000+ breeding pairs) on outer coast</li>
+            <li><strong>Volcanic activity</strong> — Last erupted 1970. Geothermal vents still active. Scientists monitor continuously</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Wildlife</h2>
+          <p>
+            The South Shetland Islands host significant wildlife populations:
+          </p>
+          <ul>
+            <li><strong>Chinstrap penguins</strong> — Dominant species, named for distinctive "chinstrap" markings</li>
+            <li><strong>Gentoo penguins</strong> — At several landing sites, recognizable by red-orange bills</li>
+            <li><strong>Antarctic fur seals</strong> — Aggressive during breeding season, maintain distance</li>
+            <li><strong>Elephant seals</strong> — Massive males weigh up to 4 tons, often seen at Hannah Point</li>
+            <li><strong>Whales</strong> — Humpback and minke whales feed in surrounding waters</li>
+            <li><strong>Seabirds</strong> — Antarctic terns, skuas, giant petrels, blue-eyed cormorants</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Research Stations</h2>
+          <p>
+            King George Island has the highest concentration of research stations in Antarctica, earning it the nickname "Antarctic Greenwich Village":
+          </p>
+          <ul>
+            <li><strong>Bellingshausen (Russia)</strong></li>
+            <li><strong>King Sejong (South Korea)</strong></li>
+            <li><strong>Artigas (Uruguay)</strong></li>
+            <li><strong>Great Wall (China)</strong></li>
+            <li><strong>Presidente Eduardo Frei Montalva (Chile)</strong> — Includes small settlement, school</li>
+            <li><strong>Escudero (Chile)</strong></li>
+            <li><strong>Carlini (Argentina)</strong></li>
+          </ul>
+          <p>Station visits depend on prior arrangement and operational schedules.</p>
+        </section>
+
+        <section class="port-section">
+          <h2>Shackleton History</h2>
+          <p>
+            Elephant Island holds special significance in Antarctic exploration:
+          </p>
+          <ul>
+            <li><strong>Point Wild</strong> — Where 22 men of Shackleton's Endurance expedition survived 4+ months awaiting rescue in 1916</li>
+            <li><strong>Pardo Bust</strong> — Bronze memorial to Chilean pilot Luis Pardo, who rescued the stranded men</li>
+            <li><strong>Difficult landings</strong> — High seas and rocky coastline often prevent Zodiac landings; scenic cruising typical</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Practical Information</h2>
+          <ul>
+            <li><strong>Location</strong> — 75 miles north of Antarctic Peninsula</li>
+            <li><strong>First landfall</strong> — Often first landing site after crossing Drake Passage</li>
+            <li><strong>Weather</strong> — Notoriously changeable; fog, wind, rain common</li>
+            <li><strong>Swimming</strong> — Possible at Deception Island's geothermal beaches (bring swimsuit!)</li>
+            <li><strong>Landings</strong> — Via Zodiac; wet landings common</li>
+          </ul>
+        </section>
+
+        <!-- Port Map -->
+        <section class="port-section">
+          <h2>South Shetland Islands Map</h2>
+          <div id="port-map" style="height: 400px; border-radius: 8px"></div>
+        </section>
+
+        <!-- FAQ Section -->
+        <section class="port-faq">
+          <h2>Frequently Asked Questions</h2>
+          <details>
+            <summary>What is Deception Island?</summary>
+            <p>
+              Deception Island is an active volcanic caldera in the South Shetland Islands. Ships sail through Neptune's Bellows into the flooded caldera. Hot springs warm the black sand beaches. Abandoned whaling station remains at Whalers Bay. It's one of Antarctica's most unique landing sites.
+            </p>
+          </details>
+          <details>
+            <summary>Can you really swim in Antarctica?</summary>
+            <p>
+              Yes, at Deception Island's Pendulum Cove. Geothermal heat warms the water near shore, though temperatures vary wildly. Dig a trench in the black sand to mix hot spring water with cold ocean water. Bring a swimsuit and prepare for bragging rights.
+            </p>
+          </details>
+          <details>
+            <summary>Which research stations can you visit?</summary>
+            <p>
+              Visits depend on prior arrangement and weather. King George Island has the most stations, some of which occasionally welcome cruise passengers. Arrangements are made through expedition staff, not passengers.
+            </p>
+          </details>
+        </section>
+
+        <!-- Disclaimers -->
+        <aside class="disclaimers">
+          <p>
+            <strong>Landing Conditions:</strong> Weather in the South Shetlands is highly unpredictable. Landing sites and activities are determined by expedition leaders based on conditions.
+          </p>
+        </aside>
+      </article>
+
+      <!-- Rail Sidebar -->
+      <aside class="port-rail">
+        <div class="rail-section">
+          <h3>Quick Answer</h3>
+          <p>
+            The South Shetland Islands are the gateway to Antarctica — first landfall after crossing the Drake Passage. Highlights include volcanic Deception Island (swim in geothermal waters!), penguin colonies, and historic Shackleton sites.
+          </p>
+        </div>
+
+        <div class="rail-section">
+          <h3>Best For</h3>
+          <ul>
+            <li>Deception Island volcano</li>
+            <li>Antarctic swimming</li>
+            <li>Chinstrap penguins</li>
+            <li>Shackleton history</li>
+            <li>Research station visits</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Key Facts</h3>
+          <ul>
+            <li><strong>Islands:</strong> 11 major</li>
+            <li><strong>Length:</strong> 335 miles</li>
+            <li><strong>Season:</strong> Nov-Mar</li>
+            <li><strong>Highlight:</strong> Deception Island</li>
+            <li><strong>History:</strong> Shackleton refuge</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Related Pages</h3>
+          <ul>
+            <li><a href="/ports/antarctica.html">Antarctica Overview</a></li>
+            <li><a href="/ports/antarctic-peninsula.html">Antarctic Peninsula</a></li>
+            <li><a href="/ports/drake-passage.html">Drake Passage</a></li>
+            <li><a href="/ports/ushuaia.html">Ushuaia</a></li>
+            <li><a href="/ports/falkland-islands.html">Falkland Islands</a></li>
+          </ul>
+        </div>
+      </aside>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 In The Wake. All rights reserved.</p>
+      <p class="disclaimer">
+        Not affiliated with Royal Caribbean International.
+      </p>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        var map = L.map("port-map").setView([-62.5, -59.5], 6);
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          attribution: "&copy; OpenStreetMap contributors",
+        }).addTo(map);
+        L.marker([-62.97, -60.55]).addTo(map).bindPopup("Deception Island");
+        L.marker([-62.21, -58.96]).addTo(map).bindPopup("King George Island");
+        L.marker([-62.59, -59.92]).addTo(map).bindPopup("Half Moon Island");
+        L.marker([-62.48, -60.05]).addTo(map).bindPopup("Livingston Island");
+        L.marker([-61.13, -55.12]).addTo(map).bindPopup("Elephant Island");
+      });
+    </script>
+  </body>
+</html>

--- a/ports/strait-of-magellan.html
+++ b/ports/strait-of-magellan.html
@@ -1,0 +1,339 @@
+<!--
+Soli Deo Gloria
+
+"Some went out on the sea in ships;
+they were merchants on the mighty waters."
+- Psalm 107:23
+
+ITW-Lite v3.010 | ICP-Lite v1.4
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Strait of Magellan Cruise Guide 2025 | Historic Passage | In the Wake</title>
+    <meta
+      name="description"
+      content="Strait of Magellan cruise guide. Historic passage connecting Atlantic and Pacific oceans. Scenic cruising through Tierra del Fuego with Patagonian wildlife."
+    />
+    <meta
+      name="ai-summary"
+      content="Strait of Magellan connects Atlantic and Pacific, bypassing Cape Horn. 350-mile passage through Tierra del Fuego. Discovered 1520 by Magellan. Scenic cruising with Magellanic penguins, glaciers. Links Punta Arenas to Ushuaia routes."
+    />
+    <meta name="last-reviewed" content="2026-01-03" />
+    <meta name="content-protocol" content="ICP-Lite v1.4" />
+    <meta
+      name="keywords"
+      content="Strait of Magellan, Magellan cruise, Tierra del Fuego, Punta Arenas, historic passage, Patagonia cruise"
+    />
+    <link rel="canonical" href="https://inthewake.io/ports/strait-of-magellan" />
+
+    <!-- Open Graph -->
+    <meta
+      property="og:title"
+      content="Strait of Magellan Cruise Guide 2025 | Historic Passage"
+    />
+    <meta
+      property="og:description"
+      content="Cruise the legendary Strait of Magellan. History, wildlife, and dramatic Patagonian scenery."
+    />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://inthewake.io/ports/strait-of-magellan" />
+    <meta
+      property="og:image"
+      content="https://inthewake.io/images/ports/strait-of-magellan-og.jpg"
+    />
+
+    <!-- Structured Data: BreadcrumbList -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://inthewake.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Ports",
+            "item": "https://inthewake.io/ports"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Strait of Magellan",
+            "item": "https://inthewake.io/ports/strait-of-magellan"
+          }
+        ]
+      }
+    </script>
+
+    <!-- Structured Data: WebPage with Place -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Strait of Magellan Cruise Guide",
+        "description": "Complete guide to cruising the historic Strait of Magellan",
+        "mainEntity": {
+          "@type": "Place",
+          "name": "Strait of Magellan",
+          "description": "Historic passage connecting Atlantic and Pacific Oceans at the tip of South America",
+          "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": -53.5,
+            "longitude": -70.5
+          }
+        }
+      }
+    </script>
+
+    <!-- Structured Data: FAQPage -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Why is the Strait of Magellan historically significant?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ferdinand Magellan discovered this passage in 1520 during the first circumnavigation of Earth. For centuries it provided the only protected route between the Atlantic and Pacific, avoiding the treacherous Cape Horn. The Panama Canal eventually reduced its commercial importance."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How long does it take to transit the Strait of Magellan?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "A full transit takes approximately 24-36 hours depending on weather, currents, and vessel speed. The strait is 350 miles long, with the narrowest section (Primera Angostura) just 1.5 miles wide."
+            }
+          }
+        ]
+      }
+    </script>
+
+    <link rel="stylesheet" href="/assets/css/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <a href="/" class="logo">In The Wake</a>
+        <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+        <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+        <ul class="nav-links">
+          <li><a href="/ships.html">Ships</a></li>
+          <li><a href="/ports.html">Ports</a></li>
+          <li><a href="/tips/">Tips</a></li>
+          <li><a href="/news/">News</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="port-guide">
+      <article class="port-content">
+        <header class="port-header">
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <ol>
+              <li><a href="/">Home</a></li>
+              <li><a href="/ports.html">Ports</a></li>
+              <li aria-current="page">Strait of Magellan</li>
+            </ol>
+          </nav>
+          <p class="port-type"><span class="badge">Scenic Cruising</span></p>
+          <h1>Strait of Magellan Cruise Guide</h1>
+          <p class="port-intro">
+            The Strait of Magellan is one of the world's most legendary maritime passages — a 350-mile waterway separating mainland South America from Tierra del Fuego. Discovered by Ferdinand Magellan in 1520, this protected route between the Atlantic and Pacific Oceans shaped five centuries of maritime history. Today, cruise ships transit the strait for its dramatic scenery, Magellanic penguin colonies, and the thrill of following in the wake of history's greatest explorers.
+          </p>
+        </header>
+
+        <!-- Logbook Entry -->
+        <section class="logbook-entry">
+          <h2>From the Logbook</h2>
+          <blockquote>
+            <p>
+              "At dawn, we entered the narrow Primera Angostura — the First Narrows — with Tierra del Fuego to starboard and the Patagonian steppe to port. The current ran swift beneath us, the passage just wide enough for two ships to pass. The captain pointed out Punta Dungeness lighthouse, marking the Atlantic entrance. By midday, we'd reached the Magellanic penguin colony at Isla Magdalena, thousands of birds waddling across the hillside. That evening, as we approached Punta Arenas, I understood why Magellan spent 38 days exploring these waters before finding the Pacific outlet. The maze of channels and dead-ends that confused explorers for centuries now unfolded before us."
+            </p>
+            <cite>— Strait of Magellan transit, approaching Punta Arenas</cite>
+          </blockquote>
+          <p class="highlight">
+            <strong>Highlight:</strong> Watching Magellanic penguins by the thousands at Isla Magdalena — a protected reserve in the middle of the strait accessible only by boat.
+          </p>
+        </section>
+
+        <!-- Main Content Sections -->
+        <section class="port-section">
+          <h2>Historical Significance</h2>
+          <ul>
+            <li><strong>Discovery (1520)</strong> — Ferdinand Magellan discovered the passage during the first circumnavigation of Earth, spending 38 days navigating its maze of channels</li>
+            <li><strong>Pre-Panama route</strong> — For centuries, the strait was the only protected passage between Atlantic and Pacific, avoiding Cape Horn's treacherous waters</li>
+            <li><strong>Maritime commerce</strong> — Major commercial route until the Panama Canal opened in 1914</li>
+            <li><strong>Exploration era</strong> — Darwin sailed through aboard HMS Beagle; countless expeditions followed Magellan's route</li>
+            <li><strong>Name origin</strong> — Magellan originally named it "Strait of All Saints" (Estrecho de Todos los Santos)</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>The Passage</h2>
+          <p>
+            The Strait of Magellan offers varied scenery across its 350-mile length:
+          </p>
+          <ul>
+            <li><strong>Atlantic entrance</strong> — Wide opening between Cape Virgenes (Argentina) and Punta Dungeness</li>
+            <li><strong>Primera Angostura</strong> — First Narrows, just 1.5 miles wide, strong tidal currents</li>
+            <li><strong>Segunda Angostura</strong> — Second Narrows, slightly wider</li>
+            <li><strong>Punta Arenas</strong> — Largest city on the strait, common port call</li>
+            <li><strong>Western channels</strong> — Maze of islands, dramatic mountains, glaciers visible</li>
+            <li><strong>Pacific exit</strong> — Multiple outlets between islands; Desolation Island marks the western end</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Wildlife</h2>
+          <ul>
+            <li><strong>Magellanic penguins</strong> — Massive colonies at Isla Magdalena and Isla Marta</li>
+            <li><strong>South American sea lions</strong> — Haul out on rocks throughout the strait</li>
+            <li><strong>Commerson's dolphins</strong> — Black and white dolphins endemic to southern waters</li>
+            <li><strong>Andean condors</strong> — Soar on thermals above the strait</li>
+            <li><strong>Seabirds</strong> — Cormorants, giant petrels, albatross in western sections</li>
+            <li><strong>Whales</strong> — Occasional humpback and orca sightings</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Scenic Highlights</h2>
+          <ul>
+            <li><strong>Isla Magdalena</strong> — Penguin reserve, accessible by Zodiac or ferry from Punta Arenas</li>
+            <li><strong>Dawson Island</strong> — Largest island in the strait, dramatic scenery</li>
+            <li><strong>Western fjords</strong> — Glaciers and peaks rivaling Chilean Fjords</li>
+            <li><strong>Tierra del Fuego</strong> — "Land of Fire" — named for indigenous peoples' campfires</li>
+            <li><strong>Historic lighthouses</strong> — Punta Dungeness and others mark the passage</li>
+          </ul>
+        </section>
+
+        <section class="port-section">
+          <h2>Practical Information</h2>
+          <ul>
+            <li><strong>Length</strong> — 350 miles (570 km) from Atlantic to Pacific</li>
+            <li><strong>Transit time</strong> — 24-36 hours depending on route and conditions</li>
+            <li><strong>Key port</strong> — Punta Arenas, Chile, is the major city on the strait</li>
+            <li><strong>Weather</strong> — Notoriously changeable; strong winds (williwaws) common</li>
+            <li><strong>Best viewing</strong> — Deck time throughout; bridge viewing if available</li>
+            <li><strong>Season</strong> — Year-round navigation; Southern Hemisphere summer (Nov-Mar) offers best conditions</li>
+          </ul>
+        </section>
+
+        <!-- Port Map -->
+        <section class="port-section">
+          <h2>Strait of Magellan Map</h2>
+          <div id="port-map" style="height: 400px; border-radius: 8px"></div>
+        </section>
+
+        <!-- FAQ Section -->
+        <section class="port-faq">
+          <h2>Frequently Asked Questions</h2>
+          <details>
+            <summary>Why is the Strait of Magellan historically significant?</summary>
+            <p>
+              Ferdinand Magellan discovered this passage in 1520 during the first circumnavigation of Earth. For centuries it provided the only protected route between the Atlantic and Pacific, avoiding the treacherous Cape Horn. The Panama Canal eventually reduced its commercial importance, but the strait remains a vital shipping lane for vessels too large for the canal.
+            </p>
+          </details>
+          <details>
+            <summary>How long does it take to transit the Strait of Magellan?</summary>
+            <p>
+              A full transit takes approximately 24-36 hours depending on weather, currents, and vessel speed. The strait is 350 miles long, with the narrowest section (Primera Angostura) just 1.5 miles wide. Ships often stop at Punta Arenas mid-transit.
+            </p>
+          </details>
+          <details>
+            <summary>Is the Strait of Magellan rough?</summary>
+            <p>
+              Generally calmer than the open ocean around Cape Horn. However, the strait can experience sudden squalls and "williwaws" — violent downdrafts from the mountains. The narrow sections have strong tidal currents. Overall, it's a protected passage.
+            </p>
+          </details>
+        </section>
+
+        <!-- Disclaimers -->
+        <aside class="disclaimers">
+          <p>
+            <strong>Weather Conditions:</strong> The strait is known for rapidly changing weather. Visibility can drop quickly, and strong winds may affect deck activities.
+          </p>
+        </aside>
+      </article>
+
+      <!-- Rail Sidebar -->
+      <aside class="port-rail">
+        <div class="rail-section">
+          <h3>Quick Answer</h3>
+          <p>
+            The Strait of Magellan is a 350-mile passage connecting the Atlantic and Pacific at South America's tip. Historic Magellan route, Magellanic penguin colonies, dramatic scenery. Calmer than rounding Cape Horn.
+          </p>
+        </div>
+
+        <div class="rail-section">
+          <h3>Best For</h3>
+          <ul>
+            <li>Maritime history</li>
+            <li>Magellanic penguins</li>
+            <li>Scenic cruising</li>
+            <li>Wildlife spotting</li>
+            <li>Explorer heritage</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Key Facts</h3>
+          <ul>
+            <li><strong>Length:</strong> 350 miles</li>
+            <li><strong>Transit:</strong> 24-36 hours</li>
+            <li><strong>Discovered:</strong> 1520</li>
+            <li><strong>Narrowest:</strong> 1.5 miles</li>
+            <li><strong>Key port:</strong> Punta Arenas</li>
+          </ul>
+        </div>
+
+        <div class="rail-section">
+          <h3>Related Pages</h3>
+          <ul>
+            <li><a href="/ports/punta-arenas.html">Punta Arenas</a></li>
+            <li><a href="/ports/ushuaia.html">Ushuaia</a></li>
+            <li><a href="/ports/cape-horn.html">Cape Horn</a></li>
+            <li><a href="/ports/chilean-fjords.html">Chilean Fjords</a></li>
+            <li><a href="/ports/falkland-islands.html">Falkland Islands</a></li>
+          </ul>
+        </div>
+      </aside>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 In The Wake. All rights reserved.</p>
+      <p class="disclaimer">
+        Not affiliated with Royal Caribbean International.
+      </p>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        var map = L.map("port-map").setView([-53.5, -70.5], 6);
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          attribution: "&copy; OpenStreetMap contributors",
+        }).addTo(map);
+        L.marker([-53.16, -70.91]).addTo(map).bindPopup("Punta Arenas");
+        L.marker([-52.40, -68.40]).addTo(map).bindPopup("Primera Angostura");
+        L.marker([-52.53, -69.10]).addTo(map).bindPopup("Isla Magdalena");
+        L.marker([-52.33, -68.63]).addTo(map).bindPopup("Atlantic Entrance");
+        L.marker([-52.78, -74.72]).addTo(map).bindPopup("Pacific Exit");
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Create expedition and scenic cruising pages:
- Antarctic Peninsula: Zodiac landings, penguin colonies
- South Shetland Islands: Deception Island volcano, research stations
- Chilean Fjords: 1000+ mile scenic cruising route
- Strait of Magellan: Historic 350-mile passage
- Glacier Alley: 7 tidewater glaciers on Beagle Channel

Update ports.html navigation with links to all new pages. Completes remaining P2-P3 ports from audit (39 of 43 done).