### PR TITLE
feat(ports): Add Beijing and Kyoto redirect pages

### DIFF
--- a/ports/beijing.html
+++ b/ports/beijing.html
@@ -1,0 +1,23 @@
+<!--
+Soli Deo Gloria
+ITW-Lite v3.010 | ICP-Lite v1.4
+Redirect: Beijing → Tianjin (Beijing's cruise port)
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/ports/tianjin.html" />
+    <link rel="canonical" href="https://inthewake.io/ports/tianjin" />
+    <title>Beijing Cruise Port → Tianjin | In the Wake</title>
+    <meta name="robots" content="noindex, follow" />
+    <meta name="description" content="Beijing cruises dock at Tianjin port, 2-3 hours from the city. Redirecting to our Tianjin cruise port guide." />
+    <meta name="ai-summary" content="Redirect page. Beijing has no cruise port; ships dock at Tianjin (Xingang), 80 miles southeast. Full-day shore excursions to Great Wall, Forbidden City available." />
+    <meta name="last-reviewed" content="2026-01-03" />
+    <meta name="content-protocol" content="ICP-Lite v1.4" />
+  </head>
+  <body>
+    <p>Beijing cruises use <a href="/ports/tianjin.html">Tianjin</a> as the cruise port. Redirecting...</p>
+    <script>window.location.replace("/ports/tianjin.html");</script>
+  </body>
+</html>

--- a/ports/kyoto.html
+++ b/ports/kyoto.html
@@ -1,0 +1,23 @@
+<!--
+Soli Deo Gloria
+ITW-Lite v3.010 | ICP-Lite v1.4
+Redirect: Kyoto → Osaka (Kyoto's nearest cruise port)
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/ports/osaka.html" />
+    <link rel="canonical" href="https://inthewake.io/ports/osaka" />
+    <title>Kyoto Cruise Port → Osaka | In the Wake</title>
+    <meta name="robots" content="noindex, follow" />
+    <meta name="description" content="Kyoto cruises dock at Osaka port, 1 hour from the ancient capital. Redirecting to our Osaka cruise port guide." />
+    <meta name="ai-summary" content="Redirect page. Kyoto is landlocked; ships dock at Osaka (75 min by train) or Kobe (50 min). Shore excursions to temples, geisha districts, bamboo groves available." />
+    <meta name="last-reviewed" content="2026-01-03" />
+    <meta name="content-protocol" content="ICP-Lite v1.4" />
+  </head>
+  <body>
+    <p>Kyoto cruises use <a href="/ports/osaka.html">Osaka</a> or <a href="/ports/kobe.html">Kobe</a> as the cruise port. Redirecting to Osaka...</p>
+    <script>window.location.replace("/ports/osaka.html");</script>
+  </body>
+</html>


### PR DESCRIPTION
Create alias redirects for landlocked destinations:
- beijing.html → tianjin.html (Beijing's cruise port, 80mi SE)
- kyoto.html → osaka.html (Kyoto access via Osaka/Kobe)

Uses meta refresh + JS redirect with noindex directive. Completes P4 alias ports from audit (41 of 43 done).