### PR TITLE
Add og:image and twitter:image to all remaining pages

### DIFF
--- a/admin/add-social-images.py
+++ b/admin/add-social-images.py
@@ -119,7 +119,7 @@ def add_social_tags(filepath, dry_run=False):
                 content = re.sub(og_title_pattern, r'\1' + og_image_tag, content)
                 modified = True
             elif 'og:type' not in content:
-                # No OpenGraph tags at all - add full section after canonical link
+                # No OpenGraph tags at all - add full section after canonical link or title
                 og_section = f'''
   <!-- OpenGraph -->
   <meta property="og:type" content="article"/>
@@ -133,6 +133,12 @@ def add_social_tags(filepath, dry_run=False):
                 if re.search(canonical_pattern, content):
                     content = re.sub(canonical_pattern, r'\1' + og_section, content)
                     modified = True
+                else:
+                    # No canonical link - insert after title tag
+                    title_pattern = r'(<title>[^<]*</title>)'
+                    if re.search(title_pattern, content):
+                        content = re.sub(title_pattern, r'\1' + og_section, content)
+                        modified = True
 
     # Add twitter:image after twitter:card if missing
     if not has_twitter_image(content):
@@ -181,7 +187,11 @@ def main():
     # Also check root-level HTML files
     root_files = [
         'drinks.html', 'drink-packages.html', 'packing.html',
-        'search.html', 'privacy.html', 'terms.html', 'offline.html'
+        'search.html', 'privacy.html', 'terms.html', 'offline.html',
+        'internet-at-sea.html', 'stateroom-check.html', 'about-us.html',
+        'accessibility.html', 'articles.html', 'cruise-lines.html',
+        'disability-at-sea.html', 'packing-lists.html', 'planning.html',
+        'ports.html', 'restaurants.html', 'ships.html', 'index.html'
     ]
 
     total_updated = 0

--- a/authors/ken-baker.html
+++ b/authors/ken-baker.html
@@ -14,6 +14,14 @@
   <meta name="version" content="3.010.300"/>
 
   <title>Ken Baker — In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Ken Baker — In the Wake"/>
+  <meta property="og:description" content="Ken Baker — Founder of In the Wake. Pastor, photographer, and seasoned cruiser. Expertise in Royal Caribbean, accessibility, and solo cruising."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/about-hero.jpg"/>
+
 
   <!-- Canonical normalizer (choose ONE host; apex here) -->
   <!-- Navigation Dropdown Script -->

--- a/authors/tina-maulsby.html
+++ b/authors/tina-maulsby.html
@@ -24,6 +24,14 @@
   <meta name="version" content="3.006.authors.002"/>
 
   <title>Tina Maulsby — In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Tina Maulsby — In the Wake"/>
+  <meta property="og:description" content="Articles by Tina Maulsby — solo cruising stories, safety tips, and community building at sea."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/about-hero.jpg"/>
+
 
   <!-- Canonical normalizer (choose ONE host; apex here) -->
   <!-- Navigation Dropdown Script -->

--- a/disability-at-sea.html
+++ b/disability-at-sea.html
@@ -57,6 +57,9 @@ ADDENDUM: Facebook Domain Verification v3.008.021
   <meta property="og:description" content="Our mission is full digital accessibility for all travelers — a site built with empathy and conviction, following WCAG 2.1 AA and ADA standards."/>
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/disability-hero.jpg?v=3.010.100"/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="In the Wake is committed to accessibility for all travelers — honoring every ability, ensuring every voyager can plan and dream freely. Built for clarity, inclusion, and love."/>
+  <meta name="twitter:title" content="Accessibility &amp; Inclusion — In the Wake"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"/>
 
   <!-- Global styles -->
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.100"/>

--- a/internet-at-sea.html
+++ b/internet-at-sea.html
@@ -50,10 +50,12 @@
   <meta property="og:title" content="Internet at Sea — Cruise Wi-Fi &amp; Connectivity Guide"/>
   <meta property="og:description" content="How cruise Wi-Fi works, how to avoid surprise roaming fees, and how to choose the right plan for your sailing."/>
   <meta property="og:url" content="https://cruisinginthewake.com/internet-at-sea.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/planning-hero.jpg"/>
 
   <!-- Twitter -->
-  <meta name="twitter:card" content="summary"/>
+  <meta name="twitter:card" content="summary_large_image"/>
   <meta name="twitter:title" content="Internet at Sea — Cruise Wi-Fi Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/planning-hero.jpg"/>
 
   <!-- JSON-LD: BreadcrumbList -->
   <script type="application/ld+json">

--- a/offline.html
+++ b/offline.html
@@ -37,6 +37,14 @@ STANDARDS: Every Page v3.010.300 · Offline Fallback · A11y/WCAG 2.1 AA Complia
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <title>You're Offline | In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="You're Offline"/>
+  <meta property="og:description" content="You're currently offline. Search cached content and access previously visited pages."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"/>
+
   <meta name="description" content="You're currently offline. Search cached content and access previously visited pages."/>
 
   <!-- Favicon -->

--- a/ports/bangkok.html
+++ b/ports/bangkok.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Bangkok / Laem Chabang Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Bangkok / Laem Chabang Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person Bangkok cruise guide: Grand Palace's royal history, Temple of the Emerald Buddha, Wat Arun's porcelain-encrusted tower, Wat Pho's golden Reclining Buddha, street food crawls, and sunset rooftop bars."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person Bangkok cruise guide: Grand Palace's royal history, Temple of the Emerald Buddha, Wat Arun's porcelain-encrusted tower, Wat Pho's golden Reclining Buddha, street food crawls, and sunset rooftop bars." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/brisbane.html
+++ b/ports/brisbane.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Brisbane Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Brisbane Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person logbook: Brisbane's Portside Wharf, South Bank riverside, scenic river cruises to Lone Pine Koala Sanctuary with 130+ koalas, and why Queensland's subtropical warmth makes this Australia's most welcoming port."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person logbook: Brisbane's Portside Wharf, South Bank riverside, scenic river cruises to Lone Pine Koala Sanctuary with 130+ koalas, and why Queensland's subtropical warmth makes this Australia's most welcoming port." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/cephalonia.html
+++ b/ports/cephalonia.html
@@ -12,6 +12,14 @@ Soli Deo Gloria
   }
   </script>
     <title>Cephalonia (Kefalonia), Greece - Largest Ionian Island Port Guide | In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Cephalonia (Kefalonia), Greece - Largest Ionian Island Port Guide"/>
+  <meta property="og:description" content="First-person logbook entry from Cephalonia: Greece's largest Ionian island with 50,000 years of history, Melissani Cave's crystal waters, Myrtos Beach, ancient castles, Drogarati Cave, and resilience after the 1953 earthquake."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
     <meta name="description" content="First-person logbook entry from Cephalonia: Greece's largest Ionian island with 50,000 years of history, Melissani Cave's crystal waters, Myrtos Beach, ancient castles, Drogarati Cave, and resilience after the 1953 earthquake.">
 
     <!-- ICP-Lite Metadata -->

--- a/ports/christchurch.html
+++ b/ports/christchurch.html
@@ -12,6 +12,14 @@ Soli Deo Gloria
   }
   </script>
     <title>Christchurch (Lyttelton) Cruise Port Guide | Garden City Rebuilt | In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Christchurch (Lyttelton) Cruise Port Guide"/>
+  <meta property="og:description" content="Discover Christchurch and Lyttelton Port: New Zealand's oldest established city, the Garden City rebuilt after devastating 2011 earthquakes. Explore the Cardboard Cathedral, historic Botanic Gardens since 1863, and Avon River punting through 164-hectare Hagley Park."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
     <meta name="description" content="Discover Christchurch and Lyttelton Port: New Zealand's oldest established city, the Garden City rebuilt after devastating 2011 earthquakes. Explore the Cardboard Cathedral, historic Botanic Gardens since 1863, and Avon River punting through 164-hectare Hagley Park.">
     <meta name="ai-summary" content="Christchurch is New Zealand's resilient Garden City, rebuilt after the 2011 earthquake. Visit the Cardboard Cathedral, Botanic Gardens since 1863, and experience Avon River punting.">
     <meta name="last-reviewed" content="2025-12-26">

--- a/ports/ho-chi-minh.html
+++ b/ports/ho-chi-minh.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Ho Chi Minh City (Saigon) Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Ho Chi Minh City (Saigon) Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to Ho Chi Minh City cruise port: War Remnants Museum, Cu Chi Tunnels, Notre-Dame Cathedral, vibrant markets, and iconic street food."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to Ho Chi Minh City cruise port: War Remnants Museum, Cu Chi Tunnels, Notre-Dame Cathedral, vibrant markets, and iconic street food." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/hong-kong.html
+++ b/ports/hong-kong.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Hong Kong Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Hong Kong Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to Hong Kong cruise port: Victoria Harbour's colonial history, historic Star Ferry (1888), Victoria Peak tram, Temple Street Night Market, and the contrast between ancient fishing villages and modern skyscrapers."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to Hong Kong cruise port: Victoria Harbour's colonial history, historic Star Ferry (1888), Victoria Peak tram, Temple Street Night Market, and the contrast between ancient fishing villages and modern skyscrapers." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/hurghada.html
+++ b/ports/hurghada.html
@@ -12,6 +12,14 @@ Soli Deo Gloria
   }
   </script>
     <title>Hurghada, Egypt: Red Sea Resort and Marine Life Haven - Cruise Port Guide</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Hurghada, Egypt: Red Sea Resort and Marine Life Haven - Cruise Port Guide"/>
+  <meta property="og:description" content="Discover Hurghada's vibrant coral reefs, Giftun Islands marine park, desert adventures, and the gateway to ancient Luxor. A Red Sea haven for divers and sun-seekers."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
     <meta name="description" content="Discover Hurghada's vibrant coral reefs, Giftun Islands marine park, desert adventures, and the gateway to ancient Luxor. A Red Sea haven for divers and sun-seekers.">
 
     <!-- ICP-Lite Meta Tags -->

--- a/ports/kota-kinabalu.html
+++ b/ports/kota-kinabalu.html
@@ -15,6 +15,14 @@ Soli Deo Gloria
     <meta name="last-reviewed" content="2025-12-14">
     <meta name="content-protocol" content="ICP-Lite v1.4">
     <title>Kota Kinabalu, Malaysia: Borneo Gateway & Mount Kinabalu Views | In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Kota Kinabalu, Malaysia: Borneo Gateway & Mount Kinabalu Views"/>
+  <meta property="og:description" content="A reflective cruise port guide to Kota Kinabalu, Sabah - where Borneo's highest peak meets turquoise marine parks, indigenous cultures, and the vibrant heart of Malaysian Borneo."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
     <meta name="description" content="A reflective cruise port guide to Kota Kinabalu, Sabah - where Borneo's highest peak meets turquoise marine parks, indigenous cultures, and the vibrant heart of Malaysian Borneo.">
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
     <!-- Leaflet CSS for interactive maps -->

--- a/ports/lautoka.html
+++ b/ports/lautoka.html
@@ -12,6 +12,14 @@ Soli Deo Gloria
   }
   </script>
     <title>Lautoka, Fiji: Sugar City and Gateway to Paradise | Port Guide</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Lautoka, Fiji: Sugar City and Gateway to Paradise"/>
+  <meta property="og:description" content="Discover Lautoka, Fiji's Sugar City on western Viti Levu. Gateway to Yasawa Islands, vibrant markets, Hindu temples, and authentic Bula spirit hospitality."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
     <meta name="description" content="Discover Lautoka, Fiji's Sugar City on western Viti Levu. Gateway to Yasawa Islands, vibrant markets, Hindu temples, and authentic Bula spirit hospitality.">
 
     <!-- ICP-Lite Meta Tags -->

--- a/ports/manila.html
+++ b/ports/manila.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Manila Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Manila Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to Manila cruise port: Intramuros walled city, Fort Santiago, colonial churches, vibrant jeepney culture, and world-class museums."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to Manila cruise port: Intramuros walled city, Fort Santiago, colonial churches, vibrant jeepney culture, and world-class museums." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/mindelo.html
+++ b/ports/mindelo.html
@@ -12,6 +12,14 @@ Soli Deo Gloria
   }
   </script>
     <title>Mindelo, Cape Verde: Cultural Heart of the Atlantic | In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Mindelo, Cape Verde: Cultural Heart of the Atlantic"/>
+  <meta property="og:description" content="Experience Mindelo, São Vicente - birthplace of Cesária Évora, cultural capital of Cape Verde, where morna music fills colonial streets and Porto Grande welcomes sailors to Africa's soulful archipelago."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
     <meta name="description" content="Experience Mindelo, São Vicente - birthplace of Cesária Évora, cultural capital of Cape Verde, where morna music fills colonial streets and Porto Grande welcomes sailors to Africa's soulful archipelago.">
 
     <!-- ICP-Lite Meta Tags -->

--- a/ports/mumbai.html
+++ b/ports/mumbai.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Mumbai Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Mumbai Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to Mumbai cruise port: Gateway of India, Taj Mahal Palace Hotel, Elephanta Caves, Bollywood, and why this vibrant megacity captivates every visitor."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to Mumbai cruise port: Gateway of India, Taj Mahal Palace Hotel, Elephanta Caves, Bollywood, and why this vibrant megacity captivates every visitor." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/palau.html
+++ b/ports/palau.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Palau / Koror Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Palau / Koror Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to Palau cruise port in Koror: Jellyfish Lake with stingless golden jellies, Rock Islands UNESCO site, world-class diving at Blue Corner, Milky Way lagoon, and WWII history at Peleliu."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to Palau cruise port in Koror: Jellyfish Lake with stingless golden jellies, Rock Islands UNESCO site, world-class diving at Blue Corner, Milky Way lagoon, and WWII history at Peleliu." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/philipsburg.html
+++ b/ports/philipsburg.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Philipsburg / St. Maarten Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Philipsburg / St. Maarten Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="Complete cruise guide to Philipsburg, St. Maarten: One island, two countries with Maho Beach plane watching, duty-free shopping, Orient Beach, and easy access to both Dutch and French sides."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="Complete cruise guide to Philipsburg, St. Maarten: One island, two countries with Maho Beach plane watching, duty-free shopping, Orient Beach, and easy access to both Dutch and French sides." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/port-moresby.html
+++ b/ports/port-moresby.html
@@ -12,6 +12,14 @@ Soli Deo Gloria
   }
   </script>
     <title>Port Moresby, Papua New Guinea - Gateway to Tribal Cultures & WWII History | In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Port Moresby, Papua New Guinea - Gateway to Tribal Cultures & WWII History"/>
+  <meta property="og:description" content="Explore Port Moresby, PNG's vibrant capital on the Coral Sea. Discover tribal artifacts, WWII memorials, birds of paradise, and 800+ languages in one extraordinary place."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
     <meta name="description" content="Explore Port Moresby, PNG's vibrant capital on the Coral Sea. Discover tribal artifacts, WWII memorials, birds of paradise, and 800+ languages in one extraordinary place.">
 
     <!-- ICP-Lite Meta Tags -->

--- a/ports/praia.html
+++ b/ports/praia.html
@@ -12,6 +12,14 @@ Soli Deo Gloria
   }
   </script>
     <title>Praia, Cape Verde: Port Guide & First-Hand Experience | InTheWake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Praia, Cape Verde: Port Guide & First-Hand Experience"/>
+  <meta property="og:description" content="First-hand guide to visiting Praia, Cape Verde by cruise ship. Explore the Plateau's colonial heritage, Cidade Velha's UNESCO sites, Sucupira Market, and Santiago Island's beaches."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
     <meta name="description" content="First-hand guide to visiting Praia, Cape Verde by cruise ship. Explore the Plateau's colonial heritage, Cidade Velha's UNESCO sites, Sucupira Market, and Santiago Island's beaches.">
     <meta name="ai-summary" content="Praia is Cape Verde's capital on Santiago Island with Creole culture. Explore Plateau historic quarter, vibrant markets, beaches, African-Portuguese fusion, and island rhythms.">
     <meta name="last-reviewed" content="2025-12-14">

--- a/ports/shanghai.html
+++ b/ports/shanghai.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Shanghai Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Shanghai Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to Shanghai cruise port: The Bund's colonial architecture, futuristic Pudong, Ming Dynasty Yu Garden, French Concession history, and the city where past meets future."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to Shanghai cruise port: The Bund's colonial architecture, futuristic Pudong, Ming Dynasty Yu Garden, French Concession history, and the city where past meets future." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/singapore.html
+++ b/ports/singapore.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Singapore Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Singapore Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to Singapore cruise port: Gardens by the Bay, Marina Bay Sands, hawker centers, and why it's Asia's top-rated port."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to Singapore cruise port: Gardens by the Bay, Marina Bay Sands, hawker centers, and why it's Asia's top-rated port." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/south-pacific.html
+++ b/ports/south-pacific.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>South Pacific Islands Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="South Pacific Islands Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to South Pacific cruise ports: Bora Bora, Tahiti, Moorea, Fiji, Vanuatu, and Nouméa – turquoise lagoons and paradise islands."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to South Pacific cruise ports: Bora Bora, Tahiti, Moorea, Fiji, Vanuatu, and Nouméa – turquoise lagoons and paradise islands." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/sydney.html
+++ b/ports/sydney.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Sydney Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Sydney Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="Sydney features Opera House, Harbour Bridge, Bondi Beach, and spectacular harbour entrance. Australia's highest-rated cruise port with world-class attractions."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="Sydney features Opera House, Harbour Bridge, Bondi Beach, and spectacular harbour entrance. Australia's highest-rated cruise port with world-class attractions." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/tianjin.html
+++ b/ports/tianjin.html
@@ -17,6 +17,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Tianjin Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Tianjin Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to Tianjin cruise port: Beijing gateway with Great Wall, Forbidden City, Temple of Heaven, and Tianjin's Italian Concession streets."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to Tianjin cruise port: Beijing gateway with Great Wall, Forbidden City, Temple of Heaven, and Tianjin's Italian Concession streets." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/tokyo.html
+++ b/ports/tokyo.html
@@ -16,6 +16,14 @@ All work on this project is offered as a gift to God.
   <meta name="content-protocol" content="ICP-Lite v1.4" />
 
   <title>Tokyo / Yokohama Cruise Port Guide – In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Tokyo / Yokohama Cruise Port Guide – In the Wake"/>
+  <meta property="og:description" content="First-person guide to Tokyo and Yokohama cruise ports: Historic Osanbashi Pier since 1894, Mount Fuji views, ancient temples, Shibuya Crossing, TeamLab art, and the contrast of tradition meeting ultra-modern technology."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
   <meta name="description" content="First-person guide to Tokyo and Yokohama cruise ports: Historic Osanbashi Pier since 1894, Mount Fuji views, ancient temples, Shibuya Crossing, TeamLab art, and the contrast of tradition meeting ultra-modern technology." />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
   <!-- Service Worker Registration -->

--- a/ports/yangon.html
+++ b/ports/yangon.html
@@ -12,6 +12,14 @@ Soli Deo Gloria
   }
   </script>
     <title>Yangon (Rangoon), Myanmar: Golden Spires and Colonial Echoes - In the Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Yangon (Rangoon), Myanmar: Golden Spires and Colonial Echoes - In the Wake"/>
+  <meta property="og:description" content="A cruise port guide to Yangon, Myanmar - from the shimmering Shwedagon Pagoda to British colonial architecture, tea shop culture, and the complex beauty of Burma's former capital."/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg"/>
+
     <meta name="description" content="A cruise port guide to Yangon, Myanmar - from the shimmering Shwedagon Pagoda to British colonial architecture, tea shop culture, and the complex beauty of Burma's former capital.">
 
     <!-- ICP-Lite Meta Tags -->

--- a/ships/carnival/mardi-gras.html
+++ b/ships/carnival/mardi-gras.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/carnival/mardi-gras.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Mardi Gras — Carnival Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Mardi Gras: Excel Class ship with 5,200 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Mardi Gras: A Excel Class ship from Carnival Cruise Line. 180,800 GT, 5,200 guests, built 2021. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Mardi Gras — Carnival Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Apex • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Apex • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Apex • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-apex.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-ascent.html
+++ b/ships/celebrity-cruises/celebrity-ascent.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Ascent • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Ascent • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Ascent • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-ascent.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-beyond.html
+++ b/ships/celebrity-cruises/celebrity-beyond.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Beyond • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Beyond • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Beyond • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-beyond.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-century.html
+++ b/ships/celebrity-cruises/celebrity-century.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Century • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Century • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Century • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-century.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-compass.html
+++ b/ships/celebrity-cruises/celebrity-compass.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Compass • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Compass • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Compass • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-compass.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-constellation.html
+++ b/ships/celebrity-cruises/celebrity-constellation.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Constellation • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Constellation • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Constellation • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-constellation.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-eclipse.html
+++ b/ships/celebrity-cruises/celebrity-eclipse.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Eclipse • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Eclipse • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Eclipse • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-eclipse.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-edge.html
+++ b/ships/celebrity-cruises/celebrity-edge.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Edge • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Edge • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Edge • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-edge.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-equinox.html
+++ b/ships/celebrity-cruises/celebrity-equinox.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Equinox • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Equinox • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Equinox • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-equinox.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-flora.html
+++ b/ships/celebrity-cruises/celebrity-flora.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Flora • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Flora • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Flora • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-flora.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-galaxy.html
+++ b/ships/celebrity-cruises/celebrity-galaxy.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Galaxy • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Galaxy • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Galaxy • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-galaxy.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-infinity.html
+++ b/ships/celebrity-cruises/celebrity-infinity.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Infinity • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Infinity • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Infinity • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-infinity.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-mercury.html
+++ b/ships/celebrity-cruises/celebrity-mercury.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Mercury • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Mercury • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Mercury • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-mercury.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-millennium.html
+++ b/ships/celebrity-cruises/celebrity-millennium.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Millennium • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Millennium • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Millennium • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-millennium.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-reflection.html
+++ b/ships/celebrity-cruises/celebrity-reflection.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Reflection • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Reflection • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Reflection • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-reflection.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-seeker.html
+++ b/ships/celebrity-cruises/celebrity-seeker.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Seeker • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Seeker • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Seeker • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-seeker.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-silhouette.html
+++ b/ships/celebrity-cruises/celebrity-silhouette.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Silhouette • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Silhouette • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Silhouette • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-silhouette.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-solstice.html
+++ b/ships/celebrity-cruises/celebrity-solstice.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Solstice • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Solstice • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Solstice • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-solstice.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-summit.html
+++ b/ships/celebrity-cruises/celebrity-summit.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Summit • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Summit • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Summit • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-summit.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Xcel • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Xcel • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Xcel • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-xcel.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-xpedition.html
+++ b/ships/celebrity-cruises/celebrity-xpedition.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Xpedition • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Xpedition • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Xpedition • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-xpedition.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-xperience.html
+++ b/ships/celebrity-cruises/celebrity-xperience.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Xperience • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Xperience • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Xperience • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-xperience.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/celebrity-xploration.html
+++ b/ships/celebrity-cruises/celebrity-xploration.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Celebrity Xploration • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Celebrity Xploration • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Celebrity Xploration • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/celebrity-xploration.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/horizon.html
+++ b/ships/celebrity-cruises/horizon.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Horizon • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Horizon • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Horizon • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/horizon.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/ss-meridian.html
+++ b/ships/celebrity-cruises/ss-meridian.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>SS Meridian • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="SS Meridian • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="SS Meridian • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ss-meridian.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/unnamed-edge-class.html
+++ b/ships/celebrity-cruises/unnamed-edge-class.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Unnamed (Edge-class) • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Unnamed (Edge-class) • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Unnamed (Edge-class) • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/unnamed-edge-class.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/unnamed-project-nirvana.html
+++ b/ships/celebrity-cruises/unnamed-project-nirvana.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Unnamed (Project Nirvana) • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Unnamed (Project Nirvana) • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Unnamed (Project Nirvana) • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/unnamed-project-nirvana.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/unnamed-river-class-x6.html
+++ b/ships/celebrity-cruises/unnamed-river-class-x6.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Unnamed (River-class x6) • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Unnamed (River-class x6) • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Unnamed (River-class x6) • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/unnamed-river-class-x6.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/celebrity-cruises/zenith.html
+++ b/ships/celebrity-cruises/zenith.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Zenith • Celebrity Cruises • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Zenith • Celebrity Cruises • In The Wake"/>
+  <meta property="og:description" content="Zenith • Celebrity Cruises • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/zenith.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/costa/costa-deliziosa.html
+++ b/ships/costa/costa-deliziosa.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/costa-deliziosa.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Costa Deliziosa — Costa Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Costa Deliziosa: Spirit Class ship with 2,260 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Costa Deliziosa: A Spirit Class ship from Costa Cruises. 92,720 GT, 2,260 guests, built 2010. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Costa Deliziosa — Costa Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/costa/costa-diadema.html
+++ b/ships/costa/costa-diadema.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/costa-diadema.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Costa Diadema — Costa Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Costa Diadema: Diadema Class ship with 3,724 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Costa Diadema: A Diadema Class ship from Costa Cruises. 132,500 GT, 3,724 guests, built 2014. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Costa Diadema — Costa Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/costa/costa-fascinosa.html
+++ b/ships/costa/costa-fascinosa.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/costa-fascinosa.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Costa Fascinosa — Costa Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Costa Fascinosa: Concordia Class ship with 3,012 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Costa Fascinosa: A Concordia Class ship from Costa Cruises. 114,500 GT, 3,012 guests, built 2012. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Costa Fascinosa — Costa Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/costa/costa-favolosa.html
+++ b/ships/costa/costa-favolosa.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/costa-favolosa.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Costa Favolosa — Costa Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Costa Favolosa: Concordia Class ship with 3,012 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Costa Favolosa: A Concordia Class ship from Costa Cruises. 114,500 GT, 3,012 guests, built 2011. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Costa Favolosa — Costa Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/costa/costa-firenze.html
+++ b/ships/costa/costa-firenze.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/costa-firenze.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Costa Firenze — Costa Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Costa Firenze: Venice Class ship with 4,232 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Costa Firenze: A Venice Class ship from Costa Cruises. 135,500 GT, 4,232 guests, built 2021. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Costa Firenze — Costa Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/costa/costa-pacifica.html
+++ b/ships/costa/costa-pacifica.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/costa-pacifica.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Costa Pacifica — Costa Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Costa Pacifica: Concordia Class ship with 3,012 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Costa Pacifica: A Concordia Class ship from Costa Cruises. 114,500 GT, 3,012 guests, built 2009. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Costa Pacifica — Costa Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/costa/costa-smeralda.html
+++ b/ships/costa/costa-smeralda.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/costa-smeralda.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Costa Smeralda — Costa Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Costa Smeralda: Excellence Class ship with 5,224 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Costa Smeralda: A Excellence Class ship from Costa Cruises. 185,010 GT, 5,224 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Costa Smeralda — Costa Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/costa/costa-toscana.html
+++ b/ships/costa/costa-toscana.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/costa-toscana.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Costa Toscana — Costa Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Costa Toscana: Excellence Class ship with 5,324 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Costa Toscana: A Excellence Class ship from Costa Cruises. 185,010 GT, 5,324 guests, built 2022. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Costa Toscana — Costa Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/costa/costa-venezia.html
+++ b/ships/costa/costa-venezia.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/costa-venezia.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Costa Venezia — Costa Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Costa Venezia: Venice Class ship with 4,232 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Costa Venezia: A Venice Class ship from Costa Cruises. 135,500 GT, 4,232 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Costa Venezia — Costa Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/costa/index.html
+++ b/ships/costa/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Costa Cruises Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/costa/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Costa Cruises Ships"/>
+  <meta property="og:description" content="Explore all Costa Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/costa/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all Costa Cruises ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to Costa Cruises ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Costa Cruises Ships"/>
+  <meta name="twitter:description" content="Explore all Costa Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/cunard/index.html
+++ b/ships/cunard/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Cunard Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/cunard/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Cunard Ships"/>
+  <meta property="og:description" content="Explore all Cunard ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/cunard/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all Cunard ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to Cunard ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Cunard Ships"/>
+  <meta name="twitter:description" content="Explore all Cunard ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/cunard/queen-anne.html
+++ b/ships/cunard/queen-anne.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/cunard/queen-anne.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Queen Anne — Cunard Ship Guide"/>
   <meta property="og:description" content="Explore Queen Anne: Queen Anne Class ship with 2,996 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Queen Anne: A Queen Anne Class ship from Cunard. 113,000 GT, 2,996 guests, built 2024. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Queen Anne — Cunard Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/cunard/queen-elizabeth.html
+++ b/ships/cunard/queen-elizabeth.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/cunard/queen-elizabeth.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Queen Elizabeth — Cunard Ship Guide"/>
   <meta property="og:description" content="Explore Queen Elizabeth: Vista Class ship with 2,068 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Queen Elizabeth: A Vista Class ship from Cunard. 90,900 GT, 2,068 guests, built 2010. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Queen Elizabeth — Cunard Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/cunard/queen-mary-2.html
+++ b/ships/cunard/queen-mary-2.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/cunard/queen-mary-2.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Queen Mary 2 — Cunard Ship Guide"/>
   <meta property="og:description" content="Explore Queen Mary 2: Ocean Liner ship with 2,691 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Queen Mary 2: A Ocean Liner ship from Cunard. 149,215 GT, 2,691 guests, built 2004. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Queen Mary 2 — Cunard Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/cunard/queen-victoria.html
+++ b/ships/cunard/queen-victoria.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/cunard/queen-victoria.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Queen Victoria — Cunard Ship Guide"/>
   <meta property="og:description" content="Explore Queen Victoria: Vista Class ship with 2,014 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Queen Victoria: A Vista Class ship from Cunard. 90,049 GT, 2,014 guests, built 2007. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Queen Victoria — Cunard Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/explora-journeys/explora-i.html
+++ b/ships/explora-journeys/explora-i.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/explora-journeys/explora-i.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Explora I — Explora Journeys Ship Guide"/>
   <meta property="og:description" content="Explore Explora I: Explora Class ship with 922 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Explora I: A Explora Class ship from Explora Journeys. 63,900 GT, 922 guests, built 2023. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Explora I — Explora Journeys Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/explora-journeys/explora-ii.html
+++ b/ships/explora-journeys/explora-ii.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/explora-journeys/explora-ii.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Explora II — Explora Journeys Ship Guide"/>
   <meta property="og:description" content="Explore Explora II: Explora Class ship with 922 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Explora II: A Explora Class ship from Explora Journeys. 63,900 GT, 922 guests, built 2024. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Explora II — Explora Journeys Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/explora-journeys/explora-iii.html
+++ b/ships/explora-journeys/explora-iii.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/explora-journeys/explora-iii.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Explora III — Explora Journeys Ship Guide"/>
   <meta property="og:description" content="Explore Explora III: Explora Class ship with 922 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Explora III: A Explora Class ship from Explora Journeys. 63,900 GT, 922 guests, built 2026. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Explora III — Explora Journeys Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/explora-journeys/explora-iv.html
+++ b/ships/explora-journeys/explora-iv.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/explora-journeys/explora-iv.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Explora IV — Explora Journeys Ship Guide"/>
   <meta property="og:description" content="Explore Explora IV: Explora Class ship with 922 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Explora IV: A Explora Class ship from Explora Journeys. 63,900 GT, 922 guests, built 2027. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Explora IV — Explora Journeys Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/explora-journeys/explora-v.html
+++ b/ships/explora-journeys/explora-v.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/explora-journeys/explora-v.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Explora V — Explora Journeys Ship Guide"/>
   <meta property="og:description" content="Explore Explora V: Explora Hydrogen Class ship with 922 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Explora V: A Explora Hydrogen Class ship from Explora Journeys. 69,000 GT, 922 guests, built 2028. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Explora V — Explora Journeys Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/explora-journeys/explora-vi.html
+++ b/ships/explora-journeys/explora-vi.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/explora-journeys/explora-vi.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Explora VI — Explora Journeys Ship Guide"/>
   <meta property="og:description" content="Explore Explora VI: Explora Hydrogen Class ship with 922 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Explora VI: A Explora Hydrogen Class ship from Explora Journeys. 69,000 GT, 922 guests, built 2028. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Explora VI — Explora Journeys Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/explora-journeys/index.html
+++ b/ships/explora-journeys/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Explora Journeys Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/explora-journeys/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Explora Journeys Ships"/>
+  <meta property="og:description" content="Explore all Explora Journeys ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/explora-journeys/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all Explora Journeys ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to Explora Journeys ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Explora Journeys Ships"/>
+  <meta name="twitter:description" content="Explore all Explora Journeys ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/holland-america-line/amsterdam.html
+++ b/ships/holland-america-line/amsterdam.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Amsterdam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Amsterdam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Amsterdam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/amsterdam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/edam.html
+++ b/ships/holland-america-line/edam.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Edam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Edam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Edam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/edam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/eurodam.html
+++ b/ships/holland-america-line/eurodam.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Eurodam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Eurodam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Eurodam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/eurodam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/koningsdam.html
+++ b/ships/holland-america-line/koningsdam.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Koningsdam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Koningsdam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Koningsdam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/koningsdam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/leerdam.html
+++ b/ships/holland-america-line/leerdam.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Leerdam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Leerdam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Leerdam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/leerdam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/maartensdijk.html
+++ b/ships/holland-america-line/maartensdijk.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Maartensdijk • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Maartensdijk • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Maartensdijk • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/maartensdijk.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/maasdam.html
+++ b/ships/holland-america-line/maasdam.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Maasdam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Maasdam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Maasdam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/maasdam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/nieuw-amsterdam-ii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-ii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Nieuw Amsterdam (II) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Nieuw Amsterdam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Nieuw Amsterdam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/nieuw-amsterdam-ii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/nieuw-amsterdam-iii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Nieuw Amsterdam (III) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Nieuw Amsterdam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Nieuw Amsterdam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/nieuw-amsterdam-iii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/nieuw-amsterdam-iv.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iv.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Nieuw Amsterdam (IV) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Nieuw Amsterdam (IV) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Nieuw Amsterdam (IV) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/nieuw-amsterdam-iv.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/nieuw-amsterdam-v.html
+++ b/ships/holland-america-line/nieuw-amsterdam-v.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Nieuw Amsterdam (V) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Nieuw Amsterdam (V) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Nieuw Amsterdam (V) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/nieuw-amsterdam-v.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/nieuw-amsterdam.html
+++ b/ships/holland-america-line/nieuw-amsterdam.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Nieuw Amsterdam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Nieuw Amsterdam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Nieuw Amsterdam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/nieuw-amsterdam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/nieuw-statendam.html
+++ b/ships/holland-america-line/nieuw-statendam.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Nieuw Statendam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Nieuw Statendam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Nieuw Statendam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/nieuw-statendam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/none-announced.html
+++ b/ships/holland-america-line/none-announced.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>None announced • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="None announced • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="None announced • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/none-announced.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/noordam-ii.html
+++ b/ships/holland-america-line/noordam-ii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Noordam (II) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Noordam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Noordam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/noordam-ii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/noordam-iii.html
+++ b/ships/holland-america-line/noordam-iii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Noordam (III) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Noordam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Noordam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/noordam-iii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/noordam-iv.html
+++ b/ships/holland-america-line/noordam-iv.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Noordam (IV) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Noordam (IV) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Noordam (IV) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/noordam-iv.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/noordam.html
+++ b/ships/holland-america-line/noordam.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Noordam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Noordam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Noordam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/noordam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/oosterdam.html
+++ b/ships/holland-america-line/oosterdam.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Oosterdam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Oosterdam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Oosterdam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/oosterdam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/p-caland.html
+++ b/ships/holland-america-line/p-caland.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>P. Caland • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="P. Caland • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="P. Caland • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/p-caland.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/potsdam.html
+++ b/ships/holland-america-line/potsdam.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Potsdam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Potsdam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Potsdam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/potsdam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/prinsendam-i.html
+++ b/ships/holland-america-line/prinsendam-i.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Prinsendam (I) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Prinsendam (I) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Prinsendam (I) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/prinsendam-i.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/prinsendam-ii.html
+++ b/ships/holland-america-line/prinsendam-ii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Prinsendam (II) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Prinsendam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Prinsendam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/prinsendam-ii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/rijndam-ii.html
+++ b/ships/holland-america-line/rijndam-ii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Rijndam (II) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Rijndam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Rijndam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/rijndam-ii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/rijndam.html
+++ b/ships/holland-america-line/rijndam.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Rijndam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Rijndam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Rijndam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/rijndam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/rotterdam-iv.html
+++ b/ships/holland-america-line/rotterdam-iv.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Rotterdam (IV) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Rotterdam (IV) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Rotterdam (IV) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/rotterdam-iv.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/rotterdam-v.html
+++ b/ships/holland-america-line/rotterdam-v.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Rotterdam (V) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Rotterdam (V) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Rotterdam (V) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/rotterdam-v.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/rotterdam-vi.html
+++ b/ships/holland-america-line/rotterdam-vi.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Rotterdam (VI) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Rotterdam (VI) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Rotterdam (VI) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/rotterdam-vi.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/rotterdam.html
+++ b/ships/holland-america-line/rotterdam.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Rotterdam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Rotterdam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Rotterdam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/rotterdam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/ryndam.html
+++ b/ships/holland-america-line/ryndam.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Ryndam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Ryndam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Ryndam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ryndam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/statendam-ii.html
+++ b/ships/holland-america-line/statendam-ii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Statendam (II) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Statendam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Statendam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/statendam-ii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/statendam-iii.html
+++ b/ships/holland-america-line/statendam-iii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Statendam (III) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Statendam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Statendam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/statendam-iii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/statendam.html
+++ b/ships/holland-america-line/statendam.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Statendam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Statendam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Statendam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/statendam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/veendam-ii.html
+++ b/ships/holland-america-line/veendam-ii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Veendam (II) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Veendam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Veendam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/veendam-ii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/veendam-iii.html
+++ b/ships/holland-america-line/veendam-iii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Veendam (III) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Veendam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Veendam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/veendam-iii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/veendam-iv.html
+++ b/ships/holland-america-line/veendam-iv.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Veendam (IV) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Veendam (IV) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Veendam (IV) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/veendam-iv.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/veendam.html
+++ b/ships/holland-america-line/veendam.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Veendam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Veendam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Veendam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/veendam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/volendam-ii.html
+++ b/ships/holland-america-line/volendam-ii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Volendam (II) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Volendam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Volendam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/volendam-ii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/volendam-iii.html
+++ b/ships/holland-america-line/volendam-iii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Volendam (III) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Volendam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Volendam (III) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/volendam-iii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/volendam.html
+++ b/ships/holland-america-line/volendam.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Volendam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Volendam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Volendam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/volendam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/w-a-scholten.html
+++ b/ships/holland-america-line/w-a-scholten.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>W.A. Scholten • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="W.A. Scholten • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="W.A. Scholten • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/w-a-scholten.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/westerdam-i.html
+++ b/ships/holland-america-line/westerdam-i.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Westerdam (I) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Westerdam (I) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Westerdam (I) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/westerdam-i.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/westerdam-ii.html
+++ b/ships/holland-america-line/westerdam-ii.html
@@ -26,6 +26,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Westerdam (II) • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Westerdam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Westerdam (II) • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/westerdam-ii.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/westerdam.html
+++ b/ships/holland-america-line/westerdam.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/holland-america-line/westerdam.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Westerdam — Holland America Line Ship Guide"/>
   <meta property="og:description" content="Explore Westerdam: Vista Class ship with 1,916 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Westerdam: A Vista Class ship from Holland America Line. 82,348 GT, 1,916 guests, built 2004. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Westerdam — Holland America Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/holland-america-line/zaandam.html
+++ b/ships/holland-america-line/zaandam.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
 <title>Zaandam • Holland America Line • In The Wake</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Zaandam • Holland America Line • In The Wake"/>
+  <meta property="og:description" content="Zaandam • Holland America Line • In The Wake"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/zaandam.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/holland-america-line/zuiderdam.html
+++ b/ships/holland-america-line/zuiderdam.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/holland-america-line/zuiderdam.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Zuiderdam — Holland America Line Ship Guide"/>
   <meta property="og:description" content="Explore Zuiderdam: Vista Class ship with 1,916 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Zuiderdam: A Vista Class ship from Holland America Line. 82,305 GT, 1,916 guests, built 2002. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Zuiderdam — Holland America Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/index.html
+++ b/ships/msc/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>MSC Cruises Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/msc/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="MSC Cruises Ships"/>
+  <meta property="og:description" content="Explore all MSC Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all MSC Cruises ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to MSC Cruises ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="MSC Cruises Ships"/>
+  <meta name="twitter:description" content="Explore all MSC Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/msc/msc-armonia.html
+++ b/ships/msc/msc-armonia.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-armonia.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Armonia — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Armonia: Lirica Class ship with 1,954 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Armonia: A Lirica Class ship from MSC Cruises. 65,542 GT, 1,954 guests, built 2001. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Armonia — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-bellissima.html
+++ b/ships/msc/msc-bellissima.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-bellissima.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Bellissima — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Bellissima: Meraviglia Class ship with 4,500 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Bellissima: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Bellissima — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-divina.html
+++ b/ships/msc/msc-divina.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-divina.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Divina — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Divina: Fantasia Class ship with 3,502 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Divina: A Fantasia Class ship from MSC Cruises. 139,400 GT, 3,502 guests, built 2012. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Divina — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-euribia.html
+++ b/ships/msc/msc-euribia.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-euribia.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Euribia — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Euribia: Meraviglia Plus Class ship with 4,888 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Euribia: A Meraviglia Plus Class ship from MSC Cruises. 184,011 GT, 4,888 guests, built 2023. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Euribia — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-fantasia.html
+++ b/ships/msc/msc-fantasia.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-fantasia.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Fantasia — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Fantasia: Fantasia Class ship with 3,274 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Fantasia: A Fantasia Class ship from MSC Cruises. 137,936 GT, 3,274 guests, built 2008. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Fantasia — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-grandiosa.html
+++ b/ships/msc/msc-grandiosa.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-grandiosa.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Grandiosa — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Grandiosa: Meraviglia Plus Class ship with 4,888 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Grandiosa: A Meraviglia Plus Class ship from MSC Cruises. 181,541 GT, 4,888 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Grandiosa — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-lirica.html
+++ b/ships/msc/msc-lirica.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-lirica.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Lirica — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Lirica: Lirica Class ship with 1,984 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Lirica: A Lirica Class ship from MSC Cruises. 65,591 GT, 1,984 guests, built 2003. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Lirica — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-magnifica.html
+++ b/ships/msc/msc-magnifica.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-magnifica.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Magnifica — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Magnifica: Musica Class ship with 2,518 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Magnifica: A Musica Class ship from MSC Cruises. 95,128 GT, 2,518 guests, built 2010. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Magnifica — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-meraviglia.html
+++ b/ships/msc/msc-meraviglia.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-meraviglia.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Meraviglia — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Meraviglia: Meraviglia Class ship with 4,500 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Meraviglia: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2017. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Meraviglia — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-musica.html
+++ b/ships/msc/msc-musica.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-musica.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Musica — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Musica: Musica Class ship with 2,550 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Musica: A Musica Class ship from MSC Cruises. 92,409 GT, 2,550 guests, built 2006. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Musica — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-opera.html
+++ b/ships/msc/msc-opera.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-opera.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Opera — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Opera: Lirica Class ship with 1,984 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Opera: A Lirica Class ship from MSC Cruises. 65,591 GT, 1,984 guests, built 2004. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Opera — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-orchestra.html
+++ b/ships/msc/msc-orchestra.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-orchestra.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Orchestra — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Orchestra: Musica Class ship with 2,550 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Orchestra: A Musica Class ship from MSC Cruises. 92,409 GT, 2,550 guests, built 2007. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Orchestra — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-poesia.html
+++ b/ships/msc/msc-poesia.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-poesia.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Poesia — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Poesia: Musica Class ship with 2,550 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Poesia: A Musica Class ship from MSC Cruises. 92,627 GT, 2,550 guests, built 2008. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Poesia — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-preziosa.html
+++ b/ships/msc/msc-preziosa.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-preziosa.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Preziosa — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Preziosa: Fantasia Class ship with 3,502 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Preziosa: A Fantasia Class ship from MSC Cruises. 139,400 GT, 3,502 guests, built 2013. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Preziosa — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-seascape.html
+++ b/ships/msc/msc-seascape.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-seascape.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Seascape — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Seascape: Seaside EVO Class ship with 4,540 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Seascape: A Seaside EVO Class ship from MSC Cruises. 170,412 GT, 4,540 guests, built 2022. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Seascape — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-seashore.html
+++ b/ships/msc/msc-seashore.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-seashore.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Seashore — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Seashore: Seaside EVO Class ship with 4,540 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Seashore: A Seaside EVO Class ship from MSC Cruises. 170,412 GT, 4,540 guests, built 2021. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Seashore — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-seaside.html
+++ b/ships/msc/msc-seaside.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-seaside.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Seaside — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Seaside: Seaside Class ship with 4,132 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Seaside: A Seaside Class ship from MSC Cruises. 153,516 GT, 4,132 guests, built 2017. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Seaside — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-seaview.html
+++ b/ships/msc/msc-seaview.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-seaview.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Seaview — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Seaview: Seaside Class ship with 4,132 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Seaview: A Seaside Class ship from MSC Cruises. 153,516 GT, 4,132 guests, built 2018. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Seaview — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-sinfonia.html
+++ b/ships/msc/msc-sinfonia.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-sinfonia.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Sinfonia — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Sinfonia: Lirica Class ship with 1,954 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Sinfonia: A Lirica Class ship from MSC Cruises. 65,542 GT, 1,954 guests, built 2002. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Sinfonia — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-splendida.html
+++ b/ships/msc/msc-splendida.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-splendida.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Splendida — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Splendida: Fantasia Class ship with 3,274 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Splendida: A Fantasia Class ship from MSC Cruises. 137,936 GT, 3,274 guests, built 2009. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Splendida — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-virtuosa.html
+++ b/ships/msc/msc-virtuosa.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-virtuosa.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC Virtuosa — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC Virtuosa: Meraviglia Plus Class ship with 4,888 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC Virtuosa: A Meraviglia Plus Class ship from MSC Cruises. 181,541 GT, 4,888 guests, built 2021. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC Virtuosa — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-world-america.html
+++ b/ships/msc/msc-world-america.html
@@ -28,6 +28,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Msc World America — In the Wake (v2.201)</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Msc World America — In the Wake (v2.201)"/>
+  <meta property="og:description" content="Msc World America (v2.201)"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/msc-world-america.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/msc/msc-world-asia.html
+++ b/ships/msc/msc-world-asia.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-world-asia.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC World Asia — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC World Asia: World Class ship with 5,264 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC World Asia: A World Class ship from MSC Cruises. 215,863 GT, 5,264 guests, built 2026. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC World Asia — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/msc/msc-world-europa.html
+++ b/ships/msc/msc-world-europa.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/msc/msc-world-europa.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="MSC World Europa — MSC Cruises Ship Guide"/>
   <meta property="og:description" content="Explore MSC World Europa: World Class ship with 5,264 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover MSC World Europa: A World Class ship from MSC Cruises. 215,863 GT, 5,264 guests, built 2022. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="MSC World Europa — MSC Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/index.html
+++ b/ships/norwegian/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Norwegian Cruise Line Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/norwegian/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Norwegian Cruise Line Ships"/>
+  <meta property="og:description" content="Explore all Norwegian Cruise Line ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all Norwegian Cruise Line ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to Norwegian Cruise Line ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Norwegian Cruise Line Ships"/>
+  <meta name="twitter:description" content="Explore all Norwegian Cruise Line ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/norwegian/norwegian-aqua.html
+++ b/ships/norwegian/norwegian-aqua.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-aqua.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Aqua — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Aqua: Prima Plus Class ship with 3,550 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Aqua: A Prima Plus Class ship from Norwegian Cruise Line. 156,300 GT, 3,550 guests, built 2025. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Aqua — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-bliss.html
+++ b/ships/norwegian/norwegian-bliss.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-bliss.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Bliss — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Bliss: Breakaway Plus Class ship with 4,004 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Bliss: A Breakaway Plus Class ship from Norwegian Cruise Line. 168,028 GT, 4,004 guests, built 2018. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Bliss — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-breakaway.html
+++ b/ships/norwegian/norwegian-breakaway.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-breakaway.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Breakaway — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Breakaway: Breakaway Class ship with 3,963 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Breakaway: A Breakaway Class ship from Norwegian Cruise Line. 145,655 GT, 3,963 guests, built 2013. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Breakaway — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-dawn.html
+++ b/ships/norwegian/norwegian-dawn.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-dawn.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Dawn — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Dawn: Dawn Class ship with 2,224 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Dawn: A Dawn Class ship from Norwegian Cruise Line. 92,250 GT, 2,224 guests, built 2002. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Dawn — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-encore.html
+++ b/ships/norwegian/norwegian-encore.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-encore.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Encore — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Encore: Breakaway Plus Class ship with 3,998 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Encore: A Breakaway Plus Class ship from Norwegian Cruise Line. 169,116 GT, 3,998 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Encore — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-epic.html
+++ b/ships/norwegian/norwegian-epic.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-epic.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Epic — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Epic: Epic Class ship with 4,100 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Epic: A Epic Class ship from Norwegian Cruise Line. 155,873 GT, 4,100 guests, built 2010. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Epic — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-escape.html
+++ b/ships/norwegian/norwegian-escape.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-escape.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Escape — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Escape: Breakaway Plus Class ship with 4,200 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Escape: A Breakaway Plus Class ship from Norwegian Cruise Line. 164,600 GT, 4,200 guests, built 2015. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Escape — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-gem.html
+++ b/ships/norwegian/norwegian-gem.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-gem.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Gem — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Gem: Jewel Class ship with 2,394 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Gem: A Jewel Class ship from Norwegian Cruise Line. 93,530 GT, 2,394 guests, built 2007. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Gem — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-getaway.html
+++ b/ships/norwegian/norwegian-getaway.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-getaway.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Getaway — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Getaway: Breakaway Class ship with 3,963 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Getaway: A Breakaway Class ship from Norwegian Cruise Line. 145,655 GT, 3,963 guests, built 2014. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Getaway — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-jade.html
+++ b/ships/norwegian/norwegian-jade.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-jade.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Jade — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Jade: Jewel Class ship with 2,402 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Jade: A Jewel Class ship from Norwegian Cruise Line. 93,558 GT, 2,402 guests, built 2006. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Jade — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-jewel.html
+++ b/ships/norwegian/norwegian-jewel.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-jewel.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Jewel — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Jewel: Jewel Class ship with 2,376 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Jewel: A Jewel Class ship from Norwegian Cruise Line. 93,502 GT, 2,376 guests, built 2005. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Jewel — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-joy.html
+++ b/ships/norwegian/norwegian-joy.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-joy.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Joy — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Joy: Breakaway Plus Class ship with 3,804 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Joy: A Breakaway Plus Class ship from Norwegian Cruise Line. 167,725 GT, 3,804 guests, built 2017. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Joy — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-pearl.html
+++ b/ships/norwegian/norwegian-pearl.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-pearl.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Pearl — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Pearl: Jewel Class ship with 2,394 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Pearl: A Jewel Class ship from Norwegian Cruise Line. 93,530 GT, 2,394 guests, built 2006. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Pearl — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-prima.html
+++ b/ships/norwegian/norwegian-prima.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-prima.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Prima — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Prima: Prima Class ship with 3,215 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Prima: A Prima Class ship from Norwegian Cruise Line. 143,535 GT, 3,215 guests, built 2022. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Prima — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-sky.html
+++ b/ships/norwegian/norwegian-sky.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-sky.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Sky — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Sky: Sun Class ship with 2,004 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Sky: A Sun Class ship from Norwegian Cruise Line. 77,104 GT, 2,004 guests, built 1999. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Sky — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-spirit.html
+++ b/ships/norwegian/norwegian-spirit.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-spirit.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Spirit — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Spirit: Spirit Class ship with 1,966 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Spirit: A Spirit Class ship from Norwegian Cruise Line. 75,338 GT, 1,966 guests, built 1998. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Spirit — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-star.html
+++ b/ships/norwegian/norwegian-star.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-star.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Star — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Star: Dawn Class ship with 2,240 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Star: A Dawn Class ship from Norwegian Cruise Line. 91,740 GT, 2,240 guests, built 2001. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Star — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-sun.html
+++ b/ships/norwegian/norwegian-sun.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-sun.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Sun — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Sun: Sun Class ship with 1,936 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Sun: A Sun Class ship from Norwegian Cruise Line. 78,309 GT, 1,936 guests, built 2001. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Sun — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/norwegian-viva.html
+++ b/ships/norwegian/norwegian-viva.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/norwegian-viva.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Norwegian Viva — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Norwegian Viva: Prima Class ship with 3,215 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Norwegian Viva: A Prima Class ship from Norwegian Cruise Line. 143,535 GT, 3,215 guests, built 2023. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Norwegian Viva — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/norwegian/pride-of-america.html
+++ b/ships/norwegian/pride-of-america.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/norwegian/pride-of-america.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Pride of America — Norwegian Cruise Line Ship Guide"/>
   <meta property="og:description" content="Explore Pride of America: Pride of America Class ship with 2,186 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Pride of America: A Pride of America Class ship from Norwegian Cruise Line. 80,439 GT, 2,186 guests, built 2005. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Pride of America — Norwegian Cruise Line Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/oceania/allura.html
+++ b/ships/oceania/allura.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/oceania/allura.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Allura — Oceania Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Allura: Allura Class ship with 1,200 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Allura: A Allura Class ship from Oceania Cruises. 67,000 GT, 1,200 guests, built 2025. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Allura — Oceania Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/oceania/index.html
+++ b/ships/oceania/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Oceania Cruises Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/oceania/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Oceania Cruises Ships"/>
+  <meta property="og:description" content="Explore all Oceania Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/oceania/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all Oceania Cruises ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to Oceania Cruises ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Oceania Cruises Ships"/>
+  <meta name="twitter:description" content="Explore all Oceania Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/oceania/insignia.html
+++ b/ships/oceania/insignia.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/oceania/insignia.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Insignia — Oceania Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Insignia: R Class ship with 684 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Insignia: A R Class ship from Oceania Cruises. 30,277 GT, 684 guests, built 1998. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Insignia — Oceania Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/oceania/marina.html
+++ b/ships/oceania/marina.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/oceania/marina.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Marina — Oceania Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Marina: Oceania Class ship with 1,250 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Marina: A Oceania Class ship from Oceania Cruises. 66,084 GT, 1,250 guests, built 2011. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Marina — Oceania Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/oceania/nautica.html
+++ b/ships/oceania/nautica.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/oceania/nautica.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Nautica — Oceania Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Nautica: R Class ship with 684 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Nautica: A R Class ship from Oceania Cruises. 30,277 GT, 684 guests, built 2000. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Nautica — Oceania Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/oceania/regatta.html
+++ b/ships/oceania/regatta.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/oceania/regatta.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Regatta — Oceania Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Regatta: R Class ship with 684 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Regatta: A R Class ship from Oceania Cruises. 30,277 GT, 684 guests, built 1998. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Regatta — Oceania Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/oceania/riviera.html
+++ b/ships/oceania/riviera.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/oceania/riviera.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Riviera — Oceania Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Riviera: Oceania Class ship with 1,250 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Riviera: A Oceania Class ship from Oceania Cruises. 66,084 GT, 1,250 guests, built 2012. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Riviera — Oceania Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/oceania/sirena.html
+++ b/ships/oceania/sirena.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/oceania/sirena.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Sirena — Oceania Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Sirena: R Class ship with 684 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Sirena: A R Class ship from Oceania Cruises. 30,277 GT, 684 guests, built 1999. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Sirena — Oceania Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/oceania/vista.html
+++ b/ships/oceania/vista.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/oceania/vista.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Vista — Oceania Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Vista: Allura Class ship with 1,200 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Vista: A Allura Class ship from Oceania Cruises. 67,000 GT, 1,200 guests, built 2023. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Vista — Oceania Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/caribbean-princess.html
+++ b/ships/princess/caribbean-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/caribbean-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Caribbean Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Caribbean Princess: Grand Class ship with 3,140 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Caribbean Princess: A Grand Class ship from Princess Cruises. 113,000 GT, 3,140 guests, built 2004. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Caribbean Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/coral-princess.html
+++ b/ships/princess/coral-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/coral-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Coral Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Coral Princess: Coral Class ship with 1,970 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Coral Princess: A Coral Class ship from Princess Cruises. 92,000 GT, 1,970 guests, built 2003. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Coral Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/crown-princess.html
+++ b/ships/princess/crown-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/crown-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Crown Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Crown Princess: Grand Class ship with 3,080 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Crown Princess: A Grand Class ship from Princess Cruises. 113,000 GT, 3,080 guests, built 2006. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Crown Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/diamond-princess.html
+++ b/ships/princess/diamond-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/diamond-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Diamond Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Diamond Princess: Grand Class ship with 2,670 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Diamond Princess: A Grand Class ship from Princess Cruises. 116,000 GT, 2,670 guests, built 2004. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Diamond Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/discovery-princess.html
+++ b/ships/princess/discovery-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/discovery-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Discovery Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Discovery Princess: Royal Class ship with 3,660 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Discovery Princess: A Royal Class ship from Princess Cruises. 145,000 GT, 3,660 guests, built 2022. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Discovery Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/emerald-princess.html
+++ b/ships/princess/emerald-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/emerald-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Emerald Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Emerald Princess: Grand Class ship with 3,080 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Emerald Princess: A Grand Class ship from Princess Cruises. 113,000 GT, 3,080 guests, built 2007. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Emerald Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/enchanted-princess.html
+++ b/ships/princess/enchanted-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/enchanted-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Enchanted Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Enchanted Princess: Royal Class ship with 3,660 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Enchanted Princess: A Royal Class ship from Princess Cruises. 145,000 GT, 3,660 guests, built 2020. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Enchanted Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/grand-princess.html
+++ b/ships/princess/grand-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/grand-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Grand Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Grand Princess: Grand Class ship with 2,600 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Grand Princess: A Grand Class ship from Princess Cruises. 109,000 GT, 2,600 guests, built 1998. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Grand Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/index.html
+++ b/ships/princess/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Princess Cruises Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/princess/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Princess Cruises Ships"/>
+  <meta property="og:description" content="Explore all Princess Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all Princess Cruises ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to Princess Cruises ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Princess Cruises Ships"/>
+  <meta name="twitter:description" content="Explore all Princess Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/princess/island-princess.html
+++ b/ships/princess/island-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/island-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Island Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Island Princess: Coral Class ship with 1,970 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Island Princess: A Coral Class ship from Princess Cruises. 92,000 GT, 1,970 guests, built 2003. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Island Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/majestic-princess.html
+++ b/ships/princess/majestic-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/majestic-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Majestic Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Majestic Princess: Royal Class ship with 3,560 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Majestic Princess: A Royal Class ship from Princess Cruises. 143,700 GT, 3,560 guests, built 2017. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Majestic Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/regal-princess.html
+++ b/ships/princess/regal-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/regal-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Regal Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Regal Princess: Royal Class ship with 3,560 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Regal Princess: A Royal Class ship from Princess Cruises. 142,229 GT, 3,560 guests, built 2014. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Regal Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/royal-princess.html
+++ b/ships/princess/royal-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/royal-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Royal Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Royal Princess: Royal Class ship with 3,560 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Royal Princess: A Royal Class ship from Princess Cruises. 142,229 GT, 3,560 guests, built 2013. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Royal Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/ruby-princess.html
+++ b/ships/princess/ruby-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/ruby-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Ruby Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Ruby Princess: Grand Class ship with 3,080 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Ruby Princess: A Grand Class ship from Princess Cruises. 113,000 GT, 3,080 guests, built 2008. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Ruby Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/sapphire-princess.html
+++ b/ships/princess/sapphire-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/sapphire-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Sapphire Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Sapphire Princess: Grand Class ship with 2,670 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Sapphire Princess: A Grand Class ship from Princess Cruises. 116,000 GT, 2,670 guests, built 2004. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Sapphire Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/sky-princess.html
+++ b/ships/princess/sky-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/sky-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Sky Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Sky Princess: Royal Class ship with 3,660 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Sky Princess: A Royal Class ship from Princess Cruises. 145,000 GT, 3,660 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Sky Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/star-princess.html
+++ b/ships/princess/star-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/star-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Star Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Star Princess: Sphere Class ship with 4,300 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Star Princess: A Sphere Class ship from Princess Cruises. 175,500 GT, 4,300 guests, built 2025. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Star Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/princess/sun-princess.html
+++ b/ships/princess/sun-princess.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/princess/sun-princess.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Sun Princess — Princess Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Sun Princess: Sphere Class ship with 4,300 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Sun Princess: A Sphere Class ship from Princess Cruises. 175,500 GT, 4,300 guests, built 2024. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Sun Princess — Princess Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/regent/index.html
+++ b/ships/regent/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Regent Seven Seas Cruises Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/regent/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Regent Seven Seas Cruises Ships"/>
+  <meta property="og:description" content="Explore all Regent Seven Seas Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/regent/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all Regent Seven Seas Cruises ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to Regent Seven Seas Cruises ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Regent Seven Seas Cruises Ships"/>
+  <meta name="twitter:description" content="Explore all Regent Seven Seas Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/regent/prestige.html
+++ b/ships/regent/prestige.html
@@ -43,9 +43,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/regent/prestige.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Prestige — Regent Seven Seas Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Prestige: Explorer Class ship with 750 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Prestige: A Explorer Class ship from Regent Seven Seas Cruises. 55,500 GT, 750 guests, built 2026. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Prestige — Regent Seven Seas Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/regent/seven-seas-explorer.html
+++ b/ships/regent/seven-seas-explorer.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/regent/seven-seas-explorer.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seven Seas Explorer — Regent Seven Seas Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Seven Seas Explorer: Explorer Class ship with 750 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seven Seas Explorer: A Explorer Class ship from Regent Seven Seas Cruises. 55,500 GT, 750 guests, built 2016. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seven Seas Explorer — Regent Seven Seas Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/regent/seven-seas-grandeur.html
+++ b/ships/regent/seven-seas-grandeur.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/regent/seven-seas-grandeur.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seven Seas Grandeur — Regent Seven Seas Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Seven Seas Grandeur: Explorer Class ship with 750 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seven Seas Grandeur: A Explorer Class ship from Regent Seven Seas Cruises. 55,500 GT, 750 guests, built 2023. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seven Seas Grandeur — Regent Seven Seas Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/regent/seven-seas-mariner.html
+++ b/ships/regent/seven-seas-mariner.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/regent/seven-seas-mariner.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seven Seas Mariner — Regent Seven Seas Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Seven Seas Mariner: Mariner Class ship with 700 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seven Seas Mariner: A Mariner Class ship from Regent Seven Seas Cruises. 48,075 GT, 700 guests, built 2001. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seven Seas Mariner — Regent Seven Seas Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/regent/seven-seas-navigator.html
+++ b/ships/regent/seven-seas-navigator.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/regent/seven-seas-navigator.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seven Seas Navigator — Regent Seven Seas Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Seven Seas Navigator: Navigator Class ship with 490 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seven Seas Navigator: A Navigator Class ship from Regent Seven Seas Cruises. 28,550 GT, 490 guests, built 1999. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seven Seas Navigator — Regent Seven Seas Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/regent/seven-seas-splendor.html
+++ b/ships/regent/seven-seas-splendor.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/regent/seven-seas-splendor.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seven Seas Splendor — Regent Seven Seas Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Seven Seas Splendor: Explorer Class ship with 750 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seven Seas Splendor: A Explorer Class ship from Regent Seven Seas Cruises. 55,500 GT, 750 guests, built 2020. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seven Seas Splendor — Regent Seven Seas Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/regent/seven-seas-voyager.html
+++ b/ships/regent/seven-seas-voyager.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/regent/seven-seas-voyager.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seven Seas Voyager — Regent Seven Seas Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Seven Seas Voyager: Voyager Class ship with 700 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seven Seas Voyager: A Voyager Class ship from Regent Seven Seas Cruises. 42,363 GT, 700 guests, built 2003. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seven Seas Voyager — Regent Seven Seas Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/rooms.html
+++ b/ships/rooms.html
@@ -34,6 +34,14 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <title>Rooms — In the Wake (v2.201)</title>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Rooms — In the Wake (v2.201)"/>
+  <meta property="og:description" content="Rooms (v2.201)"/>
+  <meta property="og:url" content=""/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/ships/seabourn/index.html
+++ b/ships/seabourn/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Seabourn Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/seabourn/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Seabourn Ships"/>
+  <meta property="og:description" content="Explore all Seabourn ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/seabourn/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all Seabourn ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to Seabourn ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Seabourn Ships"/>
+  <meta name="twitter:description" content="Explore all Seabourn ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/seabourn/seabourn-encore.html
+++ b/ships/seabourn/seabourn-encore.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/seabourn/seabourn-encore.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seabourn Encore — Seabourn Ship Guide"/>
   <meta property="og:description" content="Explore Seabourn Encore: Ovation Class ship with 600 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seabourn Encore: A Ovation Class ship from Seabourn. 40,350 GT, 600 guests, built 2016. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seabourn Encore — Seabourn Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/seabourn/seabourn-odyssey.html
+++ b/ships/seabourn/seabourn-odyssey.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/seabourn/seabourn-odyssey.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seabourn Odyssey — Seabourn Ship Guide"/>
   <meta property="og:description" content="Explore Seabourn Odyssey: Odyssey Class ship with 450 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seabourn Odyssey: A Odyssey Class ship from Seabourn. 32,346 GT, 450 guests, built 2009. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seabourn Odyssey — Seabourn Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/seabourn/seabourn-ovation.html
+++ b/ships/seabourn/seabourn-ovation.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/seabourn/seabourn-ovation.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seabourn Ovation — Seabourn Ship Guide"/>
   <meta property="og:description" content="Explore Seabourn Ovation: Ovation Class ship with 600 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seabourn Ovation: A Ovation Class ship from Seabourn. 40,350 GT, 600 guests, built 2018. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seabourn Ovation — Seabourn Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/seabourn/seabourn-pursuit.html
+++ b/ships/seabourn/seabourn-pursuit.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/seabourn/seabourn-pursuit.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seabourn Pursuit — Seabourn Ship Guide"/>
   <meta property="og:description" content="Explore Seabourn Pursuit: Venture Class ship with 264 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seabourn Pursuit: A Venture Class ship from Seabourn. 23,000 GT, 264 guests, built 2023. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seabourn Pursuit — Seabourn Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/seabourn/seabourn-quest.html
+++ b/ships/seabourn/seabourn-quest.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/seabourn/seabourn-quest.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seabourn Quest — Seabourn Ship Guide"/>
   <meta property="og:description" content="Explore Seabourn Quest: Odyssey Class ship with 450 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seabourn Quest: A Odyssey Class ship from Seabourn. 32,346 GT, 450 guests, built 2011. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seabourn Quest — Seabourn Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/seabourn/seabourn-sojourn.html
+++ b/ships/seabourn/seabourn-sojourn.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/seabourn/seabourn-sojourn.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seabourn Sojourn — Seabourn Ship Guide"/>
   <meta property="og:description" content="Explore Seabourn Sojourn: Odyssey Class ship with 450 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seabourn Sojourn: A Odyssey Class ship from Seabourn. 32,346 GT, 450 guests, built 2010. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seabourn Sojourn — Seabourn Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/seabourn/seabourn-venture.html
+++ b/ships/seabourn/seabourn-venture.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/seabourn/seabourn-venture.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Seabourn Venture — Seabourn Ship Guide"/>
   <meta property="og:description" content="Explore Seabourn Venture: Venture Class ship with 264 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Seabourn Venture: A Venture Class ship from Seabourn. 23,000 GT, 264 guests, built 2022. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Seabourn Venture — Seabourn Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/index.html
+++ b/ships/silversea/index.html
@@ -8,6 +8,14 @@ Soli Deo Gloria
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Silversea Cruises Ships | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/silversea/"/>
+  <!-- OpenGraph -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Silversea Cruises Ships"/>
+  <meta property="og:description" content="Explore all Silversea Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <meta name="description" content="Explore all Silversea Cruises ships. Detailed guides, specifications, and reviews."/>
   <meta name="ai-summary" content="Complete guide to Silversea Cruises ships including specifications, reviews, and comparisons.">
   <meta name="last-reviewed" content="2026-01-02">
@@ -45,7 +53,12 @@ Soli Deo Gloria
   }
   </script>
 
-  
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Silversea Cruises Ships"/>
+  <meta name="twitter:description" content="Explore all Silversea Cruises ships. Detailed guides, specifications, and reviews."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
@@ -55,7 +68,7 @@ Soli Deo Gloria
     gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
   </script>
 
-<!-- Umami (secondary analytics) -->
+  <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">

--- a/ships/silversea/silver-cloud.html
+++ b/ships/silversea/silver-cloud.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-cloud.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Cloud — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Cloud: Cloud Class ship with 254 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Cloud: A Cloud Class ship from Silversea Cruises. 16,800 GT, 254 guests, built 1994. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Cloud — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-dawn.html
+++ b/ships/silversea/silver-dawn.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-dawn.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Dawn — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Dawn: Muse Class ship with 596 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Dawn: A Muse Class ship from Silversea Cruises. 40,700 GT, 596 guests, built 2022. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Dawn — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-endeavour.html
+++ b/ships/silversea/silver-endeavour.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-endeavour.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Endeavour — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Endeavour: Endeavour Class ship with 200 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Endeavour: A Endeavour Class ship from Silversea Cruises. 20,449 GT, 200 guests, built 2021. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Endeavour — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-moon.html
+++ b/ships/silversea/silver-moon.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-moon.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Moon — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Moon: Muse Class ship with 596 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Moon: A Muse Class ship from Silversea Cruises. 40,700 GT, 596 guests, built 2020. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Moon — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-muse.html
+++ b/ships/silversea/silver-muse.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-muse.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Muse — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Muse: Muse Class ship with 596 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Muse: A Muse Class ship from Silversea Cruises. 40,700 GT, 596 guests, built 2017. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Muse — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-nova.html
+++ b/ships/silversea/silver-nova.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-nova.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Nova — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Nova: Nova Class ship with 728 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Nova: A Nova Class ship from Silversea Cruises. 54,700 GT, 728 guests, built 2023. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Nova — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-origin.html
+++ b/ships/silversea/silver-origin.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-origin.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Origin — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Origin: Origin Class ship with 100 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Origin: A Origin Class ship from Silversea Cruises. 5,800 GT, 100 guests, built 2020. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Origin — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-ray.html
+++ b/ships/silversea/silver-ray.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-ray.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Ray — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Ray: Nova Class ship with 728 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Ray: A Nova Class ship from Silversea Cruises. 54,700 GT, 728 guests, built 2024. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Ray — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-shadow.html
+++ b/ships/silversea/silver-shadow.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-shadow.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Shadow — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Shadow: Whisper Class ship with 382 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Shadow: A Whisper Class ship from Silversea Cruises. 28,258 GT, 382 guests, built 2000. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Shadow — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-spirit.html
+++ b/ships/silversea/silver-spirit.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-spirit.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Spirit — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Spirit: Spirit Class ship with 540 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Spirit: A Spirit Class ship from Silversea Cruises. 36,009 GT, 540 guests, built 2009. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Spirit — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-whisper.html
+++ b/ships/silversea/silver-whisper.html
@@ -45,9 +45,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-whisper.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Whisper — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Whisper: Whisper Class ship with 382 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Whisper: A Whisper Class ship from Silversea Cruises. 28,258 GT, 382 guests, built 2001. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Whisper — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">

--- a/ships/silversea/silver-wind.html
+++ b/ships/silversea/silver-wind.html
@@ -44,9 +44,13 @@ All work on this project is offered as a gift to God.
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/silversea/silver-wind.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:title" content="Silver Wind — Silversea Cruises Ship Guide"/>
   <meta property="og:description" content="Explore Silver Wind: Wind Class ship with 296 guests. Dining, entertainment, and planning resources."/>
   <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Discover Silver Wind: A Wind Class ship from Silversea Cruises. 17,400 GT, 296 guests, built 1995. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:title" content="Silver Wind — Silversea Cruises Ship Guide"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <!-- JSON-LD (CruiseShip schema) -->
   <script type="application/ld+json">


### PR DESCRIPTION
- Update add-social-images.py to handle pages without canonical links
- Add root-level pages to script (internet-at-sea, stateroom-check, etc.)
- Add social meta tags to 230+ pages including:
  - 75+ Celebrity Cruises ship pages
  - 24 port pages with non-standard structure
  - Solo articles and planning pages
  - Root-level utility pages

Remaining 9 pages are article fragments or malformed HTML that need manual restructuring