### PR TITLE
nav: Add missing navigation items to 5 Carnival ship pages

### DIFF
--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -270,11 +270,15 @@ if ('serviceWorker' in navigator) {
       <a href="/planning.html">Planning Overview</a>
       <a href="/ships.html">Ships</a>
       <a href="/ships/quiz.html">Ship Quiz</a>
-            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+      <a href="/restaurants.html">Restaurants &amp; Menus</a>
       <a href="/ports.html">Ports</a>
       <a href="/internet-at-sea.html">Internet at Sea</a>
-            <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/drink-calculator.html">Drink Calculator</a>
+      <a href="/stateroom-check.html">Stateroom Check</a>
       <a href="/cruise-lines.html">Cruise Lines</a>
+      <a href="/packing-lists.html">Packing Lists</a>
+      <a href="/accessibility.html">Accessibility</a>
     </div>
   </div>
 
@@ -288,6 +292,7 @@ if ('serviceWorker' in navigator) {
     </div>
   </div>
 
+  <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
   <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
   <a class="nav-pill" href="/search.html">Search</a>
   <a class="nav-pill" href="/about-us.html">About</a>

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -153,11 +153,15 @@
       <a href="/planning.html">Planning Overview</a>
       <a href="/ships.html">Ships</a>
       <a href="/ships/quiz.html">Ship Quiz</a>
-            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+      <a href="/restaurants.html">Restaurants &amp; Menus</a>
       <a href="/ports.html">Ports</a>
       <a href="/internet-at-sea.html">Internet at Sea</a>
-            <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/drink-calculator.html">Drink Calculator</a>
+      <a href="/stateroom-check.html">Stateroom Check</a>
       <a href="/cruise-lines.html">Cruise Lines</a>
+      <a href="/packing-lists.html">Packing Lists</a>
+      <a href="/accessibility.html">Accessibility</a>
     </div>
   </div>
   <div class="nav-dropdown" id="nav-travel">
@@ -167,6 +171,7 @@
       <a href="/solo.html">Solo Cruising</a>
     </div>
   </div>
+  <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
   <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
   <a class="nav-pill" href="/search.html">Search</a>
   <a class="nav-pill" href="/about-us.html">About</a>

--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -153,11 +153,15 @@
       <a href="/planning.html">Planning Overview</a>
       <a href="/ships.html">Ships</a>
       <a href="/ships/quiz.html">Ship Quiz</a>
-            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+      <a href="/restaurants.html">Restaurants &amp; Menus</a>
       <a href="/ports.html">Ports</a>
       <a href="/internet-at-sea.html">Internet at Sea</a>
-            <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/drink-calculator.html">Drink Calculator</a>
+      <a href="/stateroom-check.html">Stateroom Check</a>
       <a href="/cruise-lines.html">Cruise Lines</a>
+      <a href="/packing-lists.html">Packing Lists</a>
+      <a href="/accessibility.html">Accessibility</a>
     </div>
   </div>
   <div class="nav-dropdown" id="nav-travel">
@@ -167,6 +171,7 @@
       <a href="/solo.html">Solo Cruising</a>
     </div>
   </div>
+  <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
   <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
   <a class="nav-pill" href="/search.html">Search</a>
   <a class="nav-pill" href="/about-us.html">About</a>

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -321,7 +321,11 @@
       <a href="/ports.html">Ports</a>
       <a href="/internet-at-sea.html">Internet at Sea</a>
       <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/drink-calculator.html">Drink Calculator</a>
+      <a href="/stateroom-check.html">Stateroom Check</a>
       <a href="/cruise-lines.html">Cruise Lines</a>
+      <a href="/packing-lists.html">Packing Lists</a>
+      <a href="/accessibility.html">Accessibility</a>
     </div>
   </div>
 
@@ -335,6 +339,7 @@
     </div>
   </div>
 
+  <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
   <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
   <a class="nav-pill" href="/search.html">Search</a>
   <a class="nav-pill" href="/about-us.html">About</a>

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -319,7 +319,11 @@
       <a href="/ports.html">Ports</a>
       <a href="/internet-at-sea.html">Internet at Sea</a>
       <a href="/drink-packages.html">Drink Packages</a>
+      <a href="/drink-calculator.html">Drink Calculator</a>
+      <a href="/stateroom-check.html">Stateroom Check</a>
       <a href="/cruise-lines.html">Cruise Lines</a>
+      <a href="/packing-lists.html">Packing Lists</a>
+      <a href="/accessibility.html">Accessibility</a>
     </div>
   </div>
   <div class="nav-dropdown" id="nav-travel">
@@ -331,6 +335,7 @@
       <a href="/solo.html">Solo Cruising</a>
     </div>
   </div>
+  <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
   <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
   <a class="nav-pill" href="/search.html">Search</a>
   <a class="nav-pill" href="/about-us.html">About</a>


### PR DESCRIPTION
Added gold-standard navigation items to ship pages:
- drink-calculator.html
- stateroom-check.html
- packing-lists.html
- accessibility.html
- Port Logbook link

Ships fixed (now passing validation):
- Carnival Horizon: 76% → 86% PASS
- Carnival Sunshine: 76% → 86% PASS
- Carnival Panorama: 74% → 84% PASS

Ships with nav fixed (still have other issues):
- Carnival Firenze: has section order issue
- Carnival Venezia: has multiple issues