### PR TITLE
Fix XSS vulnerability in planning.js

### DIFF
--- a/assets/js/planning.js
+++ b/assets/js/planning.js
@@ -108,7 +108,7 @@
     const parts = [
       `<strong>Spring Break:</strong> ${E(s.spring_break?.window || 'varies')} — ${E(s.spring_break?.notes || '')}`,
       `<strong>Fall Break:</strong> ${E(s.fall_break?.window || 'varies')} — ${E(s.fall_break?.notes || '')}`,
-      s.busy_days?.length ? `<strong>Also Busy:</strong> ${s.busy_days.join(', ')}` : ''
+      s.busy_days?.length ? `<strong>Also Busy:</strong> ${E(s.busy_days.join(', '))}` : ''
     ].filter(Boolean);
     breaksEl.innerHTML = parts.map(x => `<div>${x}</div>`).join('') +
       (s.disclaimer ? `<div class="tiny muted" style="margin-top:.35rem">${E(s.disclaimer)}</div>` : '');


### PR DESCRIPTION
Wrap s.busy_days.join() with E() escape function to match the consistent escaping pattern used for other dynamic values in the same template literal block.