### PR TITLE
feat: Add Cruise Line Quiz to navigation and tool listings

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -285,6 +285,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/accessibility.html
+++ b/accessibility.html
@@ -283,6 +283,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/articles.html
+++ b/articles.html
@@ -228,6 +228,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/cruise-lines.html
+++ b/cruise-lines.html
@@ -337,6 +337,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>
@@ -406,6 +407,13 @@
           <li><strong>Resources Available:</strong> Deck plans, live trackers, restaurant menus, ship videos</li>
         </ul>
       </div>
+    </section>
+
+    <!-- Quiz CTA -->
+    <section class="callout-box" style="background: linear-gradient(135deg, #e0f4f8, #fff); border-left: 4px solid #0e6e8e; padding: 1.5rem; margin-bottom: 2rem; border-radius: 8px;">
+      <h2 style="margin-top: 0; color: #083041;">Not Sure Which Line Is Right for You?</h2>
+      <p style="margin-bottom: 1rem;">Take our quick 6-question quiz to find cruise lines that match your travel style, budget, and preferences—from mainstream to ultra-luxury.</p>
+      <a href="/cruise-lines/quiz.html" class="cta-btn" style="display: inline-block; background: #0e6e8e; color: #fff; padding: 0.75rem 1.5rem; border-radius: 6px; text-decoration: none; font-weight: 600;">Take the Cruise Line Quiz →</a>
     </section>
 
     <section class="section">

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -350,6 +350,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/drink-packages.html
+++ b/drink-packages.html
@@ -150,6 +150,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/first-cruise.html
+++ b/first-cruise.html
@@ -238,6 +238,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>
@@ -431,9 +432,16 @@
       </article>
 
       <article class="card">
-        <h2>Choosing Your First Ship</h2>
-        <p>Not sure which ship is right for you? Our <a href="/ships/quiz.html">Ship Quiz</a> asks a few questions and recommends ships that match your style.</p>
-        <p>Generally, <strong>newer mega-ships</strong> offer more activities but bigger crowds. <strong>Smaller ships</strong> are quieter with more personal service. <strong>Mainstream lines</strong> (Royal Caribbean, Carnival, Norwegian) are great for first-timers — they have something for everyone.</p>
+        <h2>Choosing Your First Cruise Line</h2>
+        <p>Not sure which cruise line is right for you? Our <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a> matches you with lines from mainstream to ultra-luxury based on your travel style, budget, and preferences.</p>
+        <p>Generally, <strong>mainstream lines</strong> (Royal Caribbean, Carnival, Norwegian) are great for first-timers — they have something for everyone. <strong>Premium lines</strong> (Celebrity, Princess) offer more refined experiences. <strong>Luxury lines</strong> (Regent, Seabourn) are all-inclusive with intimate ships.</p>
+        <p><a href="/cruise-lines/quiz.html" class="pill">Take the Cruise Line Quiz</a></p>
+      </article>
+
+      <article class="card">
+        <h2>Finding the Right Ship</h2>
+        <p>Once you've narrowed down cruise lines, our <a href="/ships/quiz.html">Ship Quiz</a> helps you find specific ships that match your style.</p>
+        <p><strong>Newer mega-ships</strong> offer more activities but bigger crowds. <strong>Smaller ships</strong> are quieter with more personal service.</p>
         <p><a href="/ships/quiz.html" class="pill">Take the Ship Quiz</a></p>
       </article>
 
@@ -459,6 +467,7 @@
             <li><a href="/drink-packages.html">Drink Packages</a></li>
             <li><a href="/drink-calculator.html">Drink Calculator</a></li>
             <li><a href="/ships/quiz.html">Ship Quiz</a></li>
+            <li><a href="/cruise-lines/quiz.html">Cruise Line Quiz</a></li>
             <li><a href="/accessibility.html">Accessibility</a></li>
           </ul>
         </div>
@@ -470,6 +479,7 @@
           <li><a href="/drink-calculator.html">Drink Calculator</a> — Should you buy a package?</li>
           <li><a href="/stateroom-check.html">Stateroom Check</a> — Find the right cabin</li>
           <li><a href="/ships/quiz.html">Ship Quiz</a> — Match your travel style</li>
+          <li><a href="/cruise-lines/quiz.html">Cruise Line Quiz</a> — Find your cruise line</li>
           <li><a href="/tools/port-tracker.html">Port Logbook</a> — Track where you've been</li>
         </ul>
       </section>

--- a/index.html
+++ b/index.html
@@ -319,6 +319,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>
@@ -421,11 +422,18 @@
         <h2 id="intent-heading">What are you planning?</h2>
         <p class="tiny content-text" style="margin-bottom: 1rem;">Choose your path — we'll point you to the most helpful resources.</p>
         <div class="intent-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem;">
+          <a href="/cruise-lines/quiz.html" class="intent-card" style="display: flex; align-items: center; gap: 0.75rem; padding: 1rem; background: linear-gradient(135deg, #f0f7fa 0%, #e8f4f8 100%); border: 2px solid #cde5ed; border-radius: 10px; text-decoration: none; color: inherit; transition: all 0.2s ease;">
+            <span style="font-size: 1.5rem;">⚓</span>
+            <div>
+              <strong style="display: block; color: #0e6e8e;">Choosing a cruise line</strong>
+              <span class="tiny" style="color: #5a7a8a;">Cruise Line Quiz</span>
+            </div>
+          </a>
           <a href="/ships/quiz.html" class="intent-card" style="display: flex; align-items: center; gap: 0.75rem; padding: 1rem; background: linear-gradient(135deg, #f0f7fa 0%, #e8f4f8 100%); border: 2px solid #cde5ed; border-radius: 10px; text-decoration: none; color: inherit; transition: all 0.2s ease;">
             <span style="font-size: 1.5rem;">🚢</span>
             <div>
               <strong style="display: block; color: #0e6e8e;">Choosing a ship</strong>
-              <span class="tiny" style="color: #5a7a8a;">Take our Ship Quiz</span>
+              <span class="tiny" style="color: #5a7a8a;">Ship Quiz</span>
             </div>
           </a>
           <a href="/planning.html" class="intent-card" style="display: flex; align-items: center; gap: 0.75rem; padding: 1rem; background: linear-gradient(135deg, #f0f7fa 0%, #e8f4f8 100%); border: 2px solid #cde5ed; border-radius: 10px; text-decoration: none; color: inherit; transition: all 0.2s ease;">
@@ -457,10 +465,15 @@
         <h2 id="tools-heading" style="color: #fff; margin-bottom: 0.5rem;">Planning Tools</h2>
         <p class="tiny" style="color: rgba(255,255,255,0.8); margin-bottom: 1rem;">Interactive calculators and guides — free, no account required.</p>
         <div class="tools-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem;">
+          <a href="/cruise-lines/quiz.html" class="tool-card" style="display: flex; flex-direction: column; align-items: center; padding: 1rem; background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2); border-radius: 10px; text-decoration: none; color: #fff; text-align: center; transition: all 0.2s ease;">
+            <span style="font-size: 2rem; margin-bottom: 0.5rem;">⚓</span>
+            <strong style="font-size: 0.9rem;">Cruise Line Quiz</strong>
+            <span class="tiny" style="color: rgba(255,255,255,0.7);">Find your line</span>
+          </a>
           <a href="/ships/quiz.html" class="tool-card" style="display: flex; flex-direction: column; align-items: center; padding: 1rem; background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2); border-radius: 10px; text-decoration: none; color: #fff; text-align: center; transition: all 0.2s ease;">
             <span style="font-size: 2rem; margin-bottom: 0.5rem;">🚢</span>
             <strong style="font-size: 0.9rem;">Ship Quiz</strong>
-            <span class="tiny" style="color: rgba(255,255,255,0.7);">Find your match</span>
+            <span class="tiny" style="color: rgba(255,255,255,0.7);">Find your ship</span>
           </a>
           <a href="/drink-calculator.html" class="tool-card" style="display: flex; flex-direction: column; align-items: center; padding: 1rem; background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2); border-radius: 10px; text-decoration: none; color: #fff; text-align: center; transition: all 0.2s ease;">
             <span style="font-size: 2rem; margin-bottom: 0.5rem;">🧮</span>

--- a/internet-at-sea.html
+++ b/internet-at-sea.html
@@ -175,6 +175,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/packing-lists.html
+++ b/packing-lists.html
@@ -282,6 +282,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/planning.html
+++ b/planning.html
@@ -287,6 +287,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>
@@ -438,6 +439,10 @@
           <a href="/ships/quiz.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
             <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Ship Quiz</strong>
             <span class="tiny" style="color: #5a7a8a;">Find your ship</span>
+          </a>
+          <a href="/cruise-lines/quiz.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+            <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Cruise Line Quiz</strong>
+            <span class="tiny" style="color: #5a7a8a;">Find your line</span>
           </a>
           <a href="/packing-lists.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
             <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Packing Lists</strong>

--- a/ports.html
+++ b/ports.html
@@ -240,6 +240,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/privacy.html
+++ b/privacy.html
@@ -187,6 +187,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/restaurants.html
+++ b/restaurants.html
@@ -273,6 +273,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/search.html
+++ b/search.html
@@ -143,6 +143,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/ships.html
+++ b/ships.html
@@ -720,6 +720,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/solo.html
+++ b/solo.html
@@ -411,6 +411,7 @@
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/stateroom-check.html
+++ b/stateroom-check.html
@@ -281,6 +281,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/terms.html
+++ b/terms.html
@@ -150,6 +150,7 @@ All work on this project is offered as a gift to God.
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>

--- a/travel.html
+++ b/travel.html
@@ -368,6 +368,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
             <a href="/drink-calculator.html">Drink Calculator</a>
             <a href="/stateroom-check.html">Stateroom Check</a>
             <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
             <a href="/packing-lists.html">Packing Lists</a>
             <a href="/accessibility.html">Accessibility</a>
           </div>


### PR DESCRIPTION
Integrate the new Cruise Line Quiz across the site:

Navigation (20 pages):
- Added "Cruise Line Quiz" link to Planning dropdown on all main pages

Homepage (index.html):
- Added "Choosing a cruise line" intent card
- Added Cruise Line Quiz to Planning Tools grid

cruise-lines.html:
- Added prominent quiz CTA box after intro section

planning.html:
- Added Cruise Line Quiz to "Start Planning" resources grid

first-cruise.html:
- Added "Choosing Your First Cruise Line" section with quiz link
- Split original ship section into separate Cruise Line and Ship sections
- Added quiz to both tool lists

The Cruise Line Quiz is now accessible from:
- Site navigation on all pages
- Homepage intent selector and tools grid
- cruise-lines.html hub page
- planning.html resources
- first-cruise.html guide