### PR TITLE
fix: Complete Grandeur of the Seas cabin category audit

### DIFF
--- a/assets/data/staterooms/stateroom-exceptions.grandeur-of-the-seas.v2.json
+++ b/assets/data/staterooms/stateroom-exceptions.grandeur-of-the-seas.v2.json
@@ -1,8 +1,31 @@
 {
   "grandeur-of-the-seas": {
     "ship_name": "Grandeur of the Seas",
-    "last_audit": "2026-01-24",
-    "audit_notes": "Room ranges converted from text descriptions to numeric format for code compatibility. Some exceptions removed due to lack of specific room numbers.",
+    "ship_class": "Vision",
+    "launch_year": 1996,
+    "last_updated": "2026-01-24",
+    "audit_notes": "2026-01-24: Complete ship audit - every cabin on Decks 2, 3, 4, 7, 8 individually verified via CruiseDeckPlans. Added category_overrides for all cabins that inferCategory() misclassifies.",
+    "category_overrides": {
+      "Interior": [
+        3009, 3011, 3013, 3025, 3039, 3051, 3053, 3061, 3507, 3509, 3519, 3527, 3529, 3535, 3539, 3557, 3565, 3575, 3581, 3603, 3653, 3655, 3659,
+        4013, 4015, 4017, 4021, 4031, 4043, 4513, 4519, 4521, 4527, 4531, 4539, 4551,
+        7023, 7027, 7065, 7107, 7115, 7119, 7143, 7145, 7565, 7569, 7573, 7605, 7615, 7643, 7649, 7655,
+        8015, 8017, 8019, 8021, 8027, 8049, 8055, 8059, 8065, 8081, 8521, 8525, 8533, 8535
+      ],
+      "Ocean View": [
+        2020, 2024, 2030, 2032, 2042, 2100, 2104, 2112, 2114, 2118, 2124, 2126, 2132, 2134, 2600, 2602, 2612, 2620, 2630, 2634,
+        7082, 7084, 7088,
+        8037, 8039, 8041, 8043, 8537, 8539, 8541
+      ],
+      "Suite": [
+        7150, 7152, 7154, 7156, 7650, 7652, 7654, 7656,
+        8000, 8001, 8002, 8004, 8008, 8010, 8012, 8014, 8016, 8018, 8022, 8024, 8028, 8032, 8034, 8036, 8038, 8040, 8044, 8046, 8054, 8056, 8062, 8064, 8068, 8070, 8074, 8078, 8084, 8086, 8088,
+        8500, 8502, 8504, 8506, 8508, 8510, 8512, 8514, 8516, 8518, 8520, 8522, 8526, 8530, 8532, 8534, 8536, 8538, 8540, 8544, 8548, 8550, 8552, 8554, 8558, 8560, 8562, 8564, 8566, 8574, 8576, 8578, 8584, 8586, 8588
+      ],
+      "_verification_source": "https://www.cruisedeckplans.com/ships/stateroom-details.php?ship=Grandeur-of-the-Seas&cabin={cabin}",
+      "_verification_date": "2026-01-24",
+      "_verification_note": "Every cabin on Decks 2, 3, 4, 7, 8 verified individually via CruiseDeckPlans."
+    },
     "exceptions": [
       {
         "rooms": "8001-8858",


### PR DESCRIPTION
Room by room, deck by deck audit of every cabin on Grandeur:

Deck 2: 10 Interior, 20 Oceanview verified
Deck 3: 23 Interior, 49 Oceanview verified
Deck 4: 13 Interior, 27 Oceanview verified
Deck 7: 16 Interior, 3 Oceanview, 37 Balcony, 8 Suite verified
Deck 8: 14 Interior, 7 Oceanview, 66 Suite verified

Each cabin individually verified via CruiseDeckPlans stateroom detail pages. Added category_overrides for all categories that inferCategory() heuristics would misclassify.