### PR TITLE
Ships That Visit: Add Carnival Cruise Line (26 ships, 70 ports)

### DIFF
--- a/admin/UNFINISHED-TASKS.md
+++ b/admin/UNFINISHED-TASKS.md
@@ -303,14 +303,14 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | "No Ads" trust messaging on about-us.html | ✅ DONE | Cruise Critic, CruiseMapper |
 | Tender Port Index + badge (`/ports/tender-ports.html`) | ✅ DONE | WhatsInPort |
 | "From the Pier" distance callout box component | PARTIAL (some ports) | WhatsInPort, IQCruising |
-| "Ships That Visit Here" section on port pages | PARTIAL (63/380 ports, RCL only) | UNIQUE - no competitor has this |
+| "Ships That Visit Here" section on port pages | PARTIAL (70/380 ports, RCL+Carnival) | UNIQUE - no competitor has this |
 | First-Timer Hub page | ✅ DONE (`first-cruise.html` 27KB) | Cruise Critic |
 | Pre-Cruise 30-Day Countdown checklist | ✅ DONE (`countdown.html` 2026-01-24) | Cruise Critic Roll Call |
 
 **P2 Strategic (Medium Effort):**
 | Task | Status | Addresses |
 |------|--------|-----------|
-| **Expand "Ships That Visit" to all 15 cruise lines** | NOT STARTED (63/380 ports, RCL only) | UNIQUE differentiator |
+| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (2/15 lines: RCL, Carnival) | UNIQUE differentiator |
 | Print CSS + PDF generation for port pages | NOT STARTED | WhatsInPort, IQCruising |
 | Transport cost callout component | NOT STARTED | WhatsInPort, Cruise Crocodile |
 | Accessibility sections on port pages | NOT STARTED | UNIQUE - market gap |
@@ -318,11 +318,12 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | Honest assessment "Real Talk" sections | NOT STARTED | Cruise Critic, CruiseMapper |
 
 **"Ships That Visit Here" Expansion Plan:**
-- Current: 63 ports with RCL ship data only
-- Needed: Add deployment data for all 15 cruise lines
-- Data file: `assets/data/ship-deployments.json`
-- JS module: `assets/js/ship-port-links.js`
-- Cruise lines to add: Carnival, Celebrity, NCL, Princess, Holland America, MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
+- Current: 70 ports, 55 ships (29 RCL + 26 Carnival)
+- Progress: 2/15 cruise lines complete
+- Data file: `assets/data/ship-deployments.json` (v1.1.0)
+- JS module: `assets/js/ship-port-links.js` (multi-cruise-line support added 2026-01-24)
+- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships)
+- Cruise lines remaining: Celebrity, NCL, Princess, Holland America, MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
 
 **Unique Differentiators to Protect:**
 - Ship-Port Integration ⭐⭐⭐ (expand with bidirectional linking)
@@ -720,11 +721,11 @@ node admin/validate-ship-page.js ships/celebrity-cruises/*.html
 - ~~Quiz Dress Code~~ — Question exists at line 1716
 - ~~30-Day Countdown Checklist~~ — `countdown.html` with 35 interactive tasks (2026-01-24)
 - ~~Works Offline Badge~~ — 376 port pages now show "Works offline" in trust badge (2026-01-24)
-- ~~Ships That Visit Here~~ — Infrastructure done (63/380 ports, RCL only — needs expansion to 15 cruise lines)
+- ~~Ships That Visit Here~~ — In progress (70/380 ports, 55 ships across RCL + Carnival — 13 cruise lines remaining)
 
 ### 🟡 HIGH PRIORITY (Remaining Work)
 5. **Quiz UX Bugs** — iPhone scroll issue, back button (NCL links is #1 above)
-6. **Ships That Visit Expansion** — Add 14 more cruise lines to ship-deployments.json (currently RCL only, 63/380 ports)
+6. **Ships That Visit Expansion** — Add 13 more cruise lines to ship-deployments.json (RCL + Carnival done, 70/380 ports, 55 ships)
 7. **Quiz Regional Features** — Regional availability filter (dress code done)
 8. **Port Weather Remaining** — 80 ports still need weather section
 

--- a/assets/data/ship-deployments.json
+++ b/assets/data/ship-deployments.json
@@ -1,477 +1,2051 @@
 {
   "metadata": {
-    "version": "1.0.0",
-    "last_updated": "2026-01-17",
-    "source": "Royal Caribbean 2025-2026 Deployment Summary, CruiseMapper, RCL Press Releases",
-    "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment."
+    "version": "1.1.0",
+    "last_updated": "2026-01-24",
+    "source": "Royal Caribbean and Carnival 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
+    "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment.",
+    "cruise_lines": [
+      "rcl",
+      "carnival"
+    ]
   },
   "ships": {
     "icon-of-the-seas": {
       "name": "Icon of the Seas",
       "class": "Icon",
-      "homeports": ["miami"],
-      "regions": ["eastern-caribbean", "western-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "miami"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "philipsburg", "st-kitts", "cozumel", "costa-maya", "roatan"],
-      "itinerary_lengths": [7]
+      "typical_ports": [
+        "cococay",
+        "philipsburg",
+        "st-kitts",
+        "cozumel",
+        "costa-maya",
+        "roatan"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     },
     "star-of-the-seas": {
       "name": "Star of the Seas",
       "class": "Icon",
-      "homeports": ["port-canaveral"],
-      "regions": ["eastern-caribbean", "western-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "nassau", "cozumel", "costa-maya", "grand-cayman"],
-      "itinerary_lengths": [7]
+      "typical_ports": [
+        "cococay",
+        "nassau",
+        "cozumel",
+        "costa-maya",
+        "grand-cayman"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     },
     "utopia-of-the-seas": {
       "name": "Utopia of the Seas",
       "class": "Oasis",
-      "homeports": ["port-canaveral"],
-      "regions": ["bahamas"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "bahamas"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "nassau"],
-      "itinerary_lengths": [3, 4]
+      "typical_ports": [
+        "cococay",
+        "nassau"
+      ],
+      "itinerary_lengths": [
+        3,
+        4
+      ]
     },
     "wonder-of-the-seas": {
       "name": "Wonder of the Seas",
       "class": "Oasis",
-      "homeports": ["miami", "port-canaveral"],
-      "regions": ["bahamas", "eastern-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "miami",
+        "port-canaveral"
+      ],
+      "regions": [
+        "bahamas",
+        "eastern-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "nassau", "st-thomas", "st-maarten"],
-      "itinerary_lengths": [3, 7]
+      "typical_ports": [
+        "cococay",
+        "nassau",
+        "st-thomas",
+        "st-maarten"
+      ],
+      "itinerary_lengths": [
+        3,
+        7
+      ]
     },
     "symphony-of-the-seas": {
       "name": "Symphony of the Seas",
       "class": "Oasis",
-      "homeports": ["galveston", "cape-liberty"],
-      "regions": ["western-caribbean", "eastern-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "galveston",
+        "cape-liberty"
+      ],
+      "regions": [
+        "western-caribbean",
+        "eastern-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "cozumel", "costa-maya", "roatan", "jamaica"],
-      "itinerary_lengths": [6, 7, 8]
+      "typical_ports": [
+        "cococay",
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "jamaica"
+      ],
+      "itinerary_lengths": [
+        6,
+        7,
+        8
+      ]
     },
     "harmony-of-the-seas": {
       "name": "Harmony of the Seas",
       "class": "Oasis",
-      "homeports": ["galveston", "barcelona"],
-      "regions": ["western-caribbean", "western-mediterranean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "galveston",
+        "barcelona"
+      ],
+      "regions": [
+        "western-caribbean",
+        "western-mediterranean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cozumel", "costa-maya", "roatan", "barcelona", "marseille", "la-spezia", "rome"],
-      "itinerary_lengths": [6, 7, 8]
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "barcelona",
+        "marseille",
+        "la-spezia",
+        "rome"
+      ],
+      "itinerary_lengths": [
+        6,
+        7,
+        8
+      ]
     },
     "allure-of-the-seas": {
       "name": "Allure of the Seas",
       "class": "Oasis",
-      "homeports": ["fort-lauderdale", "barcelona", "rome"],
-      "regions": ["eastern-caribbean", "southern-caribbean", "western-mediterranean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "fort-lauderdale",
+        "barcelona",
+        "rome"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "southern-caribbean",
+        "western-mediterranean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "st-thomas", "st-maarten", "barcelona", "rome", "naples", "marseille"],
-      "itinerary_lengths": [6, 7, 8]
+      "typical_ports": [
+        "cococay",
+        "st-thomas",
+        "st-maarten",
+        "barcelona",
+        "rome",
+        "naples",
+        "marseille"
+      ],
+      "itinerary_lengths": [
+        6,
+        7,
+        8
+      ]
     },
     "oasis-of-the-seas": {
       "name": "Oasis of the Seas",
       "class": "Oasis",
-      "homeports": ["miami"],
-      "regions": ["eastern-caribbean", "western-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "miami"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "nassau", "cozumel", "jamaica", "grand-cayman"],
-      "itinerary_lengths": [6, 7]
+      "typical_ports": [
+        "cococay",
+        "nassau",
+        "cozumel",
+        "jamaica",
+        "grand-cayman"
+      ],
+      "itinerary_lengths": [
+        6,
+        7
+      ]
     },
     "freedom-of-the-seas": {
       "name": "Freedom of the Seas",
       "class": "Freedom",
-      "homeports": ["san-juan"],
-      "regions": ["southern-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "san-juan"
+      ],
+      "regions": [
+        "southern-caribbean"
+      ],
       "season": "winter",
-      "typical_ports": ["st-thomas", "st-kitts", "antigua", "st-lucia", "barbados", "aruba", "curacao"],
-      "itinerary_lengths": [7]
+      "typical_ports": [
+        "st-thomas",
+        "st-kitts",
+        "antigua",
+        "st-lucia",
+        "barbados",
+        "aruba",
+        "curacao"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     },
     "liberty-of-the-seas": {
       "name": "Liberty of the Seas",
       "class": "Freedom",
-      "homeports": ["cape-liberty", "galveston"],
-      "regions": ["eastern-caribbean", "bermuda", "canada-new-england"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "cape-liberty",
+        "galveston"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "bermuda",
+        "canada-new-england"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "nassau", "bermuda", "portland-maine", "bar-harbor", "halifax"],
-      "itinerary_lengths": [4, 5, 7, 9]
+      "typical_ports": [
+        "cococay",
+        "nassau",
+        "bermuda",
+        "portland-maine",
+        "bar-harbor",
+        "halifax"
+      ],
+      "itinerary_lengths": [
+        4,
+        5,
+        7,
+        9
+      ]
     },
     "independence-of-the-seas": {
       "name": "Independence of the Seas",
       "class": "Freedom",
-      "homeports": ["southampton"],
-      "regions": ["northern-europe", "iberian-peninsula", "baltic"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "southampton"
+      ],
+      "regions": [
+        "northern-europe",
+        "iberian-peninsula",
+        "baltic"
+      ],
       "season": "spring-fall",
-      "typical_ports": ["amsterdam", "copenhagen", "stockholm", "tallinn", "lisbon", "vigo", "bilbao"],
-      "itinerary_lengths": [7, 12, 14]
+      "typical_ports": [
+        "amsterdam",
+        "copenhagen",
+        "stockholm",
+        "tallinn",
+        "lisbon",
+        "vigo",
+        "bilbao"
+      ],
+      "itinerary_lengths": [
+        7,
+        12,
+        14
+      ]
     },
     "voyager-of-the-seas": {
       "name": "Voyager of the Seas",
       "class": "Voyager",
-      "homeports": ["seattle", "rome", "los-angeles"],
-      "regions": ["alaska", "mediterranean", "mexican-riviera"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "seattle",
+        "rome",
+        "los-angeles"
+      ],
+      "regions": [
+        "alaska",
+        "mediterranean",
+        "mexican-riviera"
+      ],
       "season": "seasonal",
-      "typical_ports": ["juneau", "skagway", "ketchikan", "glacier-bay", "rome", "naples", "santorini", "cabo-san-lucas"],
-      "itinerary_lengths": [7, 8]
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "rome",
+        "naples",
+        "santorini",
+        "cabo-san-lucas"
+      ],
+      "itinerary_lengths": [
+        7,
+        8
+      ]
     },
     "explorer-of-the-seas": {
       "name": "Explorer of the Seas",
       "class": "Voyager",
-      "homeports": ["ravenna"],
-      "regions": ["greek-isles", "adriatic"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "ravenna"
+      ],
+      "regions": [
+        "greek-isles",
+        "adriatic"
+      ],
       "season": "spring-fall",
-      "typical_ports": ["dubrovnik", "kotor", "corfu", "santorini", "mykonos", "athens"],
-      "itinerary_lengths": [7]
+      "typical_ports": [
+        "dubrovnik",
+        "kotor",
+        "corfu",
+        "santorini",
+        "mykonos",
+        "athens"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     },
     "adventure-of-the-seas": {
       "name": "Adventure of the Seas",
       "class": "Voyager",
-      "homeports": ["port-canaveral"],
-      "regions": ["eastern-caribbean", "southern-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "southern-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "st-thomas", "st-maarten", "san-juan", "aruba", "curacao"],
-      "itinerary_lengths": [6, 8]
+      "typical_ports": [
+        "cococay",
+        "st-thomas",
+        "st-maarten",
+        "san-juan",
+        "aruba",
+        "curacao"
+      ],
+      "itinerary_lengths": [
+        6,
+        8
+      ]
     },
     "navigator-of-the-seas": {
       "name": "Navigator of the Seas",
       "class": "Voyager",
-      "homeports": ["los-angeles"],
-      "regions": ["mexican-riviera", "baja"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "los-angeles"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "baja"
+      ],
       "season": "year-round",
-      "typical_ports": ["cabo-san-lucas", "mazatlan", "puerto-vallarta", "ensenada"],
-      "itinerary_lengths": [3, 4, 7]
+      "typical_ports": [
+        "cabo-san-lucas",
+        "mazatlan",
+        "puerto-vallarta",
+        "ensenada"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7
+      ]
     },
     "mariner-of-the-seas": {
       "name": "Mariner of the Seas",
       "class": "Voyager",
-      "homeports": ["los-angeles", "galveston"],
-      "regions": ["mexican-riviera", "western-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "los-angeles",
+        "galveston"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "western-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cabo-san-lucas", "ensenada", "cozumel", "costa-maya"],
-      "itinerary_lengths": [3, 4, 5, 7]
+      "typical_ports": [
+        "cabo-san-lucas",
+        "ensenada",
+        "cozumel",
+        "costa-maya"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        5,
+        7
+      ]
     },
     "quantum-of-the-seas": {
       "name": "Quantum of the Seas",
       "class": "Quantum",
-      "homeports": ["brisbane", "singapore"],
-      "regions": ["australia", "south-pacific", "asia"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "brisbane",
+        "singapore"
+      ],
+      "regions": [
+        "australia",
+        "south-pacific",
+        "asia"
+      ],
       "season": "year-round",
-      "typical_ports": ["sydney", "melbourne", "hobart", "new-caledonia", "vanuatu", "penang", "phuket"],
-      "itinerary_lengths": [3, 7, 10]
+      "typical_ports": [
+        "sydney",
+        "melbourne",
+        "hobart",
+        "new-caledonia",
+        "vanuatu",
+        "penang",
+        "phuket"
+      ],
+      "itinerary_lengths": [
+        3,
+        7,
+        10
+      ]
     },
     "anthem-of-the-seas": {
       "name": "Anthem of the Seas",
       "class": "Quantum",
-      "homeports": ["seattle", "southampton"],
-      "regions": ["alaska", "northern-europe"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "seattle",
+        "southampton"
+      ],
+      "regions": [
+        "alaska",
+        "northern-europe"
+      ],
       "season": "seasonal",
-      "typical_ports": ["juneau", "skagway", "ketchikan", "sitka", "glacier-bay", "amsterdam", "bruges"],
-      "itinerary_lengths": [7]
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "sitka",
+        "glacier-bay",
+        "amsterdam",
+        "bruges"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     },
     "ovation-of-the-seas": {
       "name": "Ovation of the Seas",
       "class": "Quantum",
-      "homeports": ["seattle", "sydney"],
-      "regions": ["alaska", "australia", "new-zealand"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "seattle",
+        "sydney"
+      ],
+      "regions": [
+        "alaska",
+        "australia",
+        "new-zealand"
+      ],
       "season": "seasonal",
-      "typical_ports": ["juneau", "skagway", "ketchikan", "victoria-bc", "sydney", "melbourne", "auckland", "bay-of-islands"],
-      "itinerary_lengths": [7, 10, 12]
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "victoria-bc",
+        "sydney",
+        "melbourne",
+        "auckland",
+        "bay-of-islands"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        12
+      ]
     },
     "odyssey-of-the-seas": {
       "name": "Odyssey of the Seas",
       "class": "Quantum",
-      "homeports": ["cape-liberty", "rome"],
-      "regions": ["bermuda", "eastern-caribbean", "mediterranean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "cape-liberty",
+        "rome"
+      ],
+      "regions": [
+        "bermuda",
+        "eastern-caribbean",
+        "mediterranean"
+      ],
       "season": "year-round",
-      "typical_ports": ["bermuda", "cococay", "nassau", "rome", "naples", "santorini"],
-      "itinerary_lengths": [5, 7, 8]
+      "typical_ports": [
+        "bermuda",
+        "cococay",
+        "nassau",
+        "rome",
+        "naples",
+        "santorini"
+      ],
+      "itinerary_lengths": [
+        5,
+        7,
+        8
+      ]
     },
     "spectrum-of-the-seas": {
       "name": "Spectrum of the Seas",
       "class": "Quantum",
-      "homeports": ["shanghai", "singapore"],
-      "regions": ["asia"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "shanghai",
+        "singapore"
+      ],
+      "regions": [
+        "asia"
+      ],
       "season": "year-round",
-      "typical_ports": ["hong-kong", "nha-trang", "koh-samui", "phuket"],
-      "itinerary_lengths": [2, 3, 5]
+      "typical_ports": [
+        "hong-kong",
+        "nha-trang",
+        "koh-samui",
+        "phuket"
+      ],
+      "itinerary_lengths": [
+        2,
+        3,
+        5
+      ]
     },
     "brilliance-of-the-seas": {
       "name": "Brilliance of the Seas",
       "class": "Radiance",
-      "homeports": ["athens", "barcelona", "ravenna"],
-      "regions": ["greek-isles", "adriatic", "western-mediterranean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "athens",
+        "barcelona",
+        "ravenna"
+      ],
+      "regions": [
+        "greek-isles",
+        "adriatic",
+        "western-mediterranean"
+      ],
       "season": "spring-fall",
-      "typical_ports": ["santorini", "mykonos", "rhodes", "dubrovnik", "kotor", "barcelona", "marseille"],
-      "itinerary_lengths": [7]
+      "typical_ports": [
+        "santorini",
+        "mykonos",
+        "rhodes",
+        "dubrovnik",
+        "kotor",
+        "barcelona",
+        "marseille"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     },
     "radiance-of-the-seas": {
       "name": "Radiance of the Seas",
       "class": "Radiance",
-      "homeports": ["vancouver", "seward"],
-      "regions": ["alaska"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "vancouver",
+        "seward"
+      ],
+      "regions": [
+        "alaska"
+      ],
       "season": "summer",
-      "typical_ports": ["juneau", "skagway", "ketchikan", "icy-strait-point", "hubbard-glacier", "glacier-bay"],
-      "itinerary_lengths": [7]
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "icy-strait-point",
+        "hubbard-glacier",
+        "glacier-bay"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     },
     "serenade-of-the-seas": {
       "name": "Serenade of the Seas",
       "class": "Radiance",
-      "homeports": ["seattle", "san-diego"],
-      "regions": ["alaska", "pacific-coastal"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "seattle",
+        "san-diego"
+      ],
+      "regions": [
+        "alaska",
+        "pacific-coastal"
+      ],
       "season": "seasonal",
-      "typical_ports": ["juneau", "skagway", "ketchikan", "victoria-bc", "san-francisco", "catalina-island"],
-      "itinerary_lengths": [7, 5]
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "victoria-bc",
+        "san-francisco",
+        "catalina-island"
+      ],
+      "itinerary_lengths": [
+        7,
+        5
+      ]
     },
     "jewel-of-the-seas": {
       "name": "Jewel of the Seas",
       "class": "Radiance",
-      "homeports": ["san-juan"],
-      "regions": ["southern-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "san-juan"
+      ],
+      "regions": [
+        "southern-caribbean"
+      ],
       "season": "winter",
-      "typical_ports": ["st-thomas", "dominica", "barbados", "st-lucia", "antigua", "aruba"],
-      "itinerary_lengths": [7]
+      "typical_ports": [
+        "st-thomas",
+        "dominica",
+        "barbados",
+        "st-lucia",
+        "antigua",
+        "aruba"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     },
     "vision-of-the-seas": {
       "name": "Vision of the Seas",
       "class": "Vision",
-      "homeports": ["baltimore", "san-juan"],
-      "regions": ["bermuda", "bahamas", "canada-new-england", "southern-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "baltimore",
+        "san-juan"
+      ],
+      "regions": [
+        "bermuda",
+        "bahamas",
+        "canada-new-england",
+        "southern-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["bermuda", "cococay", "nassau", "portland-maine", "bar-harbor", "st-thomas", "dominica"],
-      "itinerary_lengths": [5, 7, 8, 9, 12]
+      "typical_ports": [
+        "bermuda",
+        "cococay",
+        "nassau",
+        "portland-maine",
+        "bar-harbor",
+        "st-thomas",
+        "dominica"
+      ],
+      "itinerary_lengths": [
+        5,
+        7,
+        8,
+        9,
+        12
+      ]
     },
     "rhapsody-of-the-seas": {
       "name": "Rhapsody of the Seas",
       "class": "Vision",
-      "homeports": ["san-juan", "tampa"],
-      "regions": ["southern-caribbean", "western-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "san-juan",
+        "tampa"
+      ],
+      "regions": [
+        "southern-caribbean",
+        "western-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["st-thomas", "dominica", "barbados", "aruba", "curacao", "cozumel", "grand-cayman"],
-      "itinerary_lengths": [7]
+      "typical_ports": [
+        "st-thomas",
+        "dominica",
+        "barbados",
+        "aruba",
+        "curacao",
+        "cozumel",
+        "grand-cayman"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     },
     "enchantment-of-the-seas": {
       "name": "Enchantment of the Seas",
       "class": "Vision",
-      "homeports": ["tampa"],
-      "regions": ["western-caribbean"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "tampa"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
       "season": "year-round",
-      "typical_ports": ["cozumel", "costa-maya", "grand-cayman", "jamaica"],
-      "itinerary_lengths": [4, 5, 7]
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "grand-cayman",
+        "jamaica"
+      ],
+      "itinerary_lengths": [
+        4,
+        5,
+        7
+      ]
     },
     "grandeur-of-the-seas": {
       "name": "Grandeur of the Seas",
       "class": "Vision",
-      "homeports": ["baltimore"],
-      "regions": ["bahamas", "bermuda"],
+      "cruise_line": "rcl",
+      "homeports": [
+        "baltimore"
+      ],
+      "regions": [
+        "bahamas",
+        "bermuda"
+      ],
       "season": "year-round",
-      "typical_ports": ["cococay", "nassau", "bermuda"],
-      "itinerary_lengths": [5, 7, 9]
+      "typical_ports": [
+        "cococay",
+        "nassau",
+        "bermuda"
+      ],
+      "itinerary_lengths": [
+        5,
+        7,
+        9
+      ]
+    },
+    "carnival-celebration": {
+      "name": "Carnival Celebration",
+      "class": "Excel",
+      "cruise_line": "carnival",
+      "homeports": [
+        "miami"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "nassau",
+        "half-moon-cay",
+        "grand-turk",
+        "amber-cove"
+      ],
+      "itinerary_lengths": [
+        6,
+        7,
+        8
+      ]
+    },
+    "carnival-jubilee": {
+      "name": "Carnival Jubilee",
+      "class": "Excel",
+      "cruise_line": "carnival",
+      "homeports": [
+        "galveston"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "belize"
+      ],
+      "itinerary_lengths": [
+        6,
+        7
+      ]
+    },
+    "carnival-mardi-gras": {
+      "name": "Carnival Mardi Gras",
+      "class": "Excel",
+      "cruise_line": "carnival",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "nassau",
+        "half-moon-cay",
+        "san-juan",
+        "st-thomas",
+        "amber-cove"
+      ],
+      "itinerary_lengths": [
+        6,
+        7,
+        8
+      ]
+    },
+    "carnival-dream": {
+      "name": "Carnival Dream",
+      "class": "Dream",
+      "cruise_line": "carnival",
+      "homeports": [
+        "galveston"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "belize"
+      ],
+      "itinerary_lengths": [
+        6,
+        7
+      ]
+    },
+    "carnival-magic": {
+      "name": "Carnival Magic",
+      "class": "Dream",
+      "cruise_line": "carnival",
+      "homeports": [
+        "norfolk"
+      ],
+      "regions": [
+        "bahamas",
+        "eastern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "half-moon-cay",
+        "amber-cove",
+        "grand-turk"
+      ],
+      "itinerary_lengths": [
+        5,
+        7,
+        8
+      ]
+    },
+    "carnival-breeze": {
+      "name": "Carnival Breeze",
+      "class": "Dream",
+      "cruise_line": "carnival",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "bahamas"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "half-moon-cay",
+        "amber-cove",
+        "grand-turk",
+        "st-thomas"
+      ],
+      "itinerary_lengths": [
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    "carnival-vista": {
+      "name": "Carnival Vista",
+      "class": "Vista",
+      "cruise_line": "carnival",
+      "homeports": [
+        "galveston"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "belize",
+        "mahogany-bay"
+      ],
+      "itinerary_lengths": [
+        6,
+        7
+      ]
+    },
+    "carnival-horizon": {
+      "name": "Carnival Horizon",
+      "class": "Vista",
+      "cruise_line": "carnival",
+      "homeports": [
+        "miami"
+      ],
+      "regions": [
+        "western-caribbean",
+        "eastern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "nassau",
+        "half-moon-cay",
+        "grand-turk",
+        "amber-cove"
+      ],
+      "itinerary_lengths": [
+        6,
+        7,
+        8
+      ]
+    },
+    "carnival-panorama": {
+      "name": "Carnival Panorama",
+      "class": "Vista",
+      "cruise_line": "carnival",
+      "homeports": [
+        "long-beach"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "baja"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cabo-san-lucas",
+        "mazatlan",
+        "puerto-vallarta",
+        "ensenada"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7
+      ]
+    },
+    "carnival-venezia": {
+      "name": "Carnival Venezia",
+      "class": "Vista",
+      "cruise_line": "carnival",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "bahamas"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "half-moon-cay",
+        "amber-cove",
+        "grand-turk",
+        "san-juan"
+      ],
+      "itinerary_lengths": [
+        5,
+        6,
+        8
+      ]
+    },
+    "carnival-firenze": {
+      "name": "Carnival Firenze",
+      "class": "Venice",
+      "cruise_line": "carnival",
+      "homeports": [
+        "long-beach"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "baja"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cabo-san-lucas",
+        "mazatlan",
+        "puerto-vallarta",
+        "ensenada"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7
+      ]
+    },
+    "carnival-radiance": {
+      "name": "Carnival Radiance",
+      "class": "Destiny",
+      "cruise_line": "carnival",
+      "homeports": [
+        "long-beach"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "baja"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cabo-san-lucas",
+        "ensenada",
+        "catalina-island"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        5,
+        7
+      ]
+    },
+    "carnival-sunrise": {
+      "name": "Carnival Sunrise",
+      "class": "Destiny",
+      "cruise_line": "carnival",
+      "homeports": [
+        "miami"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "bahamas"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "half-moon-cay",
+        "grand-turk",
+        "amber-cove"
+      ],
+      "itinerary_lengths": [
+        4,
+        5,
+        6
+      ]
+    },
+    "carnival-freedom": {
+      "name": "Carnival Freedom",
+      "class": "Conquest",
+      "cruise_line": "carnival",
+      "homeports": [
+        "galveston"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "mahogany-bay",
+        "belize"
+      ],
+      "itinerary_lengths": [
+        4,
+        5,
+        6,
+        7
+      ]
+    },
+    "carnival-conquest": {
+      "name": "Carnival Conquest",
+      "class": "Conquest",
+      "cruise_line": "carnival",
+      "homeports": [
+        "new-orleans"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "mahogany-bay",
+        "progreso"
+      ],
+      "itinerary_lengths": [
+        4,
+        5,
+        7
+      ]
+    },
+    "carnival-glory": {
+      "name": "Carnival Glory",
+      "class": "Conquest",
+      "cruise_line": "carnival",
+      "homeports": [
+        "new-orleans"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "mahogany-bay",
+        "belize"
+      ],
+      "itinerary_lengths": [
+        4,
+        5,
+        7
+      ]
+    },
+    "carnival-valor": {
+      "name": "Carnival Valor",
+      "class": "Conquest",
+      "cruise_line": "carnival",
+      "homeports": [
+        "new-orleans"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "progreso"
+      ],
+      "itinerary_lengths": [
+        4,
+        5
+      ]
+    },
+    "carnival-liberty": {
+      "name": "Carnival Liberty",
+      "class": "Conquest",
+      "cruise_line": "carnival",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "bahamas",
+        "eastern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "half-moon-cay",
+        "grand-turk"
+      ],
+      "itinerary_lengths": [
+        4,
+        5,
+        6
+      ]
+    },
+    "carnival-legend": {
+      "name": "Carnival Legend",
+      "class": "Spirit",
+      "cruise_line": "carnival",
+      "homeports": [
+        "baltimore",
+        "tampa"
+      ],
+      "regions": [
+        "bahamas",
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "half-moon-cay",
+        "grand-turk",
+        "cozumel"
+      ],
+      "itinerary_lengths": [
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    "carnival-pride": {
+      "name": "Carnival Pride",
+      "class": "Spirit",
+      "cruise_line": "carnival",
+      "homeports": [
+        "baltimore"
+      ],
+      "regions": [
+        "bahamas",
+        "bermuda",
+        "eastern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "half-moon-cay",
+        "bermuda",
+        "grand-turk"
+      ],
+      "itinerary_lengths": [
+        5,
+        7,
+        8,
+        10
+      ]
+    },
+    "carnival-spirit": {
+      "name": "Carnival Spirit",
+      "class": "Spirit",
+      "cruise_line": "carnival",
+      "homeports": [
+        "mobile"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "progreso"
+      ],
+      "itinerary_lengths": [
+        4,
+        5
+      ]
+    },
+    "carnival-miracle": {
+      "name": "Carnival Miracle",
+      "class": "Spirit",
+      "cruise_line": "carnival",
+      "homeports": [
+        "tampa"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "grand-cayman",
+        "mahogany-bay"
+      ],
+      "itinerary_lengths": [
+        5,
+        6,
+        7
+      ]
+    },
+    "carnival-elation": {
+      "name": "Carnival Elation",
+      "class": "Fantasy",
+      "cruise_line": "carnival",
+      "homeports": [
+        "jacksonville"
+      ],
+      "regions": [
+        "bahamas"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "half-moon-cay"
+      ],
+      "itinerary_lengths": [
+        4,
+        5
+      ]
+    },
+    "carnival-paradise": {
+      "name": "Carnival Paradise",
+      "class": "Fantasy",
+      "cruise_line": "carnival",
+      "homeports": [
+        "tampa"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "grand-cayman"
+      ],
+      "itinerary_lengths": [
+        4,
+        5
+      ]
+    },
+    "carnival-luminosa": {
+      "name": "Carnival Luminosa",
+      "class": "Spirit",
+      "cruise_line": "carnival",
+      "homeports": [
+        "brisbane"
+      ],
+      "regions": [
+        "australia",
+        "south-pacific"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "sydney",
+        "melbourne",
+        "new-caledonia",
+        "vanuatu",
+        "airlie-beach"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7,
+        10
+      ]
+    },
+    "carnival-splendor": {
+      "name": "Carnival Splendor",
+      "class": "Concordia",
+      "cruise_line": "carnival",
+      "homeports": [
+        "sydney"
+      ],
+      "regions": [
+        "australia",
+        "south-pacific",
+        "new-zealand"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "melbourne",
+        "hobart",
+        "auckland",
+        "bay-of-islands",
+        "new-caledonia"
+      ],
+      "itinerary_lengths": [
+        3,
+        7,
+        10,
+        12
+      ]
     }
   },
   "port_to_ships": {
-    "cococay": ["icon-of-the-seas", "star-of-the-seas", "utopia-of-the-seas", "wonder-of-the-seas", "symphony-of-the-seas", "oasis-of-the-seas", "liberty-of-the-seas", "adventure-of-the-seas", "odyssey-of-the-seas", "vision-of-the-seas", "grandeur-of-the-seas"],
-    "nassau": ["star-of-the-seas", "utopia-of-the-seas", "wonder-of-the-seas", "oasis-of-the-seas", "liberty-of-the-seas", "odyssey-of-the-seas", "vision-of-the-seas", "grandeur-of-the-seas"],
-    "cozumel": ["icon-of-the-seas", "star-of-the-seas", "symphony-of-the-seas", "harmony-of-the-seas", "oasis-of-the-seas", "mariner-of-the-seas", "enchantment-of-the-seas", "rhapsody-of-the-seas"],
-    "costa-maya": ["icon-of-the-seas", "star-of-the-seas", "symphony-of-the-seas", "harmony-of-the-seas", "mariner-of-the-seas", "enchantment-of-the-seas"],
-    "roatan": ["icon-of-the-seas", "symphony-of-the-seas", "harmony-of-the-seas"],
-    "jamaica": ["symphony-of-the-seas", "oasis-of-the-seas", "enchantment-of-the-seas"],
-    "grand-cayman": ["star-of-the-seas", "oasis-of-the-seas", "enchantment-of-the-seas", "rhapsody-of-the-seas"],
-    "st-thomas": ["wonder-of-the-seas", "adventure-of-the-seas", "freedom-of-the-seas", "allure-of-the-seas", "jewel-of-the-seas", "vision-of-the-seas", "rhapsody-of-the-seas"],
-    "st-maarten": ["icon-of-the-seas", "wonder-of-the-seas", "adventure-of-the-seas", "allure-of-the-seas"],
-    "st-kitts": ["icon-of-the-seas", "freedom-of-the-seas"],
-    "antigua": ["freedom-of-the-seas", "jewel-of-the-seas"],
-    "st-lucia": ["freedom-of-the-seas", "jewel-of-the-seas"],
-    "barbados": ["freedom-of-the-seas", "jewel-of-the-seas", "vision-of-the-seas", "rhapsody-of-the-seas"],
-    "aruba": ["freedom-of-the-seas", "adventure-of-the-seas", "jewel-of-the-seas", "rhapsody-of-the-seas"],
-    "curacao": ["freedom-of-the-seas", "adventure-of-the-seas", "rhapsody-of-the-seas"],
-    "dominica": ["jewel-of-the-seas", "vision-of-the-seas"],
-    "san-juan": ["adventure-of-the-seas"],
-    "bermuda": ["liberty-of-the-seas", "odyssey-of-the-seas", "vision-of-the-seas", "grandeur-of-the-seas"],
-    "juneau": ["voyager-of-the-seas", "anthem-of-the-seas", "ovation-of-the-seas", "radiance-of-the-seas", "serenade-of-the-seas"],
-    "skagway": ["voyager-of-the-seas", "anthem-of-the-seas", "ovation-of-the-seas", "radiance-of-the-seas", "serenade-of-the-seas"],
-    "ketchikan": ["voyager-of-the-seas", "anthem-of-the-seas", "ovation-of-the-seas", "radiance-of-the-seas", "serenade-of-the-seas"],
-    "glacier-bay": ["voyager-of-the-seas", "anthem-of-the-seas", "radiance-of-the-seas"],
-    "sitka": ["anthem-of-the-seas"],
-    "icy-strait-point": ["radiance-of-the-seas"],
-    "hubbard-glacier": ["radiance-of-the-seas"],
-    "victoria-bc": ["ovation-of-the-seas", "serenade-of-the-seas"],
-    "barcelona": ["harmony-of-the-seas", "allure-of-the-seas", "brilliance-of-the-seas"],
-    "rome": ["harmony-of-the-seas", "allure-of-the-seas", "voyager-of-the-seas", "odyssey-of-the-seas"],
-    "naples": ["allure-of-the-seas", "voyager-of-the-seas", "odyssey-of-the-seas"],
-    "marseille": ["harmony-of-the-seas", "allure-of-the-seas", "brilliance-of-the-seas"],
-    "la-spezia": ["harmony-of-the-seas"],
-    "santorini": ["voyager-of-the-seas", "explorer-of-the-seas", "odyssey-of-the-seas", "brilliance-of-the-seas"],
-    "mykonos": ["explorer-of-the-seas", "brilliance-of-the-seas"],
-    "athens": ["explorer-of-the-seas"],
-    "dubrovnik": ["explorer-of-the-seas", "brilliance-of-the-seas"],
-    "kotor": ["explorer-of-the-seas", "brilliance-of-the-seas"],
-    "corfu": ["explorer-of-the-seas"],
-    "rhodes": ["brilliance-of-the-seas"],
-    "amsterdam": ["independence-of-the-seas", "anthem-of-the-seas"],
-    "copenhagen": ["independence-of-the-seas"],
-    "stockholm": ["independence-of-the-seas"],
-    "tallinn": ["independence-of-the-seas"],
-    "cabo-san-lucas": ["navigator-of-the-seas", "mariner-of-the-seas", "voyager-of-the-seas"],
-    "mazatlan": ["navigator-of-the-seas"],
-    "puerto-vallarta": ["navigator-of-the-seas"],
-    "ensenada": ["navigator-of-the-seas", "mariner-of-the-seas"],
-    "portland-maine": ["liberty-of-the-seas", "vision-of-the-seas"],
-    "bar-harbor": ["liberty-of-the-seas", "vision-of-the-seas"],
-    "halifax": ["liberty-of-the-seas"],
-    "sydney": ["quantum-of-the-seas", "ovation-of-the-seas"],
-    "melbourne": ["quantum-of-the-seas", "ovation-of-the-seas"],
-    "hobart": ["quantum-of-the-seas"],
-    "auckland": ["ovation-of-the-seas"],
-    "bay-of-islands": ["ovation-of-the-seas"],
-    "penang": ["quantum-of-the-seas"],
-    "phuket": ["quantum-of-the-seas", "spectrum-of-the-seas"],
-    "hong-kong": ["spectrum-of-the-seas"],
-    "nha-trang": ["spectrum-of-the-seas"],
-    "koh-samui": ["spectrum-of-the-seas"],
-    "southampton": ["independence-of-the-seas", "anthem-of-the-seas"],
-    "lisbon": ["independence-of-the-seas"],
-    "vigo": ["independence-of-the-seas"],
-    "ravenna": ["explorer-of-the-seas", "brilliance-of-the-seas"]
+    "cococay": [
+      "icon-of-the-seas",
+      "star-of-the-seas",
+      "utopia-of-the-seas",
+      "wonder-of-the-seas",
+      "symphony-of-the-seas",
+      "oasis-of-the-seas",
+      "liberty-of-the-seas",
+      "adventure-of-the-seas",
+      "odyssey-of-the-seas",
+      "vision-of-the-seas",
+      "grandeur-of-the-seas"
+    ],
+    "nassau": [
+      "star-of-the-seas",
+      "utopia-of-the-seas",
+      "wonder-of-the-seas",
+      "oasis-of-the-seas",
+      "liberty-of-the-seas",
+      "odyssey-of-the-seas",
+      "vision-of-the-seas",
+      "grandeur-of-the-seas",
+      "carnival-celebration",
+      "carnival-mardi-gras",
+      "carnival-magic",
+      "carnival-breeze",
+      "carnival-horizon",
+      "carnival-venezia",
+      "carnival-sunrise",
+      "carnival-liberty",
+      "carnival-legend",
+      "carnival-pride",
+      "carnival-elation"
+    ],
+    "cozumel": [
+      "icon-of-the-seas",
+      "star-of-the-seas",
+      "symphony-of-the-seas",
+      "harmony-of-the-seas",
+      "oasis-of-the-seas",
+      "mariner-of-the-seas",
+      "enchantment-of-the-seas",
+      "rhapsody-of-the-seas",
+      "carnival-celebration",
+      "carnival-jubilee",
+      "carnival-mardi-gras",
+      "carnival-dream",
+      "carnival-vista",
+      "carnival-horizon",
+      "carnival-freedom",
+      "carnival-conquest",
+      "carnival-glory",
+      "carnival-valor",
+      "carnival-legend",
+      "carnival-spirit",
+      "carnival-miracle",
+      "carnival-paradise"
+    ],
+    "costa-maya": [
+      "icon-of-the-seas",
+      "star-of-the-seas",
+      "symphony-of-the-seas",
+      "harmony-of-the-seas",
+      "mariner-of-the-seas",
+      "enchantment-of-the-seas",
+      "carnival-celebration",
+      "carnival-jubilee",
+      "carnival-mardi-gras",
+      "carnival-dream",
+      "carnival-vista",
+      "carnival-horizon",
+      "carnival-conquest",
+      "carnival-glory",
+      "carnival-valor",
+      "carnival-spirit"
+    ],
+    "roatan": [
+      "icon-of-the-seas",
+      "symphony-of-the-seas",
+      "harmony-of-the-seas",
+      "carnival-jubilee",
+      "carnival-dream",
+      "carnival-vista"
+    ],
+    "jamaica": [
+      "symphony-of-the-seas",
+      "oasis-of-the-seas",
+      "enchantment-of-the-seas"
+    ],
+    "grand-cayman": [
+      "star-of-the-seas",
+      "oasis-of-the-seas",
+      "enchantment-of-the-seas",
+      "rhapsody-of-the-seas",
+      "carnival-miracle",
+      "carnival-paradise"
+    ],
+    "half-moon-cay": [
+      "carnival-celebration",
+      "carnival-mardi-gras",
+      "carnival-magic",
+      "carnival-breeze",
+      "carnival-horizon",
+      "carnival-venezia",
+      "carnival-sunrise",
+      "carnival-liberty",
+      "carnival-legend",
+      "carnival-pride",
+      "carnival-elation"
+    ],
+    "grand-turk": [
+      "carnival-magic",
+      "carnival-breeze",
+      "carnival-horizon",
+      "carnival-venezia",
+      "carnival-sunrise",
+      "carnival-liberty",
+      "carnival-legend",
+      "carnival-pride"
+    ],
+    "amber-cove": [
+      "carnival-celebration",
+      "carnival-mardi-gras",
+      "carnival-magic",
+      "carnival-breeze",
+      "carnival-horizon",
+      "carnival-venezia",
+      "carnival-sunrise"
+    ],
+    "belize": [
+      "carnival-jubilee",
+      "carnival-dream",
+      "carnival-vista",
+      "carnival-freedom",
+      "carnival-glory"
+    ],
+    "mahogany-bay": [
+      "carnival-vista",
+      "carnival-freedom",
+      "carnival-conquest",
+      "carnival-glory",
+      "carnival-miracle"
+    ],
+    "progreso": [
+      "carnival-conquest",
+      "carnival-valor",
+      "carnival-spirit"
+    ],
+    "st-thomas": [
+      "wonder-of-the-seas",
+      "adventure-of-the-seas",
+      "freedom-of-the-seas",
+      "allure-of-the-seas",
+      "jewel-of-the-seas",
+      "vision-of-the-seas",
+      "rhapsody-of-the-seas"
+    ],
+    "st-maarten": [
+      "icon-of-the-seas",
+      "wonder-of-the-seas",
+      "adventure-of-the-seas",
+      "allure-of-the-seas"
+    ],
+    "st-kitts": [
+      "icon-of-the-seas",
+      "freedom-of-the-seas"
+    ],
+    "antigua": [
+      "freedom-of-the-seas",
+      "jewel-of-the-seas"
+    ],
+    "st-lucia": [
+      "freedom-of-the-seas",
+      "jewel-of-the-seas"
+    ],
+    "barbados": [
+      "freedom-of-the-seas",
+      "jewel-of-the-seas",
+      "vision-of-the-seas",
+      "rhapsody-of-the-seas"
+    ],
+    "aruba": [
+      "freedom-of-the-seas",
+      "adventure-of-the-seas",
+      "jewel-of-the-seas",
+      "rhapsody-of-the-seas"
+    ],
+    "curacao": [
+      "freedom-of-the-seas",
+      "adventure-of-the-seas",
+      "rhapsody-of-the-seas"
+    ],
+    "dominica": [
+      "jewel-of-the-seas",
+      "vision-of-the-seas"
+    ],
+    "san-juan": [
+      "adventure-of-the-seas"
+    ],
+    "bermuda": [
+      "liberty-of-the-seas",
+      "odyssey-of-the-seas",
+      "vision-of-the-seas",
+      "grandeur-of-the-seas"
+    ],
+    "juneau": [
+      "voyager-of-the-seas",
+      "anthem-of-the-seas",
+      "ovation-of-the-seas",
+      "radiance-of-the-seas",
+      "serenade-of-the-seas"
+    ],
+    "skagway": [
+      "voyager-of-the-seas",
+      "anthem-of-the-seas",
+      "ovation-of-the-seas",
+      "radiance-of-the-seas",
+      "serenade-of-the-seas"
+    ],
+    "ketchikan": [
+      "voyager-of-the-seas",
+      "anthem-of-the-seas",
+      "ovation-of-the-seas",
+      "radiance-of-the-seas",
+      "serenade-of-the-seas"
+    ],
+    "glacier-bay": [
+      "voyager-of-the-seas",
+      "anthem-of-the-seas",
+      "radiance-of-the-seas"
+    ],
+    "sitka": [
+      "anthem-of-the-seas"
+    ],
+    "icy-strait-point": [
+      "radiance-of-the-seas"
+    ],
+    "hubbard-glacier": [
+      "radiance-of-the-seas"
+    ],
+    "victoria-bc": [
+      "ovation-of-the-seas",
+      "serenade-of-the-seas"
+    ],
+    "barcelona": [
+      "harmony-of-the-seas",
+      "allure-of-the-seas",
+      "brilliance-of-the-seas"
+    ],
+    "rome": [
+      "harmony-of-the-seas",
+      "allure-of-the-seas",
+      "voyager-of-the-seas",
+      "odyssey-of-the-seas"
+    ],
+    "naples": [
+      "allure-of-the-seas",
+      "voyager-of-the-seas",
+      "odyssey-of-the-seas"
+    ],
+    "marseille": [
+      "harmony-of-the-seas",
+      "allure-of-the-seas",
+      "brilliance-of-the-seas"
+    ],
+    "la-spezia": [
+      "harmony-of-the-seas"
+    ],
+    "santorini": [
+      "voyager-of-the-seas",
+      "explorer-of-the-seas",
+      "odyssey-of-the-seas",
+      "brilliance-of-the-seas"
+    ],
+    "mykonos": [
+      "explorer-of-the-seas",
+      "brilliance-of-the-seas"
+    ],
+    "athens": [
+      "explorer-of-the-seas"
+    ],
+    "dubrovnik": [
+      "explorer-of-the-seas",
+      "brilliance-of-the-seas"
+    ],
+    "kotor": [
+      "explorer-of-the-seas",
+      "brilliance-of-the-seas"
+    ],
+    "corfu": [
+      "explorer-of-the-seas"
+    ],
+    "rhodes": [
+      "brilliance-of-the-seas"
+    ],
+    "amsterdam": [
+      "independence-of-the-seas",
+      "anthem-of-the-seas"
+    ],
+    "copenhagen": [
+      "independence-of-the-seas"
+    ],
+    "stockholm": [
+      "independence-of-the-seas"
+    ],
+    "tallinn": [
+      "independence-of-the-seas"
+    ],
+    "cabo-san-lucas": [
+      "navigator-of-the-seas",
+      "mariner-of-the-seas",
+      "voyager-of-the-seas",
+      "carnival-panorama",
+      "carnival-firenze",
+      "carnival-radiance"
+    ],
+    "mazatlan": [
+      "navigator-of-the-seas",
+      "carnival-panorama",
+      "carnival-firenze"
+    ],
+    "puerto-vallarta": [
+      "navigator-of-the-seas",
+      "carnival-panorama",
+      "carnival-firenze"
+    ],
+    "ensenada": [
+      "navigator-of-the-seas",
+      "mariner-of-the-seas",
+      "carnival-panorama",
+      "carnival-firenze",
+      "carnival-radiance"
+    ],
+    "catalina-island": [
+      "carnival-radiance"
+    ],
+    "portland-maine": [
+      "liberty-of-the-seas",
+      "vision-of-the-seas"
+    ],
+    "bar-harbor": [
+      "liberty-of-the-seas",
+      "vision-of-the-seas"
+    ],
+    "halifax": [
+      "liberty-of-the-seas"
+    ],
+    "sydney": [
+      "quantum-of-the-seas",
+      "ovation-of-the-seas"
+    ],
+    "melbourne": [
+      "quantum-of-the-seas",
+      "ovation-of-the-seas"
+    ],
+    "hobart": [
+      "quantum-of-the-seas"
+    ],
+    "auckland": [
+      "ovation-of-the-seas"
+    ],
+    "bay-of-islands": [
+      "ovation-of-the-seas"
+    ],
+    "penang": [
+      "quantum-of-the-seas"
+    ],
+    "phuket": [
+      "quantum-of-the-seas",
+      "spectrum-of-the-seas"
+    ],
+    "hong-kong": [
+      "spectrum-of-the-seas"
+    ],
+    "nha-trang": [
+      "spectrum-of-the-seas"
+    ],
+    "koh-samui": [
+      "spectrum-of-the-seas"
+    ],
+    "southampton": [
+      "independence-of-the-seas",
+      "anthem-of-the-seas"
+    ],
+    "lisbon": [
+      "independence-of-the-seas"
+    ],
+    "vigo": [
+      "independence-of-the-seas"
+    ],
+    "ravenna": [
+      "explorer-of-the-seas",
+      "brilliance-of-the-seas"
+    ]
   },
   "homeport_details": {
     "miami": {
       "name": "Miami",
       "state": "Florida",
       "country": "USA",
-      "ships": ["icon-of-the-seas", "oasis-of-the-seas", "wonder-of-the-seas"],
+      "ships": [
+        "icon-of-the-seas",
+        "oasis-of-the-seas",
+        "wonder-of-the-seas",
+        "carnival-celebration",
+        "carnival-horizon",
+        "carnival-sunrise"
+      ],
       "port_page": "/ports/miami.html"
     },
     "port-canaveral": {
       "name": "Port Canaveral",
       "state": "Florida",
       "country": "USA",
-      "ships": ["star-of-the-seas", "utopia-of-the-seas", "adventure-of-the-seas"],
+      "ships": [
+        "star-of-the-seas",
+        "utopia-of-the-seas",
+        "adventure-of-the-seas",
+        "carnival-mardi-gras",
+        "carnival-breeze",
+        "carnival-venezia",
+        "carnival-liberty"
+      ],
       "port_page": "/ports/port-canaveral.html"
     },
     "fort-lauderdale": {
       "name": "Fort Lauderdale",
       "state": "Florida",
       "country": "USA",
-      "ships": ["allure-of-the-seas"],
+      "ships": [
+        "allure-of-the-seas"
+      ],
       "port_page": "/ports/fort-lauderdale.html"
     },
     "galveston": {
       "name": "Galveston",
       "state": "Texas",
       "country": "USA",
-      "ships": ["symphony-of-the-seas", "harmony-of-the-seas"],
+      "ships": [
+        "symphony-of-the-seas",
+        "harmony-of-the-seas",
+        "carnival-jubilee",
+        "carnival-dream",
+        "carnival-vista",
+        "carnival-freedom"
+      ],
       "port_page": "/ports/galveston.html"
     },
     "cape-liberty": {
       "name": "Cape Liberty (Bayonne)",
       "state": "New Jersey",
       "country": "USA",
-      "ships": ["liberty-of-the-seas", "odyssey-of-the-seas"],
+      "ships": [
+        "liberty-of-the-seas",
+        "odyssey-of-the-seas"
+      ],
       "port_page": "/ports/bayonne.html"
     },
     "baltimore": {
       "name": "Baltimore",
       "state": "Maryland",
       "country": "USA",
-      "ships": ["vision-of-the-seas", "grandeur-of-the-seas"],
+      "ships": [
+        "vision-of-the-seas",
+        "grandeur-of-the-seas",
+        "carnival-legend",
+        "carnival-pride"
+      ],
       "port_page": "/ports/baltimore.html"
     },
     "tampa": {
       "name": "Tampa",
       "state": "Florida",
       "country": "USA",
-      "ships": ["enchantment-of-the-seas", "rhapsody-of-the-seas"],
+      "ships": [
+        "enchantment-of-the-seas",
+        "rhapsody-of-the-seas",
+        "carnival-legend",
+        "carnival-miracle",
+        "carnival-paradise"
+      ],
       "port_page": "/ports/tampa.html"
     },
     "san-juan": {
       "name": "San Juan",
       "state": "Puerto Rico",
       "country": "USA",
-      "ships": ["freedom-of-the-seas", "jewel-of-the-seas", "vision-of-the-seas", "rhapsody-of-the-seas"],
+      "ships": [
+        "freedom-of-the-seas",
+        "jewel-of-the-seas",
+        "vision-of-the-seas",
+        "rhapsody-of-the-seas"
+      ],
       "port_page": "/ports/san-juan.html"
     },
     "seattle": {
       "name": "Seattle",
       "state": "Washington",
       "country": "USA",
-      "ships": ["voyager-of-the-seas", "anthem-of-the-seas", "ovation-of-the-seas", "serenade-of-the-seas"],
+      "ships": [
+        "voyager-of-the-seas",
+        "anthem-of-the-seas",
+        "ovation-of-the-seas",
+        "serenade-of-the-seas"
+      ],
       "port_page": "/ports/seattle.html"
     },
     "los-angeles": {
       "name": "Los Angeles",
       "state": "California",
       "country": "USA",
-      "ships": ["navigator-of-the-seas", "mariner-of-the-seas"],
+      "ships": [
+        "navigator-of-the-seas",
+        "mariner-of-the-seas"
+      ],
       "port_page": "/ports/los-angeles.html"
     },
     "san-diego": {
       "name": "San Diego",
       "state": "California",
       "country": "USA",
-      "ships": ["serenade-of-the-seas"],
+      "ships": [
+        "serenade-of-the-seas"
+      ],
       "port_page": "/ports/san-diego.html"
     },
     "vancouver": {
       "name": "Vancouver",
       "state": "British Columbia",
       "country": "Canada",
-      "ships": ["radiance-of-the-seas"],
+      "ships": [
+        "radiance-of-the-seas"
+      ],
       "port_page": "/ports/vancouver.html"
     },
     "barcelona": {
       "name": "Barcelona",
       "state": "Catalonia",
       "country": "Spain",
-      "ships": ["harmony-of-the-seas", "allure-of-the-seas", "brilliance-of-the-seas"],
+      "ships": [
+        "harmony-of-the-seas",
+        "allure-of-the-seas",
+        "brilliance-of-the-seas"
+      ],
       "port_page": "/ports/barcelona.html"
     },
     "rome": {
       "name": "Rome (Civitavecchia)",
       "state": "Lazio",
       "country": "Italy",
-      "ships": ["allure-of-the-seas", "voyager-of-the-seas", "odyssey-of-the-seas"],
+      "ships": [
+        "allure-of-the-seas",
+        "voyager-of-the-seas",
+        "odyssey-of-the-seas"
+      ],
       "port_page": "/ports/rome.html"
     },
     "southampton": {
       "name": "Southampton",
       "state": "Hampshire",
       "country": "UK",
-      "ships": ["independence-of-the-seas", "anthem-of-the-seas"],
+      "ships": [
+        "independence-of-the-seas",
+        "anthem-of-the-seas"
+      ],
       "port_page": "/ports/southampton.html"
     },
     "ravenna": {
       "name": "Ravenna",
       "state": "Emilia-Romagna",
       "country": "Italy",
-      "ships": ["explorer-of-the-seas", "brilliance-of-the-seas"],
+      "ships": [
+        "explorer-of-the-seas",
+        "brilliance-of-the-seas"
+      ],
       "port_page": "/ports/ravenna.html"
     },
     "athens": {
       "name": "Athens (Piraeus)",
       "state": "Attica",
       "country": "Greece",
-      "ships": ["brilliance-of-the-seas"],
+      "ships": [
+        "brilliance-of-the-seas"
+      ],
       "port_page": "/ports/athens.html"
     },
     "singapore": {
       "name": "Singapore",
       "country": "Singapore",
-      "ships": ["spectrum-of-the-seas", "quantum-of-the-seas"],
+      "ships": [
+        "spectrum-of-the-seas",
+        "quantum-of-the-seas"
+      ],
       "port_page": "/ports/singapore.html"
     },
     "sydney": {
       "name": "Sydney",
       "state": "New South Wales",
       "country": "Australia",
-      "ships": ["ovation-of-the-seas"],
+      "ships": [
+        "ovation-of-the-seas",
+        "carnival-splendor"
+      ],
       "port_page": "/ports/sydney.html"
     },
     "brisbane": {
       "name": "Brisbane",
       "state": "Queensland",
       "country": "Australia",
-      "ships": ["quantum-of-the-seas"],
+      "ships": [
+        "quantum-of-the-seas",
+        "carnival-luminosa"
+      ],
       "port_page": "/ports/brisbane.html"
+    },
+    "long-beach": {
+      "name": "Long Beach",
+      "state": "California",
+      "country": "USA",
+      "ships": [
+        "carnival-panorama",
+        "carnival-firenze",
+        "carnival-radiance"
+      ],
+      "port_page": "/ports/long-beach.html"
+    },
+    "jacksonville": {
+      "name": "Jacksonville",
+      "state": "Florida",
+      "country": "USA",
+      "ships": [
+        "carnival-elation"
+      ],
+      "port_page": "/ports/jacksonville.html"
+    },
+    "new-orleans": {
+      "name": "New Orleans",
+      "state": "Louisiana",
+      "country": "USA",
+      "ships": [
+        "carnival-conquest",
+        "carnival-glory",
+        "carnival-valor"
+      ],
+      "port_page": "/ports/new-orleans.html"
+    },
+    "mobile": {
+      "name": "Mobile",
+      "state": "Alabama",
+      "country": "USA",
+      "ships": [
+        "carnival-spirit"
+      ],
+      "port_page": "/ports/mobile.html"
+    },
+    "norfolk": {
+      "name": "Norfolk",
+      "state": "Virginia",
+      "country": "USA",
+      "ships": [
+        "carnival-magic"
+      ],
+      "port_page": "/ports/norfolk.html"
     }
   }
 }


### PR DESCRIPTION
Expanded ship-port cross-linking to support multiple cruise lines:
- Added 26 Carnival ships with deployment data (Excel, Vista, Dream, Conquest, Spirit, Fantasy classes)
- Updated ship-port-links.js to handle /ships/carnival/ paths
- Ships grouped by cruise line with brand colors (RCL blue, Carnival orange)
- Added new ports: Half Moon Cay, Grand Turk, Amber Cove, Mahogany Bay, etc.
- New homeports: Long Beach, New Orleans, Jacksonville, Mobile, Norfolk

Data summary:
- 55 total ships (29 RCL + 26 Carnival)
- 70 ports with ship cross-links
- Supports dynamic future expansion (Celebrity, NCL, etc.)

Closes competitor gap: No other cruise site shows which ships visit each port