### PR TITLE
Ships That Visit: Add Celebrity Cruises (16 ships)

### DIFF
--- a/admin/UNFINISHED-TASKS.md
+++ b/admin/UNFINISHED-TASKS.md
@@ -303,14 +303,14 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | "No Ads" trust messaging on about-us.html | ✅ DONE | Cruise Critic, CruiseMapper |
 | Tender Port Index + badge (`/ports/tender-ports.html`) | ✅ DONE | WhatsInPort |
 | "From the Pier" distance callout box component | PARTIAL (some ports) | WhatsInPort, IQCruising |
-| "Ships That Visit Here" section on port pages | PARTIAL (70/380 ports, RCL+Carnival) | UNIQUE - no competitor has this |
+| "Ships That Visit Here" section on port pages | PARTIAL (81/380 ports, RCL+Carnival+Celebrity) | UNIQUE - no competitor has this |
 | First-Timer Hub page | ✅ DONE (`first-cruise.html` 27KB) | Cruise Critic |
 | Pre-Cruise 30-Day Countdown checklist | ✅ DONE (`countdown.html` 2026-01-24) | Cruise Critic Roll Call |
 
 **P2 Strategic (Medium Effort):**
 | Task | Status | Addresses |
 |------|--------|-----------|
-| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (2/15 lines: RCL, Carnival) | UNIQUE differentiator |
+| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (3/15 lines: RCL, Carnival, Celebrity) | UNIQUE differentiator |
 | Print CSS + PDF generation for port pages | NOT STARTED | WhatsInPort, IQCruising |
 | Transport cost callout component | NOT STARTED | WhatsInPort, Cruise Crocodile |
 | Accessibility sections on port pages | NOT STARTED | UNIQUE - market gap |
@@ -318,12 +318,12 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | Honest assessment "Real Talk" sections | NOT STARTED | Cruise Critic, CruiseMapper |
 
 **"Ships That Visit Here" Expansion Plan:**
-- Current: 70 ports, 55 ships (29 RCL + 26 Carnival)
-- Progress: 2/15 cruise lines complete
-- Data file: `assets/data/ship-deployments.json` (v1.1.0)
-- JS module: `assets/js/ship-port-links.js` (multi-cruise-line support added 2026-01-24)
-- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships)
-- Cruise lines remaining: Celebrity, NCL, Princess, Holland America, MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
+- Current: 81 ports, 71 ships (29 RCL + 26 Carnival + 16 Celebrity)
+- Progress: 3/15 cruise lines complete
+- Data file: `assets/data/ship-deployments.json` (v1.2.0)
+- JS module: `assets/js/ship-port-links.js` (v1.1.0 - multi-cruise-line support)
+- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships)
+- Cruise lines remaining: NCL, Princess, Holland America, MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
 
 **Unique Differentiators to Protect:**
 - Ship-Port Integration ⭐⭐⭐ (expand with bidirectional linking)
@@ -721,11 +721,11 @@ node admin/validate-ship-page.js ships/celebrity-cruises/*.html
 - ~~Quiz Dress Code~~ — Question exists at line 1716
 - ~~30-Day Countdown Checklist~~ — `countdown.html` with 35 interactive tasks (2026-01-24)
 - ~~Works Offline Badge~~ — 376 port pages now show "Works offline" in trust badge (2026-01-24)
-- ~~Ships That Visit Here~~ — In progress (70/380 ports, 55 ships across RCL + Carnival — 13 cruise lines remaining)
+- ~~Ships That Visit Here~~ — In progress (81/380 ports, 71 ships across RCL + Carnival + Celebrity — 12 cruise lines remaining)
 
 ### 🟡 HIGH PRIORITY (Remaining Work)
 5. **Quiz UX Bugs** — iPhone scroll issue, back button (NCL links is #1 above)
-6. **Ships That Visit Expansion** — Add 13 more cruise lines to ship-deployments.json (RCL + Carnival done, 70/380 ports, 55 ships)
+6. **Ships That Visit Expansion** — Add 12 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity done, 81/380 ports, 71 ships)
 7. **Quiz Regional Features** — Regional availability filter (dress code done)
 8. **Port Weather Remaining** — 80 ports still need weather section
 

--- a/assets/data/ship-deployments.json
+++ b/assets/data/ship-deployments.json
@@ -1,12 +1,13 @@
 {
   "metadata": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "last_updated": "2026-01-24",
-    "source": "Royal Caribbean and Carnival 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
+    "source": "Royal Caribbean, Carnival, and Celebrity 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
     "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment.",
     "cruise_lines": [
       "rcl",
-      "carnival"
+      "carnival",
+      "celebrity"
     ]
   },
   "ships": {
@@ -1380,6 +1381,445 @@
         10,
         12
       ]
+    },
+    "celebrity-edge": {
+      "name": "Celebrity Edge",
+      "class": "Edge",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "fort-lauderdale",
+        "rome"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "st-thomas",
+        "st-maarten",
+        "san-juan",
+        "rome",
+        "naples",
+        "santorini",
+        "mykonos"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        11
+      ]
+    },
+    "celebrity-apex": {
+      "name": "Celebrity Apex",
+      "class": "Edge",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "fort-lauderdale",
+        "barcelona"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean",
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "grand-cayman",
+        "nassau",
+        "barcelona",
+        "rome",
+        "naples",
+        "marseille"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        11
+      ]
+    },
+    "celebrity-beyond": {
+      "name": "Celebrity Beyond",
+      "class": "Edge",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "fort-lauderdale",
+        "rome"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-mediterranean",
+        "greek-isles"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "nassau",
+        "rome",
+        "naples",
+        "santorini",
+        "mykonos",
+        "athens"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        11
+      ]
+    },
+    "celebrity-ascent": {
+      "name": "Celebrity Ascent",
+      "class": "Edge",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "fort-lauderdale"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "southern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "san-juan",
+        "aruba",
+        "curacao",
+        "barbados"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        11
+      ]
+    },
+    "celebrity-xcel": {
+      "name": "Celebrity Xcel",
+      "class": "Edge",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "fort-lauderdale"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "cozumel",
+        "costa-maya",
+        "grand-cayman",
+        "st-thomas"
+      ],
+      "itinerary_lengths": [
+        7,
+        8
+      ]
+    },
+    "celebrity-solstice": {
+      "name": "Celebrity Solstice",
+      "class": "Solstice",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "los-angeles",
+        "seattle"
+      ],
+      "regions": [
+        "alaska",
+        "pacific-coastal",
+        "hawaii"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "victoria-bc",
+        "san-francisco",
+        "honolulu",
+        "maui"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        14
+      ]
+    },
+    "celebrity-equinox": {
+      "name": "Celebrity Equinox",
+      "class": "Solstice",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "fort-lauderdale",
+        "barcelona"
+      ],
+      "regions": [
+        "southern-caribbean",
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "aruba",
+        "curacao",
+        "bonaire",
+        "barbados",
+        "st-lucia",
+        "barcelona",
+        "marseille",
+        "rome"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        11
+      ]
+    },
+    "celebrity-eclipse": {
+      "name": "Celebrity Eclipse",
+      "class": "Solstice",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "seattle",
+        "los-angeles"
+      ],
+      "regions": [
+        "alaska",
+        "mexican-riviera"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "cabo-san-lucas",
+        "puerto-vallarta",
+        "mazatlan"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "celebrity-silhouette": {
+      "name": "Celebrity Silhouette",
+      "class": "Solstice",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "fort-lauderdale",
+        "southampton"
+      ],
+      "regions": [
+        "southern-caribbean",
+        "northern-europe",
+        "baltic"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "aruba",
+        "curacao",
+        "barbados",
+        "st-lucia",
+        "amsterdam",
+        "copenhagen",
+        "stockholm",
+        "tallinn"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        12,
+        14
+      ]
+    },
+    "celebrity-reflection": {
+      "name": "Celebrity Reflection",
+      "class": "Solstice",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "fort-lauderdale",
+        "rome"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-mediterranean",
+        "greek-isles"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "st-thomas",
+        "st-maarten",
+        "rome",
+        "naples",
+        "santorini",
+        "mykonos",
+        "athens"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        11
+      ]
+    },
+    "celebrity-millennium": {
+      "name": "Celebrity Millennium",
+      "class": "Millennium",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "seattle",
+        "tokyo"
+      ],
+      "regions": [
+        "alaska",
+        "asia"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "icy-strait-point",
+        "hong-kong",
+        "nha-trang",
+        "singapore"
+      ],
+      "itinerary_lengths": [
+        7,
+        12,
+        14
+      ]
+    },
+    "celebrity-summit": {
+      "name": "Celebrity Summit",
+      "class": "Millennium",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "cape-liberty",
+        "san-juan"
+      ],
+      "regions": [
+        "bermuda",
+        "canada-new-england",
+        "southern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "bermuda",
+        "portland-maine",
+        "bar-harbor",
+        "halifax",
+        "st-thomas",
+        "st-kitts",
+        "barbados"
+      ],
+      "itinerary_lengths": [
+        5,
+        7,
+        10,
+        12
+      ]
+    },
+    "celebrity-infinity": {
+      "name": "Celebrity Infinity",
+      "class": "Millennium",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "buenos-aires",
+        "san-diego"
+      ],
+      "regions": [
+        "south-america",
+        "antarctica",
+        "pacific-coastal"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "montevideo",
+        "punta-arenas",
+        "ushuaia",
+        "cabo-san-lucas",
+        "san-francisco"
+      ],
+      "itinerary_lengths": [
+        10,
+        14,
+        15
+      ]
+    },
+    "celebrity-constellation": {
+      "name": "Celebrity Constellation",
+      "class": "Millennium",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "athens",
+        "barcelona"
+      ],
+      "regions": [
+        "greek-isles",
+        "adriatic",
+        "holy-land"
+      ],
+      "season": "spring-fall",
+      "typical_ports": [
+        "santorini",
+        "mykonos",
+        "rhodes",
+        "dubrovnik",
+        "kotor",
+        "haifa"
+      ],
+      "itinerary_lengths": [
+        10,
+        11,
+        12
+      ]
+    },
+    "celebrity-flora": {
+      "name": "Celebrity Flora",
+      "class": "Expedition",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "baltra"
+      ],
+      "regions": [
+        "galapagos"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "baltra",
+        "san-cristobal"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        16
+      ]
+    },
+    "celebrity-xpedition": {
+      "name": "Celebrity Xpedition",
+      "class": "Expedition",
+      "cruise_line": "celebrity",
+      "homeports": [
+        "baltra"
+      ],
+      "regions": [
+        "galapagos"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "baltra",
+        "san-cristobal"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        16
+      ]
     }
   },
   "port_to_ships": {
@@ -1415,7 +1855,12 @@
       "carnival-liberty",
       "carnival-legend",
       "carnival-pride",
-      "carnival-elation"
+      "carnival-elation",
+      "celebrity-edge",
+      "celebrity-apex",
+      "celebrity-beyond",
+      "celebrity-xcel",
+      "celebrity-reflection"
     ],
     "cozumel": [
       "icon-of-the-seas",
@@ -1439,7 +1884,9 @@
       "carnival-legend",
       "carnival-spirit",
       "carnival-miracle",
-      "carnival-paradise"
+      "carnival-paradise",
+      "celebrity-apex",
+      "celebrity-xcel"
     ],
     "costa-maya": [
       "icon-of-the-seas",
@@ -1457,7 +1904,9 @@
       "carnival-conquest",
       "carnival-glory",
       "carnival-valor",
-      "carnival-spirit"
+      "carnival-spirit",
+      "celebrity-apex",
+      "celebrity-xcel"
     ],
     "roatan": [
       "icon-of-the-seas",
@@ -1478,7 +1927,9 @@
       "enchantment-of-the-seas",
       "rhapsody-of-the-seas",
       "carnival-miracle",
-      "carnival-paradise"
+      "carnival-paradise",
+      "celebrity-apex",
+      "celebrity-xcel"
     ],
     "half-moon-cay": [
       "carnival-celebration",
@@ -1538,17 +1989,28 @@
       "allure-of-the-seas",
       "jewel-of-the-seas",
       "vision-of-the-seas",
-      "rhapsody-of-the-seas"
+      "rhapsody-of-the-seas",
+      "celebrity-edge",
+      "celebrity-beyond",
+      "celebrity-ascent",
+      "celebrity-xcel",
+      "celebrity-reflection",
+      "celebrity-summit"
     ],
     "st-maarten": [
       "icon-of-the-seas",
       "wonder-of-the-seas",
       "adventure-of-the-seas",
-      "allure-of-the-seas"
+      "allure-of-the-seas",
+      "celebrity-edge",
+      "celebrity-beyond",
+      "celebrity-ascent",
+      "celebrity-reflection"
     ],
     "st-kitts": [
       "icon-of-the-seas",
-      "freedom-of-the-seas"
+      "freedom-of-the-seas",
+      "celebrity-summit"
     ],
     "antigua": [
       "freedom-of-the-seas",
@@ -1556,97 +2018,138 @@
     ],
     "st-lucia": [
       "freedom-of-the-seas",
-      "jewel-of-the-seas"
+      "jewel-of-the-seas",
+      "celebrity-equinox",
+      "celebrity-silhouette"
     ],
     "barbados": [
       "freedom-of-the-seas",
       "jewel-of-the-seas",
       "vision-of-the-seas",
-      "rhapsody-of-the-seas"
+      "rhapsody-of-the-seas",
+      "celebrity-ascent",
+      "celebrity-equinox",
+      "celebrity-silhouette",
+      "celebrity-summit"
     ],
     "aruba": [
       "freedom-of-the-seas",
       "adventure-of-the-seas",
       "jewel-of-the-seas",
-      "rhapsody-of-the-seas"
+      "rhapsody-of-the-seas",
+      "celebrity-ascent",
+      "celebrity-equinox",
+      "celebrity-silhouette"
     ],
     "curacao": [
       "freedom-of-the-seas",
       "adventure-of-the-seas",
-      "rhapsody-of-the-seas"
+      "rhapsody-of-the-seas",
+      "celebrity-ascent",
+      "celebrity-equinox",
+      "celebrity-silhouette"
     ],
     "dominica": [
       "jewel-of-the-seas",
       "vision-of-the-seas"
     ],
     "san-juan": [
-      "adventure-of-the-seas"
+      "adventure-of-the-seas",
+      "celebrity-edge",
+      "celebrity-ascent"
     ],
     "bermuda": [
       "liberty-of-the-seas",
       "odyssey-of-the-seas",
       "vision-of-the-seas",
-      "grandeur-of-the-seas"
+      "grandeur-of-the-seas",
+      "celebrity-summit"
     ],
     "juneau": [
       "voyager-of-the-seas",
       "anthem-of-the-seas",
       "ovation-of-the-seas",
       "radiance-of-the-seas",
-      "serenade-of-the-seas"
+      "serenade-of-the-seas",
+      "celebrity-solstice",
+      "celebrity-eclipse",
+      "celebrity-millennium"
     ],
     "skagway": [
       "voyager-of-the-seas",
       "anthem-of-the-seas",
       "ovation-of-the-seas",
       "radiance-of-the-seas",
-      "serenade-of-the-seas"
+      "serenade-of-the-seas",
+      "celebrity-solstice",
+      "celebrity-eclipse",
+      "celebrity-millennium"
     ],
     "ketchikan": [
       "voyager-of-the-seas",
       "anthem-of-the-seas",
       "ovation-of-the-seas",
       "radiance-of-the-seas",
-      "serenade-of-the-seas"
+      "serenade-of-the-seas",
+      "celebrity-solstice",
+      "celebrity-eclipse",
+      "celebrity-millennium"
     ],
     "glacier-bay": [
       "voyager-of-the-seas",
       "anthem-of-the-seas",
-      "radiance-of-the-seas"
+      "radiance-of-the-seas",
+      "celebrity-eclipse"
     ],
     "sitka": [
       "anthem-of-the-seas"
     ],
     "icy-strait-point": [
-      "radiance-of-the-seas"
+      "radiance-of-the-seas",
+      "celebrity-millennium"
     ],
     "hubbard-glacier": [
       "radiance-of-the-seas"
     ],
     "victoria-bc": [
       "ovation-of-the-seas",
-      "serenade-of-the-seas"
+      "serenade-of-the-seas",
+      "celebrity-solstice"
     ],
     "barcelona": [
       "harmony-of-the-seas",
       "allure-of-the-seas",
-      "brilliance-of-the-seas"
+      "brilliance-of-the-seas",
+      "celebrity-apex",
+      "celebrity-equinox",
+      "celebrity-constellation"
     ],
     "rome": [
       "harmony-of-the-seas",
       "allure-of-the-seas",
       "voyager-of-the-seas",
-      "odyssey-of-the-seas"
+      "odyssey-of-the-seas",
+      "celebrity-edge",
+      "celebrity-apex",
+      "celebrity-beyond",
+      "celebrity-equinox",
+      "celebrity-reflection"
     ],
     "naples": [
       "allure-of-the-seas",
       "voyager-of-the-seas",
-      "odyssey-of-the-seas"
+      "odyssey-of-the-seas",
+      "celebrity-edge",
+      "celebrity-apex",
+      "celebrity-beyond",
+      "celebrity-reflection"
     ],
     "marseille": [
       "harmony-of-the-seas",
       "allure-of-the-seas",
-      "brilliance-of-the-seas"
+      "brilliance-of-the-seas",
+      "celebrity-apex",
+      "celebrity-equinox"
     ],
     "la-spezia": [
       "harmony-of-the-seas"
@@ -1655,41 +2158,59 @@
       "voyager-of-the-seas",
       "explorer-of-the-seas",
       "odyssey-of-the-seas",
-      "brilliance-of-the-seas"
+      "brilliance-of-the-seas",
+      "celebrity-edge",
+      "celebrity-beyond",
+      "celebrity-reflection",
+      "celebrity-constellation"
     ],
     "mykonos": [
       "explorer-of-the-seas",
-      "brilliance-of-the-seas"
+      "brilliance-of-the-seas",
+      "celebrity-edge",
+      "celebrity-beyond",
+      "celebrity-reflection",
+      "celebrity-constellation"
     ],
     "athens": [
-      "explorer-of-the-seas"
+      "explorer-of-the-seas",
+      "celebrity-beyond",
+      "celebrity-reflection",
+      "celebrity-constellation"
     ],
     "dubrovnik": [
       "explorer-of-the-seas",
-      "brilliance-of-the-seas"
+      "brilliance-of-the-seas",
+      "celebrity-constellation"
     ],
     "kotor": [
       "explorer-of-the-seas",
-      "brilliance-of-the-seas"
+      "brilliance-of-the-seas",
+      "celebrity-constellation"
     ],
     "corfu": [
       "explorer-of-the-seas"
     ],
     "rhodes": [
-      "brilliance-of-the-seas"
+      "brilliance-of-the-seas",
+      "celebrity-constellation"
     ],
     "amsterdam": [
       "independence-of-the-seas",
-      "anthem-of-the-seas"
+      "anthem-of-the-seas",
+      "celebrity-silhouette"
     ],
     "copenhagen": [
-      "independence-of-the-seas"
+      "independence-of-the-seas",
+      "celebrity-silhouette"
     ],
     "stockholm": [
-      "independence-of-the-seas"
+      "independence-of-the-seas",
+      "celebrity-silhouette"
     ],
     "tallinn": [
-      "independence-of-the-seas"
+      "independence-of-the-seas",
+      "celebrity-silhouette"
     ],
     "cabo-san-lucas": [
       "navigator-of-the-seas",
@@ -1697,17 +2218,21 @@
       "voyager-of-the-seas",
       "carnival-panorama",
       "carnival-firenze",
-      "carnival-radiance"
+      "carnival-radiance",
+      "celebrity-eclipse",
+      "celebrity-infinity"
     ],
     "mazatlan": [
       "navigator-of-the-seas",
       "carnival-panorama",
-      "carnival-firenze"
+      "carnival-firenze",
+      "celebrity-eclipse"
     ],
     "puerto-vallarta": [
       "navigator-of-the-seas",
       "carnival-panorama",
-      "carnival-firenze"
+      "carnival-firenze",
+      "celebrity-eclipse"
     ],
     "ensenada": [
       "navigator-of-the-seas",
@@ -1721,14 +2246,17 @@
     ],
     "portland-maine": [
       "liberty-of-the-seas",
-      "vision-of-the-seas"
+      "vision-of-the-seas",
+      "celebrity-summit"
     ],
     "bar-harbor": [
       "liberty-of-the-seas",
-      "vision-of-the-seas"
+      "vision-of-the-seas",
+      "celebrity-summit"
     ],
     "halifax": [
-      "liberty-of-the-seas"
+      "liberty-of-the-seas",
+      "celebrity-summit"
     ],
     "sydney": [
       "quantum-of-the-seas",
@@ -1755,10 +2283,12 @@
       "spectrum-of-the-seas"
     ],
     "hong-kong": [
-      "spectrum-of-the-seas"
+      "spectrum-of-the-seas",
+      "celebrity-millennium"
     ],
     "nha-trang": [
-      "spectrum-of-the-seas"
+      "spectrum-of-the-seas",
+      "celebrity-millennium"
     ],
     "koh-samui": [
       "spectrum-of-the-seas"
@@ -1776,6 +2306,42 @@
     "ravenna": [
       "explorer-of-the-seas",
       "brilliance-of-the-seas"
+    ],
+    "bonaire": [
+      "celebrity-equinox"
+    ],
+    "honolulu": [
+      "celebrity-solstice"
+    ],
+    "maui": [
+      "celebrity-solstice"
+    ],
+    "san-francisco": [
+      "celebrity-solstice",
+      "celebrity-infinity"
+    ],
+    "haifa": [
+      "celebrity-constellation"
+    ],
+    "baltra": [
+      "celebrity-flora",
+      "celebrity-xpedition"
+    ],
+    "san-cristobal": [
+      "celebrity-flora",
+      "celebrity-xpedition"
+    ],
+    "montevideo": [
+      "celebrity-infinity"
+    ],
+    "punta-arenas": [
+      "celebrity-infinity"
+    ],
+    "ushuaia": [
+      "celebrity-infinity"
+    ],
+    "singapore": [
+      "celebrity-millennium"
     ]
   },
   "homeport_details": {
@@ -1813,7 +2379,15 @@
       "state": "Florida",
       "country": "USA",
       "ships": [
-        "allure-of-the-seas"
+        "allure-of-the-seas",
+        "celebrity-edge",
+        "celebrity-apex",
+        "celebrity-beyond",
+        "celebrity-ascent",
+        "celebrity-xcel",
+        "celebrity-equinox",
+        "celebrity-silhouette",
+        "celebrity-reflection"
       ],
       "port_page": "/ports/fort-lauderdale.html"
     },
@@ -1837,7 +2411,8 @@
       "country": "USA",
       "ships": [
         "liberty-of-the-seas",
-        "odyssey-of-the-seas"
+        "odyssey-of-the-seas",
+        "celebrity-summit"
       ],
       "port_page": "/ports/bayonne.html"
     },
@@ -1874,7 +2449,8 @@
         "freedom-of-the-seas",
         "jewel-of-the-seas",
         "vision-of-the-seas",
-        "rhapsody-of-the-seas"
+        "rhapsody-of-the-seas",
+        "celebrity-summit"
       ],
       "port_page": "/ports/san-juan.html"
     },
@@ -1886,7 +2462,10 @@
         "voyager-of-the-seas",
         "anthem-of-the-seas",
         "ovation-of-the-seas",
-        "serenade-of-the-seas"
+        "serenade-of-the-seas",
+        "celebrity-solstice",
+        "celebrity-eclipse",
+        "celebrity-millennium"
       ],
       "port_page": "/ports/seattle.html"
     },
@@ -1896,7 +2475,9 @@
       "country": "USA",
       "ships": [
         "navigator-of-the-seas",
-        "mariner-of-the-seas"
+        "mariner-of-the-seas",
+        "celebrity-solstice",
+        "celebrity-eclipse"
       ],
       "port_page": "/ports/los-angeles.html"
     },
@@ -1905,7 +2486,8 @@
       "state": "California",
       "country": "USA",
       "ships": [
-        "serenade-of-the-seas"
+        "serenade-of-the-seas",
+        "celebrity-infinity"
       ],
       "port_page": "/ports/san-diego.html"
     },
@@ -1925,7 +2507,10 @@
       "ships": [
         "harmony-of-the-seas",
         "allure-of-the-seas",
-        "brilliance-of-the-seas"
+        "brilliance-of-the-seas",
+        "celebrity-apex",
+        "celebrity-equinox",
+        "celebrity-constellation"
       ],
       "port_page": "/ports/barcelona.html"
     },
@@ -1936,7 +2521,10 @@
       "ships": [
         "allure-of-the-seas",
         "voyager-of-the-seas",
-        "odyssey-of-the-seas"
+        "odyssey-of-the-seas",
+        "celebrity-edge",
+        "celebrity-beyond",
+        "celebrity-reflection"
       ],
       "port_page": "/ports/rome.html"
     },
@@ -1946,7 +2534,8 @@
       "country": "UK",
       "ships": [
         "independence-of-the-seas",
-        "anthem-of-the-seas"
+        "anthem-of-the-seas",
+        "celebrity-silhouette"
       ],
       "port_page": "/ports/southampton.html"
     },
@@ -1965,7 +2554,8 @@
       "state": "Attica",
       "country": "Greece",
       "ships": [
-        "brilliance-of-the-seas"
+        "brilliance-of-the-seas",
+        "celebrity-constellation"
       ],
       "port_page": "/ports/athens.html"
     },
@@ -1974,7 +2564,8 @@
       "country": "Singapore",
       "ships": [
         "spectrum-of-the-seas",
-        "quantum-of-the-seas"
+        "quantum-of-the-seas",
+        "celebrity-millennium"
       ],
       "port_page": "/ports/singapore.html"
     },
@@ -2046,6 +2637,33 @@
         "carnival-magic"
       ],
       "port_page": "/ports/norfolk.html"
+    },
+    "tokyo": {
+      "name": "Tokyo",
+      "state": "Tokyo",
+      "country": "Japan",
+      "ships": [
+        "celebrity-millennium"
+      ],
+      "port_page": "/ports/tokyo.html"
+    },
+    "buenos-aires": {
+      "name": "Buenos Aires",
+      "country": "Argentina",
+      "ships": [
+        "celebrity-infinity"
+      ],
+      "port_page": "/ports/buenos-aires.html"
+    },
+    "baltra": {
+      "name": "Baltra",
+      "state": "Galápagos Islands",
+      "country": "Ecuador",
+      "ships": [
+        "celebrity-flora",
+        "celebrity-xpedition"
+      ],
+      "port_page": "/ports/baltra.html"
     }
   }
 }

--- a/assets/js/ship-port-links.js
+++ b/assets/js/ship-port-links.js
@@ -1,11 +1,12 @@
 /**
  * Ship-Port Cross-Linking Module
- * Version: 1.0.0
+ * Version: 1.1.0
  *
  * Provides bidirectional linking between ship and port pages:
  * - Port pages show "Ships That Visit Here"
  * - Ship pages show "Ports on This Ship's Itineraries"
  *
+ * Supported cruise lines: Royal Caribbean, Carnival, Celebrity
  * Data source: /assets/data/ship-deployments.json
  */
 
@@ -27,6 +28,12 @@
       name: 'Carnival Cruise Line',
       path: '/ships/carnival/',
       bookingUrl: 'https://www.carnival.com/cruise-ships/',
+      allShipsUrl: '/ships.html'
+    },
+    'celebrity': {
+      name: 'Celebrity Cruises',
+      path: '/ships/celebrity-cruises/',
+      bookingUrl: 'https://www.celebritycruises.com/cruise-ships/',
       allShipsUrl: '/ships.html'
     }
   };
@@ -102,7 +109,10 @@
       'new-caledonia': 'New Caledonia',
       'los-angeles': 'Los Angeles',
       'san-diego': 'San Diego',
-      'san-francisco': 'San Francisco'
+      'san-francisco': 'San Francisco',
+      'buenos-aires': 'Buenos Aires',
+      'punta-arenas': 'Punta Arenas',
+      'san-cristobal': 'San Cristóbal'
     };
 
     if (specialNames[slug]) return specialNames[slug];
@@ -159,13 +169,15 @@
     // Class order for sorting (larger ships first)
     const classOrders = {
       'rcl': ['Icon', 'Oasis', 'Quantum', 'Freedom', 'Voyager', 'Radiance', 'Vision', 'Other'],
-      'carnival': ['Excel', 'Vista', 'Dream', 'Concordia', 'Venice', 'Destiny', 'Conquest', 'Spirit', 'Fantasy', 'Other']
+      'carnival': ['Excel', 'Vista', 'Dream', 'Concordia', 'Venice', 'Destiny', 'Conquest', 'Spirit', 'Fantasy', 'Other'],
+      'celebrity': ['Edge', 'Solstice', 'Millennium', 'Expedition', 'Other']
     };
 
     // Brand colors for cruise lines
     const brandColors = {
       'rcl': { bg: '#e6f4f8', border: '#b8d4e3', hover: '#d0e8f0', text: '#0e6e8e' },
-      'carnival': { bg: '#fff3e6', border: '#e3c8b8', hover: '#ffe6cc', text: '#c74a35' }
+      'carnival': { bg: '#fff3e6', border: '#e3c8b8', hover: '#ffe6cc', text: '#c74a35' },
+      'celebrity': { bg: '#f0f0f5', border: '#c0c0d0', hover: '#e0e0eb', text: '#1a1a4e' }
     };
 
     let html = `
@@ -176,7 +188,7 @@
     `;
 
     // Render each cruise line's ships
-    const cruiseLineOrder = ['rcl', 'carnival']; // Define display order
+    const cruiseLineOrder = ['rcl', 'celebrity', 'carnival']; // Define display order
     const activeCruiseLines = cruiseLineOrder.filter(cl => shipsByCruiseLine[cl]);
 
     activeCruiseLines.forEach((cruiseLineId, index) => {


### PR DESCRIPTION
Expanded ship-port cross-linking to include Celebrity Cruises:
- Added 16 Celebrity ships (Edge, Solstice, Millennium, Expedition classes)
- Updated port_to_ships mappings for 81 total ports (was 70)
- Added Celebrity brand colors (navy blue) to ship-port-links.js
- Added Celebrity class ordering (Edge first, Expedition last)
- Added new ports: Bonaire, Honolulu, Maui, San Francisco, Haifa, Baltra, San Cristóbal, Montevideo, Punta Arenas, Ushuaia, Singapore
- Added new homeports: Tokyo, Buenos Aires, Baltra

Progress: 3/15 cruise lines complete (RCL + Carnival + Celebrity)
Total: 71 ships across 81 ports