### PR TITLE
Ships That Visit: Add Norwegian Cruise Line (20 ships)

### DIFF
--- a/admin/UNFINISHED-TASKS.md
+++ b/admin/UNFINISHED-TASKS.md
@@ -303,14 +303,14 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | "No Ads" trust messaging on about-us.html | ✅ DONE | Cruise Critic, CruiseMapper |
 | Tender Port Index + badge (`/ports/tender-ports.html`) | ✅ DONE | WhatsInPort |
 | "From the Pier" distance callout box component | PARTIAL (some ports) | WhatsInPort, IQCruising |
-| "Ships That Visit Here" section on port pages | PARTIAL (81/380 ports, RCL+Carnival+Celebrity) | UNIQUE - no competitor has this |
+| "Ships That Visit Here" section on port pages | PARTIAL (87/380 ports, RCL+Carnival+Celebrity+NCL) | UNIQUE - no competitor has this |
 | First-Timer Hub page | ✅ DONE (`first-cruise.html` 27KB) | Cruise Critic |
 | Pre-Cruise 30-Day Countdown checklist | ✅ DONE (`countdown.html` 2026-01-24) | Cruise Critic Roll Call |
 
 **P2 Strategic (Medium Effort):**
 | Task | Status | Addresses |
 |------|--------|-----------|
-| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (3/15 lines: RCL, Carnival, Celebrity) | UNIQUE differentiator |
+| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (4/15 lines: RCL, Carnival, Celebrity, NCL) | UNIQUE differentiator |
 | Print CSS + PDF generation for port pages | NOT STARTED | WhatsInPort, IQCruising |
 | Transport cost callout component | NOT STARTED | WhatsInPort, Cruise Crocodile |
 | Accessibility sections on port pages | NOT STARTED | UNIQUE - market gap |
@@ -318,12 +318,12 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | Honest assessment "Real Talk" sections | NOT STARTED | Cruise Critic, CruiseMapper |
 
 **"Ships That Visit Here" Expansion Plan:**
-- Current: 81 ports, 71 ships (29 RCL + 26 Carnival + 16 Celebrity)
-- Progress: 3/15 cruise lines complete
-- Data file: `assets/data/ship-deployments.json` (v1.2.0)
-- JS module: `assets/js/ship-port-links.js` (v1.1.0 - multi-cruise-line support)
-- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships)
-- Cruise lines remaining: NCL, Princess, Holland America, MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
+- Current: 87 ports, 91 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL)
+- Progress: 4/15 cruise lines complete (the "big four" are done)
+- Data file: `assets/data/ship-deployments.json` (v1.3.0)
+- JS module: `assets/js/ship-port-links.js` (v1.2.0 - multi-cruise-line support)
+- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships)
+- Cruise lines remaining: Princess, Holland America, MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
 
 **Unique Differentiators to Protect:**
 - Ship-Port Integration ⭐⭐⭐ (expand with bidirectional linking)
@@ -721,11 +721,11 @@ node admin/validate-ship-page.js ships/celebrity-cruises/*.html
 - ~~Quiz Dress Code~~ — Question exists at line 1716
 - ~~30-Day Countdown Checklist~~ — `countdown.html` with 35 interactive tasks (2026-01-24)
 - ~~Works Offline Badge~~ — 376 port pages now show "Works offline" in trust badge (2026-01-24)
-- ~~Ships That Visit Here~~ — In progress (81/380 ports, 71 ships across RCL + Carnival + Celebrity — 12 cruise lines remaining)
+- ~~Ships That Visit Here~~ — In progress (87/380 ports, 91 ships across RCL + Carnival + Celebrity + NCL — 11 cruise lines remaining)
 
 ### 🟡 HIGH PRIORITY (Remaining Work)
 5. **Quiz UX Bugs** — iPhone scroll issue, back button (NCL links is #1 above)
-6. **Ships That Visit Expansion** — Add 12 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity done, 81/380 ports, 71 ships)
+6. **Ships That Visit Expansion** — Add 11 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL done, 87/380 ports, 91 ships)
 7. **Quiz Regional Features** — Regional availability filter (dress code done)
 8. **Port Weather Remaining** — 80 ports still need weather section
 

--- a/assets/data/ship-deployments.json
+++ b/assets/data/ship-deployments.json
@@ -1,13 +1,14 @@
 {
   "metadata": {
-    "version": "1.2.0",
-    "last_updated": "2026-01-24",
-    "source": "Royal Caribbean, Carnival, and Celebrity 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
+    "version": "1.3.0",
+    "last_updated": "2026-01-25",
+    "source": "Royal Caribbean, Carnival, Celebrity, and Norwegian 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
     "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment.",
     "cruise_lines": [
       "rcl",
       "carnival",
-      "celebrity"
+      "celebrity",
+      "ncl"
     ]
   },
   "ships": {
@@ -1820,6 +1821,518 @@
         10,
         16
       ]
+    },
+    "norwegian-prima": {
+      "name": "Norwegian Prima",
+      "class": "Prima",
+      "cruise_line": "ncl",
+      "homeports": [
+        "galveston",
+        "new-york"
+      ],
+      "regions": [
+        "western-caribbean",
+        "bermuda",
+        "canada-new-england"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "bermuda",
+        "portland-maine",
+        "bar-harbor",
+        "halifax"
+      ],
+      "itinerary_lengths": [
+        5,
+        7,
+        10
+      ]
+    },
+    "norwegian-viva": {
+      "name": "Norwegian Viva",
+      "class": "Prima",
+      "cruise_line": "ncl",
+      "homeports": [
+        "miami",
+        "barcelona"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "san-juan",
+        "nassau",
+        "barcelona",
+        "rome",
+        "naples",
+        "marseille"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        11
+      ]
+    },
+    "norwegian-aqua": {
+      "name": "Norwegian Aqua",
+      "class": "Prima",
+      "cruise_line": "ncl",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "nassau",
+        "st-thomas",
+        "st-maarten"
+      ],
+      "itinerary_lengths": [
+        7,
+        8
+      ]
+    },
+    "norwegian-escape": {
+      "name": "Norwegian Escape",
+      "class": "Breakaway Plus",
+      "cruise_line": "ncl",
+      "homeports": [
+        "miami"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "nassau",
+        "st-thomas",
+        "tortola"
+      ],
+      "itinerary_lengths": [
+        5,
+        7
+      ]
+    },
+    "norwegian-joy": {
+      "name": "Norwegian Joy",
+      "class": "Breakaway Plus",
+      "cruise_line": "ncl",
+      "homeports": [
+        "los-angeles",
+        "seattle"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "alaska"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "cabo-san-lucas",
+        "mazatlan",
+        "puerto-vallarta",
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "norwegian-bliss": {
+      "name": "Norwegian Bliss",
+      "class": "Breakaway Plus",
+      "cruise_line": "ncl",
+      "homeports": [
+        "seattle",
+        "miami"
+      ],
+      "regions": [
+        "alaska",
+        "eastern-caribbean"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "victoria-bc",
+        "st-thomas",
+        "st-maarten",
+        "nassau"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "norwegian-encore": {
+      "name": "Norwegian Encore",
+      "class": "Breakaway Plus",
+      "cruise_line": "ncl",
+      "homeports": [
+        "seattle",
+        "miami"
+      ],
+      "regions": [
+        "alaska",
+        "western-caribbean"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "belize"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "norwegian-breakaway": {
+      "name": "Norwegian Breakaway",
+      "class": "Breakaway",
+      "cruise_line": "ncl",
+      "homeports": [
+        "new-orleans"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "belize"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "norwegian-getaway": {
+      "name": "Norwegian Getaway",
+      "class": "Breakaway",
+      "cruise_line": "ncl",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "bahamas",
+        "eastern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "great-stirrup-cay",
+        "st-thomas",
+        "tortola"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7
+      ]
+    },
+    "norwegian-epic": {
+      "name": "Norwegian Epic",
+      "class": "Epic",
+      "cruise_line": "ncl",
+      "homeports": [
+        "barcelona",
+        "rome"
+      ],
+      "regions": [
+        "western-mediterranean",
+        "greek-isles"
+      ],
+      "season": "spring-fall",
+      "typical_ports": [
+        "barcelona",
+        "rome",
+        "naples",
+        "marseille",
+        "la-spezia",
+        "santorini",
+        "mykonos"
+      ],
+      "itinerary_lengths": [
+        7,
+        10
+      ]
+    },
+    "norwegian-gem": {
+      "name": "Norwegian Gem",
+      "class": "Jewel",
+      "cruise_line": "ncl",
+      "homeports": [
+        "new-york",
+        "boston"
+      ],
+      "regions": [
+        "bermuda",
+        "bahamas",
+        "canada-new-england"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "bermuda",
+        "nassau",
+        "great-stirrup-cay",
+        "portland-maine",
+        "bar-harbor",
+        "halifax"
+      ],
+      "itinerary_lengths": [
+        4,
+        5,
+        7
+      ]
+    },
+    "norwegian-jewel": {
+      "name": "Norwegian Jewel",
+      "class": "Jewel",
+      "cruise_line": "ncl",
+      "homeports": [
+        "sydney",
+        "auckland"
+      ],
+      "regions": [
+        "australia",
+        "new-zealand",
+        "south-pacific"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "sydney",
+        "melbourne",
+        "hobart",
+        "auckland",
+        "bay-of-islands",
+        "new-caledonia"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        12
+      ]
+    },
+    "norwegian-jade": {
+      "name": "Norwegian Jade",
+      "class": "Jewel",
+      "cruise_line": "ncl",
+      "homeports": [
+        "athens",
+        "rome"
+      ],
+      "regions": [
+        "greek-isles",
+        "adriatic"
+      ],
+      "season": "spring-fall",
+      "typical_ports": [
+        "santorini",
+        "mykonos",
+        "rhodes",
+        "dubrovnik",
+        "kotor",
+        "corfu"
+      ],
+      "itinerary_lengths": [
+        7,
+        10
+      ]
+    },
+    "norwegian-pearl": {
+      "name": "Norwegian Pearl",
+      "class": "Jewel",
+      "cruise_line": "ncl",
+      "homeports": [
+        "tampa"
+      ],
+      "regions": [
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "belize"
+      ],
+      "itinerary_lengths": [
+        5,
+        7
+      ]
+    },
+    "norwegian-dawn": {
+      "name": "Norwegian Dawn",
+      "class": "Dawn",
+      "cruise_line": "ncl",
+      "homeports": [
+        "boston",
+        "tampa"
+      ],
+      "regions": [
+        "bermuda",
+        "canada-new-england",
+        "bahamas"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "bermuda",
+        "portland-maine",
+        "bar-harbor",
+        "halifax",
+        "nassau",
+        "great-stirrup-cay"
+      ],
+      "itinerary_lengths": [
+        5,
+        7
+      ]
+    },
+    "norwegian-star": {
+      "name": "Norwegian Star",
+      "class": "Dawn",
+      "cruise_line": "ncl",
+      "homeports": [
+        "los-angeles",
+        "seattle"
+      ],
+      "regions": [
+        "alaska",
+        "pacific-coastal",
+        "mexican-riviera"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "victoria-bc",
+        "san-francisco",
+        "cabo-san-lucas",
+        "mazatlan"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        14
+      ]
+    },
+    "norwegian-sun": {
+      "name": "Norwegian Sun",
+      "class": "Sun",
+      "cruise_line": "ncl",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "bahamas",
+        "cuba"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "great-stirrup-cay",
+        "havana"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        5
+      ]
+    },
+    "norwegian-spirit": {
+      "name": "Norwegian Spirit",
+      "class": "Spirit",
+      "cruise_line": "ncl",
+      "homeports": [
+        "southampton",
+        "barcelona"
+      ],
+      "regions": [
+        "northern-europe",
+        "baltic",
+        "western-mediterranean"
+      ],
+      "season": "spring-fall",
+      "typical_ports": [
+        "amsterdam",
+        "copenhagen",
+        "stockholm",
+        "tallinn",
+        "barcelona",
+        "rome"
+      ],
+      "itinerary_lengths": [
+        9,
+        10,
+        12
+      ]
+    },
+    "norwegian-sky": {
+      "name": "Norwegian Sky",
+      "class": "Sky",
+      "cruise_line": "ncl",
+      "homeports": [
+        "miami"
+      ],
+      "regions": [
+        "bahamas"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "great-stirrup-cay"
+      ],
+      "itinerary_lengths": [
+        3,
+        4
+      ]
+    },
+    "pride-of-america": {
+      "name": "Pride of America",
+      "class": "America",
+      "cruise_line": "ncl",
+      "homeports": [
+        "honolulu"
+      ],
+      "regions": [
+        "hawaii"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "honolulu",
+        "maui",
+        "kona",
+        "hilo",
+        "kauai"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     }
   },
   "port_to_ships": {
@@ -1860,7 +2373,15 @@
       "celebrity-apex",
       "celebrity-beyond",
       "celebrity-xcel",
-      "celebrity-reflection"
+      "celebrity-reflection",
+      "norwegian-viva",
+      "norwegian-aqua",
+      "norwegian-getaway",
+      "norwegian-bliss",
+      "norwegian-gem",
+      "norwegian-dawn",
+      "norwegian-sun",
+      "norwegian-sky"
     ],
     "cozumel": [
       "icon-of-the-seas",
@@ -1886,7 +2407,13 @@
       "carnival-miracle",
       "carnival-paradise",
       "celebrity-apex",
-      "celebrity-xcel"
+      "celebrity-xcel",
+      "norwegian-prima",
+      "norwegian-aqua",
+      "norwegian-escape",
+      "norwegian-encore",
+      "norwegian-breakaway",
+      "norwegian-pearl"
     ],
     "costa-maya": [
       "icon-of-the-seas",
@@ -1906,7 +2433,13 @@
       "carnival-valor",
       "carnival-spirit",
       "celebrity-apex",
-      "celebrity-xcel"
+      "celebrity-xcel",
+      "norwegian-prima",
+      "norwegian-aqua",
+      "norwegian-escape",
+      "norwegian-encore",
+      "norwegian-breakaway",
+      "norwegian-pearl"
     ],
     "roatan": [
       "icon-of-the-seas",
@@ -1914,7 +2447,12 @@
       "harmony-of-the-seas",
       "carnival-jubilee",
       "carnival-dream",
-      "carnival-vista"
+      "carnival-vista",
+      "norwegian-prima",
+      "norwegian-escape",
+      "norwegian-encore",
+      "norwegian-breakaway",
+      "norwegian-pearl"
     ],
     "jamaica": [
       "symphony-of-the-seas",
@@ -1968,7 +2506,10 @@
       "carnival-dream",
       "carnival-vista",
       "carnival-freedom",
-      "carnival-glory"
+      "carnival-glory",
+      "norwegian-encore",
+      "norwegian-breakaway",
+      "norwegian-pearl"
     ],
     "mahogany-bay": [
       "carnival-vista",
@@ -1995,7 +2536,12 @@
       "celebrity-ascent",
       "celebrity-xcel",
       "celebrity-reflection",
-      "celebrity-summit"
+      "celebrity-summit",
+      "norwegian-viva",
+      "norwegian-aqua",
+      "norwegian-escape",
+      "norwegian-bliss",
+      "norwegian-getaway"
     ],
     "st-maarten": [
       "icon-of-the-seas",
@@ -2005,7 +2551,10 @@
       "celebrity-edge",
       "celebrity-beyond",
       "celebrity-ascent",
-      "celebrity-reflection"
+      "celebrity-reflection",
+      "norwegian-viva",
+      "norwegian-aqua",
+      "norwegian-bliss"
     ],
     "st-kitts": [
       "icon-of-the-seas",
@@ -2056,14 +2605,18 @@
     "san-juan": [
       "adventure-of-the-seas",
       "celebrity-edge",
-      "celebrity-ascent"
+      "celebrity-ascent",
+      "norwegian-viva"
     ],
     "bermuda": [
       "liberty-of-the-seas",
       "odyssey-of-the-seas",
       "vision-of-the-seas",
       "grandeur-of-the-seas",
-      "celebrity-summit"
+      "celebrity-summit",
+      "norwegian-prima",
+      "norwegian-gem",
+      "norwegian-dawn"
     ],
     "juneau": [
       "voyager-of-the-seas",
@@ -2073,7 +2626,11 @@
       "serenade-of-the-seas",
       "celebrity-solstice",
       "celebrity-eclipse",
-      "celebrity-millennium"
+      "celebrity-millennium",
+      "norwegian-joy",
+      "norwegian-bliss",
+      "norwegian-encore",
+      "norwegian-star"
     ],
     "skagway": [
       "voyager-of-the-seas",
@@ -2083,7 +2640,11 @@
       "serenade-of-the-seas",
       "celebrity-solstice",
       "celebrity-eclipse",
-      "celebrity-millennium"
+      "celebrity-millennium",
+      "norwegian-joy",
+      "norwegian-bliss",
+      "norwegian-encore",
+      "norwegian-star"
     ],
     "ketchikan": [
       "voyager-of-the-seas",
@@ -2093,13 +2654,20 @@
       "serenade-of-the-seas",
       "celebrity-solstice",
       "celebrity-eclipse",
-      "celebrity-millennium"
+      "celebrity-millennium",
+      "norwegian-joy",
+      "norwegian-bliss",
+      "norwegian-encore",
+      "norwegian-star"
     ],
     "glacier-bay": [
       "voyager-of-the-seas",
       "anthem-of-the-seas",
       "radiance-of-the-seas",
-      "celebrity-eclipse"
+      "celebrity-eclipse",
+      "norwegian-joy",
+      "norwegian-bliss",
+      "norwegian-encore"
     ],
     "sitka": [
       "anthem-of-the-seas"
@@ -2114,7 +2682,9 @@
     "victoria-bc": [
       "ovation-of-the-seas",
       "serenade-of-the-seas",
-      "celebrity-solstice"
+      "celebrity-solstice",
+      "norwegian-bliss",
+      "norwegian-star"
     ],
     "barcelona": [
       "harmony-of-the-seas",
@@ -2122,7 +2692,10 @@
       "brilliance-of-the-seas",
       "celebrity-apex",
       "celebrity-equinox",
-      "celebrity-constellation"
+      "celebrity-constellation",
+      "norwegian-viva",
+      "norwegian-epic",
+      "norwegian-spirit"
     ],
     "rome": [
       "harmony-of-the-seas",
@@ -2133,7 +2706,10 @@
       "celebrity-apex",
       "celebrity-beyond",
       "celebrity-equinox",
-      "celebrity-reflection"
+      "celebrity-reflection",
+      "norwegian-viva",
+      "norwegian-epic",
+      "norwegian-spirit"
     ],
     "naples": [
       "allure-of-the-seas",
@@ -2142,17 +2718,22 @@
       "celebrity-edge",
       "celebrity-apex",
       "celebrity-beyond",
-      "celebrity-reflection"
+      "celebrity-reflection",
+      "norwegian-viva",
+      "norwegian-epic"
     ],
     "marseille": [
       "harmony-of-the-seas",
       "allure-of-the-seas",
       "brilliance-of-the-seas",
       "celebrity-apex",
-      "celebrity-equinox"
+      "celebrity-equinox",
+      "norwegian-viva",
+      "norwegian-epic"
     ],
     "la-spezia": [
-      "harmony-of-the-seas"
+      "harmony-of-the-seas",
+      "norwegian-epic"
     ],
     "santorini": [
       "voyager-of-the-seas",
@@ -2162,7 +2743,9 @@
       "celebrity-edge",
       "celebrity-beyond",
       "celebrity-reflection",
-      "celebrity-constellation"
+      "celebrity-constellation",
+      "norwegian-epic",
+      "norwegian-jade"
     ],
     "mykonos": [
       "explorer-of-the-seas",
@@ -2170,7 +2753,9 @@
       "celebrity-edge",
       "celebrity-beyond",
       "celebrity-reflection",
-      "celebrity-constellation"
+      "celebrity-constellation",
+      "norwegian-epic",
+      "norwegian-jade"
     ],
     "athens": [
       "explorer-of-the-seas",
@@ -2181,36 +2766,44 @@
     "dubrovnik": [
       "explorer-of-the-seas",
       "brilliance-of-the-seas",
-      "celebrity-constellation"
+      "celebrity-constellation",
+      "norwegian-jade"
     ],
     "kotor": [
       "explorer-of-the-seas",
       "brilliance-of-the-seas",
-      "celebrity-constellation"
+      "celebrity-constellation",
+      "norwegian-jade"
     ],
     "corfu": [
-      "explorer-of-the-seas"
+      "explorer-of-the-seas",
+      "norwegian-jade"
     ],
     "rhodes": [
       "brilliance-of-the-seas",
-      "celebrity-constellation"
+      "celebrity-constellation",
+      "norwegian-jade"
     ],
     "amsterdam": [
       "independence-of-the-seas",
       "anthem-of-the-seas",
-      "celebrity-silhouette"
+      "celebrity-silhouette",
+      "norwegian-spirit"
     ],
     "copenhagen": [
       "independence-of-the-seas",
-      "celebrity-silhouette"
+      "celebrity-silhouette",
+      "norwegian-spirit"
     ],
     "stockholm": [
       "independence-of-the-seas",
-      "celebrity-silhouette"
+      "celebrity-silhouette",
+      "norwegian-spirit"
     ],
     "tallinn": [
       "independence-of-the-seas",
-      "celebrity-silhouette"
+      "celebrity-silhouette",
+      "norwegian-spirit"
     ],
     "cabo-san-lucas": [
       "navigator-of-the-seas",
@@ -2220,19 +2813,24 @@
       "carnival-firenze",
       "carnival-radiance",
       "celebrity-eclipse",
-      "celebrity-infinity"
+      "celebrity-infinity",
+      "norwegian-joy",
+      "norwegian-star"
     ],
     "mazatlan": [
       "navigator-of-the-seas",
       "carnival-panorama",
       "carnival-firenze",
-      "celebrity-eclipse"
+      "celebrity-eclipse",
+      "norwegian-joy",
+      "norwegian-star"
     ],
     "puerto-vallarta": [
       "navigator-of-the-seas",
       "carnival-panorama",
       "carnival-firenze",
-      "celebrity-eclipse"
+      "celebrity-eclipse",
+      "norwegian-joy"
     ],
     "ensenada": [
       "navigator-of-the-seas",
@@ -2247,33 +2845,47 @@
     "portland-maine": [
       "liberty-of-the-seas",
       "vision-of-the-seas",
-      "celebrity-summit"
+      "celebrity-summit",
+      "norwegian-prima",
+      "norwegian-gem",
+      "norwegian-dawn"
     ],
     "bar-harbor": [
       "liberty-of-the-seas",
       "vision-of-the-seas",
-      "celebrity-summit"
+      "celebrity-summit",
+      "norwegian-prima",
+      "norwegian-gem",
+      "norwegian-dawn"
     ],
     "halifax": [
       "liberty-of-the-seas",
-      "celebrity-summit"
+      "celebrity-summit",
+      "norwegian-prima",
+      "norwegian-gem",
+      "norwegian-dawn"
     ],
     "sydney": [
       "quantum-of-the-seas",
-      "ovation-of-the-seas"
+      "ovation-of-the-seas",
+      "norwegian-jewel"
     ],
     "melbourne": [
       "quantum-of-the-seas",
-      "ovation-of-the-seas"
+      "ovation-of-the-seas",
+      "norwegian-jewel"
     ],
     "hobart": [
-      "quantum-of-the-seas"
+      "quantum-of-the-seas",
+      "norwegian-jewel"
     ],
     "auckland": [
-      "ovation-of-the-seas"
+      "ovation-of-the-seas",
+      "norwegian-jewel"
     ],
     "bay-of-islands": [
-      "ovation-of-the-seas"
+      "ovation-of-the-seas",
+      "norwegian-jewel"
     ],
     "penang": [
       "quantum-of-the-seas"
@@ -2311,14 +2923,17 @@
       "celebrity-equinox"
     ],
     "honolulu": [
-      "celebrity-solstice"
+      "celebrity-solstice",
+      "pride-of-america"
     ],
     "maui": [
-      "celebrity-solstice"
+      "celebrity-solstice",
+      "pride-of-america"
     ],
     "san-francisco": [
       "celebrity-solstice",
-      "celebrity-infinity"
+      "celebrity-infinity",
+      "norwegian-star"
     ],
     "haifa": [
       "celebrity-constellation"
@@ -2342,6 +2957,29 @@
     ],
     "singapore": [
       "celebrity-millennium"
+    ],
+    "great-stirrup-cay": [
+      "norwegian-getaway",
+      "norwegian-gem",
+      "norwegian-dawn",
+      "norwegian-sun",
+      "norwegian-sky"
+    ],
+    "tortola": [
+      "norwegian-escape",
+      "norwegian-getaway"
+    ],
+    "havana": [
+      "norwegian-sun"
+    ],
+    "kona": [
+      "pride-of-america"
+    ],
+    "hilo": [
+      "pride-of-america"
+    ],
+    "kauai": [
+      "pride-of-america"
     ]
   },
   "homeport_details": {
@@ -2355,7 +2993,12 @@
         "wonder-of-the-seas",
         "carnival-celebration",
         "carnival-horizon",
-        "carnival-sunrise"
+        "carnival-sunrise",
+        "norwegian-viva",
+        "norwegian-escape",
+        "norwegian-bliss",
+        "norwegian-encore",
+        "norwegian-sky"
       ],
       "port_page": "/ports/miami.html"
     },
@@ -2370,7 +3013,10 @@
         "carnival-mardi-gras",
         "carnival-breeze",
         "carnival-venezia",
-        "carnival-liberty"
+        "carnival-liberty",
+        "norwegian-aqua",
+        "norwegian-getaway",
+        "norwegian-sun"
       ],
       "port_page": "/ports/port-canaveral.html"
     },
@@ -2401,7 +3047,8 @@
         "carnival-jubilee",
         "carnival-dream",
         "carnival-vista",
-        "carnival-freedom"
+        "carnival-freedom",
+        "norwegian-prima"
       ],
       "port_page": "/ports/galveston.html"
     },
@@ -2437,7 +3084,9 @@
         "rhapsody-of-the-seas",
         "carnival-legend",
         "carnival-miracle",
-        "carnival-paradise"
+        "carnival-paradise",
+        "norwegian-pearl",
+        "norwegian-dawn"
       ],
       "port_page": "/ports/tampa.html"
     },
@@ -2465,7 +3114,11 @@
         "serenade-of-the-seas",
         "celebrity-solstice",
         "celebrity-eclipse",
-        "celebrity-millennium"
+        "celebrity-millennium",
+        "norwegian-joy",
+        "norwegian-bliss",
+        "norwegian-encore",
+        "norwegian-star"
       ],
       "port_page": "/ports/seattle.html"
     },
@@ -2477,7 +3130,9 @@
         "navigator-of-the-seas",
         "mariner-of-the-seas",
         "celebrity-solstice",
-        "celebrity-eclipse"
+        "celebrity-eclipse",
+        "norwegian-joy",
+        "norwegian-star"
       ],
       "port_page": "/ports/los-angeles.html"
     },
@@ -2510,7 +3165,10 @@
         "brilliance-of-the-seas",
         "celebrity-apex",
         "celebrity-equinox",
-        "celebrity-constellation"
+        "celebrity-constellation",
+        "norwegian-viva",
+        "norwegian-epic",
+        "norwegian-spirit"
       ],
       "port_page": "/ports/barcelona.html"
     },
@@ -2524,7 +3182,9 @@
         "odyssey-of-the-seas",
         "celebrity-edge",
         "celebrity-beyond",
-        "celebrity-reflection"
+        "celebrity-reflection",
+        "norwegian-epic",
+        "norwegian-jade"
       ],
       "port_page": "/ports/rome.html"
     },
@@ -2535,7 +3195,8 @@
       "ships": [
         "independence-of-the-seas",
         "anthem-of-the-seas",
-        "celebrity-silhouette"
+        "celebrity-silhouette",
+        "norwegian-spirit"
       ],
       "port_page": "/ports/southampton.html"
     },
@@ -2555,7 +3216,8 @@
       "country": "Greece",
       "ships": [
         "brilliance-of-the-seas",
-        "celebrity-constellation"
+        "celebrity-constellation",
+        "norwegian-jade"
       ],
       "port_page": "/ports/athens.html"
     },
@@ -2575,7 +3237,8 @@
       "country": "Australia",
       "ships": [
         "ovation-of-the-seas",
-        "carnival-splendor"
+        "carnival-splendor",
+        "norwegian-jewel"
       ],
       "port_page": "/ports/sydney.html"
     },
@@ -2616,7 +3279,8 @@
       "ships": [
         "carnival-conquest",
         "carnival-glory",
-        "carnival-valor"
+        "carnival-valor",
+        "norwegian-breakaway"
       ],
       "port_page": "/ports/new-orleans.html"
     },
@@ -2664,6 +3328,44 @@
         "celebrity-xpedition"
       ],
       "port_page": "/ports/baltra.html"
+    },
+    "new-york": {
+      "name": "New York (Manhattan)",
+      "state": "New York",
+      "country": "USA",
+      "ships": [
+        "norwegian-prima",
+        "norwegian-gem"
+      ],
+      "port_page": "/ports/new-york.html"
+    },
+    "boston": {
+      "name": "Boston",
+      "state": "Massachusetts",
+      "country": "USA",
+      "ships": [
+        "norwegian-gem",
+        "norwegian-dawn"
+      ],
+      "port_page": "/ports/boston.html"
+    },
+    "auckland": {
+      "name": "Auckland",
+      "state": "Auckland",
+      "country": "New Zealand",
+      "ships": [
+        "norwegian-jewel"
+      ],
+      "port_page": "/ports/auckland.html"
+    },
+    "honolulu": {
+      "name": "Honolulu",
+      "state": "Hawaii",
+      "country": "USA",
+      "ships": [
+        "pride-of-america"
+      ],
+      "port_page": "/ports/honolulu.html"
     }
   }
 }

--- a/assets/js/ship-port-links.js
+++ b/assets/js/ship-port-links.js
@@ -1,12 +1,12 @@
 /**
  * Ship-Port Cross-Linking Module
- * Version: 1.1.0
+ * Version: 1.2.0
  *
  * Provides bidirectional linking between ship and port pages:
  * - Port pages show "Ships That Visit Here"
  * - Ship pages show "Ports on This Ship's Itineraries"
  *
- * Supported cruise lines: Royal Caribbean, Carnival, Celebrity
+ * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian
  * Data source: /assets/data/ship-deployments.json
  */
 
@@ -34,6 +34,12 @@
       name: 'Celebrity Cruises',
       path: '/ships/celebrity-cruises/',
       bookingUrl: 'https://www.celebritycruises.com/cruise-ships/',
+      allShipsUrl: '/ships.html'
+    },
+    'ncl': {
+      name: 'Norwegian Cruise Line',
+      path: '/ships/ncl/',
+      bookingUrl: 'https://www.ncl.com/cruise-ships/',
       allShipsUrl: '/ships.html'
     }
   };
@@ -112,7 +118,9 @@
       'san-francisco': 'San Francisco',
       'buenos-aires': 'Buenos Aires',
       'punta-arenas': 'Punta Arenas',
-      'san-cristobal': 'San Cristóbal'
+      'san-cristobal': 'San Cristóbal',
+      'great-stirrup-cay': 'Great Stirrup Cay',
+      'new-york': 'New York'
     };
 
     if (specialNames[slug]) return specialNames[slug];
@@ -170,14 +178,16 @@
     const classOrders = {
       'rcl': ['Icon', 'Oasis', 'Quantum', 'Freedom', 'Voyager', 'Radiance', 'Vision', 'Other'],
       'carnival': ['Excel', 'Vista', 'Dream', 'Concordia', 'Venice', 'Destiny', 'Conquest', 'Spirit', 'Fantasy', 'Other'],
-      'celebrity': ['Edge', 'Solstice', 'Millennium', 'Expedition', 'Other']
+      'celebrity': ['Edge', 'Solstice', 'Millennium', 'Expedition', 'Other'],
+      'ncl': ['Prima', 'Breakaway Plus', 'Breakaway', 'Epic', 'Jewel', 'Dawn', 'Sun', 'Spirit', 'Sky', 'America', 'Other']
     };
 
     // Brand colors for cruise lines
     const brandColors = {
       'rcl': { bg: '#e6f4f8', border: '#b8d4e3', hover: '#d0e8f0', text: '#0e6e8e' },
       'carnival': { bg: '#fff3e6', border: '#e3c8b8', hover: '#ffe6cc', text: '#c74a35' },
-      'celebrity': { bg: '#f0f0f5', border: '#c0c0d0', hover: '#e0e0eb', text: '#1a1a4e' }
+      'celebrity': { bg: '#f0f0f5', border: '#c0c0d0', hover: '#e0e0eb', text: '#1a1a4e' },
+      'ncl': { bg: '#e6f0ff', border: '#b8c8e3', hover: '#d0e0f5', text: '#003087' }
     };
 
     let html = `
@@ -188,7 +198,7 @@
     `;
 
     // Render each cruise line's ships
-    const cruiseLineOrder = ['rcl', 'celebrity', 'carnival']; // Define display order
+    const cruiseLineOrder = ['rcl', 'celebrity', 'ncl', 'carnival']; // Define display order
     const activeCruiseLines = cruiseLineOrder.filter(cl => shipsByCruiseLine[cl]);
 
     activeCruiseLines.forEach((cruiseLineId, index) => {


### PR DESCRIPTION
Expanded ship-port cross-linking to include Norwegian Cruise Line:
- Added 20 NCL ships across 10 classes (Prima, Breakaway Plus, Breakaway, Epic, Jewel, Dawn, Sun, Spirit, Sky, America)
- Updated port_to_ships mappings for 87 total ports (was 81)
- Added NCL navy blue brand colors (#003087) to ship-port-links.js
- Added new ports: Great Stirrup Cay, Tortola, Havana, Kona, Hilo, Kauai
- Added new homeports: New York, Boston, Auckland, Honolulu

Progress: 4/15 cruise lines complete (the "big four": RCL, Carnival, Celebrity, NCL)
Total: 91 ships across 87 ports