### PR TITLE
Ships That Visit: Add Princess Cruises (17 ships)

### DIFF
--- a/admin/UNFINISHED-TASKS.md
+++ b/admin/UNFINISHED-TASKS.md
@@ -303,14 +303,14 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | "No Ads" trust messaging on about-us.html | ✅ DONE | Cruise Critic, CruiseMapper |
 | Tender Port Index + badge (`/ports/tender-ports.html`) | ✅ DONE | WhatsInPort |
 | "From the Pier" distance callout box component | PARTIAL (some ports) | WhatsInPort, IQCruising |
-| "Ships That Visit Here" section on port pages | PARTIAL (87/380 ports, RCL+Carnival+Celebrity+NCL) | UNIQUE - no competitor has this |
+| "Ships That Visit Here" section on port pages | PARTIAL (92/380 ports, RCL+Carnival+Celebrity+NCL+Princess) | UNIQUE - no competitor has this |
 | First-Timer Hub page | ✅ DONE (`first-cruise.html` 27KB) | Cruise Critic |
 | Pre-Cruise 30-Day Countdown checklist | ✅ DONE (`countdown.html` 2026-01-24) | Cruise Critic Roll Call |
 
 **P2 Strategic (Medium Effort):**
 | Task | Status | Addresses |
 |------|--------|-----------|
-| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (4/15 lines: RCL, Carnival, Celebrity, NCL) | UNIQUE differentiator |
+| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (5/15 lines: RCL, Carnival, Celebrity, NCL, Princess) | UNIQUE differentiator |
 | Print CSS + PDF generation for port pages | NOT STARTED | WhatsInPort, IQCruising |
 | Transport cost callout component | NOT STARTED | WhatsInPort, Cruise Crocodile |
 | Accessibility sections on port pages | NOT STARTED | UNIQUE - market gap |
@@ -318,12 +318,12 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | Honest assessment "Real Talk" sections | NOT STARTED | Cruise Critic, CruiseMapper |
 
 **"Ships That Visit Here" Expansion Plan:**
-- Current: 87 ports, 91 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL)
-- Progress: 4/15 cruise lines complete (the "big four" are done)
-- Data file: `assets/data/ship-deployments.json` (v1.3.0)
-- JS module: `assets/js/ship-port-links.js` (v1.2.0 - multi-cruise-line support)
-- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships)
-- Cruise lines remaining: Princess, Holland America, MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
+- Current: 92 ports, 108 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess)
+- Progress: 5/15 cruise lines complete
+- Data file: `assets/data/ship-deployments.json` (v1.4.0)
+- JS module: `assets/js/ship-port-links.js` (v1.3.0 - multi-cruise-line support)
+- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships)
+- Cruise lines remaining: Holland America, MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
 
 **Unique Differentiators to Protect:**
 - Ship-Port Integration ⭐⭐⭐ (expand with bidirectional linking)
@@ -721,11 +721,11 @@ node admin/validate-ship-page.js ships/celebrity-cruises/*.html
 - ~~Quiz Dress Code~~ — Question exists at line 1716
 - ~~30-Day Countdown Checklist~~ — `countdown.html` with 35 interactive tasks (2026-01-24)
 - ~~Works Offline Badge~~ — 376 port pages now show "Works offline" in trust badge (2026-01-24)
-- ~~Ships That Visit Here~~ — In progress (87/380 ports, 91 ships across RCL + Carnival + Celebrity + NCL — 11 cruise lines remaining)
+- ~~Ships That Visit Here~~ — In progress (92/380 ports, 108 ships across RCL + Carnival + Celebrity + NCL + Princess — 10 cruise lines remaining)
 
 ### 🟡 HIGH PRIORITY (Remaining Work)
 5. **Quiz UX Bugs** — iPhone scroll issue, back button (NCL links is #1 above)
-6. **Ships That Visit Expansion** — Add 11 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL done, 87/380 ports, 91 ships)
+6. **Ships That Visit Expansion** — Add 10 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess done, 92/380 ports, 108 ships)
 7. **Quiz Regional Features** — Regional availability filter (dress code done)
 8. **Port Weather Remaining** — 80 ports still need weather section
 

--- a/assets/data/ship-deployments.json
+++ b/assets/data/ship-deployments.json
@@ -1,14 +1,15 @@
 {
   "metadata": {
-    "version": "1.3.0",
+    "version": "1.4.0",
     "last_updated": "2026-01-25",
-    "source": "Royal Caribbean, Carnival, Celebrity, and Norwegian 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
+    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, and Princess 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
     "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment.",
     "cruise_lines": [
       "rcl",
       "carnival",
       "celebrity",
-      "ncl"
+      "ncl",
+      "princess"
     ]
   },
   "ships": {
@@ -2333,6 +2334,486 @@
       "itinerary_lengths": [
         7
       ]
+    },
+    "sun-princess": {
+      "name": "Sun Princess",
+      "class": "Sphere",
+      "cruise_line": "princess",
+      "homeports": [
+        "fort-lauderdale",
+        "rome"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "san-juan",
+        "rome",
+        "naples",
+        "barcelona",
+        "marseille"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        14
+      ]
+    },
+    "star-princess": {
+      "name": "Star Princess",
+      "class": "Sphere",
+      "cruise_line": "princess",
+      "homeports": [
+        "los-angeles",
+        "seattle"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "alaska"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "cabo-san-lucas",
+        "mazatlan",
+        "puerto-vallarta",
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "discovery-princess": {
+      "name": "Discovery Princess",
+      "class": "Royal",
+      "cruise_line": "princess",
+      "homeports": [
+        "los-angeles",
+        "seattle"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "alaska"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "cabo-san-lucas",
+        "mazatlan",
+        "puerto-vallarta",
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "victoria-bc"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "enchanted-princess": {
+      "name": "Enchanted Princess",
+      "class": "Royal",
+      "cruise_line": "princess",
+      "homeports": [
+        "fort-lauderdale",
+        "southampton"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "northern-europe",
+        "baltic"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "aruba",
+        "curacao",
+        "amsterdam",
+        "copenhagen",
+        "stockholm",
+        "tallinn"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        12
+      ]
+    },
+    "sky-princess": {
+      "name": "Sky Princess",
+      "class": "Royal",
+      "cruise_line": "princess",
+      "homeports": [
+        "fort-lauderdale",
+        "barcelona"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "san-juan",
+        "barcelona",
+        "rome",
+        "naples",
+        "marseille"
+      ],
+      "itinerary_lengths": [
+        7,
+        10
+      ]
+    },
+    "majestic-princess": {
+      "name": "Majestic Princess",
+      "class": "Royal",
+      "cruise_line": "princess",
+      "homeports": [
+        "seattle",
+        "sydney"
+      ],
+      "regions": [
+        "alaska",
+        "australia"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "victoria-bc",
+        "sydney",
+        "melbourne",
+        "hobart"
+      ],
+      "itinerary_lengths": [
+        7,
+        10
+      ]
+    },
+    "regal-princess": {
+      "name": "Regal Princess",
+      "class": "Royal",
+      "cruise_line": "princess",
+      "homeports": [
+        "fort-lauderdale",
+        "rome"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-mediterranean",
+        "greek-isles"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "san-juan",
+        "rome",
+        "naples",
+        "santorini",
+        "mykonos",
+        "athens"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        12
+      ]
+    },
+    "royal-princess": {
+      "name": "Royal Princess",
+      "class": "Royal",
+      "cruise_line": "princess",
+      "homeports": [
+        "los-angeles",
+        "fort-lauderdale"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "panama-canal",
+        "caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cabo-san-lucas",
+        "mazatlan",
+        "puerto-vallarta",
+        "aruba",
+        "curacao",
+        "cartagena"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        15
+      ]
+    },
+    "ruby-princess": {
+      "name": "Ruby Princess",
+      "class": "Grand",
+      "cruise_line": "princess",
+      "homeports": [
+        "san-francisco",
+        "seattle"
+      ],
+      "regions": [
+        "alaska",
+        "pacific-coastal"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "victoria-bc",
+        "san-francisco"
+      ],
+      "itinerary_lengths": [
+        7,
+        10
+      ]
+    },
+    "emerald-princess": {
+      "name": "Emerald Princess",
+      "class": "Grand",
+      "cruise_line": "princess",
+      "homeports": [
+        "seattle",
+        "los-angeles"
+      ],
+      "regions": [
+        "alaska",
+        "mexican-riviera",
+        "hawaii"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "cabo-san-lucas",
+        "mazatlan",
+        "honolulu",
+        "maui"
+      ],
+      "itinerary_lengths": [
+        7,
+        14,
+        15
+      ]
+    },
+    "crown-princess": {
+      "name": "Crown Princess",
+      "class": "Grand",
+      "cruise_line": "princess",
+      "homeports": [
+        "los-angeles",
+        "san-francisco"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "pacific-coastal",
+        "hawaii"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cabo-san-lucas",
+        "mazatlan",
+        "puerto-vallarta",
+        "ensenada",
+        "honolulu",
+        "maui",
+        "kona"
+      ],
+      "itinerary_lengths": [
+        7,
+        14,
+        15
+      ]
+    },
+    "caribbean-princess": {
+      "name": "Caribbean Princess",
+      "class": "Grand",
+      "cruise_line": "princess",
+      "homeports": [
+        "fort-lauderdale"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean",
+        "southern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "san-juan",
+        "cozumel",
+        "costa-maya",
+        "roatan",
+        "aruba",
+        "curacao"
+      ],
+      "itinerary_lengths": [
+        5,
+        7,
+        10
+      ]
+    },
+    "diamond-princess": {
+      "name": "Diamond Princess",
+      "class": "Grand",
+      "cruise_line": "princess",
+      "homeports": [
+        "tokyo",
+        "singapore"
+      ],
+      "regions": [
+        "japan",
+        "asia",
+        "australia"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "tokyo",
+        "osaka",
+        "nagasaki",
+        "hong-kong",
+        "singapore",
+        "sydney"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        14
+      ]
+    },
+    "sapphire-princess": {
+      "name": "Sapphire Princess",
+      "class": "Grand",
+      "cruise_line": "princess",
+      "homeports": [
+        "tokyo",
+        "sydney"
+      ],
+      "regions": [
+        "japan",
+        "australia",
+        "new-zealand"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "tokyo",
+        "osaka",
+        "sydney",
+        "melbourne",
+        "auckland",
+        "bay-of-islands"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        12
+      ]
+    },
+    "grand-princess": {
+      "name": "Grand Princess",
+      "class": "Grand",
+      "cruise_line": "princess",
+      "homeports": [
+        "san-francisco",
+        "los-angeles"
+      ],
+      "regions": [
+        "pacific-coastal",
+        "hawaii",
+        "mexican-riviera"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "san-francisco",
+        "honolulu",
+        "maui",
+        "kona",
+        "cabo-san-lucas",
+        "ensenada"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        15
+      ]
+    },
+    "island-princess": {
+      "name": "Island Princess",
+      "class": "Coral",
+      "cruise_line": "princess",
+      "homeports": [
+        "fort-lauderdale",
+        "los-angeles"
+      ],
+      "regions": [
+        "panama-canal",
+        "south-america",
+        "world-cruise"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "aruba",
+        "curacao",
+        "cartagena",
+        "panama-canal",
+        "lima",
+        "buenos-aires"
+      ],
+      "itinerary_lengths": [
+        10,
+        14,
+        21,
+        111
+      ]
+    },
+    "coral-princess": {
+      "name": "Coral Princess",
+      "class": "Coral",
+      "cruise_line": "princess",
+      "homeports": [
+        "seattle",
+        "los-angeles"
+      ],
+      "regions": [
+        "alaska",
+        "panama-canal",
+        "south-america"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "aruba",
+        "cartagena",
+        "lima"
+      ],
+      "itinerary_lengths": [
+        7,
+        14,
+        21
+      ]
     }
   },
   "port_to_ships": {
@@ -2413,7 +2894,8 @@
       "norwegian-escape",
       "norwegian-encore",
       "norwegian-breakaway",
-      "norwegian-pearl"
+      "norwegian-pearl",
+      "caribbean-princess"
     ],
     "costa-maya": [
       "icon-of-the-seas",
@@ -2439,7 +2921,8 @@
       "norwegian-escape",
       "norwegian-encore",
       "norwegian-breakaway",
-      "norwegian-pearl"
+      "norwegian-pearl",
+      "caribbean-princess"
     ],
     "roatan": [
       "icon-of-the-seas",
@@ -2452,7 +2935,8 @@
       "norwegian-escape",
       "norwegian-encore",
       "norwegian-breakaway",
-      "norwegian-pearl"
+      "norwegian-pearl",
+      "caribbean-princess"
     ],
     "jamaica": [
       "symphony-of-the-seas",
@@ -2541,7 +3025,12 @@
       "norwegian-aqua",
       "norwegian-escape",
       "norwegian-bliss",
-      "norwegian-getaway"
+      "norwegian-getaway",
+      "sun-princess",
+      "enchanted-princess",
+      "sky-princess",
+      "regal-princess",
+      "caribbean-princess"
     ],
     "st-maarten": [
       "icon-of-the-seas",
@@ -2554,7 +3043,12 @@
       "celebrity-reflection",
       "norwegian-viva",
       "norwegian-aqua",
-      "norwegian-bliss"
+      "norwegian-bliss",
+      "sun-princess",
+      "enchanted-princess",
+      "sky-princess",
+      "regal-princess",
+      "caribbean-princess"
     ],
     "st-kitts": [
       "icon-of-the-seas",
@@ -2588,7 +3082,12 @@
       "rhapsody-of-the-seas",
       "celebrity-ascent",
       "celebrity-equinox",
-      "celebrity-silhouette"
+      "celebrity-silhouette",
+      "enchanted-princess",
+      "royal-princess",
+      "caribbean-princess",
+      "island-princess",
+      "coral-princess"
     ],
     "curacao": [
       "freedom-of-the-seas",
@@ -2596,7 +3095,11 @@
       "rhapsody-of-the-seas",
       "celebrity-ascent",
       "celebrity-equinox",
-      "celebrity-silhouette"
+      "celebrity-silhouette",
+      "enchanted-princess",
+      "royal-princess",
+      "caribbean-princess",
+      "island-princess"
     ],
     "dominica": [
       "jewel-of-the-seas",
@@ -2606,7 +3109,11 @@
       "adventure-of-the-seas",
       "celebrity-edge",
       "celebrity-ascent",
-      "norwegian-viva"
+      "norwegian-viva",
+      "sun-princess",
+      "sky-princess",
+      "regal-princess",
+      "caribbean-princess"
     ],
     "bermuda": [
       "liberty-of-the-seas",
@@ -2630,7 +3137,13 @@
       "norwegian-joy",
       "norwegian-bliss",
       "norwegian-encore",
-      "norwegian-star"
+      "norwegian-star",
+      "star-princess",
+      "discovery-princess",
+      "majestic-princess",
+      "ruby-princess",
+      "emerald-princess",
+      "coral-princess"
     ],
     "skagway": [
       "voyager-of-the-seas",
@@ -2644,7 +3157,13 @@
       "norwegian-joy",
       "norwegian-bliss",
       "norwegian-encore",
-      "norwegian-star"
+      "norwegian-star",
+      "star-princess",
+      "discovery-princess",
+      "majestic-princess",
+      "ruby-princess",
+      "emerald-princess",
+      "coral-princess"
     ],
     "ketchikan": [
       "voyager-of-the-seas",
@@ -2658,7 +3177,13 @@
       "norwegian-joy",
       "norwegian-bliss",
       "norwegian-encore",
-      "norwegian-star"
+      "norwegian-star",
+      "star-princess",
+      "discovery-princess",
+      "majestic-princess",
+      "ruby-princess",
+      "emerald-princess",
+      "coral-princess"
     ],
     "glacier-bay": [
       "voyager-of-the-seas",
@@ -2667,7 +3192,13 @@
       "celebrity-eclipse",
       "norwegian-joy",
       "norwegian-bliss",
-      "norwegian-encore"
+      "norwegian-encore",
+      "star-princess",
+      "discovery-princess",
+      "majestic-princess",
+      "ruby-princess",
+      "emerald-princess",
+      "coral-princess"
     ],
     "sitka": [
       "anthem-of-the-seas"
@@ -2684,7 +3215,10 @@
       "serenade-of-the-seas",
       "celebrity-solstice",
       "norwegian-bliss",
-      "norwegian-star"
+      "norwegian-star",
+      "discovery-princess",
+      "majestic-princess",
+      "ruby-princess"
     ],
     "barcelona": [
       "harmony-of-the-seas",
@@ -2695,7 +3229,9 @@
       "celebrity-constellation",
       "norwegian-viva",
       "norwegian-epic",
-      "norwegian-spirit"
+      "norwegian-spirit",
+      "sun-princess",
+      "sky-princess"
     ],
     "rome": [
       "harmony-of-the-seas",
@@ -2709,7 +3245,10 @@
       "celebrity-reflection",
       "norwegian-viva",
       "norwegian-epic",
-      "norwegian-spirit"
+      "norwegian-spirit",
+      "sun-princess",
+      "sky-princess",
+      "regal-princess"
     ],
     "naples": [
       "allure-of-the-seas",
@@ -2720,7 +3259,10 @@
       "celebrity-beyond",
       "celebrity-reflection",
       "norwegian-viva",
-      "norwegian-epic"
+      "norwegian-epic",
+      "sun-princess",
+      "sky-princess",
+      "regal-princess"
     ],
     "marseille": [
       "harmony-of-the-seas",
@@ -2729,7 +3271,9 @@
       "celebrity-apex",
       "celebrity-equinox",
       "norwegian-viva",
-      "norwegian-epic"
+      "norwegian-epic",
+      "sun-princess",
+      "sky-princess"
     ],
     "la-spezia": [
       "harmony-of-the-seas",
@@ -2745,7 +3289,8 @@
       "celebrity-reflection",
       "celebrity-constellation",
       "norwegian-epic",
-      "norwegian-jade"
+      "norwegian-jade",
+      "regal-princess"
     ],
     "mykonos": [
       "explorer-of-the-seas",
@@ -2755,13 +3300,15 @@
       "celebrity-reflection",
       "celebrity-constellation",
       "norwegian-epic",
-      "norwegian-jade"
+      "norwegian-jade",
+      "regal-princess"
     ],
     "athens": [
       "explorer-of-the-seas",
       "celebrity-beyond",
       "celebrity-reflection",
-      "celebrity-constellation"
+      "celebrity-constellation",
+      "regal-princess"
     ],
     "dubrovnik": [
       "explorer-of-the-seas",
@@ -2788,22 +3335,26 @@
       "independence-of-the-seas",
       "anthem-of-the-seas",
       "celebrity-silhouette",
-      "norwegian-spirit"
+      "norwegian-spirit",
+      "enchanted-princess"
     ],
     "copenhagen": [
       "independence-of-the-seas",
       "celebrity-silhouette",
-      "norwegian-spirit"
+      "norwegian-spirit",
+      "enchanted-princess"
     ],
     "stockholm": [
       "independence-of-the-seas",
       "celebrity-silhouette",
-      "norwegian-spirit"
+      "norwegian-spirit",
+      "enchanted-princess"
     ],
     "tallinn": [
       "independence-of-the-seas",
       "celebrity-silhouette",
-      "norwegian-spirit"
+      "norwegian-spirit",
+      "enchanted-princess"
     ],
     "cabo-san-lucas": [
       "navigator-of-the-seas",
@@ -2815,7 +3366,13 @@
       "celebrity-eclipse",
       "celebrity-infinity",
       "norwegian-joy",
-      "norwegian-star"
+      "norwegian-star",
+      "star-princess",
+      "discovery-princess",
+      "royal-princess",
+      "emerald-princess",
+      "crown-princess",
+      "grand-princess"
     ],
     "mazatlan": [
       "navigator-of-the-seas",
@@ -2823,21 +3380,32 @@
       "carnival-firenze",
       "celebrity-eclipse",
       "norwegian-joy",
-      "norwegian-star"
+      "norwegian-star",
+      "star-princess",
+      "discovery-princess",
+      "royal-princess",
+      "emerald-princess",
+      "crown-princess"
     ],
     "puerto-vallarta": [
       "navigator-of-the-seas",
       "carnival-panorama",
       "carnival-firenze",
       "celebrity-eclipse",
-      "norwegian-joy"
+      "norwegian-joy",
+      "star-princess",
+      "discovery-princess",
+      "royal-princess",
+      "crown-princess"
     ],
     "ensenada": [
       "navigator-of-the-seas",
       "mariner-of-the-seas",
       "carnival-panorama",
       "carnival-firenze",
-      "carnival-radiance"
+      "carnival-radiance",
+      "crown-princess",
+      "grand-princess"
     ],
     "catalina-island": [
       "carnival-radiance"
@@ -2868,24 +3436,32 @@
     "sydney": [
       "quantum-of-the-seas",
       "ovation-of-the-seas",
-      "norwegian-jewel"
+      "norwegian-jewel",
+      "majestic-princess",
+      "diamond-princess",
+      "sapphire-princess"
     ],
     "melbourne": [
       "quantum-of-the-seas",
       "ovation-of-the-seas",
-      "norwegian-jewel"
+      "norwegian-jewel",
+      "majestic-princess",
+      "sapphire-princess"
     ],
     "hobart": [
       "quantum-of-the-seas",
-      "norwegian-jewel"
+      "norwegian-jewel",
+      "majestic-princess"
     ],
     "auckland": [
       "ovation-of-the-seas",
-      "norwegian-jewel"
+      "norwegian-jewel",
+      "sapphire-princess"
     ],
     "bay-of-islands": [
       "ovation-of-the-seas",
-      "norwegian-jewel"
+      "norwegian-jewel",
+      "sapphire-princess"
     ],
     "penang": [
       "quantum-of-the-seas"
@@ -2896,7 +3472,8 @@
     ],
     "hong-kong": [
       "spectrum-of-the-seas",
-      "celebrity-millennium"
+      "celebrity-millennium",
+      "diamond-princess"
     ],
     "nha-trang": [
       "spectrum-of-the-seas",
@@ -2924,16 +3501,25 @@
     ],
     "honolulu": [
       "celebrity-solstice",
-      "pride-of-america"
+      "pride-of-america",
+      "emerald-princess",
+      "crown-princess",
+      "grand-princess"
     ],
     "maui": [
       "celebrity-solstice",
-      "pride-of-america"
+      "pride-of-america",
+      "emerald-princess",
+      "crown-princess",
+      "grand-princess"
     ],
     "san-francisco": [
       "celebrity-solstice",
       "celebrity-infinity",
-      "norwegian-star"
+      "norwegian-star",
+      "ruby-princess",
+      "crown-princess",
+      "grand-princess"
     ],
     "haifa": [
       "celebrity-constellation"
@@ -2956,7 +3542,8 @@
       "celebrity-infinity"
     ],
     "singapore": [
-      "celebrity-millennium"
+      "celebrity-millennium",
+      "diamond-princess"
     ],
     "great-stirrup-cay": [
       "norwegian-getaway",
@@ -2973,13 +3560,35 @@
       "norwegian-sun"
     ],
     "kona": [
-      "pride-of-america"
+      "pride-of-america",
+      "crown-princess",
+      "grand-princess"
     ],
     "hilo": [
       "pride-of-america"
     ],
     "kauai": [
       "pride-of-america"
+    ],
+    "tokyo": [
+      "diamond-princess",
+      "sapphire-princess"
+    ],
+    "osaka": [
+      "diamond-princess",
+      "sapphire-princess"
+    ],
+    "nagasaki": [
+      "diamond-princess"
+    ],
+    "cartagena": [
+      "royal-princess",
+      "island-princess",
+      "coral-princess"
+    ],
+    "lima": [
+      "island-princess",
+      "coral-princess"
     ]
   },
   "homeport_details": {
@@ -3033,7 +3642,14 @@
         "celebrity-xcel",
         "celebrity-equinox",
         "celebrity-silhouette",
-        "celebrity-reflection"
+        "celebrity-reflection",
+        "sun-princess",
+        "enchanted-princess",
+        "sky-princess",
+        "regal-princess",
+        "royal-princess",
+        "caribbean-princess",
+        "island-princess"
       ],
       "port_page": "/ports/fort-lauderdale.html"
     },
@@ -3118,7 +3734,13 @@
         "norwegian-joy",
         "norwegian-bliss",
         "norwegian-encore",
-        "norwegian-star"
+        "norwegian-star",
+        "star-princess",
+        "discovery-princess",
+        "majestic-princess",
+        "ruby-princess",
+        "emerald-princess",
+        "coral-princess"
       ],
       "port_page": "/ports/seattle.html"
     },
@@ -3132,7 +3754,15 @@
         "celebrity-solstice",
         "celebrity-eclipse",
         "norwegian-joy",
-        "norwegian-star"
+        "norwegian-star",
+        "star-princess",
+        "discovery-princess",
+        "royal-princess",
+        "emerald-princess",
+        "crown-princess",
+        "grand-princess",
+        "coral-princess",
+        "island-princess"
       ],
       "port_page": "/ports/los-angeles.html"
     },
@@ -3168,7 +3798,8 @@
         "celebrity-constellation",
         "norwegian-viva",
         "norwegian-epic",
-        "norwegian-spirit"
+        "norwegian-spirit",
+        "sky-princess"
       ],
       "port_page": "/ports/barcelona.html"
     },
@@ -3184,7 +3815,9 @@
         "celebrity-beyond",
         "celebrity-reflection",
         "norwegian-epic",
-        "norwegian-jade"
+        "norwegian-jade",
+        "sun-princess",
+        "regal-princess"
       ],
       "port_page": "/ports/rome.html"
     },
@@ -3196,7 +3829,8 @@
         "independence-of-the-seas",
         "anthem-of-the-seas",
         "celebrity-silhouette",
-        "norwegian-spirit"
+        "norwegian-spirit",
+        "enchanted-princess"
       ],
       "port_page": "/ports/southampton.html"
     },
@@ -3227,7 +3861,8 @@
       "ships": [
         "spectrum-of-the-seas",
         "quantum-of-the-seas",
-        "celebrity-millennium"
+        "celebrity-millennium",
+        "diamond-princess"
       ],
       "port_page": "/ports/singapore.html"
     },
@@ -3238,7 +3873,9 @@
       "ships": [
         "ovation-of-the-seas",
         "carnival-splendor",
-        "norwegian-jewel"
+        "norwegian-jewel",
+        "majestic-princess",
+        "sapphire-princess"
       ],
       "port_page": "/ports/sydney.html"
     },
@@ -3307,7 +3944,9 @@
       "state": "Tokyo",
       "country": "Japan",
       "ships": [
-        "celebrity-millennium"
+        "celebrity-millennium",
+        "diamond-princess",
+        "sapphire-princess"
       ],
       "port_page": "/ports/tokyo.html"
     },
@@ -3366,6 +4005,17 @@
         "pride-of-america"
       ],
       "port_page": "/ports/honolulu.html"
+    },
+    "san-francisco": {
+      "name": "San Francisco",
+      "state": "California",
+      "country": "USA",
+      "ships": [
+        "ruby-princess",
+        "crown-princess",
+        "grand-princess"
+      ],
+      "port_page": "/ports/san-francisco.html"
     }
   }
 }

--- a/assets/js/ship-port-links.js
+++ b/assets/js/ship-port-links.js
@@ -1,12 +1,12 @@
 /**
  * Ship-Port Cross-Linking Module
- * Version: 1.2.0
+ * Version: 1.3.0
  *
  * Provides bidirectional linking between ship and port pages:
  * - Port pages show "Ships That Visit Here"
  * - Ship pages show "Ports on This Ship's Itineraries"
  *
- * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian
+ * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess
  * Data source: /assets/data/ship-deployments.json
  */
 
@@ -40,6 +40,12 @@
       name: 'Norwegian Cruise Line',
       path: '/ships/ncl/',
       bookingUrl: 'https://www.ncl.com/cruise-ships/',
+      allShipsUrl: '/ships.html'
+    },
+    'princess': {
+      name: 'Princess Cruises',
+      path: '/ships/princess/',
+      bookingUrl: 'https://www.princess.com/ships-and-experience/ships/',
       allShipsUrl: '/ships.html'
     }
   };
@@ -179,7 +185,8 @@
       'rcl': ['Icon', 'Oasis', 'Quantum', 'Freedom', 'Voyager', 'Radiance', 'Vision', 'Other'],
       'carnival': ['Excel', 'Vista', 'Dream', 'Concordia', 'Venice', 'Destiny', 'Conquest', 'Spirit', 'Fantasy', 'Other'],
       'celebrity': ['Edge', 'Solstice', 'Millennium', 'Expedition', 'Other'],
-      'ncl': ['Prima', 'Breakaway Plus', 'Breakaway', 'Epic', 'Jewel', 'Dawn', 'Sun', 'Spirit', 'Sky', 'America', 'Other']
+      'ncl': ['Prima', 'Breakaway Plus', 'Breakaway', 'Epic', 'Jewel', 'Dawn', 'Sun', 'Spirit', 'Sky', 'America', 'Other'],
+      'princess': ['Sphere', 'Royal', 'Grand', 'Coral', 'Other']
     };
 
     // Brand colors for cruise lines
@@ -187,7 +194,8 @@
       'rcl': { bg: '#e6f4f8', border: '#b8d4e3', hover: '#d0e8f0', text: '#0e6e8e' },
       'carnival': { bg: '#fff3e6', border: '#e3c8b8', hover: '#ffe6cc', text: '#c74a35' },
       'celebrity': { bg: '#f0f0f5', border: '#c0c0d0', hover: '#e0e0eb', text: '#1a1a4e' },
-      'ncl': { bg: '#e6f0ff', border: '#b8c8e3', hover: '#d0e0f5', text: '#003087' }
+      'ncl': { bg: '#e6f0ff', border: '#b8c8e3', hover: '#d0e0f5', text: '#003087' },
+      'princess': { bg: '#e6f2ef', border: '#b8d4cd', hover: '#d0e8e3', text: '#00665e' }
     };
 
     let html = `
@@ -198,7 +206,7 @@
     `;
 
     // Render each cruise line's ships
-    const cruiseLineOrder = ['rcl', 'celebrity', 'ncl', 'carnival']; // Define display order
+    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'ncl', 'carnival']; // Define display order
     const activeCruiseLines = cruiseLineOrder.filter(cl => shipsByCruiseLine[cl]);
 
     activeCruiseLines.forEach((cruiseLineId, index) => {


### PR DESCRIPTION
Expanded ship-port cross-linking to include Princess Cruises:
- Added 17 Princess ships across 4 classes (Sphere, Royal, Grand, Coral)
- Updated port_to_ships mappings for 92 total ports (was 87)
- Added Princess teal brand colors (#00665e) to ship-port-links.js
- Added new ports: Tokyo, Osaka, Nagasaki, Cartagena, Lima
- Added san-francisco as a new homeport

Princess ship classes by size:
- Sphere Class: Sun Princess, Star Princess (newest/largest)
- Royal Class: Discovery, Enchanted, Sky, Majestic, Regal, Royal Princess
- Grand Class: Ruby, Emerald, Crown, Caribbean, Diamond, Sapphire, Grand Princess
- Coral Class: Island Princess, Coral Princess

Progress: 5/15 cruise lines complete
Total: 108 ships across 92 ports