### PR TITLE
Ships That Visit: Add Holland America Line (11 ships)

### DIFF
--- a/admin/UNFINISHED-TASKS.md
+++ b/admin/UNFINISHED-TASKS.md
@@ -303,14 +303,14 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | "No Ads" trust messaging on about-us.html | ✅ DONE | Cruise Critic, CruiseMapper |
 | Tender Port Index + badge (`/ports/tender-ports.html`) | ✅ DONE | WhatsInPort |
 | "From the Pier" distance callout box component | PARTIAL (some ports) | WhatsInPort, IQCruising |
-| "Ships That Visit Here" section on port pages | PARTIAL (92/380 ports, RCL+Carnival+Celebrity+NCL+Princess) | UNIQUE - no competitor has this |
+| "Ships That Visit Here" section on port pages | PARTIAL (92/380 ports, RCL+Carnival+Celebrity+NCL+Princess+HAL) | UNIQUE - no competitor has this |
 | First-Timer Hub page | ✅ DONE (`first-cruise.html` 27KB) | Cruise Critic |
 | Pre-Cruise 30-Day Countdown checklist | ✅ DONE (`countdown.html` 2026-01-24) | Cruise Critic Roll Call |
 
 **P2 Strategic (Medium Effort):**
 | Task | Status | Addresses |
 |------|--------|-----------|
-| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (5/15 lines: RCL, Carnival, Celebrity, NCL, Princess) | UNIQUE differentiator |
+| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (6/15 lines: RCL, Carnival, Celebrity, NCL, Princess, HAL) | UNIQUE differentiator |
 | Print CSS + PDF generation for port pages | NOT STARTED | WhatsInPort, IQCruising |
 | Transport cost callout component | NOT STARTED | WhatsInPort, Cruise Crocodile |
 | Accessibility sections on port pages | NOT STARTED | UNIQUE - market gap |
@@ -318,12 +318,12 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | Honest assessment "Real Talk" sections | NOT STARTED | Cruise Critic, CruiseMapper |
 
 **"Ships That Visit Here" Expansion Plan:**
-- Current: 92 ports, 108 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess)
-- Progress: 5/15 cruise lines complete
-- Data file: `assets/data/ship-deployments.json` (v1.4.0)
+- Current: 92 ports, 119 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess + 11 HAL)
+- Progress: 6/15 cruise lines complete
+- Data file: `assets/data/ship-deployments.json` (v1.5.0)
 - JS module: `assets/js/ship-port-links.js` (v1.3.0 - multi-cruise-line support)
-- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships)
-- Cruise lines remaining: Holland America, MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
+- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships), ✅ Holland America (11 ships)
+- Cruise lines remaining: MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
 
 **Unique Differentiators to Protect:**
 - Ship-Port Integration ⭐⭐⭐ (expand with bidirectional linking)
@@ -721,11 +721,11 @@ node admin/validate-ship-page.js ships/celebrity-cruises/*.html
 - ~~Quiz Dress Code~~ — Question exists at line 1716
 - ~~30-Day Countdown Checklist~~ — `countdown.html` with 35 interactive tasks (2026-01-24)
 - ~~Works Offline Badge~~ — 376 port pages now show "Works offline" in trust badge (2026-01-24)
-- ~~Ships That Visit Here~~ — In progress (92/380 ports, 108 ships across RCL + Carnival + Celebrity + NCL + Princess — 10 cruise lines remaining)
+- ~~Ships That Visit Here~~ — In progress (92/380 ports, 119 ships across RCL + Carnival + Celebrity + NCL + Princess + HAL — 9 cruise lines remaining)
 
 ### 🟡 HIGH PRIORITY (Remaining Work)
 5. **Quiz UX Bugs** — iPhone scroll issue, back button (NCL links is #1 above)
-6. **Ships That Visit Expansion** — Add 10 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess done, 92/380 ports, 108 ships)
+6. **Ships That Visit Expansion** — Add 9 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess + HAL done, 92/380 ports, 119 ships)
 7. **Quiz Regional Features** — Regional availability filter (dress code done)
 8. **Port Weather Remaining** — 80 ports still need weather section
 

--- a/assets/data/ship-deployments.json
+++ b/assets/data/ship-deployments.json
@@ -1,15 +1,16 @@
 {
   "metadata": {
-    "version": "1.4.0",
+    "version": "1.5.0",
     "last_updated": "2026-01-25",
-    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, and Princess 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
+    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, and Holland America 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
     "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment.",
     "cruise_lines": [
       "rcl",
       "carnival",
       "celebrity",
       "ncl",
-      "princess"
+      "princess",
+      "hal"
     ]
   },
   "ships": {
@@ -2814,6 +2815,313 @@
         14,
         21
       ]
+    },
+    "rotterdam": {
+      "name": "Rotterdam",
+      "class": "Pinnacle",
+      "cruise_line": "hal",
+      "homeports": [
+        "fort-lauderdale",
+        "seattle"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "alaska"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "san-juan",
+        "half-moon-cay",
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        14
+      ]
+    },
+    "nieuw-statendam": {
+      "name": "Nieuw Statendam",
+      "class": "Pinnacle",
+      "cruise_line": "hal",
+      "homeports": [
+        "fort-lauderdale",
+        "rome"
+      ],
+      "regions": [
+        "southern-caribbean",
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "aruba",
+        "curacao",
+        "barbados",
+        "st-lucia",
+        "rome",
+        "naples",
+        "barcelona",
+        "marseille"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        11
+      ]
+    },
+    "koningsdam": {
+      "name": "Koningsdam",
+      "class": "Pinnacle",
+      "cruise_line": "hal",
+      "homeports": [
+        "san-diego",
+        "seattle"
+      ],
+      "regions": [
+        "mexican-riviera",
+        "alaska",
+        "pacific-coastal"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cabo-san-lucas",
+        "mazatlan",
+        "puerto-vallarta",
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "victoria-bc"
+      ],
+      "itinerary_lengths": [
+        7,
+        14
+      ]
+    },
+    "nieuw-amsterdam": {
+      "name": "Nieuw Amsterdam",
+      "class": "Signature",
+      "cruise_line": "hal",
+      "homeports": [
+        "seattle",
+        "san-diego"
+      ],
+      "regions": [
+        "alaska",
+        "mexican-riviera",
+        "hawaii"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "cabo-san-lucas",
+        "mazatlan",
+        "honolulu",
+        "maui"
+      ],
+      "itinerary_lengths": [
+        7,
+        14,
+        17
+      ]
+    },
+    "eurodam": {
+      "name": "Eurodam",
+      "class": "Signature",
+      "cruise_line": "hal",
+      "homeports": [
+        "fort-lauderdale",
+        "boston"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "canada-new-england"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "st-maarten",
+        "half-moon-cay",
+        "portland-maine",
+        "bar-harbor",
+        "halifax"
+      ],
+      "itinerary_lengths": [
+        7,
+        10
+      ]
+    },
+    "oosterdam": {
+      "name": "Oosterdam",
+      "class": "Vista",
+      "cruise_line": "hal",
+      "homeports": [
+        "sydney",
+        "singapore"
+      ],
+      "regions": [
+        "australia",
+        "new-zealand",
+        "asia"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "sydney",
+        "melbourne",
+        "hobart",
+        "auckland",
+        "bay-of-islands",
+        "singapore",
+        "hong-kong"
+      ],
+      "itinerary_lengths": [
+        10,
+        12,
+        14
+      ]
+    },
+    "westerdam": {
+      "name": "Westerdam",
+      "class": "Vista",
+      "cruise_line": "hal",
+      "homeports": [
+        "seattle",
+        "yokohama"
+      ],
+      "regions": [
+        "alaska",
+        "japan",
+        "asia"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "glacier-bay",
+        "tokyo",
+        "osaka",
+        "nagasaki"
+      ],
+      "itinerary_lengths": [
+        7,
+        14
+      ]
+    },
+    "zuiderdam": {
+      "name": "Zuiderdam",
+      "class": "Vista",
+      "cruise_line": "hal",
+      "homeports": [
+        "fort-lauderdale"
+      ],
+      "regions": [
+        "panama-canal",
+        "south-america"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "aruba",
+        "curacao",
+        "cartagena",
+        "lima",
+        "buenos-aires"
+      ],
+      "itinerary_lengths": [
+        10,
+        14,
+        21
+      ]
+    },
+    "noordam": {
+      "name": "Noordam",
+      "class": "Vista",
+      "cruise_line": "hal",
+      "homeports": [
+        "amsterdam",
+        "barcelona"
+      ],
+      "regions": [
+        "northern-europe",
+        "baltic",
+        "western-mediterranean"
+      ],
+      "season": "spring-fall",
+      "typical_ports": [
+        "amsterdam",
+        "copenhagen",
+        "stockholm",
+        "tallinn",
+        "barcelona",
+        "rome",
+        "naples"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        14
+      ]
+    },
+    "zaandam": {
+      "name": "Zaandam",
+      "class": "R",
+      "cruise_line": "hal",
+      "homeports": [
+        "boston",
+        "fort-lauderdale"
+      ],
+      "regions": [
+        "canada-new-england",
+        "eastern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "portland-maine",
+        "bar-harbor",
+        "halifax",
+        "st-thomas",
+        "st-maarten",
+        "half-moon-cay"
+      ],
+      "itinerary_lengths": [
+        7,
+        10
+      ]
+    },
+    "volendam": {
+      "name": "Volendam",
+      "class": "R",
+      "cruise_line": "hal",
+      "homeports": [
+        "san-diego",
+        "vancouver"
+      ],
+      "regions": [
+        "pacific-coastal",
+        "alaska",
+        "world-cruise"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "san-francisco",
+        "juneau",
+        "skagway",
+        "ketchikan",
+        "victoria-bc"
+      ],
+      "itinerary_lengths": [
+        7,
+        14,
+        111
+      ]
     }
   },
   "port_to_ships": {
@@ -3030,7 +3338,10 @@
       "enchanted-princess",
       "sky-princess",
       "regal-princess",
-      "caribbean-princess"
+      "caribbean-princess",
+      "rotterdam",
+      "eurodam",
+      "zaandam"
     ],
     "st-maarten": [
       "icon-of-the-seas",
@@ -3048,7 +3359,10 @@
       "enchanted-princess",
       "sky-princess",
       "regal-princess",
-      "caribbean-princess"
+      "caribbean-princess",
+      "rotterdam",
+      "eurodam",
+      "zaandam"
     ],
     "st-kitts": [
       "icon-of-the-seas",
@@ -3063,7 +3377,8 @@
       "freedom-of-the-seas",
       "jewel-of-the-seas",
       "celebrity-equinox",
-      "celebrity-silhouette"
+      "celebrity-silhouette",
+      "nieuw-statendam"
     ],
     "barbados": [
       "freedom-of-the-seas",
@@ -3073,7 +3388,8 @@
       "celebrity-ascent",
       "celebrity-equinox",
       "celebrity-silhouette",
-      "celebrity-summit"
+      "celebrity-summit",
+      "nieuw-statendam"
     ],
     "aruba": [
       "freedom-of-the-seas",
@@ -3087,7 +3403,9 @@
       "royal-princess",
       "caribbean-princess",
       "island-princess",
-      "coral-princess"
+      "coral-princess",
+      "nieuw-statendam",
+      "zuiderdam"
     ],
     "curacao": [
       "freedom-of-the-seas",
@@ -3099,7 +3417,9 @@
       "enchanted-princess",
       "royal-princess",
       "caribbean-princess",
-      "island-princess"
+      "island-princess",
+      "nieuw-statendam",
+      "zuiderdam"
     ],
     "dominica": [
       "jewel-of-the-seas",
@@ -3143,7 +3463,12 @@
       "majestic-princess",
       "ruby-princess",
       "emerald-princess",
-      "coral-princess"
+      "coral-princess",
+      "rotterdam",
+      "koningsdam",
+      "nieuw-amsterdam",
+      "westerdam",
+      "volendam"
     ],
     "skagway": [
       "voyager-of-the-seas",
@@ -3163,7 +3488,12 @@
       "majestic-princess",
       "ruby-princess",
       "emerald-princess",
-      "coral-princess"
+      "coral-princess",
+      "rotterdam",
+      "koningsdam",
+      "nieuw-amsterdam",
+      "westerdam",
+      "volendam"
     ],
     "ketchikan": [
       "voyager-of-the-seas",
@@ -3183,7 +3513,12 @@
       "majestic-princess",
       "ruby-princess",
       "emerald-princess",
-      "coral-princess"
+      "coral-princess",
+      "rotterdam",
+      "koningsdam",
+      "nieuw-amsterdam",
+      "westerdam",
+      "volendam"
     ],
     "glacier-bay": [
       "voyager-of-the-seas",
@@ -3198,7 +3533,11 @@
       "majestic-princess",
       "ruby-princess",
       "emerald-princess",
-      "coral-princess"
+      "coral-princess",
+      "rotterdam",
+      "koningsdam",
+      "nieuw-amsterdam",
+      "westerdam"
     ],
     "sitka": [
       "anthem-of-the-seas"
@@ -3218,7 +3557,9 @@
       "norwegian-star",
       "discovery-princess",
       "majestic-princess",
-      "ruby-princess"
+      "ruby-princess",
+      "koningsdam",
+      "volendam"
     ],
     "barcelona": [
       "harmony-of-the-seas",
@@ -3231,7 +3572,9 @@
       "norwegian-epic",
       "norwegian-spirit",
       "sun-princess",
-      "sky-princess"
+      "sky-princess",
+      "nieuw-statendam",
+      "noordam"
     ],
     "rome": [
       "harmony-of-the-seas",
@@ -3248,7 +3591,9 @@
       "norwegian-spirit",
       "sun-princess",
       "sky-princess",
-      "regal-princess"
+      "regal-princess",
+      "nieuw-statendam",
+      "noordam"
     ],
     "naples": [
       "allure-of-the-seas",
@@ -3262,7 +3607,9 @@
       "norwegian-epic",
       "sun-princess",
       "sky-princess",
-      "regal-princess"
+      "regal-princess",
+      "nieuw-statendam",
+      "noordam"
     ],
     "marseille": [
       "harmony-of-the-seas",
@@ -3273,7 +3620,8 @@
       "norwegian-viva",
       "norwegian-epic",
       "sun-princess",
-      "sky-princess"
+      "sky-princess",
+      "nieuw-statendam"
     ],
     "la-spezia": [
       "harmony-of-the-seas",

--- a/assets/js/ship-port-links.js
+++ b/assets/js/ship-port-links.js
@@ -1,12 +1,12 @@
 /**
  * Ship-Port Cross-Linking Module
- * Version: 1.3.0
+ * Version: 1.4.0
  *
  * Provides bidirectional linking between ship and port pages:
  * - Port pages show "Ships That Visit Here"
  * - Ship pages show "Ports on This Ship's Itineraries"
  *
- * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess
+ * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America
  * Data source: /assets/data/ship-deployments.json
  */
 
@@ -46,6 +46,12 @@
       name: 'Princess Cruises',
       path: '/ships/princess/',
       bookingUrl: 'https://www.princess.com/ships-and-experience/ships/',
+      allShipsUrl: '/ships.html'
+    },
+    'hal': {
+      name: 'Holland America Line',
+      path: '/ships/hal/',
+      bookingUrl: 'https://www.hollandamerica.com/en_US/cruise-ships.html',
       allShipsUrl: '/ships.html'
     }
   };
@@ -186,7 +192,8 @@
       'carnival': ['Excel', 'Vista', 'Dream', 'Concordia', 'Venice', 'Destiny', 'Conquest', 'Spirit', 'Fantasy', 'Other'],
       'celebrity': ['Edge', 'Solstice', 'Millennium', 'Expedition', 'Other'],
       'ncl': ['Prima', 'Breakaway Plus', 'Breakaway', 'Epic', 'Jewel', 'Dawn', 'Sun', 'Spirit', 'Sky', 'America', 'Other'],
-      'princess': ['Sphere', 'Royal', 'Grand', 'Coral', 'Other']
+      'princess': ['Sphere', 'Royal', 'Grand', 'Coral', 'Other'],
+      'hal': ['Pinnacle', 'Signature', 'Vista', 'R', 'Other']
     };
 
     // Brand colors for cruise lines
@@ -195,7 +202,8 @@
       'carnival': { bg: '#fff3e6', border: '#e3c8b8', hover: '#ffe6cc', text: '#c74a35' },
       'celebrity': { bg: '#f0f0f5', border: '#c0c0d0', hover: '#e0e0eb', text: '#1a1a4e' },
       'ncl': { bg: '#e6f0ff', border: '#b8c8e3', hover: '#d0e0f5', text: '#003087' },
-      'princess': { bg: '#e6f2ef', border: '#b8d4cd', hover: '#d0e8e3', text: '#00665e' }
+      'princess': { bg: '#e6f2ef', border: '#b8d4cd', hover: '#d0e8e3', text: '#00665e' },
+      'hal': { bg: '#e8eef5', border: '#c0cee0', hover: '#d8e4f0', text: '#1a3a5c' }
     };
 
     let html = `
@@ -206,7 +214,7 @@
     `;
 
     // Render each cruise line's ships
-    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'ncl', 'carnival']; // Define display order
+    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'hal', 'ncl', 'carnival']; // Define display order
     const activeCruiseLines = cruiseLineOrder.filter(cl => shipsByCruiseLine[cl]);
 
     activeCruiseLines.forEach((cruiseLineId, index) => {


### PR DESCRIPTION
Expanded ship-port cross-linking to include Holland America Line:
- Added 11 HAL ships across 4 classes (Pinnacle, Signature, Vista, R)
- Updated port_to_ships mappings for HAL ports
- Added HAL navy blue brand colors (#1a3a5c) to ship-port-links.js
- HAL ships: Rotterdam, Nieuw Statendam, Koningsdam, Nieuw Amsterdam, Eurodam, Oosterdam, Westerdam, Zuiderdam, Noordam, Zaandam, Volendam

Progress: 6/15 cruise lines complete
Total: 119 ships across 92 ports