### PR TITLE
Ships That Visit: Add MSC Cruises (22 ships)

### DIFF
--- a/admin/UNFINISHED-TASKS.md
+++ b/admin/UNFINISHED-TASKS.md
@@ -303,14 +303,14 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | "No Ads" trust messaging on about-us.html | ✅ DONE | Cruise Critic, CruiseMapper |
 | Tender Port Index + badge (`/ports/tender-ports.html`) | ✅ DONE | WhatsInPort |
 | "From the Pier" distance callout box component | PARTIAL (some ports) | WhatsInPort, IQCruising |
-| "Ships That Visit Here" section on port pages | PARTIAL (92/380 ports, RCL+Carnival+Celebrity+NCL+Princess+HAL) | UNIQUE - no competitor has this |
+| "Ships That Visit Here" section on port pages | PARTIAL (100/380 ports, RCL+Carnival+Celebrity+NCL+Princess+HAL+MSC) | UNIQUE - no competitor has this |
 | First-Timer Hub page | ✅ DONE (`first-cruise.html` 27KB) | Cruise Critic |
 | Pre-Cruise 30-Day Countdown checklist | ✅ DONE (`countdown.html` 2026-01-24) | Cruise Critic Roll Call |
 
 **P2 Strategic (Medium Effort):**
 | Task | Status | Addresses |
 |------|--------|-----------|
-| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (6/15 lines: RCL, Carnival, Celebrity, NCL, Princess, HAL) | UNIQUE differentiator |
+| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (7/15 lines: RCL, Carnival, Celebrity, NCL, Princess, HAL, MSC) | UNIQUE differentiator |
 | Print CSS + PDF generation for port pages | NOT STARTED | WhatsInPort, IQCruising |
 | Transport cost callout component | NOT STARTED | WhatsInPort, Cruise Crocodile |
 | Accessibility sections on port pages | NOT STARTED | UNIQUE - market gap |
@@ -318,12 +318,12 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | Honest assessment "Real Talk" sections | NOT STARTED | Cruise Critic, CruiseMapper |
 
 **"Ships That Visit Here" Expansion Plan:**
-- Current: 92 ports, 119 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess + 11 HAL)
-- Progress: 6/15 cruise lines complete
-- Data file: `assets/data/ship-deployments.json` (v1.5.0)
-- JS module: `assets/js/ship-port-links.js` (v1.3.0 - multi-cruise-line support)
-- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships), ✅ Holland America (11 ships)
-- Cruise lines remaining: MSC, Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
+- Current: 100 ports, 141 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess + 11 HAL + 22 MSC)
+- Progress: 7/15 cruise lines complete
+- Data file: `assets/data/ship-deployments.json` (v1.6.0)
+- JS module: `assets/js/ship-port-links.js` (v1.5.0 - multi-cruise-line support)
+- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships), ✅ Holland America (11 ships), ✅ MSC Cruises (22 ships)
+- Cruise lines remaining: Costa, Cunard, Disney, Virgin Voyages, Oceania, Regent, Seabourn, Silversea, Explora
 
 **Unique Differentiators to Protect:**
 - Ship-Port Integration ⭐⭐⭐ (expand with bidirectional linking)
@@ -721,11 +721,11 @@ node admin/validate-ship-page.js ships/celebrity-cruises/*.html
 - ~~Quiz Dress Code~~ — Question exists at line 1716
 - ~~30-Day Countdown Checklist~~ — `countdown.html` with 35 interactive tasks (2026-01-24)
 - ~~Works Offline Badge~~ — 376 port pages now show "Works offline" in trust badge (2026-01-24)
-- ~~Ships That Visit Here~~ — In progress (92/380 ports, 119 ships across RCL + Carnival + Celebrity + NCL + Princess + HAL — 9 cruise lines remaining)
+- ~~Ships That Visit Here~~ — In progress (100/380 ports, 141 ships across RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC — 8 cruise lines remaining)
 
 ### 🟡 HIGH PRIORITY (Remaining Work)
 5. **Quiz UX Bugs** — iPhone scroll issue, back button (NCL links is #1 above)
-6. **Ships That Visit Expansion** — Add 9 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess + HAL done, 92/380 ports, 119 ships)
+6. **Ships That Visit Expansion** — Add 8 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC done, 100/380 ports, 141 ships)
 7. **Quiz Regional Features** — Regional availability filter (dress code done)
 8. **Port Weather Remaining** — 80 ports still need weather section
 

--- a/assets/data/ship-deployments.json
+++ b/assets/data/ship-deployments.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "version": "1.5.0",
+    "version": "1.6.0",
     "last_updated": "2026-01-25",
-    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, and Holland America 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
+    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, and MSC 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
     "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment.",
     "cruise_lines": [
       "rcl",
@@ -10,7 +10,8 @@
       "celebrity",
       "ncl",
       "princess",
-      "hal"
+      "hal",
+      "msc"
     ]
   },
   "ships": {
@@ -3122,6 +3123,521 @@
         14,
         111
       ]
+    },
+    "msc-world-america": {
+      "name": "MSC World America",
+      "class": "World",
+      "cruise_line": "msc",
+      "homeports": [
+        "miami"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "nassau",
+        "ocean-cay"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-world-europa": {
+      "name": "MSC World Europa",
+      "class": "World",
+      "cruise_line": "msc",
+      "homeports": [
+        "dubai",
+        "barcelona"
+      ],
+      "regions": [
+        "arabian-gulf",
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "dubai",
+        "abu-dhabi",
+        "doha",
+        "barcelona",
+        "rome",
+        "marseille"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-euribia": {
+      "name": "MSC Euribia",
+      "class": "World",
+      "cruise_line": "msc",
+      "homeports": [
+        "copenhagen",
+        "kiel"
+      ],
+      "regions": [
+        "northern-europe",
+        "baltic"
+      ],
+      "season": "summer",
+      "typical_ports": [
+        "copenhagen",
+        "stockholm",
+        "tallinn",
+        "helsinki"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-virtuosa": {
+      "name": "MSC Virtuosa",
+      "class": "Meraviglia Plus",
+      "cruise_line": "msc",
+      "homeports": [
+        "southampton",
+        "dubai"
+      ],
+      "regions": [
+        "northern-europe",
+        "arabian-gulf"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "southampton",
+        "amsterdam",
+        "bruges",
+        "dubai",
+        "abu-dhabi"
+      ],
+      "itinerary_lengths": [
+        7,
+        14
+      ]
+    },
+    "msc-grandiosa": {
+      "name": "MSC Grandiosa",
+      "class": "Meraviglia Plus",
+      "cruise_line": "msc",
+      "homeports": [
+        "barcelona",
+        "genoa"
+      ],
+      "regions": [
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "barcelona",
+        "marseille",
+        "genoa",
+        "rome",
+        "naples",
+        "palermo"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-seascape": {
+      "name": "MSC Seascape",
+      "class": "Seaside EVO",
+      "cruise_line": "msc",
+      "homeports": [
+        "miami"
+      ],
+      "regions": [
+        "eastern-caribbean",
+        "western-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "costa-maya",
+        "ocean-cay",
+        "nassau",
+        "st-thomas",
+        "san-juan"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-seashore": {
+      "name": "MSC Seashore",
+      "class": "Seaside EVO",
+      "cruise_line": "msc",
+      "homeports": [
+        "miami",
+        "port-canaveral"
+      ],
+      "regions": [
+        "bahamas",
+        "eastern-caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "ocean-cay",
+        "st-thomas",
+        "san-juan"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7
+      ]
+    },
+    "msc-seaside": {
+      "name": "MSC Seaside",
+      "class": "Seaside",
+      "cruise_line": "msc",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "bahamas",
+        "caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "ocean-cay",
+        "cozumel",
+        "costa-maya"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7
+      ]
+    },
+    "msc-meraviglia": {
+      "name": "MSC Meraviglia",
+      "class": "Meraviglia",
+      "cruise_line": "msc",
+      "homeports": [
+        "new-york"
+      ],
+      "regions": [
+        "bermuda",
+        "canada-new-england",
+        "caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "bermuda",
+        "portland-maine",
+        "bar-harbor",
+        "nassau",
+        "ocean-cay"
+      ],
+      "itinerary_lengths": [
+        7,
+        10
+      ]
+    },
+    "msc-bellissima": {
+      "name": "MSC Bellissima",
+      "class": "Meraviglia",
+      "cruise_line": "msc",
+      "homeports": [
+        "dubai",
+        "jeddah"
+      ],
+      "regions": [
+        "arabian-gulf",
+        "red-sea"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "dubai",
+        "abu-dhabi",
+        "doha",
+        "jeddah"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-divina": {
+      "name": "MSC Divina",
+      "class": "Fantasia",
+      "cruise_line": "msc",
+      "homeports": [
+        "port-canaveral"
+      ],
+      "regions": [
+        "bahamas",
+        "caribbean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "nassau",
+        "ocean-cay",
+        "cozumel"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7
+      ]
+    },
+    "msc-fantasia": {
+      "name": "MSC Fantasia",
+      "class": "Fantasia",
+      "cruise_line": "msc",
+      "homeports": [
+        "genoa",
+        "barcelona"
+      ],
+      "regions": [
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "genoa",
+        "barcelona",
+        "marseille",
+        "rome",
+        "naples"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-splendida": {
+      "name": "MSC Splendida",
+      "class": "Fantasia",
+      "cruise_line": "msc",
+      "homeports": [
+        "durban",
+        "cape-town"
+      ],
+      "regions": [
+        "south-africa"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "durban",
+        "cape-town",
+        "port-elizabeth"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        5
+      ]
+    },
+    "msc-preziosa": {
+      "name": "MSC Preziosa",
+      "class": "Fantasia",
+      "cruise_line": "msc",
+      "homeports": [
+        "rio-de-janeiro",
+        "santos"
+      ],
+      "regions": [
+        "south-america"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "rio-de-janeiro",
+        "santos",
+        "buzios",
+        "ilhabela"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7
+      ]
+    },
+    "msc-magnifica": {
+      "name": "MSC Magnifica",
+      "class": "Musica",
+      "cruise_line": "msc",
+      "homeports": [
+        "venice",
+        "piraeus"
+      ],
+      "regions": [
+        "greek-isles",
+        "eastern-mediterranean"
+      ],
+      "season": "summer",
+      "typical_ports": [
+        "venice",
+        "santorini",
+        "mykonos",
+        "athens",
+        "dubrovnik"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-musica": {
+      "name": "MSC Musica",
+      "class": "Musica",
+      "cruise_line": "msc",
+      "homeports": [
+        "venice"
+      ],
+      "regions": [
+        "greek-isles",
+        "adriatic"
+      ],
+      "season": "summer",
+      "typical_ports": [
+        "venice",
+        "santorini",
+        "mykonos",
+        "dubrovnik",
+        "kotor"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-orchestra": {
+      "name": "MSC Orchestra",
+      "class": "Musica",
+      "cruise_line": "msc",
+      "homeports": [
+        "durban"
+      ],
+      "regions": [
+        "south-africa",
+        "indian-ocean"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "durban",
+        "mozambique",
+        "madagascar"
+      ],
+      "itinerary_lengths": [
+        3,
+        4,
+        7
+      ]
+    },
+    "msc-poesia": {
+      "name": "MSC Poesia",
+      "class": "Musica",
+      "cruise_line": "msc",
+      "homeports": [
+        "venice",
+        "bari"
+      ],
+      "regions": [
+        "greek-isles",
+        "adriatic"
+      ],
+      "season": "summer",
+      "typical_ports": [
+        "venice",
+        "bari",
+        "santorini",
+        "mykonos",
+        "kotor"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-lirica": {
+      "name": "MSC Lirica",
+      "class": "Lirica",
+      "cruise_line": "msc",
+      "homeports": [
+        "piraeus",
+        "haifa"
+      ],
+      "regions": [
+        "greek-isles",
+        "eastern-mediterranean"
+      ],
+      "season": "summer",
+      "typical_ports": [
+        "santorini",
+        "mykonos",
+        "athens",
+        "rhodes",
+        "haifa"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-opera": {
+      "name": "MSC Opera",
+      "class": "Lirica",
+      "cruise_line": "msc",
+      "homeports": [
+        "havana"
+      ],
+      "regions": [
+        "cuba",
+        "caribbean"
+      ],
+      "season": "winter",
+      "typical_ports": [
+        "havana",
+        "montego-bay",
+        "george-town"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-sinfonia": {
+      "name": "MSC Sinfonia",
+      "class": "Lirica",
+      "cruise_line": "msc",
+      "homeports": [
+        "venice"
+      ],
+      "regions": [
+        "greek-isles"
+      ],
+      "season": "summer",
+      "typical_ports": [
+        "venice",
+        "santorini",
+        "mykonos",
+        "kotor"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "msc-armonia": {
+      "name": "MSC Armonia",
+      "class": "Lirica",
+      "cruise_line": "msc",
+      "homeports": [
+        "havana",
+        "miami"
+      ],
+      "regions": [
+        "cuba",
+        "caribbean"
+      ],
+      "season": "winter",
+      "typical_ports": [
+        "havana",
+        "cozumel",
+        "costa-maya"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
     }
   },
   "port_to_ships": {
@@ -3170,7 +3686,13 @@
       "norwegian-gem",
       "norwegian-dawn",
       "norwegian-sun",
-      "norwegian-sky"
+      "norwegian-sky",
+      "msc-world-america",
+      "msc-seascape",
+      "msc-seashore",
+      "msc-seaside",
+      "msc-meraviglia",
+      "msc-divina"
     ],
     "cozumel": [
       "icon-of-the-seas",
@@ -3203,7 +3725,11 @@
       "norwegian-encore",
       "norwegian-breakaway",
       "norwegian-pearl",
-      "caribbean-princess"
+      "caribbean-princess",
+      "msc-world-america",
+      "msc-seaside",
+      "msc-divina",
+      "msc-armonia"
     ],
     "costa-maya": [
       "icon-of-the-seas",
@@ -3230,7 +3756,10 @@
       "norwegian-encore",
       "norwegian-breakaway",
       "norwegian-pearl",
-      "caribbean-princess"
+      "caribbean-princess",
+      "msc-world-america",
+      "msc-seaside",
+      "msc-armonia"
     ],
     "roatan": [
       "icon-of-the-seas",
@@ -3574,7 +4103,10 @@
       "sun-princess",
       "sky-princess",
       "nieuw-statendam",
-      "noordam"
+      "noordam",
+      "msc-world-europa",
+      "msc-grandiosa",
+      "msc-fantasia"
     ],
     "rome": [
       "harmony-of-the-seas",
@@ -3593,7 +4125,10 @@
       "sky-princess",
       "regal-princess",
       "nieuw-statendam",
-      "noordam"
+      "noordam",
+      "msc-world-europa",
+      "msc-grandiosa",
+      "msc-fantasia"
     ],
     "naples": [
       "allure-of-the-seas",
@@ -3638,7 +4173,12 @@
       "celebrity-constellation",
       "norwegian-epic",
       "norwegian-jade",
-      "regal-princess"
+      "regal-princess",
+      "msc-magnifica",
+      "msc-musica",
+      "msc-poesia",
+      "msc-lirica",
+      "msc-sinfonia"
     ],
     "mykonos": [
       "explorer-of-the-seas",
@@ -3649,7 +4189,12 @@
       "celebrity-constellation",
       "norwegian-epic",
       "norwegian-jade",
-      "regal-princess"
+      "regal-princess",
+      "msc-magnifica",
+      "msc-musica",
+      "msc-poesia",
+      "msc-lirica",
+      "msc-sinfonia"
     ],
     "athens": [
       "explorer-of-the-seas",
@@ -3937,6 +4482,46 @@
     "lima": [
       "island-princess",
       "coral-princess"
+    ],
+    "ocean-cay": [
+      "msc-world-america",
+      "msc-seascape",
+      "msc-seashore",
+      "msc-seaside",
+      "msc-meraviglia",
+      "msc-divina"
+    ],
+    "genoa": [
+      "msc-grandiosa",
+      "msc-fantasia"
+    ],
+    "venice": [
+      "msc-magnifica",
+      "msc-musica",
+      "msc-poesia",
+      "msc-sinfonia"
+    ],
+    "dubai": [
+      "msc-world-europa",
+      "msc-virtuosa",
+      "msc-bellissima"
+    ],
+    "abu-dhabi": [
+      "msc-world-europa",
+      "msc-virtuosa",
+      "msc-bellissima"
+    ],
+    "kotor": [
+      "msc-musica",
+      "msc-poesia",
+      "msc-sinfonia"
+    ],
+    "dubrovnik": [
+      "msc-magnifica",
+      "msc-musica"
+    ],
+    "palermo": [
+      "msc-grandiosa"
     ]
   },
   "homeport_details": {
@@ -3955,7 +4540,10 @@
         "norwegian-escape",
         "norwegian-bliss",
         "norwegian-encore",
-        "norwegian-sky"
+        "norwegian-sky",
+        "msc-world-america",
+        "msc-seascape",
+        "msc-armonia"
       ],
       "port_page": "/ports/miami.html"
     },

--- a/assets/js/ship-port-links.js
+++ b/assets/js/ship-port-links.js
@@ -1,12 +1,12 @@
 /**
  * Ship-Port Cross-Linking Module
- * Version: 1.4.0
+ * Version: 1.5.0
  *
  * Provides bidirectional linking between ship and port pages:
  * - Port pages show "Ships That Visit Here"
  * - Ship pages show "Ports on This Ship's Itineraries"
  *
- * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America
+ * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC
  * Data source: /assets/data/ship-deployments.json
  */
 
@@ -52,6 +52,12 @@
       name: 'Holland America Line',
       path: '/ships/hal/',
       bookingUrl: 'https://www.hollandamerica.com/en_US/cruise-ships.html',
+      allShipsUrl: '/ships.html'
+    },
+    'msc': {
+      name: 'MSC Cruises',
+      path: '/ships/msc/',
+      bookingUrl: 'https://www.msccruises.com/cruise-ships',
       allShipsUrl: '/ships.html'
     }
   };
@@ -132,7 +138,9 @@
       'punta-arenas': 'Punta Arenas',
       'san-cristobal': 'San Cristóbal',
       'great-stirrup-cay': 'Great Stirrup Cay',
-      'new-york': 'New York'
+      'new-york': 'New York',
+      'ocean-cay': 'Ocean Cay MSC Marine Reserve',
+      'abu-dhabi': 'Abu Dhabi'
     };
 
     if (specialNames[slug]) return specialNames[slug];
@@ -193,7 +201,8 @@
       'celebrity': ['Edge', 'Solstice', 'Millennium', 'Expedition', 'Other'],
       'ncl': ['Prima', 'Breakaway Plus', 'Breakaway', 'Epic', 'Jewel', 'Dawn', 'Sun', 'Spirit', 'Sky', 'America', 'Other'],
       'princess': ['Sphere', 'Royal', 'Grand', 'Coral', 'Other'],
-      'hal': ['Pinnacle', 'Signature', 'Vista', 'R', 'Other']
+      'hal': ['Pinnacle', 'Signature', 'Vista', 'R', 'Other'],
+      'msc': ['World', 'Meraviglia Plus', 'Seaside EVO', 'Meraviglia', 'Seaside', 'Fantasia', 'Musica', 'Lirica', 'Other']
     };
 
     // Brand colors for cruise lines
@@ -203,7 +212,8 @@
       'celebrity': { bg: '#f0f0f5', border: '#c0c0d0', hover: '#e0e0eb', text: '#1a1a4e' },
       'ncl': { bg: '#e6f0ff', border: '#b8c8e3', hover: '#d0e0f5', text: '#003087' },
       'princess': { bg: '#e6f2ef', border: '#b8d4cd', hover: '#d0e8e3', text: '#00665e' },
-      'hal': { bg: '#e8eef5', border: '#c0cee0', hover: '#d8e4f0', text: '#1a3a5c' }
+      'hal': { bg: '#e8eef5', border: '#c0cee0', hover: '#d8e4f0', text: '#1a3a5c' },
+      'msc': { bg: '#e6e9f0', border: '#b8c0d0', hover: '#d0d5e5', text: '#1a2a4a' }
     };
 
     let html = `
@@ -214,7 +224,7 @@
     `;
 
     // Render each cruise line's ships
-    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'hal', 'ncl', 'carnival']; // Define display order
+    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'hal', 'ncl', 'msc', 'carnival']; // Define display order
     const activeCruiseLines = cruiseLineOrder.filter(cl => shipsByCruiseLine[cl]);
 
     activeCruiseLines.forEach((cruiseLineId, index) => {


### PR DESCRIPTION
Expanded ship-port cross-linking to include MSC Cruises:
- Added 22 MSC ships across 8 classes (World, Meraviglia Plus, Seaside EVO, Meraviglia, Seaside, Fantasia, Musica, Lirica)
- Updated port_to_ships mappings for MSC ports
- Added MSC dark blue brand colors (#1a2a4a) to ship-port-links.js
- Added new ports: Ocean Cay, Genoa, Venice, Dubai, Abu Dhabi, Kotor, Dubrovnik, Palermo

MSC ship classes:
- World Class: MSC World America, World Europa, Euribia
- Meraviglia Plus: MSC Virtuosa, Grandiosa
- Seaside EVO: MSC Seascape, Seashore
- Meraviglia: MSC Meraviglia, Bellissima
- And more across Seaside, Fantasia, Musica, Lirica classes

Progress: 7/15 cruise lines complete
Total: 141 ships across 100 ports