### PR TITLE
Ships That Visit: Add Costa Cruises (9 ships)

### DIFF
--- a/admin/UNFINISHED-TASKS.md
+++ b/admin/UNFINISHED-TASKS.md
@@ -303,14 +303,14 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | "No Ads" trust messaging on about-us.html | ✅ DONE | Cruise Critic, CruiseMapper |
 | Tender Port Index + badge (`/ports/tender-ports.html`) | ✅ DONE | WhatsInPort |
 | "From the Pier" distance callout box component | PARTIAL (some ports) | WhatsInPort, IQCruising |
-| "Ships That Visit Here" section on port pages | PARTIAL (100/380 ports, RCL+Carnival+Celebrity+NCL+Princess+HAL+MSC+Virgin) | UNIQUE - no competitor has this |
+| "Ships That Visit Here" section on port pages | PARTIAL (100/380 ports, RCL+Carnival+Celebrity+NCL+Princess+HAL+MSC+Virgin+Costa) | UNIQUE - no competitor has this |
 | First-Timer Hub page | ✅ DONE (`first-cruise.html` 27KB) | Cruise Critic |
 | Pre-Cruise 30-Day Countdown checklist | ✅ DONE (`countdown.html` 2026-01-24) | Cruise Critic Roll Call |
 
 **P2 Strategic (Medium Effort):**
 | Task | Status | Addresses |
 |------|--------|-----------|
-| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (8/15 lines: RCL, Carnival, Celebrity, NCL, Princess, HAL, MSC, Virgin) | UNIQUE differentiator |
+| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (9/15 lines: RCL, Carnival, Celebrity, NCL, Princess, HAL, MSC, Virgin, Costa) | UNIQUE differentiator |
 | Print CSS + PDF generation for port pages | NOT STARTED | WhatsInPort, IQCruising |
 | Transport cost callout component | NOT STARTED | WhatsInPort, Cruise Crocodile |
 | Accessibility sections on port pages | NOT STARTED | UNIQUE - market gap |
@@ -318,12 +318,12 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | Honest assessment "Real Talk" sections | NOT STARTED | Cruise Critic, CruiseMapper |
 
 **"Ships That Visit Here" Expansion Plan:**
-- Current: 100 ports, 145 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess + 11 HAL + 22 MSC + 4 Virgin)
-- Progress: 8/15 cruise lines complete
-- Data file: `assets/data/ship-deployments.json` (v1.7.0)
-- JS module: `assets/js/ship-port-links.js` (v1.6.0 - multi-cruise-line support)
-- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships), ✅ Holland America (11 ships), ✅ MSC Cruises (22 ships), ✅ Virgin Voyages (4 ships)
-- Cruise lines remaining: Costa, Cunard, Disney, Oceania, Regent, Seabourn, Silversea, Explora
+- Current: 100 ports, 154 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess + 11 HAL + 22 MSC + 4 Virgin + 9 Costa)
+- Progress: 9/15 cruise lines complete
+- Data file: `assets/data/ship-deployments.json` (v1.8.0)
+- JS module: `assets/js/ship-port-links.js` (v1.7.0 - multi-cruise-line support)
+- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships), ✅ Holland America (11 ships), ✅ MSC Cruises (22 ships), ✅ Virgin Voyages (4 ships), ✅ Costa Cruises (9 ships)
+- Cruise lines remaining: Cunard, Disney, Oceania, Regent, Seabourn, Silversea, Explora
 
 **Unique Differentiators to Protect:**
 - Ship-Port Integration ⭐⭐⭐ (expand with bidirectional linking)
@@ -721,11 +721,11 @@ node admin/validate-ship-page.js ships/celebrity-cruises/*.html
 - ~~Quiz Dress Code~~ — Question exists at line 1716
 - ~~30-Day Countdown Checklist~~ — `countdown.html` with 35 interactive tasks (2026-01-24)
 - ~~Works Offline Badge~~ — 376 port pages now show "Works offline" in trust badge (2026-01-24)
-- ~~Ships That Visit Here~~ — In progress (100/380 ports, 145 ships across RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin — 7 cruise lines remaining)
+- ~~Ships That Visit Here~~ — In progress (100/380 ports, 154 ships across RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa — 6 cruise lines remaining)
 
 ### 🟡 HIGH PRIORITY (Remaining Work)
 5. **Quiz UX Bugs** — iPhone scroll issue, back button (NCL links is #1 above)
-6. **Ships That Visit Expansion** — Add 7 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin done, 100/380 ports, 145 ships)
+6. **Ships That Visit Expansion** — Add 6 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa done, 100/380 ports, 154 ships)
 7. **Quiz Regional Features** — Regional availability filter (dress code done)
 8. **Port Weather Remaining** — 80 ports still need weather section
 

--- a/assets/data/ship-deployments.json
+++ b/assets/data/ship-deployments.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "version": "1.7.0",
+    "version": "1.8.0",
     "last_updated": "2026-01-25",
-    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, and Virgin Voyages 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
+    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, and Costa Cruises 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
     "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment.",
     "cruise_lines": [
       "rcl",
@@ -12,7 +12,8 @@
       "princess",
       "hal",
       "msc",
-      "virgin"
+      "virgin",
+      "costa"
     ]
   },
   "ships": {
@@ -3741,6 +3742,233 @@
         7,
         8
       ]
+    },
+    "costa-toscana": {
+      "name": "Costa Toscana",
+      "class": "Excellence",
+      "cruise_line": "costa",
+      "homeports": [
+        "barcelona",
+        "civitavecchia"
+      ],
+      "regions": [
+        "western-mediterranean",
+        "eastern-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "barcelona",
+        "marseille",
+        "genoa",
+        "civitavecchia",
+        "naples",
+        "palma-de-mallorca",
+        "ibiza"
+      ],
+      "itinerary_lengths": [
+        7,
+        8
+      ]
+    },
+    "costa-smeralda": {
+      "name": "Costa Smeralda",
+      "class": "Excellence",
+      "cruise_line": "costa",
+      "homeports": [
+        "civitavecchia",
+        "genoa"
+      ],
+      "regions": [
+        "western-mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "civitavecchia",
+        "genoa",
+        "marseille",
+        "barcelona",
+        "palma-de-mallorca",
+        "naples",
+        "la-spezia"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "costa-firenze": {
+      "name": "Costa Firenze",
+      "class": "Venice",
+      "cruise_line": "costa",
+      "homeports": [
+        "dubai",
+        "singapore"
+      ],
+      "regions": [
+        "arabian-gulf",
+        "asia"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "dubai",
+        "abu-dhabi",
+        "muscat",
+        "singapore",
+        "koh-samui",
+        "hong-kong"
+      ],
+      "itinerary_lengths": [
+        7,
+        8
+      ]
+    },
+    "costa-venezia": {
+      "name": "Costa Venezia",
+      "class": "Venice",
+      "cruise_line": "costa",
+      "homeports": [
+        "tokyo",
+        "singapore"
+      ],
+      "regions": [
+        "asia"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "tokyo",
+        "osaka",
+        "nagasaki",
+        "singapore",
+        "hong-kong",
+        "nha-trang"
+      ],
+      "itinerary_lengths": [
+        7,
+        8
+      ]
+    },
+    "costa-diadema": {
+      "name": "Costa Diadema",
+      "class": "Diadema",
+      "cruise_line": "costa",
+      "homeports": [
+        "venice",
+        "civitavecchia"
+      ],
+      "regions": [
+        "eastern-mediterranean"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "venice",
+        "dubrovnik",
+        "kotor",
+        "corfu",
+        "santorini",
+        "mykonos"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "costa-fascinosa": {
+      "name": "Costa Fascinosa",
+      "class": "Concordia",
+      "cruise_line": "costa",
+      "homeports": [
+        "santos",
+        "buenos-aires"
+      ],
+      "regions": [
+        "south-america"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "santos",
+        "buenos-aires",
+        "montevideo",
+        "punta-del-este"
+      ],
+      "itinerary_lengths": [
+        7,
+        8
+      ]
+    },
+    "costa-favolosa": {
+      "name": "Costa Favolosa",
+      "class": "Concordia",
+      "cruise_line": "costa",
+      "homeports": [
+        "savona",
+        "genoa"
+      ],
+      "regions": [
+        "western-mediterranean"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "genoa",
+        "barcelona",
+        "marseille",
+        "civitavecchia",
+        "naples",
+        "palermo"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "costa-pacifica": {
+      "name": "Costa Pacifica",
+      "class": "Concordia",
+      "cruise_line": "costa",
+      "homeports": [
+        "dubai",
+        "genoa"
+      ],
+      "regions": [
+        "arabian-gulf",
+        "western-mediterranean"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "dubai",
+        "abu-dhabi",
+        "muscat",
+        "genoa",
+        "barcelona",
+        "marseille"
+      ],
+      "itinerary_lengths": [
+        7
+      ]
+    },
+    "costa-deliziosa": {
+      "name": "Costa Deliziosa",
+      "class": "Spirit",
+      "cruise_line": "costa",
+      "homeports": [
+        "venice",
+        "genoa"
+      ],
+      "regions": [
+        "mediterranean",
+        "northern-europe"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "venice",
+        "dubrovnik",
+        "kotor",
+        "corfu",
+        "genoa",
+        "amsterdam",
+        "copenhagen"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        14
+      ]
     }
   },
   "port_to_ships": {
@@ -4214,7 +4442,11 @@
       "noordam",
       "msc-world-europa",
       "msc-grandiosa",
-      "msc-fantasia"
+      "msc-fantasia",
+      "costa-toscana",
+      "costa-smeralda",
+      "costa-favolosa",
+      "costa-pacifica"
     ],
     "rome": [
       "harmony-of-the-seas",
@@ -4252,7 +4484,10 @@
       "sky-princess",
       "regal-princess",
       "nieuw-statendam",
-      "noordam"
+      "noordam",
+      "costa-toscana",
+      "costa-smeralda",
+      "costa-favolosa"
     ],
     "marseille": [
       "harmony-of-the-seas",
@@ -4264,11 +4499,16 @@
       "norwegian-epic",
       "sun-princess",
       "sky-princess",
-      "nieuw-statendam"
+      "nieuw-statendam",
+      "costa-toscana",
+      "costa-smeralda",
+      "costa-favolosa",
+      "costa-pacifica"
     ],
     "la-spezia": [
       "harmony-of-the-seas",
-      "norwegian-epic"
+      "norwegian-epic",
+      "costa-smeralda"
     ],
     "santorini": [
       "voyager-of-the-seas",
@@ -4287,7 +4527,8 @@
       "msc-poesia",
       "msc-lirica",
       "msc-sinfonia",
-      "resilient-lady"
+      "resilient-lady",
+      "costa-diadema"
     ],
     "mykonos": [
       "explorer-of-the-seas",
@@ -4304,7 +4545,8 @@
       "msc-poesia",
       "msc-lirica",
       "msc-sinfonia",
-      "resilient-lady"
+      "resilient-lady",
+      "costa-diadema"
     ],
     "athens": [
       "explorer-of-the-seas",
@@ -4317,17 +4559,23 @@
       "explorer-of-the-seas",
       "brilliance-of-the-seas",
       "celebrity-constellation",
-      "norwegian-jade"
+      "norwegian-jade",
+      "costa-diadema",
+      "costa-deliziosa"
     ],
     "kotor": [
       "explorer-of-the-seas",
       "brilliance-of-the-seas",
       "celebrity-constellation",
-      "norwegian-jade"
+      "norwegian-jade",
+      "costa-diadema",
+      "costa-deliziosa"
     ],
     "corfu": [
       "explorer-of-the-seas",
-      "norwegian-jade"
+      "norwegian-jade",
+      "costa-diadema",
+      "costa-deliziosa"
     ],
     "rhodes": [
       "brilliance-of-the-seas",
@@ -4339,13 +4587,15 @@
       "anthem-of-the-seas",
       "celebrity-silhouette",
       "norwegian-spirit",
-      "enchanted-princess"
+      "enchanted-princess",
+      "costa-deliziosa"
     ],
     "copenhagen": [
       "independence-of-the-seas",
       "celebrity-silhouette",
       "norwegian-spirit",
-      "enchanted-princess"
+      "enchanted-princess",
+      "costa-deliziosa"
     ],
     "stockholm": [
       "independence-of-the-seas",
@@ -4479,14 +4729,18 @@
     "hong-kong": [
       "spectrum-of-the-seas",
       "celebrity-millennium",
-      "diamond-princess"
+      "diamond-princess",
+      "costa-firenze",
+      "costa-venezia"
     ],
     "nha-trang": [
       "spectrum-of-the-seas",
-      "celebrity-millennium"
+      "celebrity-millennium",
+      "costa-venezia"
     ],
     "koh-samui": [
-      "spectrum-of-the-seas"
+      "spectrum-of-the-seas",
+      "costa-firenze"
     ],
     "southampton": [
       "independence-of-the-seas",
@@ -4539,7 +4793,8 @@
       "celebrity-xpedition"
     ],
     "montevideo": [
-      "celebrity-infinity"
+      "celebrity-infinity",
+      "costa-fascinosa"
     ],
     "punta-arenas": [
       "celebrity-infinity"
@@ -4549,7 +4804,9 @@
     ],
     "singapore": [
       "celebrity-millennium",
-      "diamond-princess"
+      "diamond-princess",
+      "costa-firenze",
+      "costa-venezia"
     ],
     "great-stirrup-cay": [
       "norwegian-getaway",
@@ -4578,14 +4835,17 @@
     ],
     "tokyo": [
       "diamond-princess",
-      "sapphire-princess"
+      "sapphire-princess",
+      "costa-venezia"
     ],
     "osaka": [
       "diamond-princess",
-      "sapphire-princess"
+      "sapphire-princess",
+      "costa-venezia"
     ],
     "nagasaki": [
-      "diamond-princess"
+      "diamond-princess",
+      "costa-venezia"
     ],
     "cartagena": [
       "royal-princess",
@@ -4606,23 +4866,34 @@
     ],
     "genoa": [
       "msc-grandiosa",
-      "msc-fantasia"
+      "msc-fantasia",
+      "costa-toscana",
+      "costa-smeralda",
+      "costa-favolosa",
+      "costa-pacifica",
+      "costa-deliziosa"
     ],
     "venice": [
       "msc-magnifica",
       "msc-musica",
       "msc-poesia",
-      "msc-sinfonia"
+      "msc-sinfonia",
+      "costa-diadema",
+      "costa-deliziosa"
     ],
     "dubai": [
       "msc-world-europa",
       "msc-virtuosa",
-      "msc-bellissima"
+      "msc-bellissima",
+      "costa-firenze",
+      "costa-pacifica"
     ],
     "abu-dhabi": [
       "msc-world-europa",
       "msc-virtuosa",
-      "msc-bellissima"
+      "msc-bellissima",
+      "costa-firenze",
+      "costa-pacifica"
     ],
     "kotor": [
       "msc-musica",
@@ -4634,7 +4905,8 @@
       "msc-musica"
     ],
     "palermo": [
-      "msc-grandiosa"
+      "msc-grandiosa",
+      "costa-favolosa"
     ],
     "bimini": [
       "scarlet-lady",
@@ -4645,16 +4917,42 @@
       "scarlet-lady"
     ],
     "ibiza": [
-      "valiant-lady"
+      "valiant-lady",
+      "costa-toscana"
     ],
     "palma-de-mallorca": [
-      "valiant-lady"
+      "valiant-lady",
+      "costa-toscana",
+      "costa-smeralda"
     ],
     "rhodes": [
       "resilient-lady"
     ],
     "st-croix": [
       "brilliant-lady"
+    ],
+    "civitavecchia": [
+      "costa-toscana",
+      "costa-smeralda",
+      "costa-diadema",
+      "costa-favolosa"
+    ],
+    "muscat": [
+      "costa-firenze",
+      "costa-pacifica"
+    ],
+    "santos": [
+      "costa-fascinosa"
+    ],
+    "punta-del-este": [
+      "costa-fascinosa"
+    ],
+    "savona": [
+      "costa-favolosa"
+    ],
+    "buenos-aires": [
+      "celebrity-infinity",
+      "costa-fascinosa"
     ]
   },
   "homeport_details": {

--- a/assets/js/ship-port-links.js
+++ b/assets/js/ship-port-links.js
@@ -1,12 +1,12 @@
 /**
  * Ship-Port Cross-Linking Module
- * Version: 1.6.0
+ * Version: 1.7.0
  *
  * Provides bidirectional linking between ship and port pages:
  * - Port pages show "Ships That Visit Here"
  * - Ship pages show "Ports on This Ship's Itineraries"
  *
- * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages
+ * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, Costa Cruises
  * Data source: /assets/data/ship-deployments.json
  */
 
@@ -64,6 +64,12 @@
       name: 'Virgin Voyages',
       path: '/ships/virgin/',
       bookingUrl: 'https://www.virginvoyages.com/ships',
+      allShipsUrl: '/ships.html'
+    },
+    'costa': {
+      name: 'Costa Cruises',
+      path: '/ships/costa/',
+      bookingUrl: 'https://www.costacruises.com/ships.html',
       allShipsUrl: '/ships.html'
     }
   };
@@ -151,7 +157,10 @@
       'key-west': 'Key West',
       'palma-de-mallorca': 'Palma de Mallorca',
       'st-croix': 'St. Croix',
-      'puerto-plata': 'Puerto Plata'
+      'puerto-plata': 'Puerto Plata',
+      'civitavecchia': 'Civitavecchia (Rome)',
+      'punta-del-este': 'Punta del Este',
+      'la-spezia': 'La Spezia'
     };
 
     if (specialNames[slug]) return specialNames[slug];
@@ -214,7 +223,8 @@
       'princess': ['Sphere', 'Royal', 'Grand', 'Coral', 'Other'],
       'hal': ['Pinnacle', 'Signature', 'Vista', 'R', 'Other'],
       'msc': ['World', 'Meraviglia Plus', 'Seaside EVO', 'Meraviglia', 'Seaside', 'Fantasia', 'Musica', 'Lirica', 'Other'],
-      'virgin': ['Lady', 'Other']
+      'virgin': ['Lady', 'Other'],
+      'costa': ['Excellence', 'Venice', 'Diadema', 'Concordia', 'Spirit', 'Other']
     };
 
     // Brand colors for cruise lines
@@ -226,7 +236,8 @@
       'princess': { bg: '#e6f2ef', border: '#b8d4cd', hover: '#d0e8e3', text: '#00665e' },
       'hal': { bg: '#e8eef5', border: '#c0cee0', hover: '#d8e4f0', text: '#1a3a5c' },
       'msc': { bg: '#e6e9f0', border: '#b8c0d0', hover: '#d0d5e5', text: '#1a2a4a' },
-      'virgin': { bg: '#fce8e8', border: '#e8c0c0', hover: '#f5d5d5', text: '#cc0000' }
+      'virgin': { bg: '#fce8e8', border: '#e8c0c0', hover: '#f5d5d5', text: '#cc0000' },
+      'costa': { bg: '#fff8e6', border: '#e8d8b0', hover: '#fff0cc', text: '#c09000' }
     };
 
     let html = `
@@ -237,7 +248,7 @@
     `;
 
     // Render each cruise line's ships
-    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'hal', 'ncl', 'msc', 'virgin', 'carnival']; // Define display order
+    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'hal', 'ncl', 'msc', 'costa', 'virgin', 'carnival']; // Define display order
     const activeCruiseLines = cruiseLineOrder.filter(cl => shipsByCruiseLine[cl]);
 
     activeCruiseLines.forEach((cruiseLineId, index) => {


### PR DESCRIPTION
Expanded ship-port cross-linking to include Costa Cruises:
- Added 9 Costa ships across 5 classes (Excellence, Venice, Diadema, Concordia, Spirit)
- Ships: Costa Toscana, Costa Smeralda, Costa Firenze, Costa Venezia, Costa Diadema, Costa Fascinosa, Costa Favolosa, Costa Pacifica, Costa Deliziosa
- Added Costa golden yellow brand colors (#c09000) to ship-port-links.js
- Added new ports: Civitavecchia, Muscat, Santos, Punta del Este, Savona
- Updated Mediterranean, Arabian Gulf, Asia, and South America port mappings

Progress: 9/15 cruise lines complete
Total: 154 ships across ~110 ports