### PR TITLE
Ships That Visit: Add Cunard (4 ships)

### DIFF
--- a/admin/UNFINISHED-TASKS.md
+++ b/admin/UNFINISHED-TASKS.md
@@ -303,14 +303,14 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | "No Ads" trust messaging on about-us.html | ✅ DONE | Cruise Critic, CruiseMapper |
 | Tender Port Index + badge (`/ports/tender-ports.html`) | ✅ DONE | WhatsInPort |
 | "From the Pier" distance callout box component | PARTIAL (some ports) | WhatsInPort, IQCruising |
-| "Ships That Visit Here" section on port pages | PARTIAL (100/380 ports, RCL+Carnival+Celebrity+NCL+Princess+HAL+MSC+Virgin+Costa) | UNIQUE - no competitor has this |
+| "Ships That Visit Here" section on port pages | PARTIAL (100/380 ports, RCL+Carnival+Celebrity+NCL+Princess+HAL+MSC+Virgin+Costa+Cunard) | UNIQUE - no competitor has this |
 | First-Timer Hub page | ✅ DONE (`first-cruise.html` 27KB) | Cruise Critic |
 | Pre-Cruise 30-Day Countdown checklist | ✅ DONE (`countdown.html` 2026-01-24) | Cruise Critic Roll Call |
 
 **P2 Strategic (Medium Effort):**
 | Task | Status | Addresses |
 |------|--------|-----------|
-| **Expand "Ships That Visit" to all 15 cruise lines** | IN PROGRESS (9/15 lines: RCL, Carnival, Celebrity, NCL, Princess, HAL, MSC, Virgin, Costa) | UNIQUE differentiator |
+| **Expand "Ships That Visit" to all 14 cruise lines** | IN PROGRESS (10/14 lines: RCL, Carnival, Celebrity, NCL, Princess, HAL, MSC, Virgin, Costa, Cunard) | UNIQUE differentiator |
 | Print CSS + PDF generation for port pages | NOT STARTED | WhatsInPort, IQCruising |
 | Transport cost callout component | NOT STARTED | WhatsInPort, Cruise Crocodile |
 | Accessibility sections on port pages | NOT STARTED | UNIQUE - market gap |
@@ -318,12 +318,12 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | Honest assessment "Real Talk" sections | NOT STARTED | Cruise Critic, CruiseMapper |
 
 **"Ships That Visit Here" Expansion Plan:**
-- Current: 100 ports, 154 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess + 11 HAL + 22 MSC + 4 Virgin + 9 Costa)
-- Progress: 9/15 cruise lines complete
-- Data file: `assets/data/ship-deployments.json` (v1.8.0)
-- JS module: `assets/js/ship-port-links.js` (v1.7.0 - multi-cruise-line support)
-- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships), ✅ Holland America (11 ships), ✅ MSC Cruises (22 ships), ✅ Virgin Voyages (4 ships), ✅ Costa Cruises (9 ships)
-- Cruise lines remaining: Cunard, Disney, Oceania, Regent, Seabourn, Silversea, Explora
+- Current: 100 ports, 158 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess + 11 HAL + 22 MSC + 4 Virgin + 9 Costa + 4 Cunard)
+- Progress: 10/14 cruise lines complete (Disney excluded per user preference)
+- Data file: `assets/data/ship-deployments.json` (v1.9.0)
+- JS module: `assets/js/ship-port-links.js` (v1.8.0 - multi-cruise-line support)
+- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships), ✅ Holland America (11 ships), ✅ MSC Cruises (22 ships), ✅ Virgin Voyages (4 ships), ✅ Costa Cruises (9 ships), ✅ Cunard (4 ships)
+- Cruise lines remaining: Oceania, Regent, Seabourn, Silversea, Explora
 
 **Unique Differentiators to Protect:**
 - Ship-Port Integration ⭐⭐⭐ (expand with bidirectional linking)
@@ -721,11 +721,11 @@ node admin/validate-ship-page.js ships/celebrity-cruises/*.html
 - ~~Quiz Dress Code~~ — Question exists at line 1716
 - ~~30-Day Countdown Checklist~~ — `countdown.html` with 35 interactive tasks (2026-01-24)
 - ~~Works Offline Badge~~ — 376 port pages now show "Works offline" in trust badge (2026-01-24)
-- ~~Ships That Visit Here~~ — In progress (100/380 ports, 154 ships across RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa — 6 cruise lines remaining)
+- ~~Ships That Visit Here~~ — In progress (100/380 ports, 158 ships across RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa + Cunard — 4 cruise lines remaining)
 
 ### 🟡 HIGH PRIORITY (Remaining Work)
 5. **Quiz UX Bugs** — iPhone scroll issue, back button (NCL links is #1 above)
-6. **Ships That Visit Expansion** — Add 6 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa done, 100/380 ports, 154 ships)
+6. **Ships That Visit Expansion** — Add 4 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa + Cunard done, 100/380 ports, 158 ships)
 7. **Quiz Regional Features** — Regional availability filter (dress code done)
 8. **Port Weather Remaining** — 80 ports still need weather section
 

--- a/assets/data/ship-deployments.json
+++ b/assets/data/ship-deployments.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "version": "1.8.0",
+    "version": "1.9.0",
     "last_updated": "2026-01-25",
-    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, and Costa Cruises 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
+    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, Costa Cruises, and Cunard 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
     "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment.",
     "cruise_lines": [
       "rcl",
@@ -13,7 +13,8 @@
       "hal",
       "msc",
       "virgin",
-      "costa"
+      "costa",
+      "cunard"
     ]
   },
   "ships": {
@@ -3969,6 +3970,126 @@
         10,
         14
       ]
+    },
+    "queen-mary-2": {
+      "name": "Queen Mary 2",
+      "class": "Ocean Liner",
+      "cruise_line": "cunard",
+      "homeports": [
+        "southampton",
+        "new-york"
+      ],
+      "regions": [
+        "transatlantic",
+        "northern-europe",
+        "world-cruise"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "southampton",
+        "new-york",
+        "hamburg",
+        "amsterdam",
+        "reykjavik",
+        "halifax",
+        "quebec-city",
+        "sydney-australia",
+        "cape-town"
+      ],
+      "itinerary_lengths": [
+        7,
+        14,
+        28,
+        108
+      ]
+    },
+    "queen-anne": {
+      "name": "Queen Anne",
+      "class": "Queen",
+      "cruise_line": "cunard",
+      "homeports": [
+        "southampton"
+      ],
+      "regions": [
+        "mediterranean",
+        "northern-europe",
+        "caribbean"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "barcelona",
+        "rome",
+        "naples",
+        "lisbon",
+        "amsterdam",
+        "copenhagen",
+        "stockholm"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        14
+      ]
+    },
+    "queen-elizabeth": {
+      "name": "Queen Elizabeth",
+      "class": "Queen",
+      "cruise_line": "cunard",
+      "homeports": [
+        "southampton",
+        "melbourne"
+      ],
+      "regions": [
+        "australia",
+        "mediterranean",
+        "world-cruise"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "sydney",
+        "melbourne",
+        "hobart",
+        "auckland",
+        "barcelona",
+        "rome",
+        "gibraltar",
+        "funchal"
+      ],
+      "itinerary_lengths": [
+        7,
+        14,
+        28,
+        108
+      ]
+    },
+    "queen-victoria": {
+      "name": "Queen Victoria",
+      "class": "Queen",
+      "cruise_line": "cunard",
+      "homeports": [
+        "southampton"
+      ],
+      "regions": [
+        "mediterranean",
+        "northern-europe",
+        "caribbean"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "barcelona",
+        "rome",
+        "naples",
+        "lisbon",
+        "amsterdam",
+        "bergen",
+        "st-thomas",
+        "barbados"
+      ],
+      "itinerary_lengths": [
+        7,
+        12,
+        14
+      ]
     }
   },
   "port_to_ships": {
@@ -4205,7 +4326,8 @@
       "rotterdam",
       "eurodam",
       "zaandam",
-      "brilliant-lady"
+      "brilliant-lady",
+      "queen-victoria"
     ],
     "st-maarten": [
       "icon-of-the-seas",
@@ -4253,7 +4375,8 @@
       "celebrity-equinox",
       "celebrity-silhouette",
       "celebrity-summit",
-      "nieuw-statendam"
+      "nieuw-statendam",
+      "queen-victoria"
     ],
     "aruba": [
       "freedom-of-the-seas",
@@ -4446,7 +4569,10 @@
       "costa-toscana",
       "costa-smeralda",
       "costa-favolosa",
-      "costa-pacifica"
+      "costa-pacifica",
+      "queen-anne",
+      "queen-elizabeth",
+      "queen-victoria"
     ],
     "rome": [
       "harmony-of-the-seas",
@@ -4468,7 +4594,9 @@
       "noordam",
       "msc-world-europa",
       "msc-grandiosa",
-      "msc-fantasia"
+      "msc-fantasia",
+      "queen-anne",
+      "queen-elizabeth"
     ],
     "naples": [
       "allure-of-the-seas",
@@ -4487,7 +4615,9 @@
       "noordam",
       "costa-toscana",
       "costa-smeralda",
-      "costa-favolosa"
+      "costa-favolosa",
+      "queen-anne",
+      "queen-victoria"
     ],
     "marseille": [
       "harmony-of-the-seas",
@@ -4588,20 +4718,25 @@
       "celebrity-silhouette",
       "norwegian-spirit",
       "enchanted-princess",
-      "costa-deliziosa"
+      "costa-deliziosa",
+      "queen-mary-2",
+      "queen-anne",
+      "queen-victoria"
     ],
     "copenhagen": [
       "independence-of-the-seas",
       "celebrity-silhouette",
       "norwegian-spirit",
       "enchanted-princess",
-      "costa-deliziosa"
+      "costa-deliziosa",
+      "queen-anne"
     ],
     "stockholm": [
       "independence-of-the-seas",
       "celebrity-silhouette",
       "norwegian-spirit",
-      "enchanted-princess"
+      "enchanted-princess",
+      "queen-anne"
     ],
     "tallinn": [
       "independence-of-the-seas",
@@ -4693,7 +4828,9 @@
       "majestic-princess",
       "diamond-princess",
       "sapphire-princess",
-      "resilient-lady"
+      "resilient-lady",
+      "queen-mary-2",
+      "queen-elizabeth"
     ],
     "melbourne": [
       "quantum-of-the-seas",
@@ -4701,18 +4838,21 @@
       "norwegian-jewel",
       "majestic-princess",
       "sapphire-princess",
-      "resilient-lady"
+      "resilient-lady",
+      "queen-elizabeth"
     ],
     "hobart": [
       "quantum-of-the-seas",
       "norwegian-jewel",
       "majestic-princess",
-      "resilient-lady"
+      "resilient-lady",
+      "queen-elizabeth"
     ],
     "auckland": [
       "ovation-of-the-seas",
       "norwegian-jewel",
-      "sapphire-princess"
+      "sapphire-princess",
+      "queen-elizabeth"
     ],
     "bay-of-islands": [
       "ovation-of-the-seas",
@@ -4744,10 +4884,16 @@
     ],
     "southampton": [
       "independence-of-the-seas",
-      "anthem-of-the-seas"
+      "anthem-of-the-seas",
+      "queen-mary-2",
+      "queen-anne",
+      "queen-elizabeth",
+      "queen-victoria"
     ],
     "lisbon": [
-      "independence-of-the-seas"
+      "independence-of-the-seas",
+      "queen-anne",
+      "queen-victoria"
     ],
     "vigo": [
       "independence-of-the-seas"
@@ -4953,6 +5099,30 @@
     "buenos-aires": [
       "celebrity-infinity",
       "costa-fascinosa"
+    ],
+    "hamburg": [
+      "queen-mary-2"
+    ],
+    "reykjavik": [
+      "queen-mary-2"
+    ],
+    "halifax": [
+      "queen-mary-2"
+    ],
+    "quebec-city": [
+      "queen-mary-2"
+    ],
+    "cape-town": [
+      "queen-mary-2"
+    ],
+    "gibraltar": [
+      "queen-elizabeth"
+    ],
+    "funchal": [
+      "queen-elizabeth"
+    ],
+    "bergen": [
+      "queen-victoria"
     ]
   },
   "homeport_details": {

--- a/assets/js/ship-port-links.js
+++ b/assets/js/ship-port-links.js
@@ -1,12 +1,12 @@
 /**
  * Ship-Port Cross-Linking Module
- * Version: 1.7.0
+ * Version: 1.8.0
  *
  * Provides bidirectional linking between ship and port pages:
  * - Port pages show "Ships That Visit Here"
  * - Ship pages show "Ports on This Ship's Itineraries"
  *
- * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, Costa Cruises
+ * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, Costa Cruises, Cunard
  * Data source: /assets/data/ship-deployments.json
  */
 
@@ -70,6 +70,12 @@
       name: 'Costa Cruises',
       path: '/ships/costa/',
       bookingUrl: 'https://www.costacruises.com/ships.html',
+      allShipsUrl: '/ships.html'
+    },
+    'cunard': {
+      name: 'Cunard',
+      path: '/ships/cunard/',
+      bookingUrl: 'https://www.cunard.com/en-gb/cruise-ships',
       allShipsUrl: '/ships.html'
     }
   };
@@ -160,7 +166,10 @@
       'puerto-plata': 'Puerto Plata',
       'civitavecchia': 'Civitavecchia (Rome)',
       'punta-del-este': 'Punta del Este',
-      'la-spezia': 'La Spezia'
+      'la-spezia': 'La Spezia',
+      'quebec-city': 'Quebec City',
+      'cape-town': 'Cape Town',
+      'sydney-australia': 'Sydney, Australia'
     };
 
     if (specialNames[slug]) return specialNames[slug];
@@ -224,7 +233,8 @@
       'hal': ['Pinnacle', 'Signature', 'Vista', 'R', 'Other'],
       'msc': ['World', 'Meraviglia Plus', 'Seaside EVO', 'Meraviglia', 'Seaside', 'Fantasia', 'Musica', 'Lirica', 'Other'],
       'virgin': ['Lady', 'Other'],
-      'costa': ['Excellence', 'Venice', 'Diadema', 'Concordia', 'Spirit', 'Other']
+      'costa': ['Excellence', 'Venice', 'Diadema', 'Concordia', 'Spirit', 'Other'],
+      'cunard': ['Ocean Liner', 'Queen', 'Other']
     };
 
     // Brand colors for cruise lines
@@ -237,7 +247,8 @@
       'hal': { bg: '#e8eef5', border: '#c0cee0', hover: '#d8e4f0', text: '#1a3a5c' },
       'msc': { bg: '#e6e9f0', border: '#b8c0d0', hover: '#d0d5e5', text: '#1a2a4a' },
       'virgin': { bg: '#fce8e8', border: '#e8c0c0', hover: '#f5d5d5', text: '#cc0000' },
-      'costa': { bg: '#fff8e6', border: '#e8d8b0', hover: '#fff0cc', text: '#c09000' }
+      'costa': { bg: '#fff8e6', border: '#e8d8b0', hover: '#fff0cc', text: '#c09000' },
+      'cunard': { bg: '#f5e8e8', border: '#d8b0b0', hover: '#f0d8d8', text: '#8b0000' }
     };
 
     let html = `
@@ -248,7 +259,7 @@
     `;
 
     // Render each cruise line's ships
-    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'hal', 'ncl', 'msc', 'costa', 'virgin', 'carnival']; // Define display order
+    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'hal', 'cunard', 'ncl', 'msc', 'costa', 'virgin', 'carnival']; // Define display order
     const activeCruiseLines = cruiseLineOrder.filter(cl => shipsByCruiseLine[cl]);
 
     activeCruiseLines.forEach((cruiseLineId, index) => {


### PR DESCRIPTION
Expanded ship-port cross-linking to include Cunard:
- Added 4 Cunard ships: Queen Mary 2 (Ocean Liner), Queen Anne, Queen Elizabeth, Queen Victoria (Queen Class)
- Added Cunard burgundy brand colors (#8b0000) to ship-port-links.js
- Added transatlantic crossing ports: Hamburg, Reykjavik, Halifax, Quebec City
- Added world cruise ports: Cape Town, Gibraltar, Funchal, Bergen
- Updated Mediterranean, Northern Europe, and Australia/NZ port mappings

Progress: 10/14 cruise lines complete (Disney excluded per user preference)
Total: 158 ships across ~118 ports