### PR TITLE
Ships That Visit: Add Oceania Cruises (8 ships)

### DIFF
--- a/admin/UNFINISHED-TASKS.md
+++ b/admin/UNFINISHED-TASKS.md
@@ -303,14 +303,14 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | "No Ads" trust messaging on about-us.html | ✅ DONE | Cruise Critic, CruiseMapper |
 | Tender Port Index + badge (`/ports/tender-ports.html`) | ✅ DONE | WhatsInPort |
 | "From the Pier" distance callout box component | PARTIAL (some ports) | WhatsInPort, IQCruising |
-| "Ships That Visit Here" section on port pages | PARTIAL (100/380 ports, RCL+Carnival+Celebrity+NCL+Princess+HAL+MSC+Virgin+Costa+Cunard) | UNIQUE - no competitor has this |
+| "Ships That Visit Here" section on port pages | PARTIAL (100/380 ports, RCL+Carnival+Celebrity+NCL+Princess+HAL+MSC+Virgin+Costa+Cunard+Oceania) | UNIQUE - no competitor has this |
 | First-Timer Hub page | ✅ DONE (`first-cruise.html` 27KB) | Cruise Critic |
 | Pre-Cruise 30-Day Countdown checklist | ✅ DONE (`countdown.html` 2026-01-24) | Cruise Critic Roll Call |
 
 **P2 Strategic (Medium Effort):**
 | Task | Status | Addresses |
 |------|--------|-----------|
-| **Expand "Ships That Visit" to all 14 cruise lines** | IN PROGRESS (10/14 lines: RCL, Carnival, Celebrity, NCL, Princess, HAL, MSC, Virgin, Costa, Cunard) | UNIQUE differentiator |
+| **Expand "Ships That Visit" to all 14 cruise lines** | IN PROGRESS (11/14 lines: RCL, Carnival, Celebrity, NCL, Princess, HAL, MSC, Virgin, Costa, Cunard, Oceania) | UNIQUE differentiator |
 | Print CSS + PDF generation for port pages | NOT STARTED | WhatsInPort, IQCruising |
 | Transport cost callout component | NOT STARTED | WhatsInPort, Cruise Crocodile |
 | Accessibility sections on port pages | NOT STARTED | UNIQUE - market gap |
@@ -318,12 +318,12 @@ The stateroom checker tool (`stateroom-check.js`) loads exception data from indi
 | Honest assessment "Real Talk" sections | NOT STARTED | Cruise Critic, CruiseMapper |
 
 **"Ships That Visit Here" Expansion Plan:**
-- Current: 100 ports, 158 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess + 11 HAL + 22 MSC + 4 Virgin + 9 Costa + 4 Cunard)
-- Progress: 10/14 cruise lines complete (Disney excluded per user preference)
-- Data file: `assets/data/ship-deployments.json` (v1.9.0)
-- JS module: `assets/js/ship-port-links.js` (v1.8.0 - multi-cruise-line support)
-- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships), ✅ Holland America (11 ships), ✅ MSC Cruises (22 ships), ✅ Virgin Voyages (4 ships), ✅ Costa Cruises (9 ships), ✅ Cunard (4 ships)
-- Cruise lines remaining: Oceania, Regent, Seabourn, Silversea, Explora
+- Current: 100 ports, 166 ships (29 RCL + 26 Carnival + 16 Celebrity + 20 NCL + 17 Princess + 11 HAL + 22 MSC + 4 Virgin + 9 Costa + 4 Cunard + 8 Oceania)
+- Progress: 11/14 cruise lines complete (Disney excluded per user preference)
+- Data file: `assets/data/ship-deployments.json` (v1.10.0)
+- JS module: `assets/js/ship-port-links.js` (v1.9.0 - multi-cruise-line support)
+- Cruise lines done: ✅ Royal Caribbean (29 ships), ✅ Carnival (26 ships), ✅ Celebrity (16 ships), ✅ Norwegian (20 ships), ✅ Princess (17 ships), ✅ Holland America (11 ships), ✅ MSC Cruises (22 ships), ✅ Virgin Voyages (4 ships), ✅ Costa Cruises (9 ships), ✅ Cunard (4 ships), ✅ Oceania Cruises (8 ships)
+- Cruise lines remaining: Regent, Seabourn, Silversea, Explora
 
 **Unique Differentiators to Protect:**
 - Ship-Port Integration ⭐⭐⭐ (expand with bidirectional linking)
@@ -721,11 +721,11 @@ node admin/validate-ship-page.js ships/celebrity-cruises/*.html
 - ~~Quiz Dress Code~~ — Question exists at line 1716
 - ~~30-Day Countdown Checklist~~ — `countdown.html` with 35 interactive tasks (2026-01-24)
 - ~~Works Offline Badge~~ — 376 port pages now show "Works offline" in trust badge (2026-01-24)
-- ~~Ships That Visit Here~~ — In progress (100/380 ports, 158 ships across RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa + Cunard — 4 cruise lines remaining)
+- ~~Ships That Visit Here~~ — In progress (100/380 ports, 166 ships across RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa + Cunard + Oceania — 3 cruise lines remaining)
 
 ### 🟡 HIGH PRIORITY (Remaining Work)
 5. **Quiz UX Bugs** — iPhone scroll issue, back button (NCL links is #1 above)
-6. **Ships That Visit Expansion** — Add 4 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa + Cunard done, 100/380 ports, 158 ships)
+6. **Ships That Visit Expansion** — Add 3 more cruise lines to ship-deployments.json (RCL + Carnival + Celebrity + NCL + Princess + HAL + MSC + Virgin + Costa + Cunard + Oceania done, 100/380 ports, 166 ships)
 7. **Quiz Regional Features** — Regional availability filter (dress code done)
 8. **Port Weather Remaining** — 80 ports still need weather section
 

--- a/assets/data/ship-deployments.json
+++ b/assets/data/ship-deployments.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "version": "1.9.0",
+    "version": "1.10.0",
     "last_updated": "2026-01-25",
-    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, Costa Cruises, and Cunard 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
+    "source": "Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, Costa Cruises, Cunard, and Oceania 2025-2026 Deployment Summaries, CruiseMapper, Press Releases",
     "notes": "Ship-to-port mappings for bidirectional cross-linking. Ports listed are typical calls for each ship's current deployment.",
     "cruise_lines": [
       "rcl",
@@ -14,7 +14,8 @@
       "msc",
       "virgin",
       "costa",
-      "cunard"
+      "cunard",
+      "oceania"
     ]
   },
   "ships": {
@@ -4090,6 +4091,220 @@
         12,
         14
       ]
+    },
+    "oceania-vista": {
+      "name": "Vista",
+      "class": "Vista",
+      "cruise_line": "oceania",
+      "homeports": [
+        "miami",
+        "barcelona"
+      ],
+      "regions": [
+        "caribbean",
+        "mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "cozumel",
+        "grand-cayman",
+        "st-thomas",
+        "barcelona",
+        "rome",
+        "monte-carlo",
+        "florence"
+      ],
+      "itinerary_lengths": [
+        10,
+        12,
+        14
+      ]
+    },
+    "oceania-allura": {
+      "name": "Allura",
+      "class": "Allura",
+      "cruise_line": "oceania",
+      "homeports": [
+        "barcelona",
+        "rome"
+      ],
+      "regions": [
+        "mediterranean",
+        "northern-europe"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "barcelona",
+        "rome",
+        "naples",
+        "monte-carlo",
+        "florence",
+        "amsterdam",
+        "copenhagen"
+      ],
+      "itinerary_lengths": [
+        10,
+        12
+      ]
+    },
+    "oceania-marina": {
+      "name": "Marina",
+      "class": "Oceania",
+      "cruise_line": "oceania",
+      "homeports": [
+        "miami",
+        "rome"
+      ],
+      "regions": [
+        "caribbean",
+        "mediterranean"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "st-thomas",
+        "barbados",
+        "aruba",
+        "rome",
+        "barcelona",
+        "monte-carlo"
+      ],
+      "itinerary_lengths": [
+        10,
+        12,
+        14
+      ]
+    },
+    "oceania-riviera": {
+      "name": "Riviera",
+      "class": "Oceania",
+      "cruise_line": "oceania",
+      "homeports": [
+        "athens",
+        "rome"
+      ],
+      "regions": [
+        "mediterranean",
+        "holy-land"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "santorini",
+        "mykonos",
+        "dubrovnik",
+        "kotor",
+        "rome",
+        "monte-carlo"
+      ],
+      "itinerary_lengths": [
+        10,
+        12
+      ]
+    },
+    "oceania-regatta": {
+      "name": "Regatta",
+      "class": "R-Class",
+      "cruise_line": "oceania",
+      "homeports": [
+        "seattle",
+        "los-angeles"
+      ],
+      "regions": [
+        "alaska",
+        "pacific-coast"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "juneau",
+        "ketchikan",
+        "sitka",
+        "skagway",
+        "victoria-bc",
+        "los-angeles"
+      ],
+      "itinerary_lengths": [
+        7,
+        10,
+        12
+      ]
+    },
+    "oceania-insignia": {
+      "name": "Insignia",
+      "class": "R-Class",
+      "cruise_line": "oceania",
+      "homeports": [
+        "sydney",
+        "auckland"
+      ],
+      "regions": [
+        "australia",
+        "south-pacific"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "sydney",
+        "melbourne",
+        "auckland",
+        "bay-of-islands",
+        "fiji",
+        "tahiti"
+      ],
+      "itinerary_lengths": [
+        10,
+        14,
+        18
+      ]
+    },
+    "oceania-nautica": {
+      "name": "Nautica",
+      "class": "R-Class",
+      "cruise_line": "oceania",
+      "homeports": [
+        "lisbon",
+        "barcelona"
+      ],
+      "regions": [
+        "mediterranean",
+        "atlantic-isles"
+      ],
+      "season": "seasonal",
+      "typical_ports": [
+        "lisbon",
+        "barcelona",
+        "gibraltar",
+        "funchal",
+        "rome",
+        "monte-carlo"
+      ],
+      "itinerary_lengths": [
+        10,
+        12
+      ]
+    },
+    "oceania-sirena": {
+      "name": "Sirena",
+      "class": "R-Class",
+      "cruise_line": "oceania",
+      "homeports": [
+        "rome",
+        "athens"
+      ],
+      "regions": [
+        "mediterranean",
+        "holy-land"
+      ],
+      "season": "year-round",
+      "typical_ports": [
+        "rome",
+        "athens",
+        "santorini",
+        "mykonos",
+        "dubrovnik",
+        "venice"
+      ],
+      "itinerary_lengths": [
+        10,
+        12
+      ]
     }
   },
   "port_to_ships": {
@@ -4183,7 +4398,8 @@
       "msc-divina",
       "msc-armonia",
       "scarlet-lady",
-      "valiant-lady"
+      "valiant-lady",
+      "oceania-vista"
     ],
     "costa-maya": [
       "icon-of-the-seas",
@@ -4243,7 +4459,8 @@
       "carnival-miracle",
       "carnival-paradise",
       "celebrity-apex",
-      "celebrity-xcel"
+      "celebrity-xcel",
+      "oceania-vista"
     ],
     "half-moon-cay": [
       "carnival-celebration",
@@ -4327,7 +4544,9 @@
       "eurodam",
       "zaandam",
       "brilliant-lady",
-      "queen-victoria"
+      "queen-victoria",
+      "oceania-vista",
+      "oceania-marina"
     ],
     "st-maarten": [
       "icon-of-the-seas",
@@ -4376,7 +4595,8 @@
       "celebrity-silhouette",
       "celebrity-summit",
       "nieuw-statendam",
-      "queen-victoria"
+      "queen-victoria",
+      "oceania-marina"
     ],
     "aruba": [
       "freedom-of-the-seas",
@@ -4393,7 +4613,8 @@
       "coral-princess",
       "nieuw-statendam",
       "zuiderdam",
-      "brilliant-lady"
+      "brilliant-lady",
+      "oceania-marina"
     ],
     "curacao": [
       "freedom-of-the-seas",
@@ -4456,7 +4677,8 @@
       "koningsdam",
       "nieuw-amsterdam",
       "westerdam",
-      "volendam"
+      "volendam",
+      "oceania-regatta"
     ],
     "skagway": [
       "voyager-of-the-seas",
@@ -4481,7 +4703,8 @@
       "koningsdam",
       "nieuw-amsterdam",
       "westerdam",
-      "volendam"
+      "volendam",
+      "oceania-regatta"
     ],
     "ketchikan": [
       "voyager-of-the-seas",
@@ -4506,7 +4729,8 @@
       "koningsdam",
       "nieuw-amsterdam",
       "westerdam",
-      "volendam"
+      "volendam",
+      "oceania-regatta"
     ],
     "glacier-bay": [
       "voyager-of-the-seas",
@@ -4528,7 +4752,8 @@
       "westerdam"
     ],
     "sitka": [
-      "anthem-of-the-seas"
+      "anthem-of-the-seas",
+      "oceania-regatta"
     ],
     "icy-strait-point": [
       "radiance-of-the-seas",
@@ -4547,7 +4772,8 @@
       "majestic-princess",
       "ruby-princess",
       "koningsdam",
-      "volendam"
+      "volendam",
+      "oceania-regatta"
     ],
     "barcelona": [
       "harmony-of-the-seas",
@@ -4572,7 +4798,11 @@
       "costa-pacifica",
       "queen-anne",
       "queen-elizabeth",
-      "queen-victoria"
+      "queen-victoria",
+      "oceania-vista",
+      "oceania-allura",
+      "oceania-marina",
+      "oceania-nautica"
     ],
     "rome": [
       "harmony-of-the-seas",
@@ -4596,7 +4826,13 @@
       "msc-grandiosa",
       "msc-fantasia",
       "queen-anne",
-      "queen-elizabeth"
+      "queen-elizabeth",
+      "oceania-vista",
+      "oceania-allura",
+      "oceania-marina",
+      "oceania-riviera",
+      "oceania-nautica",
+      "oceania-sirena"
     ],
     "naples": [
       "allure-of-the-seas",
@@ -4617,7 +4853,8 @@
       "costa-smeralda",
       "costa-favolosa",
       "queen-anne",
-      "queen-victoria"
+      "queen-victoria",
+      "oceania-allura"
     ],
     "marseille": [
       "harmony-of-the-seas",
@@ -4658,7 +4895,9 @@
       "msc-lirica",
       "msc-sinfonia",
       "resilient-lady",
-      "costa-diadema"
+      "costa-diadema",
+      "oceania-riviera",
+      "oceania-sirena"
     ],
     "mykonos": [
       "explorer-of-the-seas",
@@ -4676,14 +4915,18 @@
       "msc-lirica",
       "msc-sinfonia",
       "resilient-lady",
-      "costa-diadema"
+      "costa-diadema",
+      "oceania-riviera",
+      "oceania-sirena"
     ],
     "athens": [
       "explorer-of-the-seas",
       "celebrity-beyond",
       "celebrity-reflection",
       "celebrity-constellation",
-      "regal-princess"
+      "regal-princess",
+      "oceania-riviera",
+      "oceania-sirena"
     ],
     "dubrovnik": [
       "explorer-of-the-seas",
@@ -4691,7 +4934,9 @@
       "celebrity-constellation",
       "norwegian-jade",
       "costa-diadema",
-      "costa-deliziosa"
+      "costa-deliziosa",
+      "oceania-riviera",
+      "oceania-sirena"
     ],
     "kotor": [
       "explorer-of-the-seas",
@@ -4699,7 +4944,9 @@
       "celebrity-constellation",
       "norwegian-jade",
       "costa-diadema",
-      "costa-deliziosa"
+      "costa-deliziosa",
+      "oceania-riviera",
+      "oceania-sirena"
     ],
     "corfu": [
       "explorer-of-the-seas",
@@ -4721,7 +4968,8 @@
       "costa-deliziosa",
       "queen-mary-2",
       "queen-anne",
-      "queen-victoria"
+      "queen-victoria",
+      "oceania-allura"
     ],
     "copenhagen": [
       "independence-of-the-seas",
@@ -4729,7 +4977,8 @@
       "norwegian-spirit",
       "enchanted-princess",
       "costa-deliziosa",
-      "queen-anne"
+      "queen-anne",
+      "oceania-allura"
     ],
     "stockholm": [
       "independence-of-the-seas",
@@ -4830,7 +5079,8 @@
       "sapphire-princess",
       "resilient-lady",
       "queen-mary-2",
-      "queen-elizabeth"
+      "queen-elizabeth",
+      "oceania-insignia"
     ],
     "melbourne": [
       "quantum-of-the-seas",
@@ -4839,7 +5089,8 @@
       "majestic-princess",
       "sapphire-princess",
       "resilient-lady",
-      "queen-elizabeth"
+      "queen-elizabeth",
+      "oceania-insignia"
     ],
     "hobart": [
       "quantum-of-the-seas",
@@ -4852,12 +5103,14 @@
       "ovation-of-the-seas",
       "norwegian-jewel",
       "sapphire-princess",
-      "queen-elizabeth"
+      "queen-elizabeth",
+      "oceania-insignia"
     ],
     "bay-of-islands": [
       "ovation-of-the-seas",
       "norwegian-jewel",
-      "sapphire-princess"
+      "sapphire-princess",
+      "oceania-insignia"
     ],
     "penang": [
       "quantum-of-the-seas"
@@ -4893,7 +5146,8 @@
     "lisbon": [
       "independence-of-the-seas",
       "queen-anne",
-      "queen-victoria"
+      "queen-victoria",
+      "oceania-nautica"
     ],
     "vigo": [
       "independence-of-the-seas"
@@ -5025,7 +5279,8 @@
       "msc-poesia",
       "msc-sinfonia",
       "costa-diadema",
-      "costa-deliziosa"
+      "costa-deliziosa",
+      "oceania-sirena"
     ],
     "dubai": [
       "msc-world-europa",
@@ -5116,13 +5371,35 @@
       "queen-mary-2"
     ],
     "gibraltar": [
-      "queen-elizabeth"
+      "queen-elizabeth",
+      "oceania-nautica"
     ],
     "funchal": [
-      "queen-elizabeth"
+      "queen-elizabeth",
+      "oceania-nautica"
     ],
     "bergen": [
       "queen-victoria"
+    ],
+    "monte-carlo": [
+      "oceania-vista",
+      "oceania-allura",
+      "oceania-marina",
+      "oceania-riviera",
+      "oceania-nautica"
+    ],
+    "florence": [
+      "oceania-vista",
+      "oceania-allura"
+    ],
+    "fiji": [
+      "oceania-insignia"
+    ],
+    "tahiti": [
+      "oceania-insignia"
+    ],
+    "los-angeles": [
+      "oceania-regatta"
     ]
   },
   "homeport_details": {

--- a/assets/js/ship-port-links.js
+++ b/assets/js/ship-port-links.js
@@ -1,12 +1,12 @@
 /**
  * Ship-Port Cross-Linking Module
- * Version: 1.8.0
+ * Version: 1.9.0
  *
  * Provides bidirectional linking between ship and port pages:
  * - Port pages show "Ships That Visit Here"
  * - Ship pages show "Ports on This Ship's Itineraries"
  *
- * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, Costa Cruises, Cunard
+ * Supported cruise lines: Royal Caribbean, Carnival, Celebrity, Norwegian, Princess, Holland America, MSC, Virgin Voyages, Costa Cruises, Cunard, Oceania
  * Data source: /assets/data/ship-deployments.json
  */
 
@@ -76,6 +76,12 @@
       name: 'Cunard',
       path: '/ships/cunard/',
       bookingUrl: 'https://www.cunard.com/en-gb/cruise-ships',
+      allShipsUrl: '/ships.html'
+    },
+    'oceania': {
+      name: 'Oceania Cruises',
+      path: '/ships/oceania/',
+      bookingUrl: 'https://www.oceaniacruises.com/ships/',
       allShipsUrl: '/ships.html'
     }
   };
@@ -169,7 +175,8 @@
       'la-spezia': 'La Spezia',
       'quebec-city': 'Quebec City',
       'cape-town': 'Cape Town',
-      'sydney-australia': 'Sydney, Australia'
+      'sydney-australia': 'Sydney, Australia',
+      'monte-carlo': 'Monte Carlo'
     };
 
     if (specialNames[slug]) return specialNames[slug];
@@ -234,7 +241,8 @@
       'msc': ['World', 'Meraviglia Plus', 'Seaside EVO', 'Meraviglia', 'Seaside', 'Fantasia', 'Musica', 'Lirica', 'Other'],
       'virgin': ['Lady', 'Other'],
       'costa': ['Excellence', 'Venice', 'Diadema', 'Concordia', 'Spirit', 'Other'],
-      'cunard': ['Ocean Liner', 'Queen', 'Other']
+      'cunard': ['Ocean Liner', 'Queen', 'Other'],
+      'oceania': ['Allura', 'Vista', 'Oceania', 'R-Class', 'Other']
     };
 
     // Brand colors for cruise lines
@@ -248,7 +256,8 @@
       'msc': { bg: '#e6e9f0', border: '#b8c0d0', hover: '#d0d5e5', text: '#1a2a4a' },
       'virgin': { bg: '#fce8e8', border: '#e8c0c0', hover: '#f5d5d5', text: '#cc0000' },
       'costa': { bg: '#fff8e6', border: '#e8d8b0', hover: '#fff0cc', text: '#c09000' },
-      'cunard': { bg: '#f5e8e8', border: '#d8b0b0', hover: '#f0d8d8', text: '#8b0000' }
+      'cunard': { bg: '#f5e8e8', border: '#d8b0b0', hover: '#f0d8d8', text: '#8b0000' },
+      'oceania': { bg: '#f5f0e8', border: '#d8c8b0', hover: '#f0e8d8', text: '#8b6914' }
     };
 
     let html = `
@@ -259,7 +268,7 @@
     `;
 
     // Render each cruise line's ships
-    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'hal', 'cunard', 'ncl', 'msc', 'costa', 'virgin', 'carnival']; // Define display order
+    const cruiseLineOrder = ['rcl', 'celebrity', 'princess', 'hal', 'cunard', 'oceania', 'ncl', 'msc', 'costa', 'virgin', 'carnival']; // Define display order
     const activeCruiseLines = cruiseLineOrder.filter(cl => shipsByCruiseLine[cl]);
 
     activeCruiseLines.forEach((cruiseLineId, index) => {


### PR DESCRIPTION
Expanded ship-port cross-linking to include Oceania Cruises:
- Added 8 Oceania ships across 4 classes (Allura, Vista, Oceania, R-Class)
- Ships: Vista, Allura, Marina, Riviera, Regatta, Insignia, Nautica, Sirena
- Added Oceania bronze/gold brand colors (#8b6914) to ship-port-links.js
- Added new ports: Monte Carlo, Florence, Fiji, Tahiti
- Updated Mediterranean, Alaska, Caribbean, and Australia/NZ port mappings

Progress: 11/14 cruise lines complete (Disney excluded per user preference)
Total: 166 ships across ~125 ports