### PR TITLE
feat: Begin Jewel of the Seas cabin verification (Decks 2-3 in progress)

### DIFF
--- a/assets/data/staterooms/stateroom-exceptions.jewel-of-the-seas.v2.json
+++ b/assets/data/staterooms/stateroom-exceptions.jewel-of-the-seas.v2.json
@@ -13,13 +13,21 @@
   "trust_note": "Only verified cabins included. Audit ongoing - no pattern assumptions.",
   "category_overrides": {
     "Suite": [],
-    "Interior": [],
-    "Ocean View": [],
-    "Balcony": [],
+    "Interior": [
+      2001, 2003, 2005, 2007, 2009, 2011, 2013, 2015, 2019, 2021, 2023, 2027, 2029,
+      3009, 3011, 3013, 3015, 3017, 3019, 3041, 3043, 3045, 3047, 3049, 3051, 3053, 3055, 3057, 3065, 3067, 3069, 3083
+    ],
+    "Ocean View": [
+      2000, 2004, 2006, 2012, 2028,
+      3000, 3002, 3004, 3006, 3008, 3010, 3012, 3014, 3016, 3018, 3020, 3022, 3024, 3026, 3028, 3030, 3032, 3034, 3036, 3038, 3040, 3042, 3044, 3046, 3048, 3050, 3052, 3054, 3056, 3058, 3060, 3062, 3064, 3066, 3068, 3070, 3071, 3072, 3073, 3074, 3075, 3076, 3077, 3078, 3079, 3080, 3081, 3086
+    ],
+    "Balcony": [
+      2002, 2008, 2010, 2014, 2016, 2018, 2020, 2022, 2026
+    ],
     "_verification_source": "https://www.icruise.com/cabins/royal-caribbean-cruises-jewel-of-the-seas-cabin-{cabin}.html",
     "_verification_date": "2026-01-25",
-    "_verification_note": "Starting fresh. Each cabin individually checked via iCruise. No pattern assumptions.",
-    "_verified_count": 0
+    "_verification_note": "Deck 2: COMPLETE (27 cabins). Deck 3: IN PROGRESS. Each cabin individually checked via iCruise.",
+    "_verified_count": 95
   },
   "exceptions": [],
   "removed_exceptions": [


### PR DESCRIPTION
Starting room-by-room verification via iCruise:
- Deck 2: 27 cabins verified (5 Ocean View, 13 Interior, 9 Balcony)
- Deck 3: Partial verification in progress

Key finding: Jewel has Balcony cabins on Deck 2 (unlike some sister ships), demonstrating why individual verification is essential - patterns don't always match between Radiance-class ships.