### PR TITLE
fix: Correct NCL menu data for 16 venues after audit against real sou…

### DIFF
--- a/assets/data/ncl-venue-menus.json
+++ b/assets/data/ncl-venue-menus.json
@@ -12,17 +12,20 @@
           "Jumbo Lump Crab Cake",
           "Shrimp Cocktail",
           "Caesar Salad",
-          "Wedge Salad with Blue Cheese"
+          "Wedge Salad with Blue Cheese",
+          "Grilled Thick-Cut Bacon"
         ],
         "entrees": [
           "Rib Eye Steak (16 oz)",
-          "Filet Mignon (9 oz)",
+          "Filet Mignon (8 oz)",
           "NY Strip Steak (14 oz)",
           "Porterhouse Steak (24 oz)",
           "Bone-In Ribeye",
           "Grilled Lamb Chops",
           "Whole Roasted Chicken",
-          "Grilled Swordfish"
+          "Grilled Swordfish",
+          "Fisherman's Platter",
+          "Jumbo Shrimp Skewers"
         ],
         "sides": [
           "Baked Potato",
@@ -34,7 +37,7 @@
         ],
         "desserts": [
           "Seven Layer Chocolate Cake",
-          "New York Cheesecake",
+          "OMG Caramel Butterscotch Cheesecake",
           "Crème Brûlée",
           "Warm Apple Crisp"
         ]
@@ -53,7 +56,10 @@
           "French Onion Soup Gratinée",
           "Salade Niçoise",
           "Duck Confit Salad",
-          "Moules Marinières"
+          "Moules Marinières",
+          "Steak Tartare",
+          "Salade d'Endive",
+          "Goat Cheese Croquettes"
         ],
         "entrees": [
           "Coq au Vin",
@@ -61,14 +67,19 @@
           "Rack of Lamb Provençal",
           "Beef Bourguignon",
           "Duck à l'Orange",
-          "Seared Sea Bass with Ratatouille"
+          "Seared Sea Bass with Ratatouille",
+          "Filet de Bœuf",
+          "Filet de Loup de Mer",
+          "Lobster Thermidor",
+          "Dover Sole"
         ],
         "desserts": [
           "Marquise au Chocolat",
           "Tarte Tatin",
           "Crème Brûlée",
           "Profiteroles",
-          "Soufflé du Jour"
+          "Soufflé du Jour",
+          "Fraisier"
         ]
       },
       "notes": [
@@ -78,19 +89,24 @@
       ]
     },
     "onda-by-scarpetta": {
-      "pricing": "$60 per person cover charge",
+      "pricing": "$40 per person cover charge",
       "courses": {
         "appetizers": [
           "Burrata with Roasted Tomatoes",
           "Yellowfin Tuna Crudo",
           "Roasted Beet Salad",
-          "Crispy Polenta with Mushroom Ragù"
+          "Crispy Polenta with Mushroom Ragù",
+          "Margherita Pizza",
+          "Fritto Misto",
+          "Beef Carpaccio"
         ],
         "pasta": [
           "Scarpetta's Spaghetti with Tomato and Basil",
           "Black Pepper Tagliatelle with Braised Short Rib",
           "Creamy Polenta with Sausage Ragù",
-          "Lemon Spaghetti"
+          "Lemon Spaghetti",
+          "Pappardelle Bolognese",
+          "Scialatielli"
         ],
         "entrees": [
           "Branzino",
@@ -116,30 +132,28 @@
       "courses": {
         "appetizers": [
           "Guacamole Fresco (tableside preparation)",
-          "Queso Fundido with Chorizo",
-          "Elote (Mexican Street Corn)",
-          "Ceviche Trio",
-          "Tortilla Soup"
+          "Queso Fundido (melted Mexican cheeses with agave drizzle)",
+          "Sopa de Tortilla (tortilla soup in smoky tomato broth)"
         ],
         "entrees": [
-          "Cochinita Pibil (slow-roasted pork)",
-          "Carne Asada",
-          "Pollo en Mole Poblano",
-          "Grilled Red Snapper Veracruzana",
-          "Carnitas Tacos",
-          "Chile Relleno"
+          "Fajitas (chicken, shrimp, or carne asada)",
+          "Cochinita Pibil (slow-braised pork on banana leaf)",
+          "Pescado al Estilo Nayarit (grilled fish with red adobo and salsa verde)",
+          "Enchiladas de Mole (rotisserie chicken with mole sauce)"
         ],
         "desserts": [
-          "Churros con Chocolate",
-          "Tres Leches Cake",
-          "Mexican Chocolate Flan",
-          "Mango Sorbet"
+          "Churros with Dulce de Leche Caramel",
+          "Pastel de Tres Leches (with coconut cream)",
+          "Tarteleta Maya (guava gel and spicy chocolate ganache)",
+          "Hibiscus-Lime Sorbet",
+          "Passion Fruit-Piloncillo Sorbet"
         ]
       },
       "notes": [
         "Modern Mexican restaurant with tableside guacamole. Cover charge includes three courses.",
         "Tequila and mezcal flights available at additional charge.",
-        "Available on select ships."
+        "Available on select ships.",
+        "Select 3 appetizers, 1 entrée, 2 sides, and 3 desserts per person."
       ]
     },
     "teppanyaki": {
@@ -151,23 +165,22 @@
           "Seaweed Salad"
         ],
         "entrees": [
-          "NY Strip Steak with Grilled Vegetables",
-          "Filet Mignon Combination",
-          "Lobster Tail Teppanyaki",
-          "Chicken Teriyaki",
-          "Shrimp and Scallop Combination",
-          "Tofu Steak with Seasonal Vegetables"
+          "NY Strip Steak",
+          "Chicken Yaki Udon",
+          "Seafood (jumbo shrimp, sea scallops, calamari)",
+          "Yamato (chicken breast and jumbo shrimp)",
+          "Asuka (New York strip and jumbo shrimp)",
+          "Kamakura (New York strip and chicken breast)",
+          "Edo (sea scallops and jumbo shrimp)"
         ],
         "sides": [
-          "Fried Rice",
-          "Grilled Zucchini",
-          "Bean Sprouts",
-          "Mushrooms"
+          "Garlic Fried Rice",
+          "Teppanyaki-Grilled Vegetables",
+          "Onion and Creamy Mustard Dipping Sauces"
         ],
         "desserts": [
-          "Green Tea Cake",
-          "Tempura Ice Cream",
-          "Mochi"
+          "Green Tea Cake with Cashew Nut Brittle",
+          "Fresh Fruit Sashimi"
         ]
       },
       "notes": [
@@ -211,28 +224,25 @@
       "pricing": "$50 per person for 4 items",
       "courses": {
         "small-plates": [
-          "Korean Fried Chicken Wings",
-          "Pork Belly Bao Buns",
-          "Pad Thai",
-          "Chicken Tikka Masala",
-          "Tempura Shrimp",
-          "Kimchi Fried Rice",
-          "Vietnamese Pho",
-          "Bulgogi Sliders",
-          "Singapore Noodles"
+          "Spicy Korean Fried Chicken with Rice and Radish Cabbage Slaw",
+          "Salt and Pepper Calamari with Shichimi and Smoked Soy",
+          "Peruvian Beef Skewers with Rustic Aji Panca Sauce",
+          "Thai Chicken Lettuce Wraps with Tamarind and Peanut Dipping Sauces",
+          "Pork Belly Bao Buns with Sesame Soy Glaze",
+          "Shrimp Pad Thai with Tamarind Sauce and Peanuts",
+          "Kimchee Fried Rice with Charred Pork and Pineapple"
         ],
         "large-plates": [
-          "Peking Duck",
-          "Tandoori Mixed Grill",
-          "Black Cod Miso",
-          "Thai Red Curry",
-          "Szechuan Mapo Tofu"
+          "Steak and Noodle Salad",
+          "Dragon Roll (broiled eel and shrimp tempura)",
+          "Rock Shrimp Roll (spicy tuna and avocado)",
+          "Salmon Roll",
+          "Miso Chicken",
+          "Pho Tai"
         ],
         "desserts": [
-          "Mango Sticky Rice",
-          "Matcha Crème Brûlée",
-          "Chocolate Spring Rolls",
-          "Thai Coconut Pudding"
+          "Green Tea Jar (chocolate brownie and green tea mousse)",
+          "Dark and Stormy Baba au Rhum (pineapple and ginger caramel)"
         ]
       },
       "notes": [
@@ -245,37 +255,40 @@
       "pricing": "$40 per person cover charge",
       "courses": {
         "appetizers": [
+          "Mozzarella Caprese",
+          "Burrata Caprese",
           "Calamari Fritti",
-          "Caprese Salad",
-          "Bruschetta Trio",
-          "Italian Wedding Soup",
-          "Arancini (Stuffed Rice Balls)"
+          "Antipasti"
         ],
         "pasta": [
           "Spaghetti Carbonara",
-          "Fettuccine Alfredo",
-          "Lasagna Bolognese",
-          "Penne Arrabbiata",
-          "Linguine alle Vongole"
+          "Risotto ai Funghi di Bosco (Mushroom Risotto)",
+          "Pesto Gnocchi",
+          "Lasagne"
         ],
         "entrees": [
-          "Chicken Parmigiana",
-          "Osso Buco",
-          "Veal Scallopini",
-          "Branzino al Forno",
-          "Eggplant Parmigiana"
+          "Pollo Cacciatore",
+          "Filetto di Manzo al Pepe Verde",
+          "Osso Buco alla Milanese",
+          "Salmon",
+          "Frutti Di Mare"
+        ],
+        "pizza": [
+          "Margherita",
+          "Vegetali",
+          "Meat Lovers"
         ],
         "desserts": [
           "Tiramisu",
-          "Cannoli",
-          "Panna Cotta",
-          "Gelato Selection"
+          "Panna Cotta alla Vaniglia",
+          "Cannoli"
         ]
       },
       "notes": [
         "Traditional Italian trattoria. Cover charge includes three courses.",
         "Homemade pasta made fresh daily onboard.",
-        "Available on most NCL ships fleet-wide."
+        "Available on most NCL ships fleet-wide.",
+        "Lobster tail supplement: $25."
       ]
     },
     "ocean-blue": {
@@ -285,28 +298,23 @@
           "Oysters on the Half Shell",
           "Jumbo Shrimp Cocktail",
           "Tuna Tartare",
-          "Ceviche",
           "Lobster Cocktail"
         ],
         "appetizers": [
-          "New England Clam Chowder",
-          "Seared Scallops",
-          "Crab-Stuffed Mushrooms",
-          "Seafood Bisque"
+          "Ahi Tuna and Avocado Tower (pomegranate soy sauce)",
+          "Pan-Seared Scallops (caramelized pork belly, anise-spiced soy glaze)",
+          "Clam Chowder (chopped clams, potatoes, bacon, cream)"
         ],
         "entrees": [
-          "Whole Roasted Branzino",
-          "Grilled Swordfish",
-          "Pan-Seared Halibut",
-          "King Crab Legs",
-          "Lobster Thermidor",
-          "Chilean Sea Bass"
+          "Cioppino (tomato-lobster broth with lobster, shrimp, scallops, clams)",
+          "Fisherman's Platter (grilled or fried)",
+          "Simply Grilled Fish (salmon or sea bass)",
+          "8 oz Filet Mignon",
+          "Roasted Brick Chicken (jalapeño-cilantro chimichurri)"
         ],
         "desserts": [
-          "Key Lime Pie",
-          "Chocolate Soufflé",
-          "Crème Brûlée",
-          "Lemon Tart"
+          "Valrhona Dark Chocolate Mousse Cake",
+          "French Apple Tart à la Mode"
         ]
       },
       "notes": [
@@ -319,23 +327,28 @@
       "pricing": "$60 per person cover charge",
       "courses": {
         "appetizers": [
-          "Beef Carpaccio",
-          "Mediterranean Mezze Platter",
-          "Roasted Beet and Goat Cheese Salad",
-          "Seared Ahi Tuna"
+          "Tuna Crudo (sunchoke and shoyu)",
+          "Grilled Octopus (fingerling potatoes, pickled red onion)",
+          "Greek Village Salad (tomato, cucumber, feta, olives)"
         ],
         "entrees": [
-          "Pan-Seared Halibut",
-          "Grilled Lamb Rack",
-          "Filet Mignon",
-          "Lobster Risotto",
-          "Roasted Duck Breast"
+          "Mediterranean Sea Bass (saffron-carrot puree)",
+          "Whole Grilled Lobster (olive oil and lemon)",
+          "Dover Sole",
+          "Colossal Black Tiger Shrimp",
+          "New York Strip Steak (bone marrow butter)",
+          "Grilled Australian Lamb Chops (Gigantes Beans)",
+          "Filet Mignon"
+        ],
+        "sides": [
+          "Patates Tiganites",
+          "Honey Roasted Carrots",
+          "Grilled Asparagus"
         ],
         "desserts": [
-          "Dark Chocolate Fondant",
-          "Lemon Posset",
-          "Pistachio Crème Brûlée",
-          "Seasonal Fruit Tart"
+          "Galaktoboureko (Greek orange custard pie)",
+          "Valrhona Dark Chocolate Mousse Cake (salted caramel popcorn)",
+          "French Apple Tart"
         ]
       },
       "notes": [
@@ -350,61 +363,63 @@
         "appetizers": [
           "Edamame",
           "Miso Soup",
-          "Seaweed Salad",
-          "Gyoza (Pan-Fried Dumplings)"
+          "Seaweed Salad"
         ],
         "entrees": [
-          "Wagyu Beef Hot Pot",
-          "Seafood Shabu-Shabu",
-          "Sukiyaki with Premium Beef",
-          "Chicken Teriyaki Hot Pot",
-          "Vegetable Hot Pot with Tofu"
+          "NY Strip Steak",
+          "Chicken Yaki Udon",
+          "Seafood (jumbo shrimp, sea scallops, calamari)",
+          "Yamato (chicken breast and jumbo shrimp)",
+          "Asuka (New York strip and jumbo shrimp)",
+          "Kamakura (New York strip and chicken breast)",
+          "Edo (sea scallops and jumbo shrimp)"
+        ],
+        "sides": [
+          "Garlic Fried Rice",
+          "Teppanyaki-Grilled Vegetables",
+          "Onion and Creamy Mustard Dipping Sauces"
         ],
         "desserts": [
-          "Matcha Ice Cream",
-          "Yuzu Sorbet",
-          "Japanese Cheesecake"
+          "Green Tea Cake with Cashew Nut Brittle",
+          "Fresh Fruit Sashimi"
         ]
       },
       "notes": [
-        "Japanese hot pot (shabu-shabu and sukiyaki) dining exclusive to Prima class.",
-        "Each guest selects broth, protein, and accompaniments for personalized hot pot.",
+        "Teppanyaki-style hibachi dining, Prima class version of Teppanyaki. Chef performs tableside.",
+        "Cover charge includes appetizers, one entrée, sides, and dessert.",
         "Available on Norwegian Prima, Viva, Aqua, and Luna."
       ]
     },
     "nama-sushi": {
       "pricing": "$50 per person cover charge",
       "courses": {
+        "appetizers": [
+          "Kanpachi Crudo (ponzu and serrano pepper)",
+          "Tuna Pizza (crisp tortilla and garlic aioli)",
+          "Beef Striploin Carpaccio (yuzu ponzu and shiso leaf)",
+          "Rock Shrimp Tempura (spicy gochujang aioli)",
+          "Edamame with BBQ Salt"
+        ],
         "sushi-rolls": [
-          "Spicy Tuna Roll",
-          "Dragon Roll",
-          "Rainbow Roll",
           "California Roll",
-          "Salmon Avocado Roll",
-          "Shrimp Tempura Roll"
+          "Spicy Tuna Roll",
+          "Crispy Salmon Roll (panko and eel sauce)",
+          "Yellowtail Roll (crab, yuzu juice, and truffle oil)"
         ],
         "sashimi": [
-          "Tuna Sashimi",
-          "Salmon Sashimi",
-          "Yellowtail Sashimi",
-          "Chef's Sashimi Platter"
-        ],
-        "appetizers": [
-          "Edamame",
-          "Miso Soup",
-          "Seaweed Salad",
-          "Tempura Vegetables"
+          "Kanpachi",
+          "Ahi Tuna",
+          "Salmon"
         ],
         "desserts": [
-          "Mochi Ice Cream",
-          "Green Tea Crème Brûlée",
-          "Tempura Banana with Ice Cream"
+          "Pineapple Carpaccio (lemongrass syrup and pomegranate)"
         ]
       },
       "notes": [
         "Dedicated sushi and sashimi bar. Cover charge includes selection of rolls and sashimi.",
         "Premium sake and Japanese whisky available at additional charge.",
-        "Available on select NCL ships."
+        "Available on select NCL ships.",
+        "Cover charge includes 4 items per person, sharable among the table."
       ]
     },
     "sukhothai": {
@@ -414,7 +429,8 @@
           "Salt and Pepper Prawns",
           "Chicken Satay with Peanut Sauce",
           "Thai Spring Rolls",
-          "Tom Kha Gai (Coconut Chicken Soup)"
+          "Tom Kha Gai (Coconut Chicken Soup)",
+          "Thai Grilled Steak Salad"
         ],
         "entrees": [
           "Yellow Curry (mild and creamy)",
@@ -422,12 +438,16 @@
           "Red Curry (bold and spicy)",
           "Thai Cashew Chicken",
           "Roasted Duck Curry",
-          "Pad Thai"
+          "Pad Thai",
+          "Almond Beef",
+          "Pla Yum Mamuang (fried red snapper)",
+          "Vegetable Fried Rice"
         ],
         "desserts": [
           "Mango Sticky Rice",
           "Thai Coconut and Pandan Pudding",
-          "Fried Bananas with Vanilla Ice Cream"
+          "Fried Bananas with Vanilla Ice Cream",
+          "Lychee Sorbet"
         ]
       },
       "notes": [
@@ -451,7 +471,12 @@
           "Pork Spare Ribs",
           "Smoked Half Chicken",
           "Jalapeño and Cheese Sausage",
-          "Lone Star Potato (loaded baked potato)"
+          "Lone Star Potato (loaded baked potato)",
+          "Pulled Pork",
+          "Turkey Breast",
+          "Beef and Pork Smoked Sausage",
+          "Broiled Citrus Honey Salmon",
+          "Cajun Shrimp Skewers"
         ],
         "sides": [
           "Coleslaw",
@@ -459,15 +484,17 @@
           "Pickles",
           "Barbecue Bacon Baked Beans",
           "Jalapeño Cheese Cornbread",
-          "Chunky Potato Salad"
+          "Chunky Potato Salad",
+          "Corn on the Cob",
+          "Wavy Fries",
+          "Jalapeño Cheese Grits"
         ],
         "desserts": [
-          "Banana Pudding",
-          "Peach Cobbler",
-          "Pecan Pie",
-          "Sweet Potato Pie",
-          "Bread Pudding",
-          "Warm Chocolate Brownies"
+          "Aunt Josie's Mason Jar Banana Pudding",
+          "Peach Cobbler with Vanilla Ice Cream",
+          "Pecan Pie with Whiskey Sauce",
+          "Bread Pudding with Bourbon-Caramel Sauce",
+          "Warm Skillet Brownie (vanilla ice cream and hot chocolate sauce)"
         ]
       },
       "notes": [
@@ -1270,7 +1297,11 @@
           "Crab Cakes",
           "Pan-Seared Scallops",
           "Seafood Bisque",
-          "New England Clam Chowder"
+          "New England Clam Chowder",
+          "Hamachi Ceviche (yellowtail, lime, red onions, fresno chili, plantain chips)",
+          "Blazing Shrimp (crispy shrimp, spicy chili lime mayo)",
+          "Sautéed Calamari (garlic lemon white wine)",
+          "Sticky Thai Barbecue Ribs (Thai ginger slaw, peanut BBQ sauce)"
         ],
         "entrees": [
           "Cioppino (lobster, shrimp, scallops, clams, mussels in tomato-lobster broth)",
@@ -1331,7 +1362,7 @@
       ]
     },
     "pincho-tapas-bar": {
-      "pricing": "$50 per person cover charge (includes 4 items)",
+      "pricing": "$40 per person cover charge (includes 4 items)",
       "items": [
         "Manchego Cheese with Quince Paste",
         "Iberico Ham",
@@ -1341,7 +1372,12 @@
         "Spanish Tortilla",
         "Chorizo in Red Wine",
         "Stuffed Piquillo Peppers",
-        "Sangria (by the glass or pitcher)"
+        "Sangria (by the glass or pitcher)",
+        "Blue Crab Salad",
+        "Bacon-Wrapped Dates",
+        "Calamari a la Plancha",
+        "Shrimp a la Plancha",
+        "Scallops a la Plancha"
       ],
       "notes": [
         "Spanish-inspired tapas bar with shareable small plates. Cover charge includes 4 items.",
@@ -1388,23 +1424,24 @@
       "pricing": "$50 per person cover charge",
       "courses": {
         "appetizers": [
-          "Hot and Sour Soup",
-          "Wonton Soup",
-          "Spring Rolls",
-          "Dim Sum Selection (har gow, siu mai, char siu bao)"
+          "Pork Potstickers",
+          "Harvest Spring Rolls",
+          "Vegetable Dumplings",
+          "Crispy Crab Wontons",
+          "BBQ Pork Spare Ribs",
+          "Hot and Sour Soup"
         ],
         "entrees": [
+          "Orange Beef",
           "Kung Pao Chicken",
-          "Beef with Broccoli",
           "Sweet and Sour Pork",
-          "Mapo Tofu",
           "Shrimp Lo Mein",
-          "Peking Duck (supplemental charge)",
-          "Steamed Sea Bass with Ginger and Scallion"
+          "Steamed Sea Bass with Ginger and Scallion",
+          "Lemon Pepper Shrimp"
         ],
         "desserts": [
-          "Mango Pudding",
-          "Sesame Balls",
+          "Panda Fruit Salad",
+          "Five Spice Chocolate Cake with Ginger Sauce",
           "Lychee Sorbet"
         ]
       },

--- a/restaurants/ncl/bayamo.html
+++ b/restaurants/ncl/bayamo.html
@@ -277,6 +277,8 @@ All work on this project is offered as a gift to God.
             <li>Pan-Seared Scallops</li>
             <li>Seafood Bisque</li>
             <li>New England Clam Chowder</li>
+            <li>Hamachi Ceviche (yellowtail, lime, red onions, fresno chili, plantain chips)</li>
+            <li>Blazing Shrimp (crispy shrimp, spicy chili lime mayo)</li>
           </ul>
         </div>
         <div>

--- a/restaurants/ncl/cagneys-steakhouse.html
+++ b/restaurants/ncl/cagneys-steakhouse.html
@@ -269,13 +269,14 @@ All work on this project is offered as a gift to God.
             <li>Shrimp Cocktail</li>
             <li>Caesar Salad</li>
             <li>Wedge Salad with Blue Cheese</li>
+            <li>Grilled Thick-Cut Bacon</li>
           </ul>
         </div>
         <div>
           <h3>Entrees</h3>
           <ul>
             <li>Rib Eye Steak (16 oz)</li>
-            <li>Filet Mignon (9 oz)</li>
+            <li>Filet Mignon (8 oz)</li>
             <li>NY Strip Steak (14 oz)</li>
             <li>Porterhouse Steak (24 oz)</li>
             <li>Bone-In Ribeye</li>
@@ -300,7 +301,7 @@ All work on this project is offered as a gift to God.
         <h4>Desserts</h4>
         <ul>
           <li>Seven Layer Chocolate Cake</li>
-          <li>New York Cheesecake</li>
+          <li>OMG Caramel Butterscotch Cheesecake</li>
           <li>Crème Brûlée</li>
           <li>Warm Apple Crisp</li>
         </ul>

--- a/restaurants/ncl/chin-chin.html
+++ b/restaurants/ncl/chin-chin.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Chin Chin?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Hot and Sour Soup, Wonton Soup, Spring Rolls, Dim Sum Selection (har gow, siu mai, char siu bao), and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Pork Potstickers, Harvest Spring Rolls, Vegetable Dumplings, Crispy Crab Wontons, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -264,28 +264,30 @@ All work on this project is offered as a gift to God.
         <div>
           <h3>Appetizers</h3>
           <ul>
+            <li>Pork Potstickers</li>
+            <li>Harvest Spring Rolls</li>
+            <li>Vegetable Dumplings</li>
+            <li>Crispy Crab Wontons</li>
+            <li>BBQ Pork Spare Ribs</li>
             <li>Hot and Sour Soup</li>
-            <li>Wonton Soup</li>
-            <li>Spring Rolls</li>
-            <li>Dim Sum Selection (har gow, siu mai, char siu bao)</li>
           </ul>
         </div>
         <div>
           <h3>Entrees</h3>
           <ul>
+            <li>Orange Beef</li>
             <li>Kung Pao Chicken</li>
-            <li>Beef with Broccoli</li>
             <li>Sweet and Sour Pork</li>
-            <li>Mapo Tofu</li>
             <li>Shrimp Lo Mein</li>
-            <li>Peking Duck (supplemental charge)</li>
+            <li>Steamed Sea Bass with Ginger and Scallion</li>
+            <li>Lemon Pepper Shrimp</li>
           </ul>
         </div>
         <div>
           <h3>Desserts</h3>
           <ul>
-            <li>Mango Pudding</li>
-            <li>Sesame Balls</li>
+            <li>Panda Fruit Salad</li>
+            <li>Five Spice Chocolate Cake with Ginger Sauce</li>
             <li>Lychee Sorbet</li>
           </ul>
         </div>
@@ -392,7 +394,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Chin Chin?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Hot and Sour Soup, Wonton Soup, Spring Rolls, Dim Sum Selection (har gow, siu mai, char siu bao), and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Pork Potstickers, Harvest Spring Rolls, Vegetable Dumplings, Crispy Crab Wontons, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/food-republic.html
+++ b/restaurants/ncl/food-republic.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Food Republic?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Korean Fried Chicken Wings, Pork Belly Bao Buns, Pad Thai, Chicken Tikka Masala, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Spicy Korean Fried Chicken with Rice and Radish Cabbage Slaw, Salt and Pepper Calamari with Shichimi and Smoked Soy, Peruvian Beef Skewers with Rustic Aji Panca Sauce, Thai Chicken Lettuce Wraps with Tamarind and Peanut Dipping Sauces, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -264,31 +264,30 @@ All work on this project is offered as a gift to God.
         <div>
           <h3>Small plates</h3>
           <ul>
-            <li>Korean Fried Chicken Wings</li>
-            <li>Pork Belly Bao Buns</li>
-            <li>Pad Thai</li>
-            <li>Chicken Tikka Masala</li>
-            <li>Tempura Shrimp</li>
-            <li>Kimchi Fried Rice</li>
+            <li>Spicy Korean Fried Chicken with Rice and Radish Cabbage Slaw</li>
+            <li>Salt and Pepper Calamari with Shichimi and Smoked Soy</li>
+            <li>Peruvian Beef Skewers with Rustic Aji Panca Sauce</li>
+            <li>Thai Chicken Lettuce Wraps with Tamarind and Peanut Dipping Sauces</li>
+            <li>Pork Belly Bao Buns with Sesame Soy Glaze</li>
+            <li>Shrimp Pad Thai with Tamarind Sauce and Peanuts</li>
           </ul>
         </div>
         <div>
           <h3>Large plates</h3>
           <ul>
-            <li>Peking Duck</li>
-            <li>Tandoori Mixed Grill</li>
-            <li>Black Cod Miso</li>
-            <li>Thai Red Curry</li>
-            <li>Szechuan Mapo Tofu</li>
+            <li>Steak and Noodle Salad</li>
+            <li>Dragon Roll (broiled eel and shrimp tempura)</li>
+            <li>Rock Shrimp Roll (spicy tuna and avocado)</li>
+            <li>Salmon Roll</li>
+            <li>Miso Chicken</li>
+            <li>Pho Tai</li>
           </ul>
         </div>
         <div>
           <h3>Desserts</h3>
           <ul>
-            <li>Mango Sticky Rice</li>
-            <li>Matcha Crème Brûlée</li>
-            <li>Chocolate Spring Rolls</li>
-            <li>Thai Coconut Pudding</li>
+            <li>Green Tea Jar (chocolate brownie and green tea mousse)</li>
+            <li>Dark and Stormy Baba au Rhum (pineapple and ginger caramel)</li>
           </ul>
         </div>
       </div>
@@ -394,7 +393,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Food Republic?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Korean Fried Chicken Wings, Pork Belly Bao Buns, Pad Thai, Chicken Tikka Masala, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Spicy Korean Fried Chicken with Rice and Radish Cabbage Slaw, Salt and Pepper Calamari with Shichimi and Smoked Soy, Peruvian Beef Skewers with Rustic Aji Panca Sauce, Thai Chicken Lettuce Wraps with Tamarind and Peanut Dipping Sauces, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/hasuki.html
+++ b/restaurants/ncl/hasuki.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Hasuki?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Edamame, Miso Soup, Seaweed Salad, Gyoza (Pan-Fried Dumplings), and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Edamame, Miso Soup, Seaweed Salad, NY Strip Steak, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -267,34 +267,43 @@ All work on this project is offered as a gift to God.
             <li>Edamame</li>
             <li>Miso Soup</li>
             <li>Seaweed Salad</li>
-            <li>Gyoza (Pan-Fried Dumplings)</li>
           </ul>
         </div>
         <div>
           <h3>Entrees</h3>
           <ul>
-            <li>Wagyu Beef Hot Pot</li>
-            <li>Seafood Shabu-Shabu</li>
-            <li>Sukiyaki with Premium Beef</li>
-            <li>Chicken Teriyaki Hot Pot</li>
-            <li>Vegetable Hot Pot with Tofu</li>
+            <li>NY Strip Steak</li>
+            <li>Chicken Yaki Udon</li>
+            <li>Seafood (jumbo shrimp, sea scallops, calamari)</li>
+            <li>Yamato (chicken breast and jumbo shrimp)</li>
+            <li>Asuka (New York strip and jumbo shrimp)</li>
+            <li>Kamakura (New York strip and chicken breast)</li>
           </ul>
         </div>
         <div>
-          <h3>Desserts</h3>
+          <h3>Sides</h3>
           <ul>
-            <li>Matcha Ice Cream</li>
-            <li>Yuzu Sorbet</li>
-            <li>Japanese Cheesecake</li>
+            <li>Garlic Fried Rice</li>
+            <li>Teppanyaki-Grilled Vegetables</li>
+            <li>Onion and Creamy Mustard Dipping Sauces</li>
           </ul>
         </div>
       </div>
 
-      <p class="note tiny">Japanese hot pot (shabu-shabu and sukiyaki) dining exclusive to Prima class.</p>
+      <details class="variant">
+        <summary>More Menu Sections</summary>
+        <h4>Desserts</h4>
+        <ul>
+          <li>Green Tea Cake with Cashew Nut Brittle</li>
+          <li>Fresh Fruit Sashimi</li>
+        </ul>
+      </details>
+
+      <p class="note tiny">Teppanyaki-style hibachi dining, Prima class version of Teppanyaki. Chef performs tableside.</p>
       <details class="variant">
         <summary>Additional Notes</summary>
         <ul>
-          <li>Each guest selects broth, protein, and accompaniments for personalized hot pot.</li>
+          <li>Cover charge includes appetizers, one entrée, sides, and dessert.</li>
           <li>Available on Norwegian Prima, Viva, Aqua, and Luna.</li>
         </ul>
       </details>
@@ -391,7 +400,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Hasuki?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Edamame, Miso Soup, Seaweed Salad, Gyoza (Pan-Fried Dumplings), and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Edamame, Miso Soup, Seaweed Salad, NY Strip Steak, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/la-cucina.html
+++ b/restaurants/ncl/la-cucina.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at La Cucina?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Calamari Fritti, Caprese Salad, Bruschetta Trio, Italian Wedding Soup, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Mozzarella Caprese, Burrata Caprese, Calamari Fritti, Antipasti, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -264,43 +264,46 @@ All work on this project is offered as a gift to God.
         <div>
           <h3>Appetizers</h3>
           <ul>
+            <li>Mozzarella Caprese</li>
+            <li>Burrata Caprese</li>
             <li>Calamari Fritti</li>
-            <li>Caprese Salad</li>
-            <li>Bruschetta Trio</li>
-            <li>Italian Wedding Soup</li>
-            <li>Arancini (Stuffed Rice Balls)</li>
+            <li>Antipasti</li>
           </ul>
         </div>
         <div>
           <h3>Pasta</h3>
           <ul>
             <li>Spaghetti Carbonara</li>
-            <li>Fettuccine Alfredo</li>
-            <li>Lasagna Bolognese</li>
-            <li>Penne Arrabbiata</li>
-            <li>Linguine alle Vongole</li>
+            <li>Risotto ai Funghi di Bosco (Mushroom Risotto)</li>
+            <li>Pesto Gnocchi</li>
+            <li>Lasagne</li>
           </ul>
         </div>
         <div>
           <h3>Entrees</h3>
           <ul>
-            <li>Chicken Parmigiana</li>
-            <li>Osso Buco</li>
-            <li>Veal Scallopini</li>
-            <li>Branzino al Forno</li>
-            <li>Eggplant Parmigiana</li>
+            <li>Pollo Cacciatore</li>
+            <li>Filetto di Manzo al Pepe Verde</li>
+            <li>Osso Buco alla Milanese</li>
+            <li>Salmon</li>
+            <li>Frutti Di Mare</li>
           </ul>
         </div>
       </div>
 
       <details class="variant">
         <summary>More Menu Sections</summary>
+        <h4>Pizza</h4>
+        <ul>
+          <li>Margherita</li>
+          <li>Vegetali</li>
+          <li>Meat Lovers</li>
+        </ul>
         <h4>Desserts</h4>
         <ul>
           <li>Tiramisu</li>
+          <li>Panna Cotta alla Vaniglia</li>
           <li>Cannoli</li>
-          <li>Panna Cotta</li>
-          <li>Gelato Selection</li>
         </ul>
       </details>
 
@@ -310,6 +313,7 @@ All work on this project is offered as a gift to God.
         <ul>
           <li>Homemade pasta made fresh daily onboard.</li>
           <li>Available on most NCL ships fleet-wide.</li>
+          <li>Lobster tail supplement: $25.</li>
         </ul>
       </details>
     </div>
@@ -405,7 +409,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at La Cucina?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Calamari Fritti, Caprese Salad, Bruschetta Trio, Italian Wedding Soup, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Mozzarella Caprese, Burrata Caprese, Calamari Fritti, Antipasti, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/le-bistro.html
+++ b/restaurants/ncl/le-bistro.html
@@ -269,6 +269,7 @@ All work on this project is offered as a gift to God.
             <li>Salade Niçoise</li>
             <li>Duck Confit Salad</li>
             <li>Moules Marinières</li>
+            <li>Steak Tartare</li>
           </ul>
         </div>
         <div>
@@ -290,6 +291,7 @@ All work on this project is offered as a gift to God.
             <li>Crème Brûlée</li>
             <li>Profiteroles</li>
             <li>Soufflé du Jour</li>
+            <li>Fraisier</li>
           </ul>
         </div>
       </div>

--- a/restaurants/ncl/los-lobos.html
+++ b/restaurants/ncl/los-lobos.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Los Lobos?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Guacamole Fresco (tableside preparation), Queso Fundido with Chorizo, Elote (Mexican Street Corn), Ceviche Trio, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Guacamole Fresco (tableside preparation), Queso Fundido (melted Mexican cheeses with agave drizzle), Sopa de Tortilla (tortilla soup in smoky tomato broth), Fajitas (chicken, shrimp, or carne asada), and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -265,30 +265,27 @@ All work on this project is offered as a gift to God.
           <h3>Appetizers</h3>
           <ul>
             <li>Guacamole Fresco (tableside preparation)</li>
-            <li>Queso Fundido with Chorizo</li>
-            <li>Elote (Mexican Street Corn)</li>
-            <li>Ceviche Trio</li>
-            <li>Tortilla Soup</li>
+            <li>Queso Fundido (melted Mexican cheeses with agave drizzle)</li>
+            <li>Sopa de Tortilla (tortilla soup in smoky tomato broth)</li>
           </ul>
         </div>
         <div>
           <h3>Entrees</h3>
           <ul>
-            <li>Cochinita Pibil (slow-roasted pork)</li>
-            <li>Carne Asada</li>
-            <li>Pollo en Mole Poblano</li>
-            <li>Grilled Red Snapper Veracruzana</li>
-            <li>Carnitas Tacos</li>
-            <li>Chile Relleno</li>
+            <li>Fajitas (chicken, shrimp, or carne asada)</li>
+            <li>Cochinita Pibil (slow-braised pork on banana leaf)</li>
+            <li>Pescado al Estilo Nayarit (grilled fish with red adobo and salsa verde)</li>
+            <li>Enchiladas de Mole (rotisserie chicken with mole sauce)</li>
           </ul>
         </div>
         <div>
           <h3>Desserts</h3>
           <ul>
-            <li>Churros con Chocolate</li>
-            <li>Tres Leches Cake</li>
-            <li>Mexican Chocolate Flan</li>
-            <li>Mango Sorbet</li>
+            <li>Churros with Dulce de Leche Caramel</li>
+            <li>Pastel de Tres Leches (with coconut cream)</li>
+            <li>Tarteleta Maya (guava gel and spicy chocolate ganache)</li>
+            <li>Hibiscus-Lime Sorbet</li>
+            <li>Passion Fruit-Piloncillo Sorbet</li>
           </ul>
         </div>
       </div>
@@ -299,6 +296,7 @@ All work on this project is offered as a gift to God.
         <ul>
           <li>Tequila and mezcal flights available at additional charge.</li>
           <li>Available on select ships.</li>
+          <li>Select 3 appetizers, 1 entrée, 2 sides, and 3 desserts per person.</li>
         </ul>
       </details>
     </div>
@@ -394,7 +392,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Los Lobos?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Guacamole Fresco (tableside preparation), Queso Fundido with Chorizo, Elote (Mexican Street Corn), Ceviche Trio, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Guacamole Fresco (tableside preparation), Queso Fundido (melted Mexican cheeses with agave drizzle), Sopa de Tortilla (tortilla soup in smoky tomato broth), Fajitas (chicken, shrimp, or carne asada), and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/nama-sushi.html
+++ b/restaurants/ncl/nama-sushi.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Nama Sushi &amp; Sashimi?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Spicy Tuna Roll, Dragon Roll, Rainbow Roll, California Roll, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Kanpachi Crudo (ponzu and serrano pepper), Tuna Pizza (crisp tortilla and garlic aioli), Beef Striploin Carpaccio (yuzu ponzu and shiso leaf), Rock Shrimp Tempura (spicy gochujang aioli), and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -262,32 +262,30 @@ All work on this project is offered as a gift to God.
 
       <div class="grid grid-3">
         <div>
+          <h3>Appetizers</h3>
+          <ul>
+            <li>Kanpachi Crudo (ponzu and serrano pepper)</li>
+            <li>Tuna Pizza (crisp tortilla and garlic aioli)</li>
+            <li>Beef Striploin Carpaccio (yuzu ponzu and shiso leaf)</li>
+            <li>Rock Shrimp Tempura (spicy gochujang aioli)</li>
+            <li>Edamame with BBQ Salt</li>
+          </ul>
+        </div>
+        <div>
           <h3>Sushi rolls</h3>
           <ul>
-            <li>Spicy Tuna Roll</li>
-            <li>Dragon Roll</li>
-            <li>Rainbow Roll</li>
             <li>California Roll</li>
-            <li>Salmon Avocado Roll</li>
-            <li>Shrimp Tempura Roll</li>
+            <li>Spicy Tuna Roll</li>
+            <li>Crispy Salmon Roll (panko and eel sauce)</li>
+            <li>Yellowtail Roll (crab, yuzu juice, and truffle oil)</li>
           </ul>
         </div>
         <div>
           <h3>Sashimi</h3>
           <ul>
-            <li>Tuna Sashimi</li>
-            <li>Salmon Sashimi</li>
-            <li>Yellowtail Sashimi</li>
-            <li>Chef's Sashimi Platter</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Appetizers</h3>
-          <ul>
-            <li>Edamame</li>
-            <li>Miso Soup</li>
-            <li>Seaweed Salad</li>
-            <li>Tempura Vegetables</li>
+            <li>Kanpachi</li>
+            <li>Ahi Tuna</li>
+            <li>Salmon</li>
           </ul>
         </div>
       </div>
@@ -296,9 +294,7 @@ All work on this project is offered as a gift to God.
         <summary>More Menu Sections</summary>
         <h4>Desserts</h4>
         <ul>
-          <li>Mochi Ice Cream</li>
-          <li>Green Tea Crème Brûlée</li>
-          <li>Tempura Banana with Ice Cream</li>
+          <li>Pineapple Carpaccio (lemongrass syrup and pomegranate)</li>
         </ul>
       </details>
 
@@ -308,6 +304,7 @@ All work on this project is offered as a gift to God.
         <ul>
           <li>Premium sake and Japanese whisky available at additional charge.</li>
           <li>Available on select NCL ships.</li>
+          <li>Cover charge includes 4 items per person, sharable among the table.</li>
         </ul>
       </details>
     </div>
@@ -403,7 +400,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Nama Sushi &amp; Sashimi?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Spicy Tuna Roll, Dragon Roll, Rainbow Roll, California Roll, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Kanpachi Crudo (ponzu and serrano pepper), Tuna Pizza (crisp tortilla and garlic aioli), Beef Striploin Carpaccio (yuzu ponzu and shiso leaf), Rock Shrimp Tempura (spicy gochujang aioli), and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/ocean-blue.html
+++ b/restaurants/ncl/ocean-blue.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Ocean Blue?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Oysters on the Half Shell, Jumbo Shrimp Cocktail, Tuna Tartare, Ceviche, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Oysters on the Half Shell, Jumbo Shrimp Cocktail, Tuna Tartare, Lobster Cocktail, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -267,28 +267,25 @@ All work on this project is offered as a gift to God.
             <li>Oysters on the Half Shell</li>
             <li>Jumbo Shrimp Cocktail</li>
             <li>Tuna Tartare</li>
-            <li>Ceviche</li>
             <li>Lobster Cocktail</li>
           </ul>
         </div>
         <div>
           <h3>Appetizers</h3>
           <ul>
-            <li>New England Clam Chowder</li>
-            <li>Seared Scallops</li>
-            <li>Crab-Stuffed Mushrooms</li>
-            <li>Seafood Bisque</li>
+            <li>Ahi Tuna and Avocado Tower (pomegranate soy sauce)</li>
+            <li>Pan-Seared Scallops (caramelized pork belly, anise-spiced soy glaze)</li>
+            <li>Clam Chowder (chopped clams, potatoes, bacon, cream)</li>
           </ul>
         </div>
         <div>
           <h3>Entrees</h3>
           <ul>
-            <li>Whole Roasted Branzino</li>
-            <li>Grilled Swordfish</li>
-            <li>Pan-Seared Halibut</li>
-            <li>King Crab Legs</li>
-            <li>Lobster Thermidor</li>
-            <li>Chilean Sea Bass</li>
+            <li>Cioppino (tomato-lobster broth with lobster, shrimp, scallops, clams)</li>
+            <li>Fisherman's Platter (grilled or fried)</li>
+            <li>Simply Grilled Fish (salmon or sea bass)</li>
+            <li>8 oz Filet Mignon</li>
+            <li>Roasted Brick Chicken (jalapeño-cilantro chimichurri)</li>
           </ul>
         </div>
       </div>
@@ -297,10 +294,8 @@ All work on this project is offered as a gift to God.
         <summary>More Menu Sections</summary>
         <h4>Desserts</h4>
         <ul>
-          <li>Key Lime Pie</li>
-          <li>Chocolate Soufflé</li>
-          <li>Crème Brûlée</li>
-          <li>Lemon Tart</li>
+          <li>Valrhona Dark Chocolate Mousse Cake</li>
+          <li>French Apple Tart à la Mode</li>
         </ul>
       </details>
 
@@ -405,7 +400,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Ocean Blue?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Oysters on the Half Shell, Jumbo Shrimp Cocktail, Tuna Tartare, Ceviche, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Oysters on the Half Shell, Jumbo Shrimp Cocktail, Tuna Tartare, Lobster Cocktail, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/onda-by-scarpetta.html
+++ b/restaurants/ncl/onda-by-scarpetta.html
@@ -257,7 +257,7 @@ All work on this project is offered as a gift to God.
     <div class="card__content menu-body">
       <h2>Menu &amp; Prices</h2>
       <p class="price-note">
-        <strong>Price:</strong> $60 per person cover charge
+        <strong>Price:</strong> $40 per person cover charge
       </p>
 
       <div class="grid grid-3">
@@ -268,6 +268,8 @@ All work on this project is offered as a gift to God.
             <li>Yellowfin Tuna Crudo</li>
             <li>Roasted Beet Salad</li>
             <li>Crispy Polenta with Mushroom Ragù</li>
+            <li>Margherita Pizza</li>
+            <li>Fritto Misto</li>
           </ul>
         </div>
         <div>
@@ -277,6 +279,8 @@ All work on this project is offered as a gift to God.
             <li>Black Pepper Tagliatelle with Braised Short Rib</li>
             <li>Creamy Polenta with Sausage Ragù</li>
             <li>Lemon Spaghetti</li>
+            <li>Pappardelle Bolognese</li>
+            <li>Scialatielli</li>
           </ul>
         </div>
         <div>

--- a/restaurants/ncl/palomar.html
+++ b/restaurants/ncl/palomar.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Palomar?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Beef Carpaccio, Mediterranean Mezze Platter, Roasted Beet and Goat Cheese Salad, Seared Ahi Tuna, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Tuna Crudo (sunchoke and shoyu), Grilled Octopus (fingerling potatoes, pickled red onion), Greek Village Salad (tomato, cucumber, feta, olives), Mediterranean Sea Bass (saffron-carrot puree), and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -264,32 +264,41 @@ All work on this project is offered as a gift to God.
         <div>
           <h3>Appetizers</h3>
           <ul>
-            <li>Beef Carpaccio</li>
-            <li>Mediterranean Mezze Platter</li>
-            <li>Roasted Beet and Goat Cheese Salad</li>
-            <li>Seared Ahi Tuna</li>
+            <li>Tuna Crudo (sunchoke and shoyu)</li>
+            <li>Grilled Octopus (fingerling potatoes, pickled red onion)</li>
+            <li>Greek Village Salad (tomato, cucumber, feta, olives)</li>
           </ul>
         </div>
         <div>
           <h3>Entrees</h3>
           <ul>
-            <li>Pan-Seared Halibut</li>
-            <li>Grilled Lamb Rack</li>
-            <li>Filet Mignon</li>
-            <li>Lobster Risotto</li>
-            <li>Roasted Duck Breast</li>
+            <li>Mediterranean Sea Bass (saffron-carrot puree)</li>
+            <li>Whole Grilled Lobster (olive oil and lemon)</li>
+            <li>Dover Sole</li>
+            <li>Colossal Black Tiger Shrimp</li>
+            <li>New York Strip Steak (bone marrow butter)</li>
+            <li>Grilled Australian Lamb Chops (Gigantes Beans)</li>
           </ul>
         </div>
         <div>
-          <h3>Desserts</h3>
+          <h3>Sides</h3>
           <ul>
-            <li>Dark Chocolate Fondant</li>
-            <li>Lemon Posset</li>
-            <li>Pistachio Crème Brûlée</li>
-            <li>Seasonal Fruit Tart</li>
+            <li>Patates Tiganites</li>
+            <li>Honey Roasted Carrots</li>
+            <li>Grilled Asparagus</li>
           </ul>
         </div>
       </div>
+
+      <details class="variant">
+        <summary>More Menu Sections</summary>
+        <h4>Desserts</h4>
+        <ul>
+          <li>Galaktoboureko (Greek orange custard pie)</li>
+          <li>Valrhona Dark Chocolate Mousse Cake (salted caramel popcorn)</li>
+          <li>French Apple Tart</li>
+        </ul>
+      </details>
 
       <p class="note tiny">Mediterranean fine dining exclusive to Norwegian Prima class ships.</p>
       <details class="variant">
@@ -392,7 +401,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Palomar?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Beef Carpaccio, Mediterranean Mezze Platter, Roasted Beet and Goat Cheese Salad, Seared Ahi Tuna, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Tuna Crudo (sunchoke and shoyu), Grilled Octopus (fingerling potatoes, pickled red onion), Greek Village Salad (tomato, cucumber, feta, olives), Mediterranean Sea Bass (saffron-carrot puree), and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/pincho-tapas-bar.html
+++ b/restaurants/ncl/pincho-tapas-bar.html
@@ -257,7 +257,7 @@ All work on this project is offered as a gift to God.
     <div class="card__content menu-body">
       <h2>Menu &amp; Prices</h2>
       <p class="price-note">
-        <strong>Price:</strong> $50 per person cover charge (includes 4 items)
+        <strong>Price:</strong> $40 per person cover charge (includes 4 items)
       </p>
 
       <h3>Menu Items</h3>
@@ -271,6 +271,11 @@ All work on this project is offered as a gift to God.
         <li>Chorizo in Red Wine</li>
         <li>Stuffed Piquillo Peppers</li>
         <li>Sangria (by the glass or pitcher)</li>
+        <li>Blue Crab Salad</li>
+        <li>Bacon-Wrapped Dates</li>
+        <li>Calamari a la Plancha</li>
+        <li>Shrimp a la Plancha</li>
+        <li>Scallops a la Plancha</li>
       </ul>
 
       <p class="note tiny">Spanish-inspired tapas bar with shareable small plates. Cover charge includes 4 items.</p>

--- a/restaurants/ncl/q-texas-smokehouse.html
+++ b/restaurants/ncl/q-texas-smokehouse.html
@@ -298,12 +298,11 @@ All work on this project is offered as a gift to God.
         <summary>More Menu Sections</summary>
         <h4>Desserts</h4>
         <ul>
-          <li>Banana Pudding</li>
-          <li>Peach Cobbler</li>
-          <li>Pecan Pie</li>
-          <li>Sweet Potato Pie</li>
-          <li>Bread Pudding</li>
-          <li>Warm Chocolate Brownies</li>
+          <li>Aunt Josie's Mason Jar Banana Pudding</li>
+          <li>Peach Cobbler with Vanilla Ice Cream</li>
+          <li>Pecan Pie with Whiskey Sauce</li>
+          <li>Bread Pudding with Bourbon-Caramel Sauce</li>
+          <li>Warm Skillet Brownie (vanilla ice cream and hot chocolate sauce)</li>
         </ul>
       </details>
 

--- a/restaurants/ncl/sukhothai.html
+++ b/restaurants/ncl/sukhothai.html
@@ -268,6 +268,7 @@ All work on this project is offered as a gift to God.
             <li>Chicken Satay with Peanut Sauce</li>
             <li>Thai Spring Rolls</li>
             <li>Tom Kha Gai (Coconut Chicken Soup)</li>
+            <li>Thai Grilled Steak Salad</li>
           </ul>
         </div>
         <div>
@@ -287,6 +288,7 @@ All work on this project is offered as a gift to God.
             <li>Mango Sticky Rice</li>
             <li>Thai Coconut and Pandan Pudding</li>
             <li>Fried Bananas with Vanilla Ice Cream</li>
+            <li>Lychee Sorbet</li>
           </ul>
         </div>
       </div>

--- a/restaurants/ncl/teppanyaki.html
+++ b/restaurants/ncl/teppanyaki.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Teppanyaki?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Miso Soup, Edamame, Seaweed Salad, NY Strip Steak with Grilled Vegetables, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Miso Soup, Edamame, Seaweed Salad, NY Strip Steak, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -272,21 +272,20 @@ All work on this project is offered as a gift to God.
         <div>
           <h3>Entrees</h3>
           <ul>
-            <li>NY Strip Steak with Grilled Vegetables</li>
-            <li>Filet Mignon Combination</li>
-            <li>Lobster Tail Teppanyaki</li>
-            <li>Chicken Teriyaki</li>
-            <li>Shrimp and Scallop Combination</li>
-            <li>Tofu Steak with Seasonal Vegetables</li>
+            <li>NY Strip Steak</li>
+            <li>Chicken Yaki Udon</li>
+            <li>Seafood (jumbo shrimp, sea scallops, calamari)</li>
+            <li>Yamato (chicken breast and jumbo shrimp)</li>
+            <li>Asuka (New York strip and jumbo shrimp)</li>
+            <li>Kamakura (New York strip and chicken breast)</li>
           </ul>
         </div>
         <div>
           <h3>Sides</h3>
           <ul>
-            <li>Fried Rice</li>
-            <li>Grilled Zucchini</li>
-            <li>Bean Sprouts</li>
-            <li>Mushrooms</li>
+            <li>Garlic Fried Rice</li>
+            <li>Teppanyaki-Grilled Vegetables</li>
+            <li>Onion and Creamy Mustard Dipping Sauces</li>
           </ul>
         </div>
       </div>
@@ -295,9 +294,8 @@ All work on this project is offered as a gift to God.
         <summary>More Menu Sections</summary>
         <h4>Desserts</h4>
         <ul>
-          <li>Green Tea Cake</li>
-          <li>Tempura Ice Cream</li>
-          <li>Mochi</li>
+          <li>Green Tea Cake with Cashew Nut Brittle</li>
+          <li>Fresh Fruit Sashimi</li>
         </ul>
       </details>
 
@@ -402,7 +400,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Teppanyaki?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Miso Soup, Edamame, Seaweed Salad, NY Strip Steak with Grilled Vegetables, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Miso Soup, Edamame, Seaweed Salad, NY Strip Steak, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>


### PR DESCRIPTION
…rces

Audited all NCL specialty dining menus against real sources (Freestyle Travelers, NCL official, Prof. Cruise, Norwegian Cruise Blog, Shine Cruise).

Key corrections:
- Cagney's: 8oz filet (not 9oz), added Grilled Thick-Cut Bacon, Fisherman's Platter, OMG Caramel Butterscotch Cheesecake
- Le Bistro: Added Steak Tartare, Filet de Boeuf, Lobster Thermidor, Dover Sole, Fraisier
- Onda: Cover charge $40 (not $60), added Margherita Pizza, Fritto Misto, Pappardelle Bolognese
- Teppanyaki: Corrected to real combo entrees (Yamato, Asuka, Kamakura, Edo)
- Los Lobos: Replaced with real menu items (Fajitas, Cochinita Pibil, Pescado al Estilo Nayarit, Tarteleta Maya)
- Food Republic: Replaced with real items (Korean Fried Chicken, Peruvian Beef Skewers, Pork Belly Bao Buns, Dragon Roll)
- La Cucina: Added pizza section, Burrata Caprese, Risotto ai Funghi
- Ocean Blue: Added real appetizers and corrected entrees
- Palomar: Replaced with Mediterranean menu (Tuna Crudo, Grilled Octopus, Med Sea Bass, Galaktoboureko)
- Hasuki: Corrected from shabu-shabu to teppanyaki-style (same as Teppanyaki on Prima class)
- Nama Sushi: Corrected with real items (Kanpachi Crudo, Crispy Salmon Roll, Pineapple Carpaccio)
- Sukhothai: Added Almond Beef, Pla Yum Mamuang, Lychee Sorbet
- Q Texas Smokehouse: Added Pulled Pork, Turkey Breast, corrected dessert names (Aunt Josie's Banana Pudding)
- Pincho Tapas: Cover charge $40 (not $50), added plancha items
- Bayamo: Added Hamachi Ceviche, Blazing Shrimp, Sticky Thai BBQ Ribs
- Chin Chin: Replaced with real items (Pork Potstickers, Orange Beef, Five Spice Chocolate Cake)

https://claude.ai/code/session_014YvvbeoRt2xRLwHnZ4JttD