### PR TITLE
feat: Replace static NCL MDR menus with verified Classic + Rotating p…

### DIFF
--- a/admin/generate-ncl-venue-pages.js
+++ b/admin/generate-ncl-venue-pages.js
@@ -367,6 +367,10 @@ const COURSE_NAMES = {
   'bbq-plates': 'BBQ Plates', appetizers: 'Appetizers',
   'rice-noodles': 'Rice &amp; Noodles', experience: 'Experience',
   breakfast: 'Breakfast', lunch: 'Lunch', 'all-day': 'All Day',
+  'classic-entrees': 'Classic Entrees (Every Night)',
+  'rotating-appetizers': 'Rotating Appetizers',
+  'rotating-entrees': 'Rotating Featured Entrees',
+  'rotating-desserts': 'Rotating Desserts',
 };
 function formatCourse(n) { return COURSE_NAMES[n] || cap(n.replace(/-/g, ' ')); }
 function cap(s) { return s.charAt(0).toUpperCase() + s.slice(1); }

--- a/assets/data/ncl-venue-menus.json
+++ b/assets/data/ncl-venue-menus.json
@@ -551,153 +551,211 @@
     "taste": {
       "pricing": "Complimentary (included in cruise fare)",
       "courses": {
-        "appetizers": [
-          "Roasted Tomato Soup",
-          "Shrimp Fritters",
-          "Caesar Salad",
-          "Cream of Mushroom Soup",
-          "Italian Wedding Soup"
+        "classic-entrees": [
+          "Grilled New York Strip Steak",
+          "Breaded Flounder Fillet",
+          "Herb-Crusted Rotisserie Chicken",
+          "Shrimp & Mushroom Alfredo",
+          "Three-Cheese Baked Ziti"
         ],
-        "entrees": [
-          "Grilled Salmon",
-          "Roasted Chicken",
-          "Braised Short Ribs",
-          "Pan-Seared Sea Bass",
-          "Pork Tenderloin",
-          "Pasta Primavera",
-          "NY Strip Steak"
+        "rotating-appetizers": [
+          "Shrimp Cake",
+          "Prawn & Vegetable Provence",
+          "Waldorf Salad",
+          "Bruschetta",
+          "Cheese Ravioli",
+          "Cream of Cauliflower Soup"
         ],
-        "desserts": [
-          "Chocolate Melting Cake",
-          "Crème Brûlée",
-          "Apple Pie",
-          "Cheesecake",
-          "Tiramisu"
+        "rotating-entrees": [
+          "BBQ Spare Ribs",
+          "Leg of Lamb",
+          "Bang Bang Chicken",
+          "Chicken Cordon Bleu",
+          "Chinese-Style BBQ Pork",
+          "Braised Lamb Shank"
+        ],
+        "rotating-desserts": [
+          "Warm Chocolate Lava Cake",
+          "Honey Crème Brûlée",
+          "Bananas Foster",
+          "Tiramisu Cake",
+          "Apple Cobbler",
+          "Chocolate Eclairs"
         ]
       },
       "notes": [
-        "Main dining room with rotating nightly menus. No reservations required.",
-        "Menus rotate on a 7-night cycle with different nightly themes.",
-        "Available on most NCL ships."
+        "Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.",
+        "2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.",
+        "Same menu as Savor and The Manhattan Room. Freestyle Dining — no fixed seating times.",
+        "Ordering more than one entree incurs a $5 charge per additional entree (2026 policy)."
       ]
     },
     "savor": {
       "pricing": "Complimentary (included in cruise fare)",
       "courses": {
-        "appetizers": [
-          "Sweet Corn Hush Puppies",
-          "Vietnamese Chicken Pho",
-          "Niçoise Salad",
-          "Bistro Salad",
-          "Cobb Salad"
+        "classic-entrees": [
+          "Grilled New York Strip Steak",
+          "Breaded Flounder Fillet",
+          "Herb-Crusted Rotisserie Chicken",
+          "Shrimp & Mushroom Alfredo",
+          "Three-Cheese Baked Ziti"
         ],
-        "entrees": [
-          "Cajun Chicken Pasta",
-          "Grilled Pork Chop",
-          "Beef Moussaka",
-          "Poached Boston Bluefish",
-          "Cuban Rotisserie Chicken",
-          "St. Louis BBQ Pork",
-          "Spaghetti Carbonara"
+        "rotating-appetizers": [
+          "Shrimp Cake",
+          "Prawn & Vegetable Provence",
+          "Waldorf Salad",
+          "Bruschetta",
+          "Cheese Ravioli",
+          "Cream of Cauliflower Soup"
         ],
-        "desserts": [
-          "Chocolate Lava Cake",
-          "Key Lime Pie",
-          "Bread Pudding",
-          "Gelato Selection"
+        "rotating-entrees": [
+          "BBQ Spare Ribs",
+          "Leg of Lamb",
+          "Bang Bang Chicken",
+          "Chicken Cordon Bleu",
+          "Chinese-Style BBQ Pork",
+          "Braised Lamb Shank"
+        ],
+        "rotating-desserts": [
+          "Warm Chocolate Lava Cake",
+          "Honey Crème Brûlée",
+          "Bananas Foster",
+          "Tiramisu Cake",
+          "Apple Cobbler",
+          "Chocolate Eclairs"
         ]
       },
       "notes": [
-        "Second main dining room with same rotating menu as Taste.",
-        "Freestyle Dining — no fixed seating times, walk in anytime.",
-        "Available on most NCL ships."
+        "Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.",
+        "2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.",
+        "Same menu as Taste and The Manhattan Room. Freestyle Dining — no fixed seating times.",
+        "Ordering more than one entree incurs a $5 charge per additional entree (2026 policy)."
       ]
     },
     "the-manhattan-room": {
       "pricing": "Complimentary (included in cruise fare)",
       "courses": {
-        "appetizers": [
-          "Roasted Tomato Soup",
-          "Shrimp Cocktail",
-          "Caesar Salad",
-          "French Onion Soup"
+        "classic-entrees": [
+          "Grilled New York Strip Steak",
+          "Breaded Flounder Fillet",
+          "Herb-Crusted Rotisserie Chicken",
+          "Shrimp & Mushroom Alfredo",
+          "Three-Cheese Baked Ziti"
         ],
-        "entrees": [
-          "Grilled Salmon",
-          "Braised Short Ribs",
-          "Roasted Chicken",
-          "Pan-Seared Sea Bass",
-          "NY Strip Steak",
-          "Pork Tenderloin"
+        "rotating-appetizers": [
+          "Shrimp Cake",
+          "Prawn & Vegetable Provence",
+          "Waldorf Salad",
+          "Bruschetta",
+          "Cheese Ravioli",
+          "Cream of Cauliflower Soup"
         ],
-        "desserts": [
-          "Chocolate Melting Cake",
-          "Cheesecake",
-          "Crème Brûlée",
-          "Apple Pie"
+        "rotating-entrees": [
+          "BBQ Spare Ribs",
+          "Leg of Lamb",
+          "Bang Bang Chicken",
+          "Chicken Cordon Bleu",
+          "Chinese-Style BBQ Pork",
+          "Braised Lamb Shank"
+        ],
+        "rotating-desserts": [
+          "Warm Chocolate Lava Cake",
+          "Honey Crème Brûlée",
+          "Bananas Foster",
+          "Tiramisu Cake",
+          "Apple Cobbler",
+          "Chocolate Eclairs"
         ]
       },
       "notes": [
-        "Grand main dining room on Breakaway and Getaway class ships.",
-        "Same rotating menu as Taste and Savor. Live music during dinner.",
-        "Two-deck-high venue with panoramic ocean views."
+        "Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.",
+        "2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.",
+        "Grand two-deck dining room on Breakaway and Getaway class ships. Same menu as Taste and Savor. Live music during dinner.",
+        "Ordering more than one entree incurs a $5 charge per additional entree (2026 policy)."
       ]
     },
     "hudsons": {
       "pricing": "Complimentary (included in cruise fare)",
       "courses": {
-        "appetizers": [
-          "Roasted Tomato Soup",
-          "Shrimp Fritters",
-          "Caesar Salad",
-          "Italian Wedding Soup"
+        "classic-entrees": [
+          "Grilled New York Strip Steak",
+          "Breaded Flounder Fillet",
+          "Herb-Crusted Rotisserie Chicken",
+          "Shrimp & Mushroom Alfredo",
+          "Three-Cheese Baked Ziti"
         ],
-        "entrees": [
-          "Grilled Salmon",
-          "Braised Short Ribs",
-          "Roasted Chicken",
-          "Pan-Seared Sea Bass",
-          "NY Strip Steak"
+        "rotating-appetizers": [
+          "Shrimp Cake",
+          "Prawn & Vegetable Provence",
+          "Waldorf Salad",
+          "Bruschetta",
+          "Cheese Ravioli",
+          "Cream of Cauliflower Soup"
         ],
-        "desserts": [
-          "Chocolate Melting Cake",
-          "Cheesecake",
-          "Crème Brûlée",
-          "Apple Pie"
+        "rotating-entrees": [
+          "BBQ Spare Ribs",
+          "Leg of Lamb",
+          "Bang Bang Chicken",
+          "Chicken Cordon Bleu",
+          "Chinese-Style BBQ Pork",
+          "Braised Lamb Shank"
+        ],
+        "rotating-desserts": [
+          "Warm Chocolate Lava Cake",
+          "Honey Crème Brûlée",
+          "Bananas Foster",
+          "Tiramisu Cake",
+          "Apple Cobbler",
+          "Chocolate Eclairs"
         ]
       },
       "notes": [
-        "Main dining room exclusive to Norwegian Prima class ships.",
-        "Same rotating nightly menus. Named after the Hudson River.",
-        "Available on Norwegian Prima, Viva, Aqua, and Luna."
+        "Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.",
+        "2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.",
+        "Main dining room on Prima class ships (Prima, Viva, Aqua, Luna). Same menu as The Commodore Room.",
+        "Ordering more than one entree incurs a $5 charge per additional entree (2026 policy)."
       ]
     },
     "the-commodore-room": {
       "pricing": "Complimentary (included in cruise fare)",
       "courses": {
-        "appetizers": [
-          "Roasted Tomato Soup",
-          "Shrimp Cocktail",
-          "Caesar Salad",
-          "French Onion Soup"
+        "classic-entrees": [
+          "Grilled New York Strip Steak",
+          "Breaded Flounder Fillet",
+          "Herb-Crusted Rotisserie Chicken",
+          "Shrimp & Mushroom Alfredo",
+          "Three-Cheese Baked Ziti"
         ],
-        "entrees": [
-          "Grilled Salmon",
-          "Braised Short Ribs",
-          "Roasted Chicken",
-          "Pan-Seared Sea Bass",
-          "NY Strip Steak"
+        "rotating-appetizers": [
+          "Shrimp Cake",
+          "Prawn & Vegetable Provence",
+          "Waldorf Salad",
+          "Bruschetta",
+          "Cheese Ravioli",
+          "Cream of Cauliflower Soup"
         ],
-        "desserts": [
-          "Chocolate Melting Cake",
-          "Cheesecake",
-          "Crème Brûlée"
+        "rotating-entrees": [
+          "BBQ Spare Ribs",
+          "Leg of Lamb",
+          "Bang Bang Chicken",
+          "Chicken Cordon Bleu",
+          "Chinese-Style BBQ Pork",
+          "Braised Lamb Shank"
+        ],
+        "rotating-desserts": [
+          "Warm Chocolate Lava Cake",
+          "Honey Crème Brûlée",
+          "Bananas Foster",
+          "Tiramisu Cake",
+          "Apple Cobbler",
+          "Chocolate Eclairs"
         ]
       },
       "notes": [
-        "Second main dining room on Prima class ships.",
-        "Same rotating nightly menus as Hudson's.",
-        "Available on Norwegian Prima, Viva, Aqua, and Luna."
+        "Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.",
+        "2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.",
+        "Second main dining room on Prima class ships (Prima, Viva, Aqua, Luna). Same menu as Hudson's.",
+        "Ordering more than one entree incurs a $5 charge per additional entree (2026 policy)."
       ]
     },
     "garden-cafe": {
@@ -1211,31 +1269,43 @@
     "grand-pacific": {
       "pricing": "Complimentary (included in cruise fare)",
       "courses": {
-        "appetizers": [
-          "Roasted Tomato Soup",
-          "Shrimp Cocktail",
-          "Caesar Salad",
-          "French Onion Soup"
+        "classic-entrees": [
+          "Grilled New York Strip Steak",
+          "Breaded Flounder Fillet",
+          "Herb-Crusted Rotisserie Chicken",
+          "Shrimp & Mushroom Alfredo",
+          "Three-Cheese Baked Ziti"
         ],
-        "entrees": [
-          "Grilled Salmon",
-          "Braised Short Ribs",
-          "Roasted Chicken",
-          "Pan-Seared Sea Bass",
-          "NY Strip Steak",
-          "Pork Tenderloin"
+        "rotating-appetizers": [
+          "Shrimp Cake",
+          "Prawn & Vegetable Provence",
+          "Waldorf Salad",
+          "Bruschetta",
+          "Cheese Ravioli",
+          "Cream of Cauliflower Soup"
         ],
-        "desserts": [
-          "Chocolate Melting Cake",
-          "Cheesecake",
-          "Crème Brûlée",
-          "Apple Pie"
+        "rotating-entrees": [
+          "BBQ Spare Ribs",
+          "Leg of Lamb",
+          "Bang Bang Chicken",
+          "Chicken Cordon Bleu",
+          "Chinese-Style BBQ Pork",
+          "Braised Lamb Shank"
+        ],
+        "rotating-desserts": [
+          "Warm Chocolate Lava Cake",
+          "Honey Crème Brûlée",
+          "Bananas Foster",
+          "Tiramisu Cake",
+          "Apple Cobbler",
+          "Chocolate Eclairs"
         ]
       },
       "notes": [
-        "Main dining room on Norwegian Sun and other classic ships.",
-        "Same rotating nightly menus as other NCL main dining rooms.",
-        "Named for the Pacific Ocean. Elegant two-deck dining room."
+        "Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.",
+        "2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.",
+        "Main dining room on Norwegian Sun and other classic-era ships. Same fleet-wide menu rotation.",
+        "Ordering more than one entree incurs a $5 charge per additional entree (2026 policy)."
       ]
     },
     "surfside-grill": {

--- a/restaurants/ncl/grand-pacific.html
+++ b/restaurants/ncl/grand-pacific.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Grand Pacific?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Roasted Tomato Soup, Shrimp Cocktail, Caesar Salad, French Onion Soup, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -262,42 +262,59 @@ All work on this project is offered as a gift to God.
 
       <div class="grid grid-3">
         <div>
-          <h3>Appetizers</h3>
+          <h3>Classic Entrees (Every Night)</h3>
           <ul>
-            <li>Roasted Tomato Soup</li>
-            <li>Shrimp Cocktail</li>
-            <li>Caesar Salad</li>
-            <li>French Onion Soup</li>
+            <li>Grilled New York Strip Steak</li>
+            <li>Breaded Flounder Fillet</li>
+            <li>Herb-Crusted Rotisserie Chicken</li>
+            <li>Shrimp &amp; Mushroom Alfredo</li>
+            <li>Three-Cheese Baked Ziti</li>
           </ul>
         </div>
         <div>
-          <h3>Entrees</h3>
+          <h3>Rotating Appetizers</h3>
           <ul>
-            <li>Grilled Salmon</li>
-            <li>Braised Short Ribs</li>
-            <li>Roasted Chicken</li>
-            <li>Pan-Seared Sea Bass</li>
-            <li>NY Strip Steak</li>
-            <li>Pork Tenderloin</li>
+            <li>Shrimp Cake</li>
+            <li>Prawn &amp; Vegetable Provence</li>
+            <li>Waldorf Salad</li>
+            <li>Bruschetta</li>
+            <li>Cheese Ravioli</li>
+            <li>Cream of Cauliflower Soup</li>
           </ul>
         </div>
         <div>
-          <h3>Desserts</h3>
+          <h3>Rotating Featured Entrees</h3>
           <ul>
-            <li>Chocolate Melting Cake</li>
-            <li>Cheesecake</li>
-            <li>Crème Brûlée</li>
-            <li>Apple Pie</li>
+            <li>BBQ Spare Ribs</li>
+            <li>Leg of Lamb</li>
+            <li>Bang Bang Chicken</li>
+            <li>Chicken Cordon Bleu</li>
+            <li>Chinese-Style BBQ Pork</li>
+            <li>Braised Lamb Shank</li>
           </ul>
         </div>
       </div>
 
-      <p class="note tiny">Main dining room on Norwegian Sun and other classic ships.</p>
+      <details class="variant">
+        <summary>More Menu Sections</summary>
+        <h4>Rotating Desserts</h4>
+        <ul>
+          <li>Warm Chocolate Lava Cake</li>
+          <li>Honey Crème Brûlée</li>
+          <li>Bananas Foster</li>
+          <li>Tiramisu Cake</li>
+          <li>Apple Cobbler</li>
+          <li>Chocolate Eclairs</li>
+        </ul>
+      </details>
+
+      <p class="note tiny">Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.</p>
       <details class="variant">
         <summary>Additional Notes</summary>
         <ul>
-          <li>Same rotating nightly menus as other NCL main dining rooms.</li>
-          <li>Named for the Pacific Ocean. Elegant two-deck dining room.</li>
+          <li>2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.</li>
+          <li>Main dining room on Norwegian Sun and other classic-era ships. Same fleet-wide menu rotation.</li>
+          <li>Ordering more than one entree incurs a $5 charge per additional entree (2026 policy).</li>
         </ul>
       </details>
     </div>
@@ -393,7 +410,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Grand Pacific?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Roasted Tomato Soup, Shrimp Cocktail, Caesar Salad, French Onion Soup, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/hudsons.html
+++ b/restaurants/ncl/hudsons.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Hudson's?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Roasted Tomato Soup, Shrimp Fritters, Caesar Salad, Italian Wedding Soup, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -262,41 +262,59 @@ All work on this project is offered as a gift to God.
 
       <div class="grid grid-3">
         <div>
-          <h3>Appetizers</h3>
+          <h3>Classic Entrees (Every Night)</h3>
           <ul>
-            <li>Roasted Tomato Soup</li>
-            <li>Shrimp Fritters</li>
-            <li>Caesar Salad</li>
-            <li>Italian Wedding Soup</li>
+            <li>Grilled New York Strip Steak</li>
+            <li>Breaded Flounder Fillet</li>
+            <li>Herb-Crusted Rotisserie Chicken</li>
+            <li>Shrimp &amp; Mushroom Alfredo</li>
+            <li>Three-Cheese Baked Ziti</li>
           </ul>
         </div>
         <div>
-          <h3>Entrees</h3>
+          <h3>Rotating Appetizers</h3>
           <ul>
-            <li>Grilled Salmon</li>
-            <li>Braised Short Ribs</li>
-            <li>Roasted Chicken</li>
-            <li>Pan-Seared Sea Bass</li>
-            <li>NY Strip Steak</li>
+            <li>Shrimp Cake</li>
+            <li>Prawn &amp; Vegetable Provence</li>
+            <li>Waldorf Salad</li>
+            <li>Bruschetta</li>
+            <li>Cheese Ravioli</li>
+            <li>Cream of Cauliflower Soup</li>
           </ul>
         </div>
         <div>
-          <h3>Desserts</h3>
+          <h3>Rotating Featured Entrees</h3>
           <ul>
-            <li>Chocolate Melting Cake</li>
-            <li>Cheesecake</li>
-            <li>Crème Brûlée</li>
-            <li>Apple Pie</li>
+            <li>BBQ Spare Ribs</li>
+            <li>Leg of Lamb</li>
+            <li>Bang Bang Chicken</li>
+            <li>Chicken Cordon Bleu</li>
+            <li>Chinese-Style BBQ Pork</li>
+            <li>Braised Lamb Shank</li>
           </ul>
         </div>
       </div>
 
-      <p class="note tiny">Main dining room exclusive to Norwegian Prima class ships.</p>
+      <details class="variant">
+        <summary>More Menu Sections</summary>
+        <h4>Rotating Desserts</h4>
+        <ul>
+          <li>Warm Chocolate Lava Cake</li>
+          <li>Honey Crème Brûlée</li>
+          <li>Bananas Foster</li>
+          <li>Tiramisu Cake</li>
+          <li>Apple Cobbler</li>
+          <li>Chocolate Eclairs</li>
+        </ul>
+      </details>
+
+      <p class="note tiny">Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.</p>
       <details class="variant">
         <summary>Additional Notes</summary>
         <ul>
-          <li>Same rotating nightly menus. Named after the Hudson River.</li>
-          <li>Available on Norwegian Prima, Viva, Aqua, and Luna.</li>
+          <li>2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.</li>
+          <li>Main dining room on Prima class ships (Prima, Viva, Aqua, Luna). Same menu as The Commodore Room.</li>
+          <li>Ordering more than one entree incurs a $5 charge per additional entree (2026 policy).</li>
         </ul>
       </details>
     </div>
@@ -392,7 +410,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Hudson's?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Roasted Tomato Soup, Shrimp Fritters, Caesar Salad, Italian Wedding Soup, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/savor.html
+++ b/restaurants/ncl/savor.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Savor?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Sweet Corn Hush Puppies, Vietnamese Chicken Pho, Niçoise Salad, Bistro Salad, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -262,43 +262,59 @@ All work on this project is offered as a gift to God.
 
       <div class="grid grid-3">
         <div>
-          <h3>Appetizers</h3>
+          <h3>Classic Entrees (Every Night)</h3>
           <ul>
-            <li>Sweet Corn Hush Puppies</li>
-            <li>Vietnamese Chicken Pho</li>
-            <li>Niçoise Salad</li>
-            <li>Bistro Salad</li>
-            <li>Cobb Salad</li>
+            <li>Grilled New York Strip Steak</li>
+            <li>Breaded Flounder Fillet</li>
+            <li>Herb-Crusted Rotisserie Chicken</li>
+            <li>Shrimp &amp; Mushroom Alfredo</li>
+            <li>Three-Cheese Baked Ziti</li>
           </ul>
         </div>
         <div>
-          <h3>Entrees</h3>
+          <h3>Rotating Appetizers</h3>
           <ul>
-            <li>Cajun Chicken Pasta</li>
-            <li>Grilled Pork Chop</li>
-            <li>Beef Moussaka</li>
-            <li>Poached Boston Bluefish</li>
-            <li>Cuban Rotisserie Chicken</li>
-            <li>St. Louis BBQ Pork</li>
+            <li>Shrimp Cake</li>
+            <li>Prawn &amp; Vegetable Provence</li>
+            <li>Waldorf Salad</li>
+            <li>Bruschetta</li>
+            <li>Cheese Ravioli</li>
+            <li>Cream of Cauliflower Soup</li>
           </ul>
         </div>
         <div>
-          <h3>Desserts</h3>
+          <h3>Rotating Featured Entrees</h3>
           <ul>
-            <li>Chocolate Lava Cake</li>
-            <li>Key Lime Pie</li>
-            <li>Bread Pudding</li>
-            <li>Gelato Selection</li>
+            <li>BBQ Spare Ribs</li>
+            <li>Leg of Lamb</li>
+            <li>Bang Bang Chicken</li>
+            <li>Chicken Cordon Bleu</li>
+            <li>Chinese-Style BBQ Pork</li>
+            <li>Braised Lamb Shank</li>
           </ul>
         </div>
       </div>
 
-      <p class="note tiny">Second main dining room with same rotating menu as Taste.</p>
+      <details class="variant">
+        <summary>More Menu Sections</summary>
+        <h4>Rotating Desserts</h4>
+        <ul>
+          <li>Warm Chocolate Lava Cake</li>
+          <li>Honey Crème Brûlée</li>
+          <li>Bananas Foster</li>
+          <li>Tiramisu Cake</li>
+          <li>Apple Cobbler</li>
+          <li>Chocolate Eclairs</li>
+        </ul>
+      </details>
+
+      <p class="note tiny">Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.</p>
       <details class="variant">
         <summary>Additional Notes</summary>
         <ul>
-          <li>Freestyle Dining — no fixed seating times, walk in anytime.</li>
-          <li>Available on most NCL ships.</li>
+          <li>2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.</li>
+          <li>Same menu as Taste and The Manhattan Room. Freestyle Dining — no fixed seating times.</li>
+          <li>Ordering more than one entree incurs a $5 charge per additional entree (2026 policy).</li>
         </ul>
       </details>
     </div>
@@ -394,7 +410,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Savor?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Sweet Corn Hush Puppies, Vietnamese Chicken Pho, Niçoise Salad, Bistro Salad, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/taste.html
+++ b/restaurants/ncl/taste.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at Taste?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Roasted Tomato Soup, Shrimp Fritters, Caesar Salad, Cream of Mushroom Soup, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -262,44 +262,59 @@ All work on this project is offered as a gift to God.
 
       <div class="grid grid-3">
         <div>
-          <h3>Appetizers</h3>
+          <h3>Classic Entrees (Every Night)</h3>
           <ul>
-            <li>Roasted Tomato Soup</li>
-            <li>Shrimp Fritters</li>
-            <li>Caesar Salad</li>
-            <li>Cream of Mushroom Soup</li>
-            <li>Italian Wedding Soup</li>
+            <li>Grilled New York Strip Steak</li>
+            <li>Breaded Flounder Fillet</li>
+            <li>Herb-Crusted Rotisserie Chicken</li>
+            <li>Shrimp &amp; Mushroom Alfredo</li>
+            <li>Three-Cheese Baked Ziti</li>
           </ul>
         </div>
         <div>
-          <h3>Entrees</h3>
+          <h3>Rotating Appetizers</h3>
           <ul>
-            <li>Grilled Salmon</li>
-            <li>Roasted Chicken</li>
-            <li>Braised Short Ribs</li>
-            <li>Pan-Seared Sea Bass</li>
-            <li>Pork Tenderloin</li>
-            <li>Pasta Primavera</li>
+            <li>Shrimp Cake</li>
+            <li>Prawn &amp; Vegetable Provence</li>
+            <li>Waldorf Salad</li>
+            <li>Bruschetta</li>
+            <li>Cheese Ravioli</li>
+            <li>Cream of Cauliflower Soup</li>
           </ul>
         </div>
         <div>
-          <h3>Desserts</h3>
+          <h3>Rotating Featured Entrees</h3>
           <ul>
-            <li>Chocolate Melting Cake</li>
-            <li>Crème Brûlée</li>
-            <li>Apple Pie</li>
-            <li>Cheesecake</li>
-            <li>Tiramisu</li>
+            <li>BBQ Spare Ribs</li>
+            <li>Leg of Lamb</li>
+            <li>Bang Bang Chicken</li>
+            <li>Chicken Cordon Bleu</li>
+            <li>Chinese-Style BBQ Pork</li>
+            <li>Braised Lamb Shank</li>
           </ul>
         </div>
       </div>
 
-      <p class="note tiny">Main dining room with rotating nightly menus. No reservations required.</p>
+      <details class="variant">
+        <summary>More Menu Sections</summary>
+        <h4>Rotating Desserts</h4>
+        <ul>
+          <li>Warm Chocolate Lava Cake</li>
+          <li>Honey Crème Brûlée</li>
+          <li>Bananas Foster</li>
+          <li>Tiramisu Cake</li>
+          <li>Apple Cobbler</li>
+          <li>Chocolate Eclairs</li>
+        </ul>
+      </details>
+
+      <p class="note tiny">Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.</p>
       <details class="variant">
         <summary>Additional Notes</summary>
         <ul>
-          <li>Menus rotate on a 7-night cycle with different nightly themes.</li>
-          <li>Available on most NCL ships.</li>
+          <li>2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.</li>
+          <li>Same menu as Savor and The Manhattan Room. Freestyle Dining — no fixed seating times.</li>
+          <li>Ordering more than one entree incurs a $5 charge per additional entree (2026 policy).</li>
         </ul>
       </details>
     </div>
@@ -395,7 +410,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at Taste?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Roasted Tomato Soup, Shrimp Fritters, Caesar Salad, Cream of Mushroom Soup, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/the-commodore-room.html
+++ b/restaurants/ncl/the-commodore-room.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at The Commodore Room?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Roasted Tomato Soup, Shrimp Cocktail, Caesar Salad, French Onion Soup, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -262,40 +262,59 @@ All work on this project is offered as a gift to God.
 
       <div class="grid grid-3">
         <div>
-          <h3>Appetizers</h3>
+          <h3>Classic Entrees (Every Night)</h3>
           <ul>
-            <li>Roasted Tomato Soup</li>
-            <li>Shrimp Cocktail</li>
-            <li>Caesar Salad</li>
-            <li>French Onion Soup</li>
+            <li>Grilled New York Strip Steak</li>
+            <li>Breaded Flounder Fillet</li>
+            <li>Herb-Crusted Rotisserie Chicken</li>
+            <li>Shrimp &amp; Mushroom Alfredo</li>
+            <li>Three-Cheese Baked Ziti</li>
           </ul>
         </div>
         <div>
-          <h3>Entrees</h3>
+          <h3>Rotating Appetizers</h3>
           <ul>
-            <li>Grilled Salmon</li>
-            <li>Braised Short Ribs</li>
-            <li>Roasted Chicken</li>
-            <li>Pan-Seared Sea Bass</li>
-            <li>NY Strip Steak</li>
+            <li>Shrimp Cake</li>
+            <li>Prawn &amp; Vegetable Provence</li>
+            <li>Waldorf Salad</li>
+            <li>Bruschetta</li>
+            <li>Cheese Ravioli</li>
+            <li>Cream of Cauliflower Soup</li>
           </ul>
         </div>
         <div>
-          <h3>Desserts</h3>
+          <h3>Rotating Featured Entrees</h3>
           <ul>
-            <li>Chocolate Melting Cake</li>
-            <li>Cheesecake</li>
-            <li>Crème Brûlée</li>
+            <li>BBQ Spare Ribs</li>
+            <li>Leg of Lamb</li>
+            <li>Bang Bang Chicken</li>
+            <li>Chicken Cordon Bleu</li>
+            <li>Chinese-Style BBQ Pork</li>
+            <li>Braised Lamb Shank</li>
           </ul>
         </div>
       </div>
 
-      <p class="note tiny">Second main dining room on Prima class ships.</p>
+      <details class="variant">
+        <summary>More Menu Sections</summary>
+        <h4>Rotating Desserts</h4>
+        <ul>
+          <li>Warm Chocolate Lava Cake</li>
+          <li>Honey Crème Brûlée</li>
+          <li>Bananas Foster</li>
+          <li>Tiramisu Cake</li>
+          <li>Apple Cobbler</li>
+          <li>Chocolate Eclairs</li>
+        </ul>
+      </details>
+
+      <p class="note tiny">Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.</p>
       <details class="variant">
         <summary>Additional Notes</summary>
         <ul>
-          <li>Same rotating nightly menus as Hudson's.</li>
-          <li>Available on Norwegian Prima, Viva, Aqua, and Luna.</li>
+          <li>2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.</li>
+          <li>Second main dining room on Prima class ships (Prima, Viva, Aqua, Luna). Same menu as Hudson's.</li>
+          <li>Ordering more than one entree incurs a $5 charge per additional entree (2026 policy).</li>
         </ul>
       </details>
     </div>
@@ -391,7 +410,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at The Commodore Room?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Roasted Tomato Soup, Shrimp Cocktail, Caesar Salad, French Onion Soup, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>

--- a/restaurants/ncl/the-manhattan-room.html
+++ b/restaurants/ncl/the-manhattan-room.html
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
       "name": "What are the menu highlights at The Manhattan Room?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Popular items include Roasted Tomato Soup, Shrimp Cocktail, Caesar Salad, French Onion Soup, and more. The menu may vary by ship and sailing."
+        "text": "Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing."
       }
     }
   ]
@@ -262,42 +262,59 @@ All work on this project is offered as a gift to God.
 
       <div class="grid grid-3">
         <div>
-          <h3>Appetizers</h3>
+          <h3>Classic Entrees (Every Night)</h3>
           <ul>
-            <li>Roasted Tomato Soup</li>
-            <li>Shrimp Cocktail</li>
-            <li>Caesar Salad</li>
-            <li>French Onion Soup</li>
+            <li>Grilled New York Strip Steak</li>
+            <li>Breaded Flounder Fillet</li>
+            <li>Herb-Crusted Rotisserie Chicken</li>
+            <li>Shrimp &amp; Mushroom Alfredo</li>
+            <li>Three-Cheese Baked Ziti</li>
           </ul>
         </div>
         <div>
-          <h3>Entrees</h3>
+          <h3>Rotating Appetizers</h3>
           <ul>
-            <li>Grilled Salmon</li>
-            <li>Braised Short Ribs</li>
-            <li>Roasted Chicken</li>
-            <li>Pan-Seared Sea Bass</li>
-            <li>NY Strip Steak</li>
-            <li>Pork Tenderloin</li>
+            <li>Shrimp Cake</li>
+            <li>Prawn &amp; Vegetable Provence</li>
+            <li>Waldorf Salad</li>
+            <li>Bruschetta</li>
+            <li>Cheese Ravioli</li>
+            <li>Cream of Cauliflower Soup</li>
           </ul>
         </div>
         <div>
-          <h3>Desserts</h3>
+          <h3>Rotating Featured Entrees</h3>
           <ul>
-            <li>Chocolate Melting Cake</li>
-            <li>Cheesecake</li>
-            <li>Crème Brûlée</li>
-            <li>Apple Pie</li>
+            <li>BBQ Spare Ribs</li>
+            <li>Leg of Lamb</li>
+            <li>Bang Bang Chicken</li>
+            <li>Chicken Cordon Bleu</li>
+            <li>Chinese-Style BBQ Pork</li>
+            <li>Braised Lamb Shank</li>
           </ul>
         </div>
       </div>
 
-      <p class="note tiny">Grand main dining room on Breakaway and Getaway class ships.</p>
+      <details class="variant">
+        <summary>More Menu Sections</summary>
+        <h4>Rotating Desserts</h4>
+        <ul>
+          <li>Warm Chocolate Lava Cake</li>
+          <li>Honey Crème Brûlée</li>
+          <li>Bananas Foster</li>
+          <li>Tiramisu Cake</li>
+          <li>Apple Cobbler</li>
+          <li>Chocolate Eclairs</li>
+        </ul>
+      </details>
+
+      <p class="note tiny">Menus rotate on a 7-night cycle. Classic Entrees are available every night; appetizers, featured entrees, and desserts change nightly.</p>
       <details class="variant">
         <summary>Additional Notes</summary>
         <ul>
-          <li>Same rotating menu as Taste and Savor. Live music during dinner.</li>
-          <li>Two-deck-high venue with panoramic ocean views.</li>
+          <li>2026 change: NY Strip Steak now alternates with Montreal Spice-Rubbed Brisket every other night.</li>
+          <li>Grand two-deck dining room on Breakaway and Getaway class ships. Same menu as Taste and Savor. Live music during dinner.</li>
+          <li>Ordering more than one entree incurs a $5 charge per additional entree (2026 policy).</li>
         </ul>
       </details>
     </div>
@@ -393,7 +410,7 @@ All work on this project is offered as a gift to God.
       </details>
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What are the menu highlights at The Manhattan Room?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Roasted Tomato Soup, Shrimp Cocktail, Caesar Salad, French Onion Soup, and more. The menu may vary by ship and sailing.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Popular items include Grilled New York Strip Steak, Breaded Flounder Fillet, Herb-Crusted Rotisserie Chicken, Shrimp &amp; Mushroom Alfredo, and more. The menu may vary by ship and sailing.</p>
       </details>
     </div>
   </section>


### PR DESCRIPTION
…attern

Update all 6 complimentary dining venues (Taste, Savor, Manhattan Room, Hudson's, Commodore Room, Grand Pacific) with the actual NCL menu structure:
- Classic Entrees available every night (NY Strip, Flounder, Chicken, Alfredo, Ziti)
- Rotating appetizers, featured entrees, and desserts on 7-night cycle
- 2026 policy: NY Strip alternates with Montreal Brisket every other night
- 2026 policy: $5 charge for additional entrees beyond first

Add course name mappings to page generator for new rotation categories.

Sources: Norwegian Cruise Blog, Freestyle Travelers, Brent's Crossroads, Forever Karen (Norwegian Bliss), Prof Cruise, Daily Cruise Info, Cruise Gear.

https://claude.ai/code/session_014YvvbeoRt2xRLwHnZ4JttD