### PR TITLE
Add 7 missing cruise-lines pages and update hub links

### DIFF
--- a/admin/reports/SHIP_PAGE_AUDIT_2026_01_30.md
+++ b/admin/reports/SHIP_PAGE_AUDIT_2026_01_30.md
@@ -1,0 +1,211 @@
+# Ship Page Comprehensive Audit — 2026-01-30
+
+**Auditor:** Claude (Session: audit-ship-pages-UsCC9)
+**Branch:** `claude/audit-ship-pages-UsCC9`
+**Date:** 2026-01-30
+**Scope:** All 15 cruise lines, all ship pages, cruise-lines directory pages
+
+---
+
+## Executive Summary
+
+The In the Wake site covers **15 cruise lines** with **~308 ship HTML pages** across 16 ship directories (including a legacy `ships/explora/` duplicate). This audit identified **7 missing cruise-lines pages** and created stub pages for each with full site shell, navigation, and "coming soon" verbiage. The `cruise-lines.html` hub page was updated to link to the new pages instead of ship directory indexes.
+
+### Key Findings
+
+| Metric | Before Audit | After Audit |
+|--------|-------------|-------------|
+| Cruise-lines pages | 8 of 15 | **15 of 15** |
+| cruise-lines.html links correct | 8 of 15 | **15 of 15** |
+| Ship directories | 16 (incl. legacy explora/) | 16 (unchanged) |
+| Total ship HTML files | ~308 | ~308 (unchanged) |
+| Ship pages passing validation | ~106 (34%) | ~106 (34%) — unchanged, plan below |
+
+---
+
+## Cruise Line Coverage Matrix
+
+### Tier 1: Mainstream Lines
+
+| # | Cruise Line | cruise-lines/ page | ships/ directory | Ship count | Status |
+|---|------------|-------------------|-----------------|------------|--------|
+| 1 | Royal Caribbean | `royal-caribbean.html` (existed) | `ships/rcl/` | 50 | Full content page |
+| 2 | Carnival | `carnival.html` (existed) | `ships/carnival/` | 49 | Full content page |
+| 3 | Norwegian | `norwegian.html` (existed) | `ships/norwegian/` | 21 | Full content page |
+| 4 | MSC Cruises | `msc.html` (existed) | `ships/msc/` | 25 | Full content page |
+| 5 | Costa Cruises | **`costa.html` (NEW)** | `ships/costa/` | 10 | Coming Soon stub |
+
+### Tier 2: Premium Lines
+
+| # | Cruise Line | cruise-lines/ page | ships/ directory | Ship count | Status |
+|---|------------|-------------------|-----------------|------------|--------|
+| 6 | Celebrity Cruises | `celebrity.html` (existed) | `ships/celebrity-cruises/` | 30 | Full content page |
+| 7 | Princess | `princess.html` (existed) | `ships/princess/` | 18 | Full content page |
+| 8 | Holland America | `holland-america.html` (existed) | `ships/holland-america-line/` | 47 | Full content page |
+| 9 | Cunard | **`cunard.html` (NEW)** | `ships/cunard/` | 5 | Coming Soon stub |
+| 10 | Virgin Voyages | `virgin.html` (existed) | `ships/virgin-voyages/` | 5 | Full content page |
+
+### Tier 3: Luxury Lines
+
+| # | Cruise Line | cruise-lines/ page | ships/ directory | Ship count | Status |
+|---|------------|-------------------|-----------------|------------|--------|
+| 11 | Oceania Cruises | **`oceania.html` (NEW)** | `ships/oceania/` | 9 | Coming Soon stub |
+| 12 | Regent Seven Seas | **`regent.html` (NEW)** | `ships/regent/` | 8 | Coming Soon stub |
+| 13 | Seabourn | **`seabourn.html` (NEW)** | `ships/seabourn/` | 8 | Coming Soon stub |
+| 14 | Silversea | **`silversea.html` (NEW)** | `ships/silversea/` | 13 | Coming Soon stub |
+| 15 | Explora Journeys | **`explora-journeys.html` (NEW)** | `ships/explora-journeys/` | 7 | Coming Soon stub |
+
+### Legacy/Duplicate Directory
+- `ships/explora/` — Contains 3 files (explora-i.html, explora-ii.html, index.html). Appears to be a legacy duplicate of `ships/explora-journeys/`. Recommend consolidating in a future cleanup.
+
+---
+
+## Changes Made in This Audit
+
+### 1. New Cruise-Lines Pages Created (7 files)
+
+All new pages follow the established template pattern from existing pages (carnival.html, royal-caribbean.html) with:
+- Soli Deo Gloria invocation
+- AI-breadcrumbs metadata
+- ICP-Lite v1.4 meta tags (ai-summary, last-reviewed, content-protocol)
+- JSON-LD: BreadcrumbList, WebPage, FAQPage, Person
+- Full site navigation (Planning, Tools, Onboard, Travel dropdowns)
+- Hero header with compass rose
+- Answer-first content with Quick Answer, Fit Guidance, Key Facts
+- "Comprehensive Guides Coming Soon" section
+- Fleet listing with links to all ship pages
+- Related Resources grid
+- FAQ section (3 questions each)
+- Right rail (Quiz CTA, Author card, Recent Stories)
+- Standard footer with trust badge
+- Dropdown JS and Recent Articles rail script
+
+**Files created:**
+1. `cruise-lines/costa.html` — Costa Cruises (Italian heritage, 9 ships)
+2. `cruise-lines/cunard.html` — Cunard (British ocean liner, 4 Queens)
+3. `cruise-lines/oceania.html` — Oceania Cruises (Finest Cuisine at Sea, 8 ships)
+4. `cruise-lines/regent.html` — Regent Seven Seas (All-inclusive luxury, 7 ships)
+5. `cruise-lines/seabourn.html` — Seabourn (Ultra-luxury & expedition, 7 ships)
+6. `cruise-lines/silversea.html` — Silversea (Italian elegance, 12 ships)
+7. `cruise-lines/explora-journeys.html` — Explora Journeys (Modern ocean luxury, 6 ships)
+
+### 2. cruise-lines.html Hub Page Updated (14 link changes)
+
+Updated 14 references (7 JSON-LD + 7 HTML hrefs) from `/ships/{line}/` directory paths to `/cruise-lines/{line}.html` pages:
+- `/ships/costa/` → `/cruise-lines/costa.html`
+- `/ships/cunard/` → `/cruise-lines/cunard.html`
+- `/ships/oceania/` → `/cruise-lines/oceania.html`
+- `/ships/regent/` → `/cruise-lines/regent.html`
+- `/ships/seabourn/` → `/cruise-lines/seabourn.html`
+- `/ships/silversea/` → `/cruise-lines/silversea.html`
+- `/ships/explora-journeys/` → `/cruise-lines/explora-journeys.html`
+
+---
+
+## Ship Page Health by Cruise Line
+
+Based on the claude.md report: **106 of 311 ship pages (34%) currently pass validation** with **981 blocking errors** remaining. The breakdown by line requires per-page validation, but the general categories of issues are:
+
+### Common Blocking Issues (from SHIP_PAGE_CHECKLIST_v3.010)
+1. **Missing Soli Deo Gloria invocation** — Required before line 20
+2. **Missing/incorrect ICP-Lite v1.4 meta tags** — ai-summary, last-reviewed, content-protocol
+3. **JSON-LD schema mismatches** — description ≠ ai-summary, dateModified ≠ last-reviewed
+4. **Missing mainEntity in JSON-LD** — Entity pages need Product/Place/Restaurant declaration
+5. **Missing AI-breadcrumbs** — Structured context comments for entity identification
+6. **Missing content sections** — 8 required sections per ship page
+7. **Missing JSON-LD blocks** — 7 required per ship page
+8. **Accessibility gaps** — WCAG AA violations (alt text, ARIA, skip links)
+9. **Stale dates** — last-reviewed and dateModified not updated
+
+---
+
+## Plan to Bring All Ship Pages to 100/100
+
+### Phase 1: Infrastructure & Validation (Priority: CRITICAL)
+**Goal:** Establish baseline and fix blocking infrastructure issues
+
+1. **Run full validation across all 308+ ship pages** — Use `node admin/validate-icp-lite-v14.js --all` to get exact error counts per file
+2. **Fix Soli Deo Gloria invocations** — Batch ensure all pages have the invocation before line 20
+3. **Fix ICP-Lite v1.4 meta tags** — Batch ensure ai-summary (dual-cap rule), last-reviewed, content-protocol on every page
+4. **Fix JSON-LD mirroring** — Ensure description = ai-summary, dateModified = last-reviewed on every page
+
+### Phase 2: Structural Compliance (Priority: HIGH)
+**Goal:** All pages have required sections and schema
+
+5. **Add missing AI-breadcrumbs** — entity, type, parent, category, cruise-line, ship-class, updated
+6. **Add missing mainEntity JSON-LD** — Product type with manufacturer Organization
+7. **Ensure 7 JSON-LD blocks per page** — WebPage, BreadcrumbList, FAQPage, Person, Organization, mainEntity, Review
+8. **Ensure 8 required content sections** — Page intro, first look/dining, logbook, video, deck plans, FAQ, attributions
+9. **Fix navigation consistency** — All pages should have the standard dropdown nav
+
+### Phase 3: Content Quality (Priority: MEDIUM)
+**Goal:** Rich, natural content meeting word count and quality standards
+
+10. **Expand thin ship pages** — Target 2,500-6,000 words per page
+11. **Add/improve FAQ sections** — Natural language, not robotic SEO copy
+12. **Add logbook stories** — 6 traveler personas per ship
+13. **Add image attributions** — Minimum 8 locally-hosted images with proper alt text
+14. **Add fit-guidance sections** — Help users decide if this ship is right for them
+
+### Phase 4: Premium & Luxury Lines (Priority: MEDIUM)
+**Goal:** Bring 7 new cruise-lines pages from "Coming Soon" to full content
+
+15. **Costa Cruises** — Expand with ship classes, experience section, gallery, search
+16. **Cunard** — Expand with Queens detail, Grill dining, Transatlantic focus
+17. **Oceania** — Expand with culinary focus, Jacques Pepin, ship classes
+18. **Regent Seven Seas** — Expand with all-inclusive detail, Regent Suite, ship profiles
+19. **Seabourn** — Expand with expedition detail, Thomas Keller, expedition ships
+20. **Silversea** — Expand with S.A.L.T. program, expedition fleet, butler service
+21. **Explora Journeys** — Expand with new-brand positioning, suite detail, dining experiences
+
+### Phase 5: Polish & Optimization (Priority: LOW)
+**Goal:** Performance, accessibility, and SEO refinements
+
+22. **WCAG AA compliance sweep** — Full accessibility audit
+23. **Performance optimization** — LCP preloads, image optimization, lazy loading
+24. **Cross-link network** — Ensure ships link to restaurants, ports, and articles
+25. **Consolidate legacy directories** — Merge `ships/explora/` into `ships/explora-journeys/`
+26. **Update stale dates** — Refresh all last-reviewed and dateModified to current
+
+### Estimated Scope
+- **Phase 1:** ~308 pages (batch scriptable)
+- **Phase 2:** ~308 pages (batch scriptable with manual review)
+- **Phase 3:** ~200+ pages need content expansion (manual/AI-assisted)
+- **Phase 4:** 7 pages (manual/AI-assisted)
+- **Phase 5:** Site-wide sweep (tooling + manual)
+
+### Success Criteria
+- [ ] 311/311 ship pages pass validation (0 blocking errors)
+- [ ] 15/15 cruise-lines pages have full content
+- [ ] All JSON-LD mirroring correct
+- [ ] All ICP-Lite v1.4 compliant
+- [ ] All Soli Deo Gloria invocations present
+- [ ] WCAG AA compliance across all pages
+
+---
+
+## Appendix: Ship Count by Directory
+
+| Directory | Total HTML | Index | Ship Pages | Notes |
+|-----------|-----------|-------|------------|-------|
+| ships/rcl/ | 50 | 0 | 49 + venues.html | Largest fleet, includes retired ships |
+| ships/carnival/ | 49 | 1 | 48 | Includes retired + future ships |
+| ships/holland-america-line/ | 47 | 1 | 45 + none-announced.html | Heavy historical fleet |
+| ships/celebrity-cruises/ | 30 | 1 | 29 | Includes retired + future ships |
+| ships/msc/ | 25 | 1 | 24 | All active/near-active |
+| ships/norwegian/ | 21 | 1 | 20 | All active + Pride of America |
+| ships/princess/ | 18 | 1 | 17 | All active fleet |
+| ships/silversea/ | 13 | 1 | 12 | Classic + expedition fleet |
+| ships/costa/ | 10 | 1 | 9 | Active fleet |
+| ships/oceania/ | 9 | 1 | 8 | Upper-premium fleet |
+| ships/regent/ | 8 | 1 | 7 | All-suite luxury fleet |
+| ships/seabourn/ | 8 | 1 | 7 | Luxury + expedition |
+| ships/explora-journeys/ | 7 | 1 | 6 | New brand, 2 active + 4 future |
+| ships/cunard/ | 5 | 1 | 4 | The four Queens |
+| ships/virgin-voyages/ | 5 | 1 | 4 | Lady class fleet |
+| ships/explora/ | 3 | 1 | 2 | LEGACY DUPLICATE |
+| **TOTAL** | **308** | **14** | **~291 unique** | |
+
+---
+
+*Soli Deo Gloria*

--- a/cruise-lines.html
+++ b/cruise-lines.html
@@ -175,17 +175,17 @@
       {"@type":"ListItem","position":2,"url":"https://cruisinginthewake.com/cruise-lines/carnival.html","name":"Carnival"},
       {"@type":"ListItem","position":3,"url":"https://cruisinginthewake.com/cruise-lines/norwegian.html","name":"Norwegian"},
       {"@type":"ListItem","position":4,"url":"https://cruisinginthewake.com/cruise-lines/msc.html","name":"MSC Cruises"},
-      {"@type":"ListItem","position":5,"url":"https://cruisinginthewake.com/ships/costa/","name":"Costa Cruises"},
+      {"@type":"ListItem","position":5,"url":"https://cruisinginthewake.com/cruise-lines/costa.html","name":"Costa Cruises"},
       {"@type":"ListItem","position":6,"url":"https://cruisinginthewake.com/cruise-lines/celebrity.html","name":"Celebrity Cruises"},
       {"@type":"ListItem","position":7,"url":"https://cruisinginthewake.com/cruise-lines/princess.html","name":"Princess"},
       {"@type":"ListItem","position":8,"url":"https://cruisinginthewake.com/cruise-lines/holland-america.html","name":"Holland America"},
-      {"@type":"ListItem","position":9,"url":"https://cruisinginthewake.com/ships/cunard/","name":"Cunard"},
+      {"@type":"ListItem","position":9,"url":"https://cruisinginthewake.com/cruise-lines/cunard.html","name":"Cunard"},
       {"@type":"ListItem","position":10,"url":"https://cruisinginthewake.com/cruise-lines/virgin.html","name":"Virgin Voyages"},
-      {"@type":"ListItem","position":11,"url":"https://cruisinginthewake.com/ships/oceania/","name":"Oceania Cruises"},
-      {"@type":"ListItem","position":12,"url":"https://cruisinginthewake.com/ships/regent/","name":"Regent Seven Seas"},
-      {"@type":"ListItem","position":13,"url":"https://cruisinginthewake.com/ships/seabourn/","name":"Seabourn"},
-      {"@type":"ListItem","position":14,"url":"https://cruisinginthewake.com/ships/silversea/","name":"Silversea"},
-      {"@type":"ListItem","position":15,"url":"https://cruisinginthewake.com/ships/explora-journeys/","name":"Explora Journeys"}
+      {"@type":"ListItem","position":11,"url":"https://cruisinginthewake.com/cruise-lines/oceania.html","name":"Oceania Cruises"},
+      {"@type":"ListItem","position":12,"url":"https://cruisinginthewake.com/cruise-lines/regent.html","name":"Regent Seven Seas"},
+      {"@type":"ListItem","position":13,"url":"https://cruisinginthewake.com/cruise-lines/seabourn.html","name":"Seabourn"},
+      {"@type":"ListItem","position":14,"url":"https://cruisinginthewake.com/cruise-lines/silversea.html","name":"Silversea"},
+      {"@type":"ListItem","position":15,"url":"https://cruisinginthewake.com/cruise-lines/explora-journeys.html","name":"Explora Journeys"}
     ]
   }
   </script>
@@ -451,7 +451,7 @@
         <div class="card"><a href="/cruise-lines/carnival.html" aria-label="Carnival guide"><strong>Carnival</strong><br><small>Fun ships &amp; casual vibes</small></a></div>
         <div class="card"><a href="/cruise-lines/norwegian.html" aria-label="Norwegian guide"><strong>Norwegian</strong><br><small>Freestyle cruising</small></a></div>
         <div class="card"><a href="/cruise-lines/msc.html" aria-label="MSC Cruises guide"><strong>MSC Cruises</strong><br><small>European style &amp; Yacht Club</small></a></div>
-        <div class="card"><a href="/ships/costa/" aria-label="Costa Cruises guide"><strong>Costa Cruises</strong><br><small>Italian flair &amp; Mediterranean</small></a></div>
+        <div class="card"><a href="/cruise-lines/costa.html" aria-label="Costa Cruises guide"><strong>Costa Cruises</strong><br><small>Italian flair &amp; Mediterranean</small></a></div>
       </div>
 
       <!-- Premium Lines -->
@@ -460,18 +460,18 @@
         <div class="card"><a href="/cruise-lines/celebrity.html" aria-label="Celebrity Cruises guide"><strong>Celebrity Cruises</strong><br><small>Modern luxury at sea</small></a></div>
         <div class="card"><a href="/cruise-lines/princess.html" aria-label="Princess guide"><strong>Princess</strong><br><small>Relaxed elegance &amp; MedallionClass</small></a></div>
         <div class="card"><a href="/cruise-lines/holland-america.html" aria-label="Holland America guide"><strong>Holland America</strong><br><small>Classic ocean voyages</small></a></div>
-        <div class="card"><a href="/ships/cunard/" aria-label="Cunard guide"><strong>Cunard</strong><br><small>British heritage &amp; transatlantic</small></a></div>
+        <div class="card"><a href="/cruise-lines/cunard.html" aria-label="Cunard guide"><strong>Cunard</strong><br><small>British heritage &amp; transatlantic</small></a></div>
         <div class="card"><a href="/cruise-lines/virgin.html" aria-label="Virgin Voyages guide"><strong>Virgin Voyages</strong><br><small>Adults-only &amp; trendy</small></a></div>
       </div>
 
       <!-- Luxury Lines -->
       <h3 style="margin: 1.5rem 0 0.5rem; color: #5a7a8a; font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em;">Luxury</h3>
       <div class="grid">
-        <div class="card"><a href="/ships/oceania/" aria-label="Oceania Cruises guide"><strong>Oceania Cruises</strong><br><small>Finest cuisine at sea</small></a></div>
-        <div class="card"><a href="/ships/regent/" aria-label="Regent Seven Seas guide"><strong>Regent Seven Seas</strong><br><small>All-inclusive luxury</small></a></div>
-        <div class="card"><a href="/ships/seabourn/" aria-label="Seabourn guide"><strong>Seabourn</strong><br><small>Ultra-luxury &amp; expedition</small></a></div>
-        <div class="card"><a href="/ships/silversea/" aria-label="Silversea guide"><strong>Silversea</strong><br><small>Italian elegance &amp; adventure</small></a></div>
-        <div class="card"><a href="/ships/explora-journeys/" aria-label="Explora Journeys guide"><strong>Explora Journeys</strong><br><small>Modern ocean luxury</small></a></div>
+        <div class="card"><a href="/cruise-lines/oceania.html" aria-label="Oceania Cruises guide"><strong>Oceania Cruises</strong><br><small>Finest cuisine at sea</small></a></div>
+        <div class="card"><a href="/cruise-lines/regent.html" aria-label="Regent Seven Seas guide"><strong>Regent Seven Seas</strong><br><small>All-inclusive luxury</small></a></div>
+        <div class="card"><a href="/cruise-lines/seabourn.html" aria-label="Seabourn guide"><strong>Seabourn</strong><br><small>Ultra-luxury &amp; expedition</small></a></div>
+        <div class="card"><a href="/cruise-lines/silversea.html" aria-label="Silversea guide"><strong>Silversea</strong><br><small>Italian elegance &amp; adventure</small></a></div>
+        <div class="card"><a href="/cruise-lines/explora-journeys.html" aria-label="Explora Journeys guide"><strong>Explora Journeys</strong><br><small>Modern ocean luxury</small></a></div>
       </div>
     </section>
 

--- a/cruise-lines/costa.html
+++ b/cruise-lines/costa.html
@@ -1,0 +1,364 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+<!-- ai-breadcrumbs
+     entity: Costa Cruises
+     type: Cruise Line Guide
+     parent: /cruise-lines.html
+     category: Cruise Line Information
+     updated: 2026-01-30
+     expertise: Cruise line comparisons, fleet analysis, policy research, cruise planning
+     target-audience: Cruise line comparison shoppers, first-time cruisers, travel planners
+     answer-first: Costa Cruises brings Italian style to sea with vibrant ships, Mediterranean itineraries, and la dolce vita dining experiences across a fleet of 9 active vessels.
+     core-facts: Italian-heritage cruise line owned by Carnival Corporation; fleet of 9 ships; signature Italian dining, Mediterranean focus, multilingual international atmosphere
+     decisions-informed: whether Costa's Italian flair and European itinerary focus matches your travel style; understanding the international cruising experience
+     -->
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart, and do not lean on your own understanding." — Proverbs 3:5
+"Whatever you do, work heartily, as for the Lord and not for men." — Colossians 3:23
+-->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Costa Cruises | In the Wake (V1.Beta)</title>
+  <meta name="version" content="V1.Beta"/>
+  <meta name="description" content="Costa Cruises guide: Italian-heritage cruise line with vibrant ships, Mediterranean itineraries, and la dolce vita dining. Explore ships, planning tools, and onboard experiences."/>
+  <meta name="robots" content="index,follow"/>
+
+  <!-- ICP-Lite v1.4: AI-First Metadata -->
+  <meta name="ai-summary" content="Costa Cruises guide: Italian-heritage line with 9 ships featuring authentic Italian dining, Mediterranean focus, and multilingual international atmosphere. Explore fleet and planning resources."/>
+  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+
+  <!-- Canonical / Social -->
+  <link rel="canonical" href="https://cruisinginthewake.com/cruise-lines/costa.html"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:url" content="https://cruisinginthewake.com/cruise-lines/costa.html"/>
+  <meta property="og:title" content="Costa Cruises | In the Wake"/>
+  <meta property="og:description" content="Italian-heritage cruising with authentic dining and Mediterranean itineraries."/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Costa Cruises guide: Italian-heritage cruise line with vibrant ships, Mediterranean itineraries, and la dolce vita dining."/>
+  <meta name="twitter:title" content="Costa Cruises | In the Wake"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {"@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+     {"@type":"ListItem","position":1,"name":"Home","item":"https://cruisinginthewake.com/"},
+     {"@type":"ListItem","position":2,"name":"Cruise Lines","item":"https://cruisinginthewake.com/cruise-lines.html"},
+     {"@type":"ListItem","position":3,"name":"Costa Cruises","item":"https://cruisinginthewake.com/cruise-lines/costa.html"}
+   ]}
+  </script>
+
+  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Costa Cruises | In the Wake",
+    "url": "https://cruisinginthewake.com/cruise-lines/costa.html",
+    "description": "Costa Cruises guide: Italian-heritage line with 9 ships featuring authentic Italian dining, Mediterranean focus, and multilingual international atmosphere. Explore fleet and planning resources.",
+    "dateModified": "2026-01-30"
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What makes Costa Cruises unique?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Costa Cruises brings Italian heritage and la dolce vita to the seas. Known for authentic Italian dining, vibrant entertainment, Mediterranean itineraries, and a multilingual international atmosphere that feels like floating through Italy."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What dining does Costa offer?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Costa ships feature authentic Italian cuisine as a cornerstone, with regional specialties, fresh pasta, and Italian wines. The dining experience emphasizes la dolce vita with leisurely multi-course meals and specialty restaurants."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Where does Costa cruise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Costa Cruises focuses heavily on the Mediterranean, including Western and Eastern Mediterranean itineraries, but also offers Caribbean, South American, Northern European, and world cruise voyages."
+        }
+      }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ken Baker",
+    "url": "https://cruisinginthewake.com/about/ken-baker.html",
+    "jobTitle": "Cruise Research Analyst & Data Specialist",
+    "description": "Cruise industry analyst specializing in ship comparisons, deck plan analysis, and dining venue research.",
+    "knowsAbout": ["Cruise Ship Analysis","Deck Plans","Costa Cruises","Cruise Dining","Ship Comparisons"]
+  }
+  </script>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
+</head>
+
+<body class="page">
+  <a class="skip-link" href="#content">Skip to main content</a>
+
+  <header class="site-header hero-header">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+
+    <div class="hero" role="img" aria-label="Ship wake at sunrise">
+      <div class="latlon-grid" aria-hidden="true"></div>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo &copy; Flickers of Majesty</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="content">
+  <div>
+    <section class="icp-header" aria-labelledby="line-name">
+      <h1 id="line-name">Costa Cruises</h1>
+      <p class="answer-line"><strong>Quick Answer:</strong> La dolce vita at sea. Costa Cruises wraps you in Italian elegance — from authentic regional cuisine and espresso bars to vibrant piazzas and Mediterranean itineraries that read like a love letter to Europe. With a multilingual international atmosphere and 9 active ships, Costa delivers the warmth of Italian hospitality on every voyage.</p>
+
+      <div class="fit-guidance">
+        <h2>Is Costa Right for You?</h2>
+        <p>If you dream of sipping limoncello as the Amalfi Coast glides past your balcony, or savoring handmade pasta while the sun sets over Santorini, Costa Cruises was made for you. This Italian-heritage line infuses every moment with Mediterranean charm — from the piazza-style atrium to the leisurely multi-course dinners that celebrate la bella vita.</p>
+        <p>Costa's international atmosphere means you'll share the deck with fellow travelers from across Europe and beyond, creating a cosmopolitan energy you won't find on North American-focused lines. Entertainment blends Italian flair with global appeal, and the itineraries showcase the Mediterranean's greatest hits alongside hidden coastal gems.</p>
+        <p>Ideal for travelers who appreciate European culture, international dining experiences, and Mediterranean exploration. Costa's inclusive packages and family-friendly programming also make it accessible for multigenerational groups seeking something beyond the typical Caribbean cruise.</p>
+      </div>
+
+      <div class="key-facts">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Brand Identity:</strong> Italian-heritage cruising with la dolce vita spirit</li>
+          <li><strong>Parent Company:</strong> Carnival Corporation &amp; plc</li>
+          <li><strong>Signature Features:</strong> Authentic Italian dining, piazza-style atriums, Samsara Spa, multilingual international atmosphere</li>
+          <li><strong>Best For:</strong> Mediterranean enthusiasts, international travelers, food lovers, families seeking European itineraries</li>
+          <li><strong>Fleet Size:</strong> 9 active ships</li>
+          <li><strong>Primary Itineraries:</strong> Western &amp; Eastern Mediterranean, Northern Europe, Caribbean, South America</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="card" aria-labelledby="coming-soon-h">
+      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
+      <p>We're expanding our Costa Cruises coverage with in-depth ship profiles, dining venue breakdowns, stateroom guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Costa vessel — check back soon for comprehensive guides.</p>
+      <p>In the meantime, explore our <a href="/ships/costa/">Costa ship directory</a> for the fleet overview, or visit <a href="https://www.costacruises.com" target="_blank" rel="noopener">CostaCruises.com</a> to browse current sailings.</p>
+    </section>
+
+    <!-- Ships A-Z -->
+    <section id="ships" class="card" aria-labelledby="ships-h">
+      <h2 id="ships-h">Costa Fleet</h2>
+      <ul>
+        <li><a href="/ships/costa/costa-deliziosa.html">Costa Deliziosa</a></li>
+        <li><a href="/ships/costa/costa-diadema.html">Costa Diadema</a></li>
+        <li><a href="/ships/costa/costa-fascinosa.html">Costa Fascinosa</a></li>
+        <li><a href="/ships/costa/costa-favolosa.html">Costa Favolosa</a></li>
+        <li><a href="/ships/costa/costa-firenze.html">Costa Firenze</a></li>
+        <li><a href="/ships/costa/costa-pacifica.html">Costa Pacifica</a></li>
+        <li><a href="/ships/costa/costa-smeralda.html">Costa Smeralda</a></li>
+        <li><a href="/ships/costa/costa-toscana.html">Costa Toscana</a></li>
+        <li><a href="/ships/costa/costa-venezia.html">Costa Venezia</a></li>
+      </ul>
+    </section>
+
+    <!-- Related Resources -->
+    <section class="card related-resources" style="margin: 1.5rem 0; padding: 1.25rem; background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
+      <h2 style="margin: 0 0 0.75rem; font-size: 1.15rem; color: #083041;">Continue Planning Your Costa Cruise</h2>
+      <p class="tiny content-text" style="margin-bottom: 1rem; color: #5a7a8a;">Tools and guides to help you prepare.</p>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem;">
+        <a href="/first-cruise.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">First Cruise Guide</strong>
+          <span class="tiny" style="color: #5a7a8a;">New to cruising?</span>
+        </a>
+        <a href="/packing-lists.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Packing Lists</strong>
+          <span class="tiny" style="color: #5a7a8a;">Don't forget anything</span>
+        </a>
+        <a href="/cruise-lines.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Compare Lines</strong>
+          <span class="tiny" style="color: #5a7a8a;">See all cruise lines</span>
+        </a>
+        <a href="/planning.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
+          <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <h3>What makes Costa Cruises unique?</h3>
+        <p>Costa Cruises brings Italian heritage and la dolce vita to the seas. Known for authentic Italian dining, vibrant entertainment, Mediterranean itineraries, and a multilingual international atmosphere that feels like floating through Italy.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What dining does Costa offer?</h3>
+        <p>Costa ships feature authentic Italian cuisine as a cornerstone, with regional specialties, fresh pasta, and Italian wines. The dining experience emphasizes la dolce vita with leisurely multi-course meals and specialty restaurants.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Where does Costa cruise?</h3>
+        <p>Costa Cruises focuses heavily on the Mediterranean, including Western and Eastern Mediterranean itineraries, but also offers Caribbean, South American, Northern European, and world cruise voyages.</p>
+      </div>
+    </section>
+  </div>
+
+  <!-- RIGHT RAIL -->
+  <aside class="rail" role="complementary" aria-label="Author & articles">
+    <section class="card quiz-cta" style="background: linear-gradient(135deg, #e0f4f8, #fff); border-left: 4px solid #0e6e8e; padding: 1rem; margin-bottom: 1rem;">
+      <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #083041;">Exploring Other Lines?</h3>
+      <p class="tiny" style="margin-bottom: 0.75rem; color: #5a7a8a;">Take our quick quiz to find cruise lines that match your travel style.</p>
+      <a href="/cruise-lines/quiz.html" class="pill" style="font-size: 0.85rem;">Cruise Line Quiz &rarr;</a>
+    </section>
+
+    <section class="card author-card-vertical" aria-labelledby="author-heading">
+      <h3 id="author-heading">About the Author</h3>
+      <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+        <picture>
+          <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+          <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </picture>
+      </a>
+      <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+      <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+      <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+    </section>
+
+    <section class="card" aria-labelledby="recent-rail-title">
+      <h3 id="recent-rail-title">Recent Stories</h3>
+      <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+      <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+      <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles&hellip;</p>
+    </section>
+  </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> &middot;
+      <a href="/terms.html">Terms</a> &middot;
+      <a href="/about-us.html">About</a> &middot;
+      <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. &#10013;</p>
+    <p class="trust-badge">&check; No ads. Minimal analytics. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+  <script src="/assets/js/in-app-browser-escape.js"></script>
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a =>
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
+  })();
+  </script>
+</body>
+</html>

--- a/cruise-lines/cunard.html
+++ b/cruise-lines/cunard.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+<!-- ai-breadcrumbs
+     entity: Cunard
+     type: Cruise Line Guide
+     parent: /cruise-lines.html
+     category: Cruise Line Information
+     updated: 2026-01-30
+     expertise: Cruise line comparisons, fleet analysis, policy research, cruise planning
+     target-audience: Cruise line comparison shoppers, first-time cruisers, travel planners
+     answer-first: Cunard defines ocean liner heritage with white-glove service, Transatlantic crossings, and Grill-class dining aboard 4 legendary Queens.
+     core-facts: British ocean liner heritage since 1840; 4 ships (Queen Mary 2, Queen Anne, Queen Victoria, Queen Elizabeth); signature Grill dining, Transatlantic crossings, formal dress traditions
+     decisions-informed: whether Cunard's traditional elegance, Transatlantic crossings, and formal atmosphere match your travel expectations
+     -->
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart, and do not lean on your own understanding." — Proverbs 3:5
+"Whatever you do, work heartily, as for the Lord and not for men." — Colossians 3:23
+-->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Cunard | In the Wake (V1.Beta)</title>
+  <meta name="version" content="V1.Beta"/>
+  <meta name="description" content="Cunard guide: British ocean liner heritage since 1840 with white-glove service, Transatlantic crossings, and Grill-class dining aboard 4 legendary Queens."/>
+  <meta name="robots" content="index,follow"/>
+
+  <!-- ICP-Lite v1.4: AI-First Metadata -->
+  <meta name="ai-summary" content="Cunard guide: British ocean liner heritage since 1840 with 4 Queens — Queen Mary 2, Queen Anne, Queen Victoria, Queen Elizabeth. Signature Grill dining, Transatlantic crossings, and formal traditions."/>
+  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+
+  <!-- Canonical / Social -->
+  <link rel="canonical" href="https://cruisinginthewake.com/cruise-lines/cunard.html"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:url" content="https://cruisinginthewake.com/cruise-lines/cunard.html"/>
+  <meta property="og:title" content="Cunard | In the Wake"/>
+  <meta property="og:description" content="British ocean liner heritage with Transatlantic crossings and Grill-class dining."/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Cunard guide: British ocean liner heritage since 1840 with white-glove service and Transatlantic crossings."/>
+  <meta name="twitter:title" content="Cunard | In the Wake"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[
+    {"@type":"ListItem","position":1,"name":"Home","item":"https://cruisinginthewake.com/"},
+    {"@type":"ListItem","position":2,"name":"Cruise Lines","item":"https://cruisinginthewake.com/cruise-lines.html"},
+    {"@type":"ListItem","position":3,"name":"Cunard","item":"https://cruisinginthewake.com/cruise-lines/cunard.html"}
+  ]}
+  </script>
+
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"WebPage",
+   "name":"Cunard | In the Wake",
+   "url":"https://cruisinginthewake.com/cruise-lines/cunard.html",
+   "description":"Cunard guide: British ocean liner heritage since 1840 with 4 Queens — Queen Mary 2, Queen Anne, Queen Victoria, Queen Elizabeth. Signature Grill dining, Transatlantic crossings, and formal traditions.",
+   "dateModified":"2026-01-30"}
+  </script>
+
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
+    {"@type":"Question","name":"What makes Cunard unique?","acceptedAnswer":{"@type":"Answer","text":"Cunard is the world's most iconic ocean liner company, operating since 1840. Known for Transatlantic crossings on Queen Mary 2, Grill-class dining hierarchy, formal evening traditions, and white-glove British service that harkens to the golden age of ocean travel."}},
+    {"@type":"Question","name":"What is Grill-class dining?","acceptedAnswer":{"@type":"Answer","text":"Cunard's Grill dining is a tiered system: Queens Grill (top suites), Princess Grill (premium suites), and Britannia Restaurant (standard). Each Grill offers exclusive dining, private lounges, and dedicated concierge services."}},
+    {"@type":"Question","name":"Does Cunard still do Transatlantic crossings?","acceptedAnswer":{"@type":"Answer","text":"Yes. Queen Mary 2 offers regular scheduled Transatlantic crossings between New York and Southampton — the only ocean liner still providing this classic service."}}
+  ]}
+  </script>
+
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/about/ken-baker.html","jobTitle":"Cruise Research Analyst & Data Specialist","description":"Cruise industry analyst specializing in ship comparisons, deck plan analysis, and dining venue research.","knowsAbout":["Cruise Ship Analysis","Deck Plans","Cunard","Cruise Dining","Ship Comparisons"]}
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
+</head>
+
+<body class="page">
+  <a class="skip-link" href="#content">Skip to main content</a>
+
+  <header class="site-header hero-header">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Tools <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Onboard <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="Ship wake at sunrise">
+      <div class="latlon-grid" aria-hidden="true"></div>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo &copy; Flickers of Majesty</a></div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="content">
+  <div>
+    <section class="icp-header" aria-labelledby="line-name">
+      <h1 id="line-name">Cunard</h1>
+      <p class="answer-line"><strong>Quick Answer:</strong> Where ocean travel becomes an art form. Since 1840, Cunard has defined elegance at sea with Transatlantic crossings, Grill-class dining, and the kind of white-glove service that makes every guest feel like royalty. Four legendary Queens — Queen Mary 2, Queen Anne, Queen Victoria, and Queen Elizabeth — carry forward a heritage that transformed sea travel from transport into tradition.</p>
+
+      <div class="fit-guidance">
+        <h2>Is Cunard Right for You?</h2>
+        <p>Imagine stepping aboard and feeling centuries of maritime history beneath your feet. The afternoon tea arrives on fine china, the evening calls for black tie, and the library holds more volumes than some small-town branches. Cunard isn't just a cruise — it's a portal to a more gracious era of travel, where the journey truly matters as much as the destination.</p>
+        <p>Queen Mary 2 remains the only true ocean liner in service, offering scheduled Transatlantic crossings between New York and Southampton that evoke the golden age. Onboard, Grill-class dining creates a tiered experience where suite guests enjoy exclusive restaurants and private lounges, while Britannia passengers discover elegant multi-course dinners that rival fine London establishments.</p>
+        <p>Ideal for travelers who appreciate formal traditions, enrichment lectures, classical music, afternoon tea rituals, and the singular experience of crossing the Atlantic by sea. Cunard rewards those who savor the ceremonial — from the white-gloved waiters to the Commodore's cocktail party.</p>
+      </div>
+
+      <div class="key-facts">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Brand Identity:</strong> British ocean liner heritage since 1840</li>
+          <li><strong>Parent Company:</strong> Carnival Corporation &amp; plc</li>
+          <li><strong>Signature Features:</strong> Transatlantic crossings, Grill-class dining hierarchy, formal evenings, enrichment lectures, afternoon tea</li>
+          <li><strong>Best For:</strong> History enthusiasts, formal-travel lovers, Transatlantic crossing seekers, enrichment-focused travelers</li>
+          <li><strong>Fleet Size:</strong> 4 ships (the Queens)</li>
+          <li><strong>Primary Itineraries:</strong> Transatlantic crossings, world voyages, Mediterranean, Northern Europe, Alaska</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="card" aria-labelledby="coming-soon-h">
+      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
+      <p>We're expanding our Cunard coverage with in-depth ship profiles, Grill dining breakdowns, stateroom guidance, and the insider knowledge that helps you navigate Cunard's storied traditions. Check back soon for comprehensive guides.</p>
+      <p>In the meantime, explore our <a href="/ships/cunard/">Cunard ship directory</a> for the fleet overview, or visit <a href="https://www.cunard.com" target="_blank" rel="noopener">Cunard.com</a> to browse current sailings.</p>
+    </section>
+
+    <section id="ships" class="card" aria-labelledby="ships-h">
+      <h2 id="ships-h">Cunard Fleet</h2>
+      <ul>
+        <li><a href="/ships/cunard/queen-anne.html">Queen Anne</a></li>
+        <li><a href="/ships/cunard/queen-elizabeth.html">Queen Elizabeth</a></li>
+        <li><a href="/ships/cunard/queen-mary-2.html">Queen Mary 2</a></li>
+        <li><a href="/ships/cunard/queen-victoria.html">Queen Victoria</a></li>
+      </ul>
+    </section>
+
+    <section class="card related-resources" style="margin: 1.5rem 0; padding: 1.25rem; background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
+      <h2 style="margin: 0 0 0.75rem; font-size: 1.15rem; color: #083041;">Continue Planning Your Cunard Voyage</h2>
+      <p class="tiny content-text" style="margin-bottom: 1rem; color: #5a7a8a;">Tools and guides to help you prepare.</p>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem;">
+        <a href="/first-cruise.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">First Cruise Guide</strong>
+          <span class="tiny" style="color: #5a7a8a;">New to cruising?</span>
+        </a>
+        <a href="/packing-lists.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Packing Lists</strong>
+          <span class="tiny" style="color: #5a7a8a;">Don't forget anything</span>
+        </a>
+        <a href="/cruise-lines.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Compare Lines</strong>
+          <span class="tiny" style="color: #5a7a8a;">See all cruise lines</span>
+        </a>
+        <a href="/planning.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
+          <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
+        </a>
+      </div>
+    </section>
+
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <h3>What makes Cunard unique?</h3>
+        <p>Cunard is the world's most iconic ocean liner company, operating since 1840. Known for Transatlantic crossings on Queen Mary 2, Grill-class dining hierarchy, formal evening traditions, and white-glove British service that harkens to the golden age of ocean travel.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What is Grill-class dining?</h3>
+        <p>Cunard's Grill dining is a tiered system: Queens Grill (top suites), Princess Grill (premium suites), and Britannia Restaurant (standard). Each Grill offers exclusive dining, private lounges, and dedicated concierge services.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Does Cunard still do Transatlantic crossings?</h3>
+        <p>Yes. Queen Mary 2 offers regular scheduled Transatlantic crossings between New York and Southampton — the only ocean liner still providing this classic service.</p>
+      </div>
+    </section>
+  </div>
+
+  <aside class="rail" role="complementary" aria-label="Author & articles">
+    <section class="card quiz-cta" style="background: linear-gradient(135deg, #e0f4f8, #fff); border-left: 4px solid #0e6e8e; padding: 1rem; margin-bottom: 1rem;">
+      <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #083041;">Exploring Other Lines?</h3>
+      <p class="tiny" style="margin-bottom: 0.75rem; color: #5a7a8a;">Take our quick quiz to find cruise lines that match your travel style.</p>
+      <a href="/cruise-lines/quiz.html" class="pill" style="font-size: 0.85rem;">Cruise Line Quiz &rarr;</a>
+    </section>
+    <section class="card author-card-vertical" aria-labelledby="author-heading">
+      <h3 id="author-heading">About the Author</h3>
+      <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+        <picture>
+          <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+          <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </picture>
+      </a>
+      <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+      <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+      <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+    </section>
+    <section class="card" aria-labelledby="recent-rail-title">
+      <h3 id="recent-rail-title">Recent Stories</h3>
+      <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+      <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+      <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles&hellip;</p>
+    </section>
+  </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> &middot; <a href="/terms.html">Terms</a> &middot; <a href="/about-us.html">About</a> &middot; <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria &#10013;</p>
+    <p class="trust-badge">&check; No ads. Minimal analytics. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+  <script src="/assets/js/in-app-browser-escape.js"></script>
+  <script>
+  (function(){"use strict";(async function recentRail(){const rail=document.getElementById('recent-rail');if(!rail)return;const fallback=document.getElementById('recent-rail-fallback');if(fallback)fallback.style.display='';try{const res=await fetch('/assets/data/articles/index.json',{credentials:'omit',cache:'no-cache'});if(!res.ok)throw new Error('Failed');const articles=await res.json();if(fallback)fallback.style.display='none';rail.innerHTML=articles.slice(0,4).map(a=>'<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;"><h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="'+a.url+'">'+a.title+'</a></h4></div>').join('')}catch(err){if(fallback)fallback.textContent='Unable to load articles'}})()})();
+  </script>
+</body>
+</html>

--- a/cruise-lines/explora-journeys.html
+++ b/cruise-lines/explora-journeys.html
@@ -1,0 +1,363 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+<!-- ai-breadcrumbs
+     entity: Explora Journeys
+     type: Cruise Line Guide
+     parent: /cruise-lines.html
+     category: Cruise Line Information
+     updated: 2026-01-30
+     expertise: Cruise line comparisons, fleet analysis, policy research, cruise planning
+     target-audience: Luxury cruise shoppers, European travel enthusiasts, design-conscious guests
+     answer-first: Explora Journeys redefines ocean luxury with all-suite ships, 18 dining experiences, and inclusive European elegance — the newest luxury brand from MSC Group with 6 planned vessels.
+     core-facts: New luxury MSC Group brand (launched 2023); all ocean-front suites; 18 dining experiences; inclusive pricing; 6 ships planned
+     decisions-informed: whether Explora Journeys' luxury all-suite experience and inclusive pricing matches your travel style; understanding the ocean-going luxury lifestyle concept
+     -->
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart, and do not lean on your own understanding." — Proverbs 3:5
+"Whatever you do, work heartily, as for the Lord and not for men." — Colossians 3:23
+-->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Explora Journeys | In the Wake (V1.Beta)</title>
+  <meta name="version" content="V1.Beta"/>
+  <meta name="description" content="Explora Journeys guide: luxury all-suite cruise line from MSC Group with 18 dining experiences, inclusive pricing, and refined European elegance. Explore ships, planning tools, and onboard experiences."/>
+  <meta name="robots" content="index,follow"/>
+
+  <!-- ICP-Lite v1.4: AI-First Metadata -->
+  <meta name="ai-summary" content="Explora Journeys guide: luxury MSC Group brand launched 2023 with all ocean-front suites, 18 dining experiences, inclusive pricing, and 6 planned ships. Explore fleet and planning resources."/>
+  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+
+  <!-- Canonical / Social -->
+  <link rel="canonical" href="https://cruisinginthewake.com/cruise-lines/explora-journeys.html"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:url" content="https://cruisinginthewake.com/cruise-lines/explora-journeys.html"/>
+  <meta property="og:title" content="Explora Journeys | In the Wake"/>
+  <meta property="og:description" content="Luxury all-suite cruising with 18 dining experiences and inclusive European elegance."/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Explora Journeys guide: luxury all-suite cruise line with 18 dining experiences, inclusive pricing, and refined European elegance."/>
+  <meta name="twitter:title" content="Explora Journeys | In the Wake"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {"@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+     {"@type":"ListItem","position":1,"name":"Home","item":"https://cruisinginthewake.com/"},
+     {"@type":"ListItem","position":2,"name":"Cruise Lines","item":"https://cruisinginthewake.com/cruise-lines.html"},
+     {"@type":"ListItem","position":3,"name":"Explora Journeys","item":"https://cruisinginthewake.com/cruise-lines/explora-journeys.html"}
+   ]}
+  </script>
+
+  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Explora Journeys | In the Wake",
+    "url": "https://cruisinginthewake.com/cruise-lines/explora-journeys.html",
+    "description": "Explora Journeys guide: luxury MSC Group brand launched 2023 with all ocean-front suites, 18 dining experiences, inclusive pricing, and 6 planned ships. Explore fleet and planning resources.",
+    "dateModified": "2026-01-30"
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What makes Explora Journeys unique?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Explora Journeys is the newest luxury cruise brand from MSC Group, launched in 2023. Every suite is ocean-front with a private terrace, and the experience includes 18 dining venues, inclusive pricing covering drinks, Wi-Fi, and gratuities, plus refined European design throughout — all aboard intimate 922-guest ships."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is included in an Explora Journeys fare?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Explora Journeys uses inclusive pricing that covers dining across all 18 onboard restaurants, premium beverages, unlimited Wi-Fi, gratuities, and access to wellness facilities. This all-inclusive approach means fewer surprise charges and a seamless luxury experience from embarkation to disembarkation."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Where does Explora Journeys sail?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Explora Journeys offers itineraries across the Mediterranean, Northern Europe, the Caribbean, and Transatlantic crossings. With a focus on European elegance, Mediterranean voyages are a signature strength, complemented by seasonal repositioning cruises and destination-rich sailings worldwide."
+        }
+      }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ken Baker",
+    "url": "https://cruisinginthewake.com/about/ken-baker.html",
+    "jobTitle": "Cruise Research Analyst & Data Specialist",
+    "description": "Cruise industry analyst specializing in ship comparisons, deck plan analysis, and dining venue research.",
+    "knowsAbout": ["Cruise Ship Analysis","Deck Plans","Explora Journeys","Cruise Dining","Ship Comparisons"]
+  }
+  </script>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
+</head>
+
+<body class="page">
+  <a class="skip-link" href="#content">Skip to main content</a>
+
+  <header class="site-header hero-header">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+
+    <div class="hero" role="img" aria-label="Ship wake at sunrise">
+      <div class="latlon-grid" aria-hidden="true"></div>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo &copy; Flickers of Majesty</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="content">
+  <div>
+    <section class="icp-header" aria-labelledby="line-name">
+      <h1 id="line-name">Explora Journeys</h1>
+      <p class="answer-line"><strong>Quick Answer:</strong> Ocean-going luxury, redefined. Explora Journeys is MSC Group's luxury brand launched in 2023, offering all ocean-front suites with private terraces, 18 distinctive dining experiences, and inclusive pricing that covers drinks, Wi-Fi, and gratuities. With 6 planned vessels and an intimate 922-guest capacity, Explora delivers refined European elegance on every voyage.</p>
+
+      <div class="fit-guidance">
+        <h2>Is Explora Journeys Right for You?</h2>
+        <p>If you crave a luxury experience that feels effortlessly European — where every suite opens to the ocean, every meal is a curated affair, and every detail has been designed with intention — Explora Journeys was crafted for you. This is not mass-market cruising with a luxury label; it is an entirely new concept in ocean travel, built from the keel up for discerning travelers.</p>
+        <p>With just 922 guests aboard, the atmosphere is intimate and unhurried. The Helios Pool &amp; Bar sets the scene for sun-drenched afternoons, while 18 dining experiences range from Mediterranean cuisine to Asian-inspired flavors — all included in your fare. Inclusive pricing means no signing, no surprise charges, and no nickel-and-diming: premium beverages, Wi-Fi, gratuities, and dining are woven seamlessly into the journey.</p>
+        <p>Ideal for luxury travelers who appreciate European design sensibility, food-forward experiences, and destinations explored at a leisurely pace. Explora Journeys is best suited for couples, solo travelers seeking refinement, and design-conscious guests who want their surroundings to match the destinations they visit.</p>
+      </div>
+
+      <div class="key-facts">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Brand Identity:</strong> Ocean-going luxury lifestyle from MSC Group</li>
+          <li><strong>Parent Company:</strong> MSC Group</li>
+          <li><strong>Launched:</strong> 2023</li>
+          <li><strong>Signature Features:</strong> All ocean-front suites with private terraces, 18 dining experiences, Helios Pool &amp; Bar, 64% ocean-front suite ratio, inclusive pricing</li>
+          <li><strong>Best For:</strong> Luxury travelers, European travel enthusiasts, design-conscious guests</li>
+          <li><strong>Guest Capacity:</strong> 922 guests per ship</li>
+          <li><strong>Fleet Size:</strong> 2 active ships (Explora I &amp; II), 4 additional vessels planned (Explora III–VI)</li>
+          <li><strong>Primary Itineraries:</strong> Mediterranean, Northern Europe, Caribbean, Transatlantic</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="card" aria-labelledby="coming-soon-h">
+      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
+      <p>We're expanding our Explora Journeys coverage with in-depth ship profiles, dining venue breakdowns, suite guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Explora vessel — check back soon for comprehensive guides.</p>
+      <p>In the meantime, explore our <a href="/ships/explora-journeys/">Explora Journeys ship directory</a> for the fleet overview, or visit <a href="https://www.explorajourneys.com" target="_blank" rel="noopener">ExploraJourneys.com</a> to browse current sailings.</p>
+    </section>
+
+    <!-- Ships A-Z -->
+    <section id="ships" class="card" aria-labelledby="ships-h">
+      <h2 id="ships-h">Explora Journeys Fleet</h2>
+      <ul>
+        <li><a href="/ships/explora-journeys/explora-i.html">Explora I</a></li>
+        <li><a href="/ships/explora-journeys/explora-ii.html">Explora II</a></li>
+        <li><a href="/ships/explora-journeys/explora-iii.html">Explora III</a></li>
+        <li><a href="/ships/explora-journeys/explora-iv.html">Explora IV</a></li>
+        <li><a href="/ships/explora-journeys/explora-v.html">Explora V</a></li>
+        <li><a href="/ships/explora-journeys/explora-vi.html">Explora VI</a></li>
+      </ul>
+    </section>
+
+    <!-- Related Resources -->
+    <section class="card related-resources" style="margin: 1.5rem 0; padding: 1.25rem; background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
+      <h2 style="margin: 0 0 0.75rem; font-size: 1.15rem; color: #083041;">Continue Planning Your Explora Journey</h2>
+      <p class="tiny content-text" style="margin-bottom: 1rem; color: #5a7a8a;">Tools and guides to help you prepare.</p>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem;">
+        <a href="/first-cruise.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">First Cruise Guide</strong>
+          <span class="tiny" style="color: #5a7a8a;">New to cruising?</span>
+        </a>
+        <a href="/packing-lists.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Packing Lists</strong>
+          <span class="tiny" style="color: #5a7a8a;">Don't forget anything</span>
+        </a>
+        <a href="/cruise-lines.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Compare Lines</strong>
+          <span class="tiny" style="color: #5a7a8a;">See all cruise lines</span>
+        </a>
+        <a href="/planning.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
+          <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <h3>What makes Explora Journeys unique?</h3>
+        <p>Explora Journeys is the newest luxury cruise brand from MSC Group, launched in 2023. Every suite is ocean-front with a private terrace, and the experience includes 18 dining venues, inclusive pricing covering drinks, Wi-Fi, and gratuities, plus refined European design throughout — all aboard intimate 922-guest ships.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What is included in an Explora Journeys fare?</h3>
+        <p>Explora Journeys uses inclusive pricing that covers dining across all 18 onboard restaurants, premium beverages, unlimited Wi-Fi, gratuities, and access to wellness facilities. This all-inclusive approach means fewer surprise charges and a seamless luxury experience from embarkation to disembarkation.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Where does Explora Journeys sail?</h3>
+        <p>Explora Journeys offers itineraries across the Mediterranean, Northern Europe, the Caribbean, and Transatlantic crossings. With a focus on European elegance, Mediterranean voyages are a signature strength, complemented by seasonal repositioning cruises and destination-rich sailings worldwide.</p>
+      </div>
+    </section>
+  </div>
+
+  <!-- RIGHT RAIL -->
+  <aside class="rail" role="complementary" aria-label="Author & articles">
+    <section class="card quiz-cta" style="background: linear-gradient(135deg, #e0f4f8, #fff); border-left: 4px solid #0e6e8e; padding: 1rem; margin-bottom: 1rem;">
+      <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #083041;">Exploring Other Lines?</h3>
+      <p class="tiny" style="margin-bottom: 0.75rem; color: #5a7a8a;">Take our quick quiz to find cruise lines that match your travel style.</p>
+      <a href="/cruise-lines/quiz.html" class="pill" style="font-size: 0.85rem;">Cruise Line Quiz &rarr;</a>
+    </section>
+
+    <section class="card author-card-vertical" aria-labelledby="author-heading">
+      <h3 id="author-heading">About the Author</h3>
+      <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+        <picture>
+          <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+          <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </picture>
+      </a>
+      <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+      <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+      <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+    </section>
+
+    <section class="card" aria-labelledby="recent-rail-title">
+      <h3 id="recent-rail-title">Recent Stories</h3>
+      <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+      <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+      <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles&hellip;</p>
+    </section>
+  </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> &middot;
+      <a href="/terms.html">Terms</a> &middot;
+      <a href="/about-us.html">About</a> &middot;
+      <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. &#10013;</p>
+    <p class="trust-badge">&check; No ads. Minimal analytics. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+  <script src="/assets/js/in-app-browser-escape.js"></script>
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a =>
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
+  })();
+  </script>
+</body>
+</html>

--- a/cruise-lines/oceania.html
+++ b/cruise-lines/oceania.html
@@ -1,0 +1,364 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+<!-- ai-breadcrumbs
+     entity: Oceania Cruises
+     type: Cruise Line Guide
+     parent: /cruise-lines.html
+     category: Cruise Line Information
+     updated: 2026-01-30
+     expertise: Cruise line comparisons, fleet analysis, policy research, cruise planning
+     target-audience: Cruise line comparison shoppers, foodies, experienced cruisers, travel planners
+     answer-first: Oceania Cruises delivers "The Finest Cuisine at Sea" with intimate mid-size ships, destination-focused itineraries, and Jacques Pepin-inspired dining across 7 vessels.
+     core-facts: Upper-premium line with 7 ships; Jacques Pepin as culinary director; mid-size ships (600-1200 guests); country club casual atmosphere
+     decisions-informed: whether Oceania's culinary focus and intimate ship size matches your travel style; understanding the upper-premium cruise experience
+     -->
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart, and do not lean on your own understanding." — Proverbs 3:5
+"Whatever you do, work heartily, as for the Lord and not for men." — Colossians 3:23
+-->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Oceania Cruises | In the Wake (V1.Beta)</title>
+  <meta name="version" content="V1.Beta"/>
+  <meta name="description" content="Oceania Cruises guide: upper-premium line delivering The Finest Cuisine at Sea with intimate mid-size ships, Jacques Pepin-inspired dining, and destination-focused itineraries across 7 vessels."/>
+  <meta name="robots" content="index,follow"/>
+
+  <!-- ICP-Lite v1.4: AI-First Metadata -->
+  <meta name="ai-summary" content="Oceania Cruises guide: upper-premium line with 7 mid-size ships featuring Jacques Pepin-inspired culinary excellence, destination-focused itineraries, and country club casual atmosphere. Explore fleet and planning resources."/>
+  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+
+  <!-- Canonical / Social -->
+  <link rel="canonical" href="https://cruisinginthewake.com/cruise-lines/oceania.html"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:url" content="https://cruisinginthewake.com/cruise-lines/oceania.html"/>
+  <meta property="og:title" content="Oceania Cruises | In the Wake"/>
+  <meta property="og:description" content="Upper-premium cruising with The Finest Cuisine at Sea and destination-focused itineraries."/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Oceania Cruises guide: upper-premium line with intimate mid-size ships, Jacques Pepin-inspired dining, and destination-focused itineraries."/>
+  <meta name="twitter:title" content="Oceania Cruises | In the Wake"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {"@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+     {"@type":"ListItem","position":1,"name":"Home","item":"https://cruisinginthewake.com/"},
+     {"@type":"ListItem","position":2,"name":"Cruise Lines","item":"https://cruisinginthewake.com/cruise-lines.html"},
+     {"@type":"ListItem","position":3,"name":"Oceania Cruises","item":"https://cruisinginthewake.com/cruise-lines/oceania.html"}
+   ]}
+  </script>
+
+  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Oceania Cruises | In the Wake",
+    "url": "https://cruisinginthewake.com/cruise-lines/oceania.html",
+    "description": "Oceania Cruises guide: upper-premium line with 7 mid-size ships featuring Jacques Pepin-inspired culinary excellence, destination-focused itineraries, and country club casual atmosphere. Explore fleet and planning resources.",
+    "dateModified": "2026-01-30"
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What makes Oceania Cruises unique?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Oceania Cruises occupies the upper-premium segment with intimate mid-size ships carrying just 600-1200 guests. Their hallmark is culinary excellence — branded as The Finest Cuisine at Sea — with Jacques Pepin as executive culinary director. Destination-focused itineraries feature longer port stays, and the country club casual atmosphere appeals to experienced cruisers."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What dining does Oceania Cruises offer?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Oceania's dining program is curated by legendary chef Jacques Pepin and includes multiple open-seating specialty restaurants at no extra charge. From French fine dining at Jacques to Italian at Toscana and steaks at Polo Grill, every venue emphasizes fresh ingredients and culinary artistry that rivals top shoreside restaurants."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How big are Oceania cruise ships?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Oceania operates mid-size ships carrying 600-1200 guests, deliberately smaller than mainstream mega-ships. The R-class ships (Insignia, Nautica, Regatta, Sirena) carry around 670 guests, while the larger O-class (Marina, Riviera) and newest Allura-class (Allura, Vista) carry approximately 1,200 guests — still intimate by modern standards."
+        }
+      }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ken Baker",
+    "url": "https://cruisinginthewake.com/about/ken-baker.html",
+    "jobTitle": "Cruise Research Analyst & Data Specialist",
+    "description": "Cruise industry analyst specializing in ship comparisons, deck plan analysis, and dining venue research.",
+    "knowsAbout": ["Cruise Ship Analysis","Deck Plans","Oceania Cruises","Cruise Dining","Ship Comparisons"]
+  }
+  </script>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
+</head>
+
+<body class="page">
+  <a class="skip-link" href="#content">Skip to main content</a>
+
+  <header class="site-header hero-header">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+
+    <div class="hero" role="img" aria-label="Ship wake at sunrise">
+      <div class="latlon-grid" aria-hidden="true"></div>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo &copy; Flickers of Majesty</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="content">
+  <div>
+    <section class="icp-header" aria-labelledby="line-name">
+      <h1 id="line-name">Oceania Cruises</h1>
+      <p class="answer-line"><strong>Quick Answer:</strong> The Finest Cuisine at Sea. Oceania Cruises pairs Jacques Pepin-inspired culinary excellence with intimate mid-size ships carrying just 600-1200 guests. Destination-focused itineraries feature longer port stays, a country club casual atmosphere, and an upper-premium experience that appeals to foodies and experienced cruisers who value quality over quantity.</p>
+
+      <div class="fit-guidance">
+        <h2>Is Oceania Right for You?</h2>
+        <p>If you find yourself lingering over a perfectly seared scallop at your favorite restaurant, or if you'd rather spend an afternoon exploring a Tuscan hilltop village than riding a waterslide, Oceania Cruises was designed with you in mind. This upper-premium line, part of Norwegian Cruise Line Holdings, has built its entire identity around culinary artistry and destination immersion.</p>
+        <p>With legendary chef Jacques Pepin as executive culinary director, every meal aboard is an event — from open-seating specialty restaurants included in your fare to hands-on cooking classes in the onboard Culinary Center. The mid-size ships (7 vessels carrying 600-1200 guests) create an intimate, uncrowded atmosphere where you'll never wait for a tender or fight for a lounge chair.</p>
+        <p>Ideal for foodies, destination lovers, and experienced cruisers who want refined elegance without the formality of ultra-luxury lines. The country club casual dress code sets the tone: sophisticated but never stuffy. If you've outgrown mega-ships but aren't ready for butler service, Oceania hits the sweet spot.</p>
+      </div>
+
+      <div class="key-facts">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Brand Identity:</strong> Upper-premium, "The Finest Cuisine at Sea"</li>
+          <li><strong>Parent Company:</strong> Norwegian Cruise Line Holdings</li>
+          <li><strong>Signature Features:</strong> Jacques Pepin culinary program, open-seating dining, Culinary Center cooking classes, destination-focused itineraries with longer port stays</li>
+          <li><strong>Best For:</strong> Foodies, destination lovers, experienced cruisers wanting intimate ships</li>
+          <li><strong>Fleet Size:</strong> 7 ships (600-1200 guests)</li>
+          <li><strong>Dress Code:</strong> Country club casual</li>
+          <li><strong>Primary Itineraries:</strong> Mediterranean, Alaska, Caribbean, World Cruises, Asia, South Pacific</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="card" aria-labelledby="coming-soon-h">
+      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
+      <p>We're expanding our Oceania Cruises coverage with in-depth ship profiles, dining venue breakdowns, stateroom guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Oceania vessel — check back soon for comprehensive guides.</p>
+      <p>In the meantime, explore our <a href="/ships/oceania/">Oceania ship directory</a> for the fleet overview, or visit <a href="https://www.oceaniacruises.com" target="_blank" rel="noopener">OceaniaCruises.com</a> to browse current sailings.</p>
+    </section>
+
+    <!-- Ships A-Z -->
+    <section id="ships" class="card" aria-labelledby="ships-h">
+      <h2 id="ships-h">Oceania Fleet</h2>
+      <ul>
+        <li><a href="/ships/oceania/allura.html">Allura</a></li>
+        <li><a href="/ships/oceania/insignia.html">Insignia</a></li>
+        <li><a href="/ships/oceania/marina.html">Marina</a></li>
+        <li><a href="/ships/oceania/nautica.html">Nautica</a></li>
+        <li><a href="/ships/oceania/regatta.html">Regatta</a></li>
+        <li><a href="/ships/oceania/riviera.html">Riviera</a></li>
+        <li><a href="/ships/oceania/sirena.html">Sirena</a></li>
+        <li><a href="/ships/oceania/vista.html">Vista</a></li>
+      </ul>
+    </section>
+
+    <!-- Related Resources -->
+    <section class="card related-resources" style="margin: 1.5rem 0; padding: 1.25rem; background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
+      <h2 style="margin: 0 0 0.75rem; font-size: 1.15rem; color: #083041;">Continue Planning Your Oceania Cruise</h2>
+      <p class="tiny content-text" style="margin-bottom: 1rem; color: #5a7a8a;">Tools and guides to help you prepare.</p>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem;">
+        <a href="/first-cruise.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">First Cruise Guide</strong>
+          <span class="tiny" style="color: #5a7a8a;">New to cruising?</span>
+        </a>
+        <a href="/packing-lists.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Packing Lists</strong>
+          <span class="tiny" style="color: #5a7a8a;">Don't forget anything</span>
+        </a>
+        <a href="/cruise-lines.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Compare Lines</strong>
+          <span class="tiny" style="color: #5a7a8a;">See all cruise lines</span>
+        </a>
+        <a href="/planning.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
+          <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <h3>What makes Oceania Cruises unique?</h3>
+        <p>Oceania Cruises occupies the upper-premium segment with intimate mid-size ships carrying just 600-1200 guests. Their hallmark is culinary excellence — branded as The Finest Cuisine at Sea — with Jacques Pepin as executive culinary director. Destination-focused itineraries feature longer port stays, and the country club casual atmosphere appeals to experienced cruisers.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What dining does Oceania Cruises offer?</h3>
+        <p>Oceania's dining program is curated by legendary chef Jacques Pepin and includes multiple open-seating specialty restaurants at no extra charge. From French fine dining at Jacques to Italian at Toscana and steaks at Polo Grill, every venue emphasizes fresh ingredients and culinary artistry that rivals top shoreside restaurants.</p>
+      </div>
+      <div class="faq-item">
+        <h3>How big are Oceania cruise ships?</h3>
+        <p>Oceania operates mid-size ships carrying 600-1200 guests, deliberately smaller than mainstream mega-ships. The R-class ships (Insignia, Nautica, Regatta, Sirena) carry around 670 guests, while the larger O-class (Marina, Riviera) and newest Allura-class (Allura, Vista) carry approximately 1,200 guests — still intimate by modern standards.</p>
+      </div>
+    </section>
+  </div>
+
+  <!-- RIGHT RAIL -->
+  <aside class="rail" role="complementary" aria-label="Author & articles">
+    <section class="card quiz-cta" style="background: linear-gradient(135deg, #e0f4f8, #fff); border-left: 4px solid #0e6e8e; padding: 1rem; margin-bottom: 1rem;">
+      <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #083041;">Exploring Other Lines?</h3>
+      <p class="tiny" style="margin-bottom: 0.75rem; color: #5a7a8a;">Take our quick quiz to find cruise lines that match your travel style.</p>
+      <a href="/cruise-lines/quiz.html" class="pill" style="font-size: 0.85rem;">Cruise Line Quiz &rarr;</a>
+    </section>
+
+    <section class="card author-card-vertical" aria-labelledby="author-heading">
+      <h3 id="author-heading">About the Author</h3>
+      <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+        <picture>
+          <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+          <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </picture>
+      </a>
+      <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+      <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+      <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+    </section>
+
+    <section class="card" aria-labelledby="recent-rail-title">
+      <h3 id="recent-rail-title">Recent Stories</h3>
+      <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+      <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+      <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles&hellip;</p>
+    </section>
+  </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> &middot;
+      <a href="/terms.html">Terms</a> &middot;
+      <a href="/about-us.html">About</a> &middot;
+      <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. &#10013;</p>
+    <p class="trust-badge">&check; No ads. Minimal analytics. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+  <script src="/assets/js/in-app-browser-escape.js"></script>
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a =>
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
+  })();
+  </script>
+</body>
+</html>

--- a/cruise-lines/regent.html
+++ b/cruise-lines/regent.html
@@ -1,0 +1,362 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+<!-- ai-breadcrumbs
+     entity: Regent Seven Seas Cruises
+     type: Cruise Line Guide
+     parent: /cruise-lines.html
+     category: Cruise Line Information
+     updated: 2026-01-30
+     expertise: Cruise line comparisons, fleet analysis, policy research, cruise planning
+     target-audience: Luxury cruise shoppers, experienced cruisers, special occasion travelers
+     answer-first: Regent Seven Seas delivers the most inclusive luxury at sea — all-suite ships where shore excursions, fine dining, unlimited drinks, Wi-Fi, and gratuities are all included across 7 vessels.
+     core-facts: Ultra-luxury all-inclusive; 7 all-suite ships (max 750 guests); shore excursions included; Regent Suite is most luxurious at sea
+     decisions-informed: whether Regent's all-inclusive ultra-luxury model matches your travel style; understanding the most inclusive cruise experience at sea
+     -->
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart, and do not lean on your own understanding." — Proverbs 3:5
+"Whatever you do, work heartily, as for the Lord and not for men." — Colossians 3:23
+-->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Regent Seven Seas Cruises | In the Wake (V1.Beta)</title>
+  <meta name="version" content="V1.Beta"/>
+  <meta name="description" content="Regent Seven Seas Cruises guide: ultra-luxury all-inclusive cruise line with all-suite ships, included shore excursions, fine dining, unlimited drinks, Wi-Fi, and gratuities across 7 intimate vessels."/>
+  <meta name="robots" content="index,follow"/>
+
+  <!-- ICP-Lite v1.4: AI-First Metadata -->
+  <meta name="ai-summary" content="Regent Seven Seas Cruises guide: ultra-luxury all-inclusive line with 7 all-suite ships (max 750 guests) featuring included shore excursions, fine dining, unlimited drinks, Wi-Fi, and gratuities. The Regent Suite is the most luxurious suite at sea."/>
+  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+
+  <!-- Canonical / Social -->
+  <link rel="canonical" href="https://cruisinginthewake.com/cruise-lines/regent.html"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:url" content="https://cruisinginthewake.com/cruise-lines/regent.html"/>
+  <meta property="og:title" content="Regent Seven Seas Cruises | In the Wake"/>
+  <meta property="og:description" content="Ultra-luxury all-inclusive cruising with all-suite ships and included shore excursions."/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Regent Seven Seas Cruises guide: ultra-luxury all-inclusive cruise line with all-suite ships and included shore excursions."/>
+  <meta name="twitter:title" content="Regent Seven Seas Cruises | In the Wake"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {"@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+     {"@type":"ListItem","position":1,"name":"Home","item":"https://cruisinginthewake.com/"},
+     {"@type":"ListItem","position":2,"name":"Cruise Lines","item":"https://cruisinginthewake.com/cruise-lines.html"},
+     {"@type":"ListItem","position":3,"name":"Regent Seven Seas Cruises","item":"https://cruisinginthewake.com/cruise-lines/regent.html"}
+   ]}
+  </script>
+
+  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Regent Seven Seas Cruises | In the Wake",
+    "url": "https://cruisinginthewake.com/cruise-lines/regent.html",
+    "description": "Regent Seven Seas Cruises guide: ultra-luxury all-inclusive line with 7 all-suite ships (max 750 guests) featuring included shore excursions, fine dining, unlimited drinks, Wi-Fi, and gratuities. The Regent Suite is the most luxurious suite at sea.",
+    "dateModified": "2026-01-30"
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is included with Regent Seven Seas Cruises?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Regent Seven Seas is the most inclusive luxury cruise line in the world. Every fare includes all-suite accommodations, unlimited shore excursions, specialty dining, unlimited beverages including fine wines and premium spirits, pre-paid gratuities, unlimited Wi-Fi, and roundtrip business-class airfare on select bookings."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the Regent Suite?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The Regent Suite is widely regarded as the most luxurious suite at sea. Found aboard Seven Seas Explorer and Seven Seas Splendor, it spans over 4,000 square feet and features a private spa, grand living room, king-sized bed, and a sprawling private balcony with personal hot tub."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Where does Regent Seven Seas cruise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Regent Seven Seas offers itineraries across the Mediterranean, Northern Europe, Alaska, the Caribbean, Asia, South America, Australia, and Africa. They also operate annual World Cruises that circumnavigate the globe over several months."
+        }
+      }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ken Baker",
+    "url": "https://cruisinginthewake.com/about/ken-baker.html",
+    "jobTitle": "Cruise Research Analyst & Data Specialist",
+    "description": "Cruise industry analyst specializing in ship comparisons, deck plan analysis, and dining venue research.",
+    "knowsAbout": ["Cruise Ship Analysis","Deck Plans","Regent Seven Seas Cruises","Luxury Cruising","Ship Comparisons"]
+  }
+  </script>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
+</head>
+
+<body class="page">
+  <a class="skip-link" href="#content">Skip to main content</a>
+
+  <header class="site-header hero-header">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+
+    <div class="hero" role="img" aria-label="Ship wake at sunrise">
+      <div class="latlon-grid" aria-hidden="true"></div>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo &copy; Flickers of Majesty</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="content">
+  <div>
+    <section class="icp-header" aria-labelledby="line-name">
+      <h1 id="line-name">Regent Seven Seas Cruises</h1>
+      <p class="answer-line"><strong>Quick Answer:</strong> The most inclusive luxury at sea. Regent Seven Seas Cruises wraps every voyage in uncompromising elegance — all-suite ships with no more than 750 guests, where shore excursions, fine dining, unlimited drinks, Wi-Fi, and gratuities are all included. With 7 intimate vessels and the legendary Regent Suite, this is cruising without compromise.</p>
+
+      <div class="fit-guidance">
+        <h2>Is Regent Seven Seas Right for You?</h2>
+        <p>If the phrase "all-inclusive" speaks to your soul — and you want it to truly mean everything — Regent Seven Seas was built for you. This is the cruise line where shore excursions in every port, specialty dining at every restaurant, premium beverages, unlimited Wi-Fi, and pre-paid gratuities all come standard. No nickel-and-diming, no surprise charges, just pure relaxation from the moment you step aboard.</p>
+        <p>With ships carrying no more than 750 guests, the experience is intimate and personal. Every accommodation is a suite with a private balcony, and the service ratio ensures staff know your name and your preferences. The Compass Rose restaurant serves exquisite cuisine, while the Regent Suite — the most luxurious suite at sea — sets the standard for opulence afloat.</p>
+        <p>Ideal for experienced cruisers who appreciate luxury without pretension, couples celebrating special occasions, and discerning travelers who want everything included in one seamless fare. Part of Norwegian Cruise Line Holdings, Regent consistently delivers the gold standard in all-inclusive ocean cruising.</p>
+      </div>
+
+      <div class="key-facts">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Brand Identity:</strong> Ultra-luxury, all-inclusive cruising — the most inclusive in the world</li>
+          <li><strong>Parent Company:</strong> Norwegian Cruise Line Holdings</li>
+          <li><strong>Signature Features:</strong> All-suite ships, included shore excursions, Regent Suite, Compass Rose restaurant, unlimited beverages &amp; Wi-Fi, pre-paid gratuities</li>
+          <li><strong>Best For:</strong> Luxury travelers wanting all-inclusive, experienced cruisers, special occasions</li>
+          <li><strong>Fleet Size:</strong> 7 all-suite ships (max 750 guests)</li>
+          <li><strong>Primary Itineraries:</strong> Mediterranean, Northern Europe, Alaska, Caribbean, World Cruises</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="card" aria-labelledby="coming-soon-h">
+      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
+      <p>We're expanding our Regent Seven Seas Cruises coverage with in-depth ship profiles, dining venue breakdowns, suite guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Regent vessel — check back soon for comprehensive guides.</p>
+      <p>In the meantime, explore our <a href="/ships/regent/">Regent ship directory</a> for the fleet overview, or visit <a href="https://www.rssc.com" target="_blank" rel="noopener">RSSC.com</a> to browse current sailings.</p>
+    </section>
+
+    <!-- Ships A-Z -->
+    <section id="ships" class="card" aria-labelledby="ships-h">
+      <h2 id="ships-h">Regent Seven Seas Fleet</h2>
+      <ul>
+        <li><a href="/ships/regent/prestige.html">Prestige</a></li>
+        <li><a href="/ships/regent/seven-seas-explorer.html">Seven Seas Explorer</a></li>
+        <li><a href="/ships/regent/seven-seas-grandeur.html">Seven Seas Grandeur</a></li>
+        <li><a href="/ships/regent/seven-seas-mariner.html">Seven Seas Mariner</a></li>
+        <li><a href="/ships/regent/seven-seas-navigator.html">Seven Seas Navigator</a></li>
+        <li><a href="/ships/regent/seven-seas-splendor.html">Seven Seas Splendor</a></li>
+        <li><a href="/ships/regent/seven-seas-voyager.html">Seven Seas Voyager</a></li>
+      </ul>
+    </section>
+
+    <!-- Related Resources -->
+    <section class="card related-resources" style="margin: 1.5rem 0; padding: 1.25rem; background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
+      <h2 style="margin: 0 0 0.75rem; font-size: 1.15rem; color: #083041;">Continue Planning Your Regent Cruise</h2>
+      <p class="tiny content-text" style="margin-bottom: 1rem; color: #5a7a8a;">Tools and guides to help you prepare.</p>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem;">
+        <a href="/first-cruise.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">First Cruise Guide</strong>
+          <span class="tiny" style="color: #5a7a8a;">New to cruising?</span>
+        </a>
+        <a href="/packing-lists.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Packing Lists</strong>
+          <span class="tiny" style="color: #5a7a8a;">Don't forget anything</span>
+        </a>
+        <a href="/cruise-lines.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Compare Lines</strong>
+          <span class="tiny" style="color: #5a7a8a;">See all cruise lines</span>
+        </a>
+        <a href="/planning.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
+          <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <h3>What is included with Regent Seven Seas Cruises?</h3>
+        <p>Regent Seven Seas is the most inclusive luxury cruise line in the world. Every fare includes all-suite accommodations, unlimited shore excursions, specialty dining, unlimited beverages including fine wines and premium spirits, pre-paid gratuities, unlimited Wi-Fi, and roundtrip business-class airfare on select bookings.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What is the Regent Suite?</h3>
+        <p>The Regent Suite is widely regarded as the most luxurious suite at sea. Found aboard Seven Seas Explorer and Seven Seas Splendor, it spans over 4,000 square feet and features a private spa, grand living room, king-sized bed, and a sprawling private balcony with personal hot tub.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Where does Regent Seven Seas cruise?</h3>
+        <p>Regent Seven Seas offers itineraries across the Mediterranean, Northern Europe, Alaska, the Caribbean, Asia, South America, Australia, and Africa. They also operate annual World Cruises that circumnavigate the globe over several months.</p>
+      </div>
+    </section>
+  </div>
+
+  <!-- RIGHT RAIL -->
+  <aside class="rail" role="complementary" aria-label="Author & articles">
+    <section class="card quiz-cta" style="background: linear-gradient(135deg, #e0f4f8, #fff); border-left: 4px solid #0e6e8e; padding: 1rem; margin-bottom: 1rem;">
+      <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #083041;">Exploring Other Lines?</h3>
+      <p class="tiny" style="margin-bottom: 0.75rem; color: #5a7a8a;">Take our quick quiz to find cruise lines that match your travel style.</p>
+      <a href="/cruise-lines/quiz.html" class="pill" style="font-size: 0.85rem;">Cruise Line Quiz &rarr;</a>
+    </section>
+
+    <section class="card author-card-vertical" aria-labelledby="author-heading">
+      <h3 id="author-heading">About the Author</h3>
+      <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+        <picture>
+          <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+          <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </picture>
+      </a>
+      <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+      <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+      <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+    </section>
+
+    <section class="card" aria-labelledby="recent-rail-title">
+      <h3 id="recent-rail-title">Recent Stories</h3>
+      <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+      <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+      <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles&hellip;</p>
+    </section>
+  </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> &middot;
+      <a href="/terms.html">Terms</a> &middot;
+      <a href="/about-us.html">About</a> &middot;
+      <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. &#10013;</p>
+    <p class="trust-badge">&check; No ads. Minimal analytics. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+  <script src="/assets/js/in-app-browser-escape.js"></script>
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a =>
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
+  })();
+  </script>
+</body>
+</html>

--- a/cruise-lines/seabourn.html
+++ b/cruise-lines/seabourn.html
@@ -1,0 +1,362 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+<!-- ai-breadcrumbs
+     entity: Seabourn
+     type: Cruise Line Guide
+     parent: /cruise-lines.html
+     category: Cruise Line Information
+     updated: 2026-01-30
+     expertise: Cruise line comparisons, fleet analysis, policy research, cruise planning
+     target-audience: Luxury cruise seekers, expedition travelers, intimate ship lovers
+     answer-first: Seabourn delivers intimate ultra-luxury with 450-600 guest ships, The Grill by Thomas Keller, all-inclusive service, and expedition voyages to Antarctica and the Arctic across 7 vessels.
+     core-facts: Ultra-luxury Carnival Corporation line; 7 intimate ships (450-600 guests); Thomas Keller dining; expedition ships with submarines; all-inclusive
+     decisions-informed: whether Seabourn's ultra-luxury intimate ships and expedition options match your travel style; understanding the all-inclusive ultra-luxury cruising experience
+     -->
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart, and do not lean on your own understanding." — Proverbs 3:5
+"Whatever you do, work heartily, as for the Lord and not for men." — Colossians 3:23
+-->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Seabourn | In the Wake (V1.Beta)</title>
+  <meta name="version" content="V1.Beta"/>
+  <meta name="description" content="Seabourn guide: ultra-luxury cruise line with intimate 450-600 guest ships, The Grill by Thomas Keller, all-inclusive service, and expedition voyages to Antarctica and the Arctic."/>
+  <meta name="robots" content="index,follow"/>
+
+  <!-- ICP-Lite v1.4: AI-First Metadata -->
+  <meta name="ai-summary" content="Seabourn guide: ultra-luxury Carnival Corporation line with 7 intimate ships (450-600 guests), Thomas Keller dining, expedition vessels with submarines, and all-inclusive service. Explore fleet and planning resources."/>
+  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+
+  <!-- Canonical / Social -->
+  <link rel="canonical" href="https://cruisinginthewake.com/cruise-lines/seabourn.html"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:url" content="https://cruisinginthewake.com/cruise-lines/seabourn.html"/>
+  <meta property="og:title" content="Seabourn | In the Wake"/>
+  <meta property="og:description" content="Ultra-luxury cruising with intimate ships, Thomas Keller dining, and expedition voyages."/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Seabourn guide: ultra-luxury cruise line with intimate ships, The Grill by Thomas Keller, and expedition voyages to Antarctica and the Arctic."/>
+  <meta name="twitter:title" content="Seabourn | In the Wake"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {"@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+     {"@type":"ListItem","position":1,"name":"Home","item":"https://cruisinginthewake.com/"},
+     {"@type":"ListItem","position":2,"name":"Cruise Lines","item":"https://cruisinginthewake.com/cruise-lines.html"},
+     {"@type":"ListItem","position":3,"name":"Seabourn","item":"https://cruisinginthewake.com/cruise-lines/seabourn.html"}
+   ]}
+  </script>
+
+  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Seabourn | In the Wake",
+    "url": "https://cruisinginthewake.com/cruise-lines/seabourn.html",
+    "description": "Seabourn guide: ultra-luxury Carnival Corporation line with 7 intimate ships (450-600 guests), Thomas Keller dining, expedition vessels with submarines, and all-inclusive service. Explore fleet and planning resources.",
+    "dateModified": "2026-01-30"
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What makes Seabourn unique?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Seabourn is an ultra-luxury cruise line offering intimate ships with just 450-600 guests. The experience is fully all-inclusive — complimentary drinks, gratuities, and premium dining including The Grill by Thomas Keller. Expedition ships feature submarines and Zodiacs for polar and remote voyages."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are Seabourn's expedition ships?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Seabourn Venture and Seabourn Pursuit are purpose-built expedition ships featuring custom submarines, a fleet of Zodiacs, and the 'Ventures by Seabourn' program. They sail to Antarctica, the Arctic, and other remote destinations while maintaining Seabourn's ultra-luxury standards."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Where does Seabourn cruise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Seabourn sails the Mediterranean, Northern Europe, Antarctica, the Arctic, and Asia. The expedition ships (Venture and Pursuit) focus on polar and remote destinations, while the classic fleet covers luxury itineraries in the Mediterranean, Northern Europe, and Asia."
+        }
+      }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ken Baker",
+    "url": "https://cruisinginthewake.com/about/ken-baker.html",
+    "jobTitle": "Cruise Research Analyst & Data Specialist",
+    "description": "Cruise industry analyst specializing in ship comparisons, deck plan analysis, and dining venue research.",
+    "knowsAbout": ["Cruise Ship Analysis","Deck Plans","Seabourn","Cruise Dining","Ship Comparisons"]
+  }
+  </script>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
+</head>
+
+<body class="page">
+  <a class="skip-link" href="#content">Skip to main content</a>
+
+  <header class="site-header hero-header">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+
+    <div class="hero" role="img" aria-label="Ship wake at sunrise">
+      <div class="latlon-grid" aria-hidden="true"></div>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo &copy; Flickers of Majesty</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="content">
+  <div>
+    <section class="icp-header" aria-labelledby="line-name">
+      <h1 id="line-name">Seabourn</h1>
+      <p class="answer-line"><strong>Quick Answer:</strong> Ultra-luxury, redefined. Seabourn delivers intimate voyages on ships carrying just 450-600 guests, where every detail is curated — from The Grill by Thomas Keller to all-inclusive drinks and gratuities. With 7 vessels including purpose-built expedition ships equipped with submarines and Zodiacs, Seabourn takes you from the sun-drenched Mediterranean to the ice of Antarctica in uncompromising luxury.</p>
+
+      <div class="fit-guidance">
+        <h2>Is Seabourn Right for You?</h2>
+        <p>If you crave a cruise where you know the bartender by name, where the crew-to-guest ratio feels like a private yacht, and where a submarine ride to the ocean floor is on the daily itinerary, Seabourn is your line. These intimate ships (450-600 guests) deliver a level of personalized service that larger vessels simply cannot match.</p>
+        <p>Seabourn's all-inclusive approach means complimentary premium spirits, fine wines, gratuities, and world-class dining — including The Grill by Thomas Keller — are woven into every fare. The Ventures by Seabourn expedition program adds kayaking, Zodiac tours, and submarine dives on the expedition ships, blending luxury with genuine exploration.</p>
+        <p>Ideal for luxury travelers who prefer understated elegance over mega-ship spectacle, expedition seekers who refuse to sacrifice comfort, and anyone who values intimate spaces, exceptional cuisine, and destinations that range from Mediterranean harbors to polar wilderness.</p>
+      </div>
+
+      <div class="key-facts">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Brand Identity:</strong> Ultra-luxury intimate cruising with expedition capabilities</li>
+          <li><strong>Parent Company:</strong> Carnival Corporation &amp; plc</li>
+          <li><strong>Signature Features:</strong> The Grill by Thomas Keller, Ventures by Seabourn expeditions, all-inclusive (drinks, gratuities), submarines &amp; Zodiacs on expedition ships</li>
+          <li><strong>Best For:</strong> Luxury travelers, expedition seekers, intimate ship lovers</li>
+          <li><strong>Fleet Size:</strong> 7 ships (450-600 guests each)</li>
+          <li><strong>Primary Itineraries:</strong> Mediterranean, Northern Europe, Antarctica, Arctic, Asia</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="card" aria-labelledby="coming-soon-h">
+      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
+      <p>We're expanding our Seabourn coverage with in-depth ship profiles, dining venue breakdowns, stateroom guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Seabourn vessel — check back soon for comprehensive guides.</p>
+      <p>In the meantime, explore our <a href="/ships/seabourn/">Seabourn ship directory</a> for the fleet overview, or visit <a href="https://www.seabourn.com" target="_blank" rel="noopener">Seabourn.com</a> to browse current sailings.</p>
+    </section>
+
+    <!-- Ships A-Z -->
+    <section id="ships" class="card" aria-labelledby="ships-h">
+      <h2 id="ships-h">Seabourn Fleet</h2>
+      <ul>
+        <li><a href="/ships/seabourn/seabourn-encore.html">Seabourn Encore</a></li>
+        <li><a href="/ships/seabourn/seabourn-odyssey.html">Seabourn Odyssey</a></li>
+        <li><a href="/ships/seabourn/seabourn-ovation.html">Seabourn Ovation</a></li>
+        <li><a href="/ships/seabourn/seabourn-pursuit.html">Seabourn Pursuit</a></li>
+        <li><a href="/ships/seabourn/seabourn-quest.html">Seabourn Quest</a></li>
+        <li><a href="/ships/seabourn/seabourn-sojourn.html">Seabourn Sojourn</a></li>
+        <li><a href="/ships/seabourn/seabourn-venture.html">Seabourn Venture</a></li>
+      </ul>
+    </section>
+
+    <!-- Related Resources -->
+    <section class="card related-resources" style="margin: 1.5rem 0; padding: 1.25rem; background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
+      <h2 style="margin: 0 0 0.75rem; font-size: 1.15rem; color: #083041;">Continue Planning Your Seabourn Cruise</h2>
+      <p class="tiny content-text" style="margin-bottom: 1rem; color: #5a7a8a;">Tools and guides to help you prepare.</p>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem;">
+        <a href="/first-cruise.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">First Cruise Guide</strong>
+          <span class="tiny" style="color: #5a7a8a;">New to cruising?</span>
+        </a>
+        <a href="/packing-lists.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Packing Lists</strong>
+          <span class="tiny" style="color: #5a7a8a;">Don't forget anything</span>
+        </a>
+        <a href="/cruise-lines.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Compare Lines</strong>
+          <span class="tiny" style="color: #5a7a8a;">See all cruise lines</span>
+        </a>
+        <a href="/planning.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
+          <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <h3>What makes Seabourn unique?</h3>
+        <p>Seabourn is an ultra-luxury cruise line offering intimate ships with just 450-600 guests. The experience is fully all-inclusive — complimentary drinks, gratuities, and premium dining including The Grill by Thomas Keller. Expedition ships feature submarines and Zodiacs for polar and remote voyages.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What are Seabourn's expedition ships?</h3>
+        <p>Seabourn Venture and Seabourn Pursuit are purpose-built expedition ships featuring custom submarines, a fleet of Zodiacs, and the "Ventures by Seabourn" program. They sail to Antarctica, the Arctic, and other remote destinations while maintaining Seabourn's ultra-luxury standards.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Where does Seabourn cruise?</h3>
+        <p>Seabourn sails the Mediterranean, Northern Europe, Antarctica, the Arctic, and Asia. The expedition ships (Venture and Pursuit) focus on polar and remote destinations, while the classic fleet covers luxury itineraries in the Mediterranean, Northern Europe, and Asia.</p>
+      </div>
+    </section>
+  </div>
+
+  <!-- RIGHT RAIL -->
+  <aside class="rail" role="complementary" aria-label="Author & articles">
+    <section class="card quiz-cta" style="background: linear-gradient(135deg, #e0f4f8, #fff); border-left: 4px solid #0e6e8e; padding: 1rem; margin-bottom: 1rem;">
+      <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #083041;">Exploring Other Lines?</h3>
+      <p class="tiny" style="margin-bottom: 0.75rem; color: #5a7a8a;">Take our quick quiz to find cruise lines that match your travel style.</p>
+      <a href="/cruise-lines/quiz.html" class="pill" style="font-size: 0.85rem;">Cruise Line Quiz &rarr;</a>
+    </section>
+
+    <section class="card author-card-vertical" aria-labelledby="author-heading">
+      <h3 id="author-heading">About the Author</h3>
+      <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+        <picture>
+          <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+          <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </picture>
+      </a>
+      <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+      <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+      <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+    </section>
+
+    <section class="card" aria-labelledby="recent-rail-title">
+      <h3 id="recent-rail-title">Recent Stories</h3>
+      <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+      <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+      <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles&hellip;</p>
+    </section>
+  </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> &middot;
+      <a href="/terms.html">Terms</a> &middot;
+      <a href="/about-us.html">About</a> &middot;
+      <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. &#10013;</p>
+    <p class="trust-badge">&check; No ads. Minimal analytics. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+  <script src="/assets/js/in-app-browser-escape.js"></script>
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a =>
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
+  })();
+  </script>
+</body>
+</html>

--- a/cruise-lines/silversea.html
+++ b/cruise-lines/silversea.html
@@ -1,0 +1,367 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+<!-- ai-breadcrumbs
+     entity: Silversea Cruises
+     type: Cruise Line Guide
+     parent: /cruise-lines.html
+     category: Cruise Line Information
+     updated: 2026-01-30
+     expertise: Cruise line comparisons, fleet analysis, policy research, cruise planning
+     target-audience: Ultra-luxury cruise seekers, expedition travelers, culinary enthusiasts, all-suite devotees
+     answer-first: Silversea delivers Italian-heritage ultra-luxury with all-suite butler service, the S.A.L.T. culinary program, and expedition ships reaching all 7 continents across 12 intimate vessels.
+     core-facts: Ultra-luxury Royal Caribbean Group line; 12 ships (100-728 guests); all-suite with butler; S.A.L.T. culinary program; expeditions to all 7 continents
+     decisions-informed: whether Silversea's ultra-luxury all-suite experience and expedition offerings match your travel style; understanding the all-inclusive butler-serviced cruising experience
+     -->
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart, and do not lean on your own understanding." — Proverbs 3:5
+"Whatever you do, work heartily, as for the Lord and not for men." — Colossians 3:23
+-->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Silversea Cruises | In the Wake (V1.Beta)</title>
+  <meta name="version" content="V1.Beta"/>
+  <meta name="description" content="Silversea Cruises guide: ultra-luxury Italian-heritage cruise line with all-suite butler service, S.A.L.T. culinary program, and expedition ships reaching all 7 continents across 12 intimate vessels."/>
+  <meta name="robots" content="index,follow"/>
+
+  <!-- ICP-Lite v1.4: AI-First Metadata -->
+  <meta name="ai-summary" content="Silversea Cruises guide: ultra-luxury Royal Caribbean Group line with 12 ships (100-728 guests), all-suite with butler service, S.A.L.T. culinary program, and expedition voyages to all 7 continents including Antarctica."/>
+  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+
+  <!-- Canonical / Social -->
+  <link rel="canonical" href="https://cruisinginthewake.com/cruise-lines/silversea.html"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:url" content="https://cruisinginthewake.com/cruise-lines/silversea.html"/>
+  <meta property="og:title" content="Silversea Cruises | In the Wake"/>
+  <meta property="og:description" content="Ultra-luxury Italian-heritage cruising with all-suite butler service and expedition voyages to all 7 continents."/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:description" content="Silversea Cruises guide: ultra-luxury all-suite butler service, S.A.L.T. culinary program, and expedition ships reaching all 7 continents."/>
+  <meta name="twitter:title" content="Silversea Cruises | In the Wake"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/cruise-lines-hero.jpg"/>
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {"@context":"https://schema.org",
+   "@type":"BreadcrumbList",
+   "itemListElement":[
+     {"@type":"ListItem","position":1,"name":"Home","item":"https://cruisinginthewake.com/"},
+     {"@type":"ListItem","position":2,"name":"Cruise Lines","item":"https://cruisinginthewake.com/cruise-lines.html"},
+     {"@type":"ListItem","position":3,"name":"Silversea Cruises","item":"https://cruisinginthewake.com/cruise-lines/silversea.html"}
+   ]}
+  </script>
+
+  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Silversea Cruises | In the Wake",
+    "url": "https://cruisinginthewake.com/cruise-lines/silversea.html",
+    "description": "Silversea Cruises guide: ultra-luxury Royal Caribbean Group line with 12 ships (100-728 guests), all-suite with butler service, S.A.L.T. culinary program, and expedition voyages to all 7 continents including Antarctica.",
+    "dateModified": "2026-01-30"
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What makes Silversea Cruises unique?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Silversea combines Italian heritage with ultra-luxury cruising across 12 intimate ships carrying just 100 to 728 guests. Every suite includes butler service, and the line's S.A.L.T. (Sea and Land Taste) culinary program immerses guests in destination-inspired cuisine. Silversea's expedition fleet visits all 7 continents, including Antarctica and the Galapagos."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is included on a Silversea cruise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Silversea is all-inclusive: fares cover butler service for every suite, premium beverages, dining across all onboard restaurants, gratuities, and Wi-Fi. Expedition voyages also include shore excursions, expert lectures, and specialized gear like parkas and rubber boots."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Where does Silversea cruise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Silversea sails to over 900 destinations across all 7 continents. Popular itineraries include Antarctica, the Arctic, the Mediterranean, the Galapagos, and annual World Cruises. The expedition fleet reaches some of the most remote places on Earth."
+        }
+      }
+    ]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ken Baker",
+    "url": "https://cruisinginthewake.com/about/ken-baker.html",
+    "jobTitle": "Cruise Research Analyst & Data Specialist",
+    "description": "Cruise industry analyst specializing in ship comparisons, deck plan analysis, and dining venue research.",
+    "knowsAbout": ["Cruise Ship Analysis","Deck Plans","Silversea Cruises","Cruise Dining","Ship Comparisons"]
+  }
+  </script>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
+</head>
+
+<body class="page">
+  <a class="skip-link" href="#content">Skip to main content</a>
+
+  <header class="site-header hero-header">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+
+    <div class="hero" role="img" aria-label="Ship wake at sunrise">
+      <div class="latlon-grid" aria-hidden="true"></div>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo &copy; Flickers of Majesty</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap page-grid" id="content">
+  <div>
+    <section class="icp-header" aria-labelledby="line-name">
+      <h1 id="line-name">Silversea Cruises</h1>
+      <p class="answer-line"><strong>Quick Answer:</strong> Ultra-luxury, Italian-born, and uncompromising. Silversea Cruises delivers an all-suite, all-inclusive experience with dedicated butler service on every voyage. With 12 intimate ships carrying 100 to 728 guests, the S.A.L.T. culinary program, and an expedition fleet that reaches all 7 continents — including Antarctica and the Galapagos — Silversea is where refined elegance meets bold exploration.</p>
+
+      <div class="fit-guidance">
+        <h2>Is Silversea Right for You?</h2>
+        <p>If your idea of the perfect cruise involves a personal butler unpacking your luggage while you sip champagne in your ocean-view suite, Silversea was designed with you in mind. This ultra-luxury line, part of Royal Caribbean Group, carries forward decades of Italian heritage — intimate ships, impeccable service, and an all-inclusive philosophy that means your only decision is what to enjoy next.</p>
+        <p>Silversea's S.A.L.T. (Sea and Land Taste) culinary program transforms every port into a gastronomic journey, with destination-inspired menus, cooking classes, and market tours that connect you to local food cultures. For the adventurous, the expedition fleet visits all 7 continents with expert-led Zodiac excursions, polar landings, and onboard science labs.</p>
+        <p>Ideal for ultra-luxury travelers, expedition seekers, foodies who want culinary immersion, and anyone who believes a cruise should feel like a private voyage rather than a floating resort. Small ship sizes mean fewer crowds, more ports, and the kind of personalized attention that larger vessels simply cannot match.</p>
+      </div>
+
+      <div class="key-facts">
+        <h2>Key Facts at a Glance</h2>
+        <ul>
+          <li><strong>Brand Identity:</strong> Ultra-luxury all-suite cruising with Italian heritage</li>
+          <li><strong>Parent Company:</strong> Royal Caribbean Group</li>
+          <li><strong>Signature Features:</strong> Butler service for all suites, S.A.L.T. culinary program, expedition ships, all-inclusive fares</li>
+          <li><strong>Best For:</strong> Ultra-luxury travelers, expedition seekers, foodies, all-suite devotees</li>
+          <li><strong>Fleet Size:</strong> 12 ships (100&ndash;728 guests)</li>
+          <li><strong>Primary Itineraries:</strong> Antarctica, Arctic, Mediterranean, World Cruises, Galapagos</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="card" aria-labelledby="coming-soon-h">
+      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
+      <p>We're expanding our Silversea Cruises coverage with in-depth ship profiles, suite breakdowns, S.A.L.T. dining guides, expedition itinerary details, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Silversea vessel — check back soon for comprehensive guides.</p>
+      <p>In the meantime, explore our <a href="/ships/silversea/">Silversea ship directory</a> for the fleet overview, or visit <a href="https://www.silversea.com" target="_blank" rel="noopener">Silversea.com</a> to browse current sailings.</p>
+    </section>
+
+    <!-- Ships A-Z -->
+    <section id="ships" class="card" aria-labelledby="ships-h">
+      <h2 id="ships-h">Silversea Fleet</h2>
+      <ul>
+        <li><a href="/ships/silversea/silver-cloud.html">Silver Cloud</a></li>
+        <li><a href="/ships/silversea/silver-dawn.html">Silver Dawn</a></li>
+        <li><a href="/ships/silversea/silver-endeavour.html">Silver Endeavour</a></li>
+        <li><a href="/ships/silversea/silver-moon.html">Silver Moon</a></li>
+        <li><a href="/ships/silversea/silver-muse.html">Silver Muse</a></li>
+        <li><a href="/ships/silversea/silver-nova.html">Silver Nova</a></li>
+        <li><a href="/ships/silversea/silver-origin.html">Silver Origin</a></li>
+        <li><a href="/ships/silversea/silver-ray.html">Silver Ray</a></li>
+        <li><a href="/ships/silversea/silver-shadow.html">Silver Shadow</a></li>
+        <li><a href="/ships/silversea/silver-spirit.html">Silver Spirit</a></li>
+        <li><a href="/ships/silversea/silver-whisper.html">Silver Whisper</a></li>
+        <li><a href="/ships/silversea/silver-wind.html">Silver Wind</a></li>
+      </ul>
+    </section>
+
+    <!-- Related Resources -->
+    <section class="card related-resources" style="margin: 1.5rem 0; padding: 1.25rem; background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
+      <h2 style="margin: 0 0 0.75rem; font-size: 1.15rem; color: #083041;">Continue Planning Your Silversea Cruise</h2>
+      <p class="tiny content-text" style="margin-bottom: 1rem; color: #5a7a8a;">Tools and guides to help you prepare.</p>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.75rem;">
+        <a href="/first-cruise.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">First Cruise Guide</strong>
+          <span class="tiny" style="color: #5a7a8a;">New to cruising?</span>
+        </a>
+        <a href="/packing-lists.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Packing Lists</strong>
+          <span class="tiny" style="color: #5a7a8a;">Don't forget anything</span>
+        </a>
+        <a href="/cruise-lines.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Compare Lines</strong>
+          <span class="tiny" style="color: #5a7a8a;">See all cruise lines</span>
+        </a>
+        <a href="/planning.html" style="display: block; padding: 0.75rem; background: #fff; border: 1px solid #e0e8f0; border-radius: 8px; text-decoration: none; color: inherit; text-align: center;">
+          <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
+          <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <h3>What makes Silversea Cruises unique?</h3>
+        <p>Silversea combines Italian heritage with ultra-luxury cruising across 12 intimate ships carrying just 100 to 728 guests. Every suite includes butler service, and the line's S.A.L.T. (Sea and Land Taste) culinary program immerses guests in destination-inspired cuisine. Silversea's expedition fleet visits all 7 continents, including Antarctica and the Galapagos.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What is included on a Silversea cruise?</h3>
+        <p>Silversea is all-inclusive: fares cover butler service for every suite, premium beverages, dining across all onboard restaurants, gratuities, and Wi-Fi. Expedition voyages also include shore excursions, expert lectures, and specialized gear like parkas and rubber boots.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Where does Silversea cruise?</h3>
+        <p>Silversea sails to over 900 destinations across all 7 continents. Popular itineraries include Antarctica, the Arctic, the Mediterranean, the Galapagos, and annual World Cruises. The expedition fleet reaches some of the most remote places on Earth.</p>
+      </div>
+    </section>
+  </div>
+
+  <!-- RIGHT RAIL -->
+  <aside class="rail" role="complementary" aria-label="Author & articles">
+    <section class="card quiz-cta" style="background: linear-gradient(135deg, #e0f4f8, #fff); border-left: 4px solid #0e6e8e; padding: 1rem; margin-bottom: 1rem;">
+      <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #083041;">Exploring Other Lines?</h3>
+      <p class="tiny" style="margin-bottom: 0.75rem; color: #5a7a8a;">Take our quick quiz to find cruise lines that match your travel style.</p>
+      <a href="/cruise-lines/quiz.html" class="pill" style="font-size: 0.85rem;">Cruise Line Quiz &rarr;</a>
+    </section>
+
+    <section class="card author-card-vertical" aria-labelledby="author-heading">
+      <h3 id="author-heading">About the Author</h3>
+      <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
+        <picture>
+          <source srcset="/authors/img/ken1.webp?v=3.010.300" type="image/webp"/>
+          <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" style="border-radius: 12px;" decoding="async" loading="lazy"/>
+        </picture>
+      </a>
+      <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>
+      <p class="tiny">Founder of In the Wake; writer and editor of the logbook.</p>
+      <p class="tiny"><a href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a></p>
+    </section>
+
+    <section class="card" aria-labelledby="recent-rail-title">
+      <h3 id="recent-rail-title">Recent Stories</h3>
+      <p class="tiny" style="margin-bottom: 1rem; color: var(--ink-mid, #3d5a6a); line-height: 1.5;">Real cruising experiences, practical guides, and heartfelt reflections from our community.</p>
+      <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+      <p id="recent-rail-fallback" class="tiny" style="display:none">Loading articles&hellip;</p>
+    </section>
+  </aside>
+  </main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> &middot;
+      <a href="/terms.html">Terms</a> &middot;
+      <a href="/about-us.html">About</a> &middot;
+      <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria — Every pixel and part of this project is offered as worship to God, in gratitude for the beautiful things He has created for us to enjoy. &#10013;</p>
+    <p class="trust-badge">&check; No ads. Minimal analytics. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+  <script src="/assets/js/in-app-browser-escape.js"></script>
+  <script>
+  (function(){
+    "use strict";
+    (async function recentRail(){
+      const rail = document.getElementById('recent-rail');
+      if(!rail) return;
+      const fallback = document.getElementById('recent-rail-fallback');
+      if(fallback) fallback.style.display = '';
+      try {
+        const res = await fetch('/assets/data/articles/index.json', { credentials: 'omit', cache: 'no-cache' });
+        if(!res.ok) throw new Error('Failed');
+        const articles = await res.json();
+        if(fallback) fallback.style.display = 'none';
+        rail.innerHTML = articles.slice(0, 4).map(a =>
+          '<div style="margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #e0e8f0;">' +
+          '<h4 style="margin:0 0 .25rem;font-size:.95rem;"><a href="' + a.url + '">' + a.title + '</a></h4>' +
+          '</div>'
+        ).join('');
+      } catch(err) {
+        if(fallback) fallback.textContent = 'Unable to load articles';
+      }
+    })();
+  })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Created stub pages with full site shell, nav, and "coming soon" content for Costa, Cunard, Oceania, Regent, Seabourn, Silversea, and Explora Journeys — completing all 15 cruise lines in the cruise-lines directory.

Updated cruise-lines.html to link to the new /cruise-lines/*.html pages instead of /ships/{line}/ directory indexes (14 link changes: 7 JSON-LD
+ 7 HTML hrefs).

Added comprehensive audit report documenting findings and 5-phase plan to bring all 308+ ship pages to 100% validation.

https://claude.ai/code/session_012FatAD4A6vdvKv4HpssbHu