### PR TITLE
feat: Upgrade 7 cruise-lines stubs to full content, create RCL fleet …

### DIFF
--- a/admin/reports/SHIP_PAGE_AUDIT_2026_01_30.md
+++ b/admin/reports/SHIP_PAGE_AUDIT_2026_01_30.md
@@ -1,25 +1,30 @@
-# Ship Page Comprehensive Audit — 2026-01-30
+# Ship Page Comprehensive Audit — 2026-01-30 (Updated 2026-01-31)
 
 **Auditor:** Claude (Session: audit-ship-pages-UsCC9)
 **Branch:** `claude/audit-ship-pages-UsCC9`
-**Date:** 2026-01-30
-**Scope:** All 15 cruise lines, all ship pages, cruise-lines directory pages
+**Date:** 2026-01-30 (Phase 2 update: 2026-01-31)
+**Scope:** All 15 cruise lines, all ship pages, cruise-lines directory pages, fleet index pages
 
 ---
 
 ## Executive Summary
 
-The In the Wake site covers **15 cruise lines** with **~308 ship HTML pages** across 16 ship directories (including a legacy `ships/explora/` duplicate). This audit identified **7 missing cruise-lines pages** and created stub pages for each with full site shell, navigation, and "coming soon" verbiage. The `cruise-lines.html` hub page was updated to link to the new pages instead of ship directory indexes.
+The In the Wake site covers **15 cruise lines** with **~308 ship HTML pages** across 16 ship directories (including a legacy `ships/explora/` duplicate). This audit identified and addressed integration gaps across all 15 cruise lines in two phases:
+
+- **Phase 1 (2026-01-30):** Created 7 missing cruise-lines pages as stubs, updated hub links, expanded 7 thin ship pages
+- **Phase 2 (2026-01-31):** Upgraded all 7 stub pages to full content, created missing RCL fleet index, upgraded 7 fleet index pages to class-based organization
 
 ### Key Findings
 
-| Metric | Before Audit | After Audit |
-|--------|-------------|-------------|
-| Cruise-lines pages | 8 of 15 | **15 of 15** |
-| cruise-lines.html links correct | 8 of 15 | **15 of 15** |
-| Ship directories | 16 (incl. legacy explora/) | 16 (unchanged) |
-| Total ship HTML files | ~308 | ~308 (unchanged) |
-| Ship pages passing validation | ~106 (34%) | ~106 (34%) — unchanged, plan below |
+| Metric | Before Audit | After Phase 1 | After Phase 2 |
+|--------|-------------|---------------|---------------|
+| Cruise-lines pages | 8 of 15 | **15 of 15** (7 stubs) | **15 of 15** (all full content) |
+| cruise-lines.html links correct | 8 of 15 | **15 of 15** | **15 of 15** |
+| Fleet index pages | 14 of 15 | 14 of 15 | **15 of 15** (RCL created) |
+| Fleet indexes with class organization | 8 of 14 | 8 of 14 | **15 of 15** |
+| "Coming Soon" stubs remaining | N/A | 7 | **0** |
+| Ship directories | 16 (incl. legacy explora/) | 16 | 16 |
+| Total ship HTML files | ~308 | ~308 | ~308 |
 
 ---
 
@@ -33,7 +38,7 @@ The In the Wake site covers **15 cruise lines** with **~308 ship HTML pages** ac
 | 2 | Carnival | `carnival.html` (existed) | `ships/carnival/` | 49 | Full content page |
 | 3 | Norwegian | `norwegian.html` (existed) | `ships/norwegian/` | 21 | Full content page |
 | 4 | MSC Cruises | `msc.html` (existed) | `ships/msc/` | 25 | Full content page |
-| 5 | Costa Cruises | **`costa.html` (NEW)** | `ships/costa/` | 10 | Coming Soon stub |
+| 5 | Costa Cruises | `costa.html` (created Phase 1, **upgraded Phase 2**) | `ships/costa/` | 10 | **Full content page** |
 
 ### Tier 2: Premium Lines
 
@@ -42,145 +47,143 @@ The In the Wake site covers **15 cruise lines** with **~308 ship HTML pages** ac
 | 6 | Celebrity Cruises | `celebrity.html` (existed) | `ships/celebrity-cruises/` | 30 | Full content page |
 | 7 | Princess | `princess.html` (existed) | `ships/princess/` | 18 | Full content page |
 | 8 | Holland America | `holland-america.html` (existed) | `ships/holland-america-line/` | 47 | Full content page |
-| 9 | Cunard | **`cunard.html` (NEW)** | `ships/cunard/` | 5 | Coming Soon stub |
+| 9 | Cunard | `cunard.html` (created Phase 1, **upgraded Phase 2**) | `ships/cunard/` | 5 | **Full content page** |
 | 10 | Virgin Voyages | `virgin.html` (existed) | `ships/virgin-voyages/` | 5 | Full content page |
 
 ### Tier 3: Luxury Lines
 
 | # | Cruise Line | cruise-lines/ page | ships/ directory | Ship count | Status |
 |---|------------|-------------------|-----------------|------------|--------|
-| 11 | Oceania Cruises | **`oceania.html` (NEW)** | `ships/oceania/` | 9 | Coming Soon stub |
-| 12 | Regent Seven Seas | **`regent.html` (NEW)** | `ships/regent/` | 8 | Coming Soon stub |
-| 13 | Seabourn | **`seabourn.html` (NEW)** | `ships/seabourn/` | 8 | Coming Soon stub |
-| 14 | Silversea | **`silversea.html` (NEW)** | `ships/silversea/` | 13 | Coming Soon stub |
-| 15 | Explora Journeys | **`explora-journeys.html` (NEW)** | `ships/explora-journeys/` | 7 | Coming Soon stub |
+| 11 | Oceania Cruises | `oceania.html` (created Phase 1, **upgraded Phase 2**) | `ships/oceania/` | 9 | **Full content page** |
+| 12 | Regent Seven Seas | `regent.html` (created Phase 1, **upgraded Phase 2**) | `ships/regent/` | 8 | **Full content page** |
+| 13 | Seabourn | `seabourn.html` (created Phase 1, **upgraded Phase 2**) | `ships/seabourn/` | 8 | **Full content page** |
+| 14 | Silversea | `silversea.html` (created Phase 1, **upgraded Phase 2**) | `ships/silversea/` | 13 | **Full content page** |
+| 15 | Explora Journeys | `explora-journeys.html` (created Phase 1, **upgraded Phase 2**) | `ships/explora-journeys/` | 7 | **Full content page** |
 
 ### Legacy/Duplicate Directory
-- `ships/explora/` — Contains 3 files (explora-i.html, explora-ii.html, index.html). Appears to be a legacy duplicate of `ships/explora-journeys/`. Recommend consolidating in a future cleanup.
+- `ships/explora/` — Contains 3 files (explora-i.html, explora-ii.html, index.html). Legacy duplicate of `ships/explora-journeys/`. Recommend consolidating in a future cleanup.
 
 ---
 
-## Changes Made in This Audit
+## Phase 1 Changes (2026-01-30)
 
 ### 1. New Cruise-Lines Pages Created (7 files)
 
-All new pages follow the established template pattern from existing pages (carnival.html, royal-caribbean.html) with:
-- Soli Deo Gloria invocation
-- AI-breadcrumbs metadata
-- ICP-Lite v1.4 meta tags (ai-summary, last-reviewed, content-protocol)
-- JSON-LD: BreadcrumbList, WebPage, FAQPage, Person
-- Full site navigation (Planning, Tools, Onboard, Travel dropdowns)
-- Hero header with compass rose
-- Answer-first content with Quick Answer, Fit Guidance, Key Facts
-- "Comprehensive Guides Coming Soon" section
-- Fleet listing with links to all ship pages
-- Related Resources grid
-- FAQ section (3 questions each)
-- Right rail (Quiz CTA, Author card, Recent Stories)
-- Standard footer with trust badge
-- Dropdown JS and Recent Articles rail script
-
-**Files created:**
-1. `cruise-lines/costa.html` — Costa Cruises (Italian heritage, 9 ships)
-2. `cruise-lines/cunard.html` — Cunard (British ocean liner, 4 Queens)
-3. `cruise-lines/oceania.html` — Oceania Cruises (Finest Cuisine at Sea, 8 ships)
-4. `cruise-lines/regent.html` — Regent Seven Seas (All-inclusive luxury, 7 ships)
-5. `cruise-lines/seabourn.html` — Seabourn (Ultra-luxury & expedition, 7 ships)
-6. `cruise-lines/silversea.html` — Silversea (Italian elegance, 12 ships)
-7. `cruise-lines/explora-journeys.html` — Explora Journeys (Modern ocean luxury, 6 ships)
+All new pages followed the established template pattern with Soli Deo Gloria, AI-breadcrumbs, ICP-Lite v1.4 meta tags, JSON-LD (BreadcrumbList, WebPage, FAQPage, Person), full site navigation, hero header, answer-first content, fleet listing, FAQ, right rail, and standard footer. Initially created as "Coming Soon" stubs.
 
 ### 2. cruise-lines.html Hub Page Updated (14 link changes)
 
-Updated 14 references (7 JSON-LD + 7 HTML hrefs) from `/ships/{line}/` directory paths to `/cruise-lines/{line}.html` pages:
-- `/ships/costa/` → `/cruise-lines/costa.html`
-- `/ships/cunard/` → `/cruise-lines/cunard.html`
-- `/ships/oceania/` → `/cruise-lines/oceania.html`
-- `/ships/regent/` → `/cruise-lines/regent.html`
-- `/ships/seabourn/` → `/cruise-lines/seabourn.html`
-- `/ships/silversea/` → `/cruise-lines/silversea.html`
-- `/ships/explora-journeys/` → `/cruise-lines/explora-journeys.html`
+Updated 14 references (7 JSON-LD + 7 HTML hrefs) from `/ships/{line}/` directory paths to `/cruise-lines/{line}.html` pages.
+
+### 3. Thin Ship Pages Expanded (7 files)
+
+- `ships/carnival/carnival-adventure.html` — 163 → 1,937 words
+- `ships/carnival/unnamed-project-ace-1.html` — ~499 → 732 words
+- `ships/carnival/unnamed-project-ace-2.html` — ~499 → 717 words
+- `ships/carnival/unnamed-project-ace-3.html` — ~499 → 708 words
+- `ships/celebrity-cruises/unnamed-edge-class.html` — ~440 → 685 words
+- `ships/celebrity-cruises/unnamed-project-nirvana.html` — ~450 → 673 words
+- `ships/celebrity-cruises/unnamed-river-class-x6.html` — ~440 → 679 words
 
 ---
 
-## Ship Page Health by Cruise Line
+## Phase 2 Changes (2026-01-31)
 
-Based on the claude.md report: **106 of 311 ship pages (34%) currently pass validation** with **981 blocking errors** remaining. The breakdown by line requires per-page validation, but the general categories of issues are:
+### 4. Cruise-Lines Pages Upgraded from Stubs to Full Content (7 files)
 
-### Common Blocking Issues (from SHIP_PAGE_CHECKLIST_v3.010)
-1. **Missing Soli Deo Gloria invocation** — Required before line 20
-2. **Missing/incorrect ICP-Lite v1.4 meta tags** — ai-summary, last-reviewed, content-protocol
-3. **JSON-LD schema mismatches** — description ≠ ai-summary, dateModified ≠ last-reviewed
-4. **Missing mainEntity in JSON-LD** — Entity pages need Product/Place/Restaurant declaration
-5. **Missing AI-breadcrumbs** — Structured context comments for entity identification
-6. **Missing content sections** — 8 required sections per ship page
-7. **Missing JSON-LD blocks** — 7 required per ship page
-8. **Accessibility gaps** — WCAG AA violations (alt text, ARIA, skip links)
-9. **Stale dates** — last-reviewed and dateModified not updated
+Each page was upgraded to match the quality and structure of established pages (royal-caribbean.html, carnival.html). Changes per page:
+
+| Page | Before (words) | After (words) | Sections Added |
+|------|---------------|--------------|----------------|
+| `costa.html` | ~1,200 (stub) | 1,927 | Ship classes (5), Gallery, Level Up CTAs, Dress Code, expanded FAQ (5), ICP-Lite FAQ |
+| `cunard.html` | ~1,100 (stub) | 1,756 | Ship classes (3), Gallery, Level Up CTAs, Dress Code, expanded FAQ (5), ICP-Lite FAQ |
+| `oceania.html` | ~1,300 (stub) | 2,059 | Ship classes (3), Gallery, Level Up CTAs, Dress Code, expanded FAQ (5), ICP-Lite FAQ |
+| `regent.html` | ~1,200 (stub) | 1,941 | Ship classes (4), Gallery, Level Up CTAs, Dress Code, expanded FAQ (5), ICP-Lite FAQ |
+| `seabourn.html` | ~1,200 (stub) | 1,863 | Ship classes (3), Gallery, Level Up CTAs, Dress Code, expanded FAQ (5), ICP-Lite FAQ |
+| `silversea.html` | ~1,300 (stub) | 2,060 | Ship classes (6), Gallery, Level Up CTAs, Dress Code, expanded FAQ (5), ICP-Lite FAQ |
+| `explora-journeys.html` | ~1,200 (stub) | 1,914 | Ship classes (3), Gallery, Level Up CTAs, Dress Code, expanded FAQ (5), ICP-Lite FAQ |
+
+**Structural additions per page:**
+- "Coming Soon" section removed
+- Ships organized by class with descriptions, signature venues, and pill-link grids
+- Gallery section with 2 Wikimedia Commons images (CC BY-SA attributions)
+- Two-column "Level Up Your Planning" CTAs (6 cards) + Dress Code sidebar
+- FAQ expanded from 3 to 5+ questions
+- ICP-Lite FAQ section (3 generic details/summary items)
+- Soli Deo Gloria card
+- `last-reviewed` and `dateModified` updated to 2026-01-31
+
+### 5. RCL Fleet Index Page Created (1 new file)
+
+`ships/rcl/index.html` — Royal Caribbean was the only cruise line without a fleet index page. Created with:
+- 10 ship class sections (Icon, Oasis, Quantum Ultra, Quantum, Freedom, Voyager, Radiance, Vision, Star/Future, Heritage)
+- 1,092 words
+- Full ICP-Lite v1.4 compliance, JSON-LD (Person, WebPage), standard nav/hero/footer
+- All 49 ship pages linked with pill-style buttons organized by class
+
+### 6. Fleet Index Pages Upgraded to Class-Based Organization (7 files)
+
+All 7 newer-line fleet index pages were upgraded from flat ship lists to class-organized sections matching Carnival's index page pattern:
+
+| Index Page | Classes | Ships Listed |
+|-----------|---------|-------------|
+| `ships/costa/index.html` | 5 (Excellence, Dream, Concordia, Musica, Spirit) | 9 ships |
+| `ships/cunard/index.html` | 3 (Ocean Liner, Queen Anne, Vista) | 4 ships |
+| `ships/oceania/index.html` | 3 (Allura, Marina, Regatta) | 8 ships |
+| `ships/regent/index.html` | 4 (Explorer, Voyager, Navigator, Prestige) | 6 ships |
+| `ships/seabourn/index.html` | 3 (Expedition, Ovation, Odyssey) | 7 ships |
+| `ships/silversea/index.html` | 6 (Nova, Muse, Spirit, Shadow/Whisper, Wind, Expedition) | 12 ships |
+| `ships/explora-journeys/index.html` | 3 (Gen I, Gen II LNG, Gen III Hydrogen) | 6 ships |
+
+Each upgraded index includes: intro paragraph, class sections with colored borders, description paragraphs, signature venues, pill-style ship links, navigation pills (line guide, ship quiz, packing), and bottom CTA navigation.
 
 ---
 
-## Plan to Bring All Ship Pages to 100/100
+## Files Changed Summary
 
-### Phase 1: Infrastructure & Validation (Priority: CRITICAL)
-**Goal:** Establish baseline and fix blocking infrastructure issues
+### Phase 2 File Manifest (15 files)
 
-1. **Run full validation across all 308+ ship pages** — Use `node admin/validate-icp-lite-v14.js --all` to get exact error counts per file
-2. **Fix Soli Deo Gloria invocations** — Batch ensure all pages have the invocation before line 20
-3. **Fix ICP-Lite v1.4 meta tags** — Batch ensure ai-summary (dual-cap rule), last-reviewed, content-protocol on every page
-4. **Fix JSON-LD mirroring** — Ensure description = ai-summary, dateModified = last-reviewed on every page
+**Modified (14):**
+1. `cruise-lines/costa.html` — Stub → full content
+2. `cruise-lines/cunard.html` — Stub → full content
+3. `cruise-lines/oceania.html` — Stub → full content
+4. `cruise-lines/regent.html` — Stub → full content
+5. `cruise-lines/seabourn.html` — Stub → full content
+6. `cruise-lines/silversea.html` — Stub → full content
+7. `cruise-lines/explora-journeys.html` — Stub → full content
+8. `ships/costa/index.html` — Flat list → class-based
+9. `ships/cunard/index.html` — Flat list → class-based
+10. `ships/oceania/index.html` — Flat list → class-based
+11. `ships/regent/index.html` — Flat list → class-based
+12. `ships/seabourn/index.html` — Flat list → class-based
+13. `ships/silversea/index.html` — Flat list → class-based
+14. `ships/explora-journeys/index.html` — Flat list → class-based
 
-### Phase 2: Structural Compliance (Priority: HIGH)
-**Goal:** All pages have required sections and schema
+**Created (1):**
+15. `ships/rcl/index.html` — New RCL fleet index page
 
-5. **Add missing AI-breadcrumbs** — entity, type, parent, category, cruise-line, ship-class, updated
-6. **Add missing mainEntity JSON-LD** — Product type with manufacturer Organization
-7. **Ensure 7 JSON-LD blocks per page** — WebPage, BreadcrumbList, FAQPage, Person, Organization, mainEntity, Review
-8. **Ensure 8 required content sections** — Page intro, first look/dining, logbook, video, deck plans, FAQ, attributions
-9. **Fix navigation consistency** — All pages should have the standard dropdown nav
+**Updated (1):**
+16. `admin/reports/SHIP_PAGE_AUDIT_2026_01_30.md` — This report
 
-### Phase 3: Content Quality (Priority: MEDIUM)
-**Goal:** Rich, natural content meeting word count and quality standards
+---
 
-10. **Expand thin ship pages** — Target 2,500-6,000 words per page
-11. **Add/improve FAQ sections** — Natural language, not robotic SEO copy
-12. **Add logbook stories** — 6 traveler personas per ship
-13. **Add image attributions** — Minimum 8 locally-hosted images with proper alt text
-14. **Add fit-guidance sections** — Help users decide if this ship is right for them
+## Remaining Work (Future Phases)
 
-### Phase 4: Premium & Luxury Lines (Priority: MEDIUM)
-**Goal:** Bring 7 new cruise-lines pages from "Coming Soon" to full content
+### Still Needed for Full 15-Line Integration
 
-15. **Costa Cruises** — Expand with ship classes, experience section, gallery, search
-16. **Cunard** — Expand with Queens detail, Grill dining, Transatlantic focus
-17. **Oceania** — Expand with culinary focus, Jacques Pepin, ship classes
-18. **Regent Seven Seas** — Expand with all-inclusive detail, Regent Suite, ship profiles
-19. **Seabourn** — Expand with expedition detail, Thomas Keller, expedition ships
-20. **Silversea** — Expand with S.A.L.T. program, expedition fleet, butler service
-21. **Explora Journeys** — Expand with new-brand positioning, suite detail, dining experiences
-
-### Phase 5: Polish & Optimization (Priority: LOW)
-**Goal:** Performance, accessibility, and SEO refinements
-
-22. **WCAG AA compliance sweep** — Full accessibility audit
-23. **Performance optimization** — LCP preloads, image optimization, lazy loading
-24. **Cross-link network** — Ensure ships link to restaurants, ports, and articles
-25. **Consolidate legacy directories** — Merge `ships/explora/` into `ships/explora-journeys/`
-26. **Update stale dates** — Refresh all last-reviewed and dateModified to current
-
-### Estimated Scope
-- **Phase 1:** ~308 pages (batch scriptable)
-- **Phase 2:** ~308 pages (batch scriptable with manual review)
-- **Phase 3:** ~200+ pages need content expansion (manual/AI-assisted)
-- **Phase 4:** 7 pages (manual/AI-assisted)
-- **Phase 5:** Site-wide sweep (tooling + manual)
-
-### Success Criteria
-- [ ] 311/311 ship pages pass validation (0 blocking errors)
-- [ ] 15/15 cruise-lines pages have full content
-- [ ] All JSON-LD mirroring correct
-- [ ] All ICP-Lite v1.4 compliant
-- [ ] All Soli Deo Gloria invocations present
-- [ ] WCAG AA compliance across all pages
+1. **Brand configuration** — 12 of 15 lines missing from `assets/data/brands.json`
+2. **Brand CSS** — `assets/css/brands/` directory doesn't exist; referenced by brands.json
+3. **Per-line JSON configs** — Only `assets/data/lines/royal-caribbean.json` exists; 14 missing
+4. **Venue/restaurant data** — Only RCL and NCL have comprehensive venue data; 11 lines have none
+5. **Explora Journeys video data** — Only line with zero video files
+6. **Costa fleet data** — Empty classes/ships arrays in `fleets.json`
+7. **Cunard class data** — Empty classes array in `fleets.json`
+8. **Ship page content expansion** — ~200+ pages need enrichment toward 2,500-6,000 word targets
+9. **Ship image catalog** — Only covers RCL; needs expansion to all 15 lines
+10. **Ship quiz data** — Primarily RCL-focused; needs balancing across 15 lines
+11. **Sitemap generation** — No static sitemap.xml published
+12. **Legacy cleanup** — Consolidate `ships/explora/` into `ships/explora-journeys/`
+13. **Naming inconsistencies** — Virgin (virgin.html vs virgin-voyages/), Norwegian (ncl vs norwegian)
 
 ---
 
@@ -188,7 +191,7 @@ Based on the claude.md report: **106 of 311 ship pages (34%) currently pass vali
 
 | Directory | Total HTML | Index | Ship Pages | Notes |
 |-----------|-----------|-------|------------|-------|
-| ships/rcl/ | 50 | 0 | 49 + venues.html | Largest fleet, includes retired ships |
+| ships/rcl/ | 51 | 1 (NEW) | 49 + venues.html | Largest fleet, includes retired ships |
 | ships/carnival/ | 49 | 1 | 48 | Includes retired + future ships |
 | ships/holland-america-line/ | 47 | 1 | 45 + none-announced.html | Heavy historical fleet |
 | ships/celebrity-cruises/ | 30 | 1 | 29 | Includes retired + future ships |
@@ -204,7 +207,7 @@ Based on the claude.md report: **106 of 311 ship pages (34%) currently pass vali
 | ships/cunard/ | 5 | 1 | 4 | The four Queens |
 | ships/virgin-voyages/ | 5 | 1 | 4 | Lady class fleet |
 | ships/explora/ | 3 | 1 | 2 | LEGACY DUPLICATE |
-| **TOTAL** | **308** | **14** | **~291 unique** | |
+| **TOTAL** | **309** | **15** | **~291 unique** | |
 
 ---
 

--- a/cruise-lines/costa.html
+++ b/cruise-lines/costa.html
@@ -30,7 +30,7 @@ All work on this project is offered as a gift to God.
 
   <!-- ICP-Lite v1.4: AI-First Metadata -->
   <meta name="ai-summary" content="Costa Cruises guide: Italian-heritage line with 9 ships featuring authentic Italian dining, Mediterranean focus, and multilingual international atmosphere. Explore fleet and planning resources."/>
-  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="last-reviewed" content="2026-01-31"/>
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- Canonical / Social -->
@@ -65,7 +65,7 @@ All work on this project is offered as a gift to God.
     "name": "Costa Cruises | In the Wake",
     "url": "https://cruisinginthewake.com/cruise-lines/costa.html",
     "description": "Costa Cruises guide: Italian-heritage line with 9 ships featuring authentic Italian dining, Mediterranean focus, and multilingual international atmosphere. Explore fleet and planning resources.",
-    "dateModified": "2026-01-30"
+    "dateModified": "2026-01-31"
   }
   </script>
 
@@ -97,6 +97,22 @@ All work on this project is offered as a gift to God.
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Costa Cruises focuses heavily on the Mediterranean, including Western and Eastern Mediterranean itineraries, but also offers Caribbean, South American, Northern European, and world cruise voyages."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which Costa ship is best for first-timers?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Costa Smeralda or Costa Toscana (Excellence Class) are ideal for first-time Costa cruisers. Their LNG-powered design, 13 restaurants, Colosseo atrium, and Solemio Spa showcase everything Costa does best — Italian elegance, vibrant entertainment, and Mediterranean cuisine at the grandest scale."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are Costa's ship classes?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Costa operates five ship classes: Excellence Class (LNG-powered flagships), Dream Class (Vista-platform ships with Italian theming), Concordia Class (mid-size Mediterranean workhorses), Musica Class (music-themed vessels), and Spirit Class (intimate ships ideal for longer voyages)."
         }
       }
     ]
@@ -228,26 +244,190 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
-    <section class="card" aria-labelledby="coming-soon-h">
-      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
-      <p>We're expanding our Costa Cruises coverage with in-depth ship profiles, dining venue breakdowns, stateroom guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Costa vessel — check back soon for comprehensive guides.</p>
-      <p>In the meantime, explore our <a href="/ships/costa/">Costa ship directory</a> for the fleet overview, or visit <a href="https://www.costacruises.com" target="_blank" rel="noopener">CostaCruises.com</a> to browse current sailings.</p>
+    <!-- Ships by Class -->
+    <section class="card" id="ships" aria-labelledby="ships-h">
+      <h2 id="ships-h">Ships by Class</h2>
+      <p class="tiny">Explore each ship's page for deck plans, live trackers, dining venues, and stateroom guides. Classes ordered largest to smallest.</p>
+
+      <!-- Excellence Class -->
+      <div class="class-section">
+        <h3>Excellence Class</h3>
+        <p class="blurb">LNG-powered, 185K GT flagships with the stunning Colosseo atrium, 13 restaurants, and Solemio Spa. The Italian piazza concept at its grandest — these are Costa's crown jewels.</p>
+        <div class="ship-grid">
+          <a href="/ships/costa/costa-smeralda.html" class="ship-link">Costa Smeralda <span class="year">2019</span></a>
+          <a href="/ships/costa/costa-toscana.html" class="ship-link">Costa Toscana <span class="year">2021</span></a>
+        </div>
+      </div>
+
+      <!-- Dream Class -->
+      <div class="class-section">
+        <h3>Dream Class</h3>
+        <p class="blurb">Built on Carnival's Vista platform and infused with Italian soul. Piazza Colosseo, Italian-themed entertainment, and Mediterranean flair at 135K GT. Where Carnival engineering meets Costa character.</p>
+        <div class="ship-grid">
+          <a href="/ships/costa/costa-firenze.html" class="ship-link">Costa Firenze <span class="year">2020</span></a>
+          <a href="/ships/costa/costa-venezia.html" class="ship-link">Costa Venezia <span class="year">2019</span></a>
+        </div>
+      </div>
+
+      <!-- Concordia Class -->
+      <div class="class-section">
+        <h3>Concordia Class</h3>
+        <p class="blurb">Mid-size 114K GT workhorses with Samsara Spa, grand piazzas, and classic Costa style. Reliable Mediterranean favorites that deliver the full Italian cruising experience.</p>
+        <div class="ship-grid">
+          <a href="/ships/costa/costa-diadema.html" class="ship-link">Costa Diadema <span class="year">2014</span></a>
+          <a href="/ships/costa/costa-fascinosa.html" class="ship-link">Costa Fascinosa <span class="year">2012</span></a>
+          <a href="/ships/costa/costa-favolosa.html" class="ship-link">Costa Favolosa <span class="year">2011</span></a>
+        </div>
+      </div>
+
+      <!-- Musica Class -->
+      <div class="class-section">
+        <h3>Musica Class</h3>
+        <p class="blurb">114K GT with Samsara Spa, music-themed decor, and Mediterranean character. A proven platform with Italian warmth and personality.</p>
+        <div class="ship-grid">
+          <a href="/ships/costa/costa-pacifica.html" class="ship-link">Costa Pacifica <span class="year">2009</span></a>
+        </div>
+      </div>
+
+      <!-- Spirit Class -->
+      <div class="class-section">
+        <h3>Spirit Class</h3>
+        <p class="blurb">Intimate 92K GT vessel with Samsara Spa and refined Italian atmosphere. Ideal for longer voyages where connection and tranquility matter most.</p>
+        <div class="ship-grid">
+          <a href="/ships/costa/costa-deliziosa.html" class="ship-link">Costa Deliziosa <span class="year">2010</span></a>
+        </div>
+      </div>
     </section>
 
-    <!-- Ships A-Z -->
-    <section id="ships" class="card" aria-labelledby="ships-h">
-      <h2 id="ships-h">Costa Fleet</h2>
-      <ul>
-        <li><a href="/ships/costa/costa-deliziosa.html">Costa Deliziosa</a></li>
-        <li><a href="/ships/costa/costa-diadema.html">Costa Diadema</a></li>
-        <li><a href="/ships/costa/costa-fascinosa.html">Costa Fascinosa</a></li>
-        <li><a href="/ships/costa/costa-favolosa.html">Costa Favolosa</a></li>
-        <li><a href="/ships/costa/costa-firenze.html">Costa Firenze</a></li>
-        <li><a href="/ships/costa/costa-pacifica.html">Costa Pacifica</a></li>
-        <li><a href="/ships/costa/costa-smeralda.html">Costa Smeralda</a></li>
-        <li><a href="/ships/costa/costa-toscana.html">Costa Toscana</a></li>
-        <li><a href="/ships/costa/costa-venezia.html">Costa Venezia</a></li>
-      </ul>
+    <!-- Gallery -->
+    <section class="card" aria-labelledby="gallery-h">
+      <h2 id="gallery-h">Gallery</h2>
+      <div class="grid two" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/Costa_Smeralda_%28ship%2C_2019%29_001.jpg/1200px-Costa_Smeralda_%28ship%2C_2019%29_001.jpg" alt="Costa Smeralda cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Costa_Smeralda_(ship,_2019)_001.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/Costa_Diadema_in_Marseille%2C_2018.jpg/1200px-Costa_Diadema_in_Marseille%2C_2018.jpg" alt="Costa Diadema in Marseille" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Costa_Diadema_in_Marseille,_2018.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <!-- Two-column: CTAs + Dress Code -->
+    <div class="two-col">
+      <div>
+        <!-- CTAs to Other Content -->
+        <section class="card">
+          <h2>Level Up Your Planning</h2>
+          <p>You've picked your ship class — now make your voyage unforgettable. These resources turn good cruises into great ones.</p>
+
+          <div class="cta-grid">
+            <a href="/restaurants.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Restaurants &amp; Menus</h3>
+              <p>Browse every dining venue with menus, dress codes, and honest reviews. Know what to book before you board.</p>
+            </a>
+
+            <a href="/packing-lists.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Packing Lists</h3>
+              <p>Mediterranean or Northern Europe? Formal night or casual? Get ship-tested lists that fit your itinerary — nothing forgotten, nothing wasted.</p>
+            </a>
+
+            <a href="/ports.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Port Guides</h3>
+              <p>What to do when you dock. Honest snapshots, DIY options, and accessibility notes for every port of call.</p>
+            </a>
+
+            <a href="/solo.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Solo Cruising</h3>
+              <p>First time sailing alone? Learn how to own your itinerary, find your people, and love the freedom.</p>
+            </a>
+
+            <a href="/first-cruise.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>First Cruise Guide</h3>
+              <p>New to cruising? Our step-by-step guide covers booking, boarding, and everything in between.</p>
+            </a>
+
+            <a href="/cruise-lines.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Compare Lines</h3>
+              <p>Not sure Costa is the one? Compare cruise lines side by side and find your perfect match.</p>
+            </a>
+          </div>
+        </section>
+
+        <!-- FAQs -->
+        <section class="card faq" aria-labelledby="faq-heading">
+          <h2 id="faq-heading">Frequently Asked Questions</h2>
+
+          <div class="faq-item">
+            <h3>What makes Costa Cruises unique?</h3>
+            <p>Costa Cruises brings Italian heritage and la dolce vita to the seas. Known for authentic Italian dining, vibrant entertainment, Mediterranean itineraries, and a multilingual international atmosphere that feels like floating through Italy. The signature piazza-style atriums, Samsara Spa wellness programs, and leisurely multi-course dinners set Costa apart from North American-focused lines.</p>
+          </div>
+
+          <div class="faq-item">
+            <h3>What dining does Costa offer?</h3>
+            <p>Costa ships feature authentic Italian cuisine as a cornerstone, with regional specialties, fresh pasta, and Italian wines. The dining experience emphasizes la dolce vita with leisurely multi-course meals and specialty restaurants. Excellence Class ships offer up to 13 dining venues, from traditional Italian trattorias to international specialty restaurants and casual buffets with live cooking stations.</p>
+          </div>
+
+          <div class="faq-item">
+            <h3>Where does Costa cruise?</h3>
+            <p>Costa Cruises focuses heavily on the Mediterranean, including Western and Eastern Mediterranean itineraries, but also offers Caribbean, South American, Northern European, and world cruise voyages. The Mediterranean remains the heartland, with itineraries calling at iconic ports in Italy, Spain, France, Greece, and Croatia.</p>
+          </div>
+
+          <div class="faq-item">
+            <h3>Which Costa ship is best for first-timers?</h3>
+            <p>Costa Smeralda or Costa Toscana (Excellence Class) are ideal for first-time Costa cruisers. Their LNG-powered design, 13 restaurants, Colosseo atrium, and Solemio Spa showcase everything Costa does best — Italian elegance, vibrant entertainment, and Mediterranean cuisine at the grandest scale. For a more intimate first experience, Costa Deliziosa offers refined charm on longer voyages.</p>
+          </div>
+
+          <div class="faq-item">
+            <h3>What are Costa's ship classes?</h3>
+            <p>Costa operates five ship classes: <strong>Excellence Class</strong> (LNG-powered flagships at 185K GT), <strong>Dream Class</strong> (Vista-platform ships with Italian theming at 135K GT), <strong>Concordia Class</strong> (mid-size 114K GT Mediterranean workhorses), <strong>Musica Class</strong> (music-themed vessels at 114K GT), and <strong>Spirit Class</strong> (intimate 92K GT ships for longer voyages). Each class brings a distinct take on Costa's Italian cruising philosophy.</p>
+          </div>
+        </section>
+      </div>
+
+      <!-- Right Column: Dress Code -->
+      <aside>
+        <section class="card">
+          <h2>Dress Code</h2>
+
+          <h3>Casual (Daytime &amp; Pool Deck)</h3>
+          <p>Relaxed resort wear — shorts, sundresses, polos, and sandals. Swimwear stays at the pool; cover-ups required in dining areas and the piazza.</p>
+
+          <h3>Smart Casual (Evenings &amp; Restaurants)</h3>
+          <p>The Italian standard — collared shirts, dresses, blouses, chinos, or elegant trousers. Think aperitivo on the Amalfi Coast. Costa leans into Italian elegance more than most lines.</p>
+
+          <h3>Formal (Gala Evenings)</h3>
+          <p>On longer voyages, Costa hosts gala evenings where suits, cocktail dresses, and evening wear shine. Shorter Mediterranean sailings may skip formal nights entirely in favor of smart casual elegance throughout.</p>
+          <p class="tiny">7-night voyages: typically 1 gala night. Longer voyages: 2+ gala nights at the captain's discretion. Smart casual is always welcome.</p>
+
+          <h3>Specialty Dining</h3>
+          <p class="tiny">Most specialty restaurants expect smart casual attire. The piazza venues are more relaxed during daytime hours.</p>
+
+          <h3>Ashore</h3>
+          <p class="tiny">Mediterranean ports often include churches and sacred sites — modest dress (covered shoulders and knees) is respectful and sometimes required. See local guidance on our <a href="/ports.html">Ports</a> pages.</p>
+        </section>
+
+        <section class="card">
+          <h3>Quick Links</h3>
+          <ul>
+            <li><a href="/ships.html">All Ships (full fleet)</a></li>
+            <li><a href="/restaurants.html">All Restaurants</a></li>
+            <li><a href="/cruise-lines.html">Compare Cruise Lines</a></li>
+            <li><a href="/planning.html">Planning Hub</a></li>
+          </ul>
+        </section>
+      </aside>
+    </div>
+
+    <section class="card center">
+      <p class="tiny">All pages are offered as a gift to God. <em>Soli Deo Gloria.</em></p>
     </section>
 
     <!-- Related Resources -->
@@ -274,21 +454,24 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
-    <!-- FAQ -->
-    <section class="card faq" aria-labelledby="faq-heading">
-      <h2 id="faq-heading">Frequently Asked Questions</h2>
-      <div class="faq-item">
-        <h3>What makes Costa Cruises unique?</h3>
-        <p>Costa Cruises brings Italian heritage and la dolce vita to the seas. Known for authentic Italian dining, vibrant entertainment, Mediterranean itineraries, and a multilingual international atmosphere that feels like floating through Italy.</p>
-      </div>
-      <div class="faq-item">
-        <h3>What dining does Costa offer?</h3>
-        <p>Costa ships feature authentic Italian cuisine as a cornerstone, with regional specialties, fresh pasta, and Italian wines. The dining experience emphasizes la dolce vita with leisurely multi-course meals and specialty restaurants.</p>
-      </div>
-      <div class="faq-item">
-        <h3>Where does Costa cruise?</h3>
-        <p>Costa Cruises focuses heavily on the Mediterranean, including Western and Eastern Mediterranean itineraries, but also offers Caribbean, South American, Northern European, and world cruise voyages.</p>
-      </div>
+    <!-- ICP-Lite FAQ Section -->
+    <section class="card faq" id="faq" style="margin: 1.5rem 0; padding: 1rem;">
+      <h2 style="margin: 0 0 1rem; font-size: 1.25rem;">Frequently Asked Questions</h2>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What information does this page provide?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and information about Costa Cruises. Use it alongside official cruise line resources when planning your trip.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides community insights and planning resources. Always confirm details with your cruise line or travel advisor before making final decisions.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How can I get more help?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">For additional assistance, contact your cruise line directly or work with a travel advisor who specializes in cruises.</p>
+      </details>
     </section>
   </div>
 

--- a/cruise-lines/cunard.html
+++ b/cruise-lines/cunard.html
@@ -30,7 +30,7 @@ All work on this project is offered as a gift to God.
 
   <!-- ICP-Lite v1.4: AI-First Metadata -->
   <meta name="ai-summary" content="Cunard guide: British ocean liner heritage since 1840 with 4 Queens — Queen Mary 2, Queen Anne, Queen Victoria, Queen Elizabeth. Signature Grill dining, Transatlantic crossings, and formal traditions."/>
-  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="last-reviewed" content="2026-01-31"/>
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- Canonical / Social -->
@@ -59,14 +59,16 @@ All work on this project is offered as a gift to God.
    "name":"Cunard | In the Wake",
    "url":"https://cruisinginthewake.com/cruise-lines/cunard.html",
    "description":"Cunard guide: British ocean liner heritage since 1840 with 4 Queens — Queen Mary 2, Queen Anne, Queen Victoria, Queen Elizabeth. Signature Grill dining, Transatlantic crossings, and formal traditions.",
-   "dateModified":"2026-01-30"}
+   "dateModified":"2026-01-31"}
   </script>
 
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
     {"@type":"Question","name":"What makes Cunard unique?","acceptedAnswer":{"@type":"Answer","text":"Cunard is the world's most iconic ocean liner company, operating since 1840. Known for Transatlantic crossings on Queen Mary 2, Grill-class dining hierarchy, formal evening traditions, and white-glove British service that harkens to the golden age of ocean travel."}},
     {"@type":"Question","name":"What is Grill-class dining?","acceptedAnswer":{"@type":"Answer","text":"Cunard's Grill dining is a tiered system: Queens Grill (top suites), Princess Grill (premium suites), and Britannia Restaurant (standard). Each Grill offers exclusive dining, private lounges, and dedicated concierge services."}},
-    {"@type":"Question","name":"Does Cunard still do Transatlantic crossings?","acceptedAnswer":{"@type":"Answer","text":"Yes. Queen Mary 2 offers regular scheduled Transatlantic crossings between New York and Southampton — the only ocean liner still providing this classic service."}}
+    {"@type":"Question","name":"Does Cunard still do Transatlantic crossings?","acceptedAnswer":{"@type":"Answer","text":"Yes. Queen Mary 2 offers regular scheduled Transatlantic crossings between New York and Southampton — the only ocean liner still providing this classic service."}},
+    {"@type":"Question","name":"Which Cunard ship is best for first-timers?","acceptedAnswer":{"@type":"Answer","text":"Queen Victoria or Queen Elizabeth. These Vista-class sisters offer an intimate, classic Cunard experience at 90,000 GT with elegant public spaces, Royal Court Theatre, and Queens Room ballroom — ideal for discovering Cunard traditions without the scale of Queen Mary 2."}},
+    {"@type":"Question","name":"What are Cunard's ship classes?","acceptedAnswer":{"@type":"Answer","text":"Cunard operates three ship classes: the Ocean Liner class (Queen Mary 2, the only true ocean liner in service), Queen Anne Class (the newest Queen with reimagined public spaces), and Vista Class (Queen Victoria and Queen Elizabeth, elegant 90K GT sisters with classic Cunard design)."}}
   ]}
   </script>
 
@@ -171,22 +173,178 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
-    <section class="card" aria-labelledby="coming-soon-h">
-      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
-      <p>We're expanding our Cunard coverage with in-depth ship profiles, Grill dining breakdowns, stateroom guidance, and the insider knowledge that helps you navigate Cunard's storied traditions. Check back soon for comprehensive guides.</p>
-      <p>In the meantime, explore our <a href="/ships/cunard/">Cunard ship directory</a> for the fleet overview, or visit <a href="https://www.cunard.com" target="_blank" rel="noopener">Cunard.com</a> to browse current sailings.</p>
+    <!-- Ships by Class -->
+    <section class="card" id="ships" aria-labelledby="ships-h">
+      <h2 id="ships-h">Ships by Class</h2>
+      <p class="tiny">Explore each ship's page for deck plans, live trackers, dining venues, and stateroom guides. Classes ordered by distinction.</p>
+
+      <!-- Ocean Liner -->
+      <div class="class-section">
+        <h3>Ocean Liner</h3>
+        <p class="blurb">The only true ocean liner in service. 148,000 GT, 2,691 guests, scheduled Transatlantic crossings between New York and Southampton. Kennels, planetarium, largest ballroom at sea.</p>
+        <div class="ship-grid">
+          <a href="/ships/cunard/queen-mary-2.html" class="ship-link">Queen Mary 2 <span class="year">2004</span></a>
+        </div>
+      </div>
+
+      <!-- Queen Anne Class -->
+      <div class="class-section">
+        <h3>Queen Anne Class</h3>
+        <p class="blurb">Newest Queen. 113,000 GT with reimagined public spaces, Pavilion pool with retractable roof, Bright Lights Society entertainment venue, and The Pavillion — Cunard's first al fresco dining venue.</p>
+        <div class="ship-grid">
+          <a href="/ships/cunard/queen-anne.html" class="ship-link">Queen Anne <span class="year">2024</span></a>
+        </div>
+      </div>
+
+      <!-- Vista Class -->
+      <div class="class-section">
+        <h3>Vista Class</h3>
+        <p class="blurb">90,000 GT sisters sharing elegant Vista-class design with Royal Court Theatre, Queens Room ballroom, Commodore Club, and garden lounges. Classic Cunard elegance with modern comfort.</p>
+        <div class="ship-grid">
+          <a href="/ships/cunard/queen-victoria.html" class="ship-link">Queen Victoria <span class="year">2007</span></a>
+          <a href="/ships/cunard/queen-elizabeth.html" class="ship-link">Queen Elizabeth <span class="year">2010</span></a>
+        </div>
+      </div>
     </section>
 
-    <section id="ships" class="card" aria-labelledby="ships-h">
-      <h2 id="ships-h">Cunard Fleet</h2>
-      <ul>
-        <li><a href="/ships/cunard/queen-anne.html">Queen Anne</a></li>
-        <li><a href="/ships/cunard/queen-elizabeth.html">Queen Elizabeth</a></li>
-        <li><a href="/ships/cunard/queen-mary-2.html">Queen Mary 2</a></li>
-        <li><a href="/ships/cunard/queen-victoria.html">Queen Victoria</a></li>
-      </ul>
+    <!-- Gallery -->
+    <section class="card" aria-labelledby="gallery-h">
+      <h2 id="gallery-h">Gallery</h2>
+      <div class="grid two" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/RMS_Queen_Mary_2_in_Trondheim_2007.jpg/1200px-RMS_Queen_Mary_2_in_Trondheim_2007.jpg" alt="RMS Queen Mary 2 in Trondheim" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:RMS_Queen_Mary_2_in_Trondheim_2007.jpg" target="_blank" rel="noopener">Alasdair McLellan</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/2.0" target="_blank" rel="noopener">CC BY-SA 2.0</a></figcaption>
+        </figure>
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/df/Queen_Anne_%28ship%2C_2024%29_02.jpg/1200px-Queen_Anne_%28ship%2C_2024%29_02.jpg" alt="Queen Anne cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Queen_Anne_(ship,_2024)_02.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+      </div>
     </section>
 
+    <!-- Two-column: CTAs + Dress Code -->
+    <div class="two-col">
+      <div>
+        <!-- CTAs to Other Content -->
+        <section class="card">
+          <h2>Level Up Your Planning</h2>
+          <p>You've chosen the Queens — now make your voyage unforgettable. These resources turn good crossings into great ones.</p>
+
+          <div class="cta-grid">
+            <a href="/restaurants.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Restaurants &amp; Menus</h3>
+              <p>Browse Grill-class dining, Britannia Restaurant, and specialty venues with menus, dress codes, and honest reviews.</p>
+            </a>
+
+            <a href="/packing-lists.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Packing Lists</h3>
+              <p>Transatlantic or Mediterranean? Gala night essentials? Get ship-tested lists that fit your itinerary — nothing forgotten.</p>
+            </a>
+
+            <a href="/ports.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Port Guides</h3>
+              <p>What to do when you dock. Honest snapshots, DIY options, and accessibility notes for every port of call.</p>
+            </a>
+
+            <a href="/solo.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Solo Cruising</h3>
+              <p>First time sailing alone? Learn how to own your itinerary, find your people, and love the freedom.</p>
+            </a>
+
+            <a href="/first-cruise.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>First Cruise Guide</h3>
+              <p>New to cruising? Start here for embarkation tips, what to expect on day one, and how to make the most of sea days.</p>
+            </a>
+
+            <a href="/cruise-lines.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Compare Lines</h3>
+              <p>See how Cunard stacks up against other cruise lines — from casual to ultra-luxury — and find your perfect match.</p>
+            </a>
+          </div>
+        </section>
+
+        <!-- FAQs -->
+        <section class="card faq" aria-labelledby="faq-heading">
+          <h2 id="faq-heading">Frequently Asked Questions</h2>
+
+          <div class="faq-item">
+            <h3>What makes Cunard unique?</h3>
+            <p>Cunard is the world's most iconic ocean liner company, operating since 1840. Known for Transatlantic crossings on Queen Mary 2, Grill-class dining hierarchy, formal evening traditions, and white-glove British service that harkens to the golden age of ocean travel.</p>
+          </div>
+
+          <div class="faq-item">
+            <h3>What is Grill-class dining?</h3>
+            <p>Cunard's Grill dining is a tiered system: Queens Grill (top suites), Princess Grill (premium suites), and Britannia Restaurant (standard). Each Grill offers exclusive dining, private lounges, and dedicated concierge services. Your stateroom category determines your restaurant assignment.</p>
+          </div>
+
+          <div class="faq-item">
+            <h3>Does Cunard still do Transatlantic crossings?</h3>
+            <p>Yes. Queen Mary 2 offers regular scheduled Transatlantic crossings between New York and Southampton — the only ocean liner still providing this classic seven-night service. Multiple crossings run spring through autumn each year.</p>
+          </div>
+
+          <div class="faq-item">
+            <h3>Which Cunard ship is best for first-timers?</h3>
+            <p>Queen Victoria or Queen Elizabeth. These Vista-class sisters offer an intimate, classic Cunard experience at 90,000 GT with elegant public spaces, Royal Court Theatre, and Queens Room ballroom — ideal for discovering Cunard traditions without the scale of Queen Mary 2. Their size makes them easy to navigate and fosters a warm, welcoming atmosphere.</p>
+          </div>
+
+          <div class="faq-item">
+            <h3>What are Cunard's ship classes?</h3>
+            <p>Cunard operates three distinct classes: the <strong>Ocean Liner</strong> (Queen Mary 2 — the only true ocean liner in service, built for Transatlantic crossings), <strong>Queen Anne Class</strong> (the newest Queen with reimagined public spaces and al fresco dining), and <strong>Vista Class</strong> (Queen Victoria and Queen Elizabeth — elegant 90K GT sisters with classic Cunard design).</p>
+          </div>
+
+          <div class="faq-item">
+            <h3>How formal is Cunard compared to other cruise lines?</h3>
+            <p>Cunard is <strong>more formal than most cruise lines</strong>. Daytime is relaxed casual, but evenings call for Smart Attire at minimum, and Gala nights require black tie or dark suits for men and evening gowns or cocktail dresses for women. Longer voyages feature multiple Gala nights. If you enjoy dressing up and the ceremony of formal dining, Cunard delivers that experience better than any other line at sea.</p>
+          </div>
+        </section>
+      </div>
+
+      <!-- Right Column: Dress Code -->
+      <aside>
+        <section class="card">
+          <h2>Dress Code</h2>
+
+          <h3>Casual (Daytime)</h3>
+          <p>Relaxed and comfortable — polos, sundresses, smart shorts, resort wear. Swimwear stays poolside. Cunard's daytime atmosphere is approachable while still polished.</p>
+
+          <h3>Smart Attire (Evenings)</h3>
+          <p>The default evening standard. Collared shirts, trousers, dresses, skirts, blouses, or pantsuits. Jackets and blazers encouraged. No jeans or trainers in the main dining rooms.</p>
+
+          <h3>Gala (Formal Nights)</h3>
+          <p>This is where Cunard shines. <strong>Black tie or dark suit</strong> for men; <strong>evening gowns or cocktail dresses</strong> for women. Cunard takes formal nights seriously — this is one of the last lines where black tie is genuinely expected, not merely suggested.</p>
+          <p class="tiny">Short voyages: 1 Gala night. 7-night Transatlantic: 2 Gala nights. Longer voyages and world cruises feature multiple Gala evenings — pack accordingly.</p>
+
+          <h3>Specialty Dining</h3>
+          <p class="tiny">Smart Attire minimum for all evening specialty venues. The Verandah and other premium restaurants encourage Gala-level dress on formal nights.</p>
+
+          <h3>Ashore</h3>
+          <p class="tiny">Modesty at churches and sacred sites is good seamanship. See local guidance on our <a href="/ports.html">Ports</a> pages.</p>
+        </section>
+
+        <section class="card">
+          <h3>Quick Links</h3>
+          <ul>
+            <li><a href="/ships.html">All Ships (full fleet)</a></li>
+            <li><a href="/restaurants.html">All Restaurants</a></li>
+            <li><a href="/cruise-lines.html">Compare Cruise Lines</a></li>
+            <li><a href="/planning.html">Planning Hub</a></li>
+          </ul>
+        </section>
+      </aside>
+    </div>
+
+    <!-- Soli Deo Gloria -->
+    <section class="card center">
+      <p class="tiny">All pages are offered as a gift to God. <em>Soli Deo Gloria.</em></p>
+    </section>
+
+    <!-- Related Resources -->
     <section class="card related-resources" style="margin: 1.5rem 0; padding: 1.25rem; background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
       <h2 style="margin: 0 0 0.75rem; font-size: 1.15rem; color: #083041;">Continue Planning Your Cunard Voyage</h2>
       <p class="tiny content-text" style="margin-bottom: 1rem; color: #5a7a8a;">Tools and guides to help you prepare.</p>
@@ -210,20 +368,24 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
-    <section class="card faq" aria-labelledby="faq-heading">
-      <h2 id="faq-heading">Frequently Asked Questions</h2>
-      <div class="faq-item">
-        <h3>What makes Cunard unique?</h3>
-        <p>Cunard is the world's most iconic ocean liner company, operating since 1840. Known for Transatlantic crossings on Queen Mary 2, Grill-class dining hierarchy, formal evening traditions, and white-glove British service that harkens to the golden age of ocean travel.</p>
-      </div>
-      <div class="faq-item">
-        <h3>What is Grill-class dining?</h3>
-        <p>Cunard's Grill dining is a tiered system: Queens Grill (top suites), Princess Grill (premium suites), and Britannia Restaurant (standard). Each Grill offers exclusive dining, private lounges, and dedicated concierge services.</p>
-      </div>
-      <div class="faq-item">
-        <h3>Does Cunard still do Transatlantic crossings?</h3>
-        <p>Yes. Queen Mary 2 offers regular scheduled Transatlantic crossings between New York and Southampton — the only ocean liner still providing this classic service.</p>
-      </div>
+    <!-- ICP-Lite FAQ Section -->
+    <section class="card faq" id="icp-faq" style="margin: 1.5rem 0; padding: 1rem;">
+      <h2 style="margin: 0 0 1rem; font-size: 1.25rem;">Additional Information</h2>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What information does this page provide?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and information about Cunard. Use it alongside official cruise line resources when planning your trip.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides community insights and planning resources. Always confirm details with Cunard or your travel advisor before making final decisions.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How can I get more help?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">For additional assistance, contact Cunard directly or work with a travel advisor who specializes in cruises.</p>
+      </details>
     </section>
   </div>
 

--- a/cruise-lines/explora-journeys.html
+++ b/cruise-lines/explora-journeys.html
@@ -6,7 +6,7 @@
      type: Cruise Line Guide
      parent: /cruise-lines.html
      category: Cruise Line Information
-     updated: 2026-01-30
+     updated: 2026-01-31
      expertise: Cruise line comparisons, fleet analysis, policy research, cruise planning
      target-audience: Luxury cruise shoppers, European travel enthusiasts, design-conscious guests
      answer-first: Explora Journeys redefines ocean luxury with all-suite ships, 18 dining experiences, and inclusive European elegance — the newest luxury brand from MSC Group with 6 planned vessels.
@@ -30,7 +30,7 @@ All work on this project is offered as a gift to God.
 
   <!-- ICP-Lite v1.4: AI-First Metadata -->
   <meta name="ai-summary" content="Explora Journeys guide: luxury MSC Group brand launched 2023 with all ocean-front suites, 18 dining experiences, inclusive pricing, and 6 planned ships. Explore fleet and planning resources."/>
-  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="last-reviewed" content="2026-01-31"/>
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- Canonical / Social -->
@@ -65,7 +65,7 @@ All work on this project is offered as a gift to God.
     "name": "Explora Journeys | In the Wake",
     "url": "https://cruisinginthewake.com/cruise-lines/explora-journeys.html",
     "description": "Explora Journeys guide: luxury MSC Group brand launched 2023 with all ocean-front suites, 18 dining experiences, inclusive pricing, and 6 planned ships. Explore fleet and planning resources.",
-    "dateModified": "2026-01-30"
+    "dateModified": "2026-01-31"
   }
   </script>
 
@@ -97,6 +97,22 @@ All work on this project is offered as a gift to God.
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Explora Journeys offers itineraries across the Mediterranean, Northern Europe, the Caribbean, and Transatlantic crossings. With a focus on European elegance, Mediterranean voyages are a signature strength, complemented by seasonal repositioning cruises and destination-rich sailings worldwide."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which Explora ship is best for first-timers?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Explora I is the ideal choice for first-timers. As the inaugural vessel, it has the most refined service team and established onboard routines. Mediterranean itineraries on Explora I offer a quintessential introduction to the brand's European luxury philosophy, with 18 dining experiences, inclusive pricing, and intimate 922-guest capacity that ensures personal attention."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are Explora Journeys' ship generations?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Explora Journeys has three ship generations planned: Generation I (Explora I and II, 63K GT, 922 guests) are the current all-suite ocean residences; Generation II (Explora III and IV) will be LNG-powered with enhanced sustainability; Generation III (Explora V and VI) will be hydrogen-ready vessels representing the brand's long-term vision for sustainable luxury cruising."
         }
       }
     ]
@@ -230,23 +246,182 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
-    <section class="card" aria-labelledby="coming-soon-h">
-      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
-      <p>We're expanding our Explora Journeys coverage with in-depth ship profiles, dining venue breakdowns, suite guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Explora vessel — check back soon for comprehensive guides.</p>
-      <p>In the meantime, explore our <a href="/ships/explora-journeys/">Explora Journeys ship directory</a> for the fleet overview, or visit <a href="https://www.explorajourneys.com" target="_blank" rel="noopener">ExploraJourneys.com</a> to browse current sailings.</p>
+    <!-- Ships by Class -->
+    <section class="card" id="ships" aria-labelledby="ships-h">
+      <h2 id="ships-h">Ships by Class</h2>
+      <p class="tiny">Explore each ship's page for suite guides, dining venues, and onboard experiences. Generations ordered newest to planned.</p>
+
+      <!-- Generation I -->
+      <div class="class-section">
+        <h3>Generation I <span class="badge">launched 2023</span></h3>
+        <p class="blurb">63K GT, 922 guests. All-suite ocean residences with private terraces. 18 dining experiences including Sakura, Fil Rouge, Anthology, and Emporium Marketplace. Helios Pool &amp; Bar, Ocean Wellness Spa. First ships from MSC Group's luxury brand.</p>
+        <div class="ship-grid">
+          <a href="/ships/explora-journeys/explora-i.html" class="ship-link">Explora I <span class="year">2023</span></a>
+          <a href="/ships/explora-journeys/explora-ii.html" class="ship-link">Explora II <span class="year">2024</span></a>
+        </div>
+      </div>
+
+      <!-- Generation II (LNG-powered) -->
+      <div class="class-section">
+        <h3>Generation II (LNG-powered) <span class="badge">expected 2026+</span></h3>
+        <p class="blurb">Next-generation LNG-powered ships with enhanced sustainability features. Expected 63K GT with expanded public spaces, new dining concepts, and refined suite categories.</p>
+        <div class="ship-grid">
+          <a href="/ships/explora-journeys/explora-iii.html" class="ship-link">Explora III <span class="year">2026 expected</span></a>
+          <a href="/ships/explora-journeys/explora-iv.html" class="ship-link">Explora IV <span class="year">2027 expected</span></a>
+        </div>
+      </div>
+
+      <!-- Generation III (Hydrogen-ready) -->
+      <div class="class-section">
+        <h3>Generation III (Hydrogen-ready) <span class="badge">expected 2028+</span></h3>
+        <p class="blurb">Future hydrogen-ready vessels designed for next-generation sustainable luxury. Details emerging as the brand's long-term vision unfolds.</p>
+        <div class="ship-grid">
+          <a href="/ships/explora-journeys/explora-v.html" class="ship-link">Explora V <span class="year">2028 expected</span></a>
+          <a href="/ships/explora-journeys/explora-vi.html" class="ship-link">Explora VI <span class="year">2028+ expected</span></a>
+        </div>
+      </div>
     </section>
 
-    <!-- Ships A-Z -->
-    <section id="ships" class="card" aria-labelledby="ships-h">
-      <h2 id="ships-h">Explora Journeys Fleet</h2>
-      <ul>
-        <li><a href="/ships/explora-journeys/explora-i.html">Explora I</a></li>
-        <li><a href="/ships/explora-journeys/explora-ii.html">Explora II</a></li>
-        <li><a href="/ships/explora-journeys/explora-iii.html">Explora III</a></li>
-        <li><a href="/ships/explora-journeys/explora-iv.html">Explora IV</a></li>
-        <li><a href="/ships/explora-journeys/explora-v.html">Explora V</a></li>
-        <li><a href="/ships/explora-journeys/explora-vi.html">Explora VI</a></li>
-      </ul>
+    <!-- Gallery -->
+    <section class="card" aria-labelledby="gallery-h">
+      <h2 id="gallery-h">Gallery</h2>
+      <div class="grid two" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5f/Explora_I_%28ship%2C_2023%29_001.jpg/1200px-Explora_I_%28ship%2C_2023%29_001.jpg" alt="Explora I cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Explora_I_(ship,_2023)_001.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a8/Explora_II_%282024%29.jpg/1200px-Explora_II_%282024%29.jpg" alt="Explora II cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Explora_II_(2024).jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <!-- Two-column: CTAs + Dress Code -->
+    <div class="two-col">
+      <div>
+        <!-- CTAs to Other Content -->
+        <section class="card">
+          <h2>Level Up Your Planning</h2>
+          <p>You've picked your ship — now make your voyage unforgettable. These resources turn good cruises into great ones.</p>
+
+          <div class="cta-grid">
+            <a href="/restaurants.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Restaurants &amp; Menus</h3>
+              <p>Browse dining venues with menus, dress codes, and honest reviews. Know what to book before you board.</p>
+            </a>
+
+            <a href="/packing-lists.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Packing Lists</h3>
+              <p>Mediterranean or Transatlantic? Gala night or ocean casual? Get ship-tested lists that fit your itinerary.</p>
+            </a>
+
+            <a href="/ports.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Port Guides</h3>
+              <p>What to do when you dock. Honest snapshots, DIY options, and accessibility notes for every port of call.</p>
+            </a>
+
+            <a href="/solo.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Solo Cruising</h3>
+              <p>First time sailing alone? Learn how to own your itinerary, find your people, and love the freedom.</p>
+            </a>
+
+            <a href="/first-cruise.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>First Cruise Guide</h3>
+              <p>New to cruising? Everything you need to know before your first voyage — from booking to disembarkation.</p>
+            </a>
+
+            <a href="/cruise-lines.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Compare Lines</h3>
+              <p>See how Explora Journeys stacks up against other luxury and premium cruise lines.</p>
+            </a>
+          </div>
+        </section>
+
+        <!-- FAQ -->
+        <section class="card faq" aria-labelledby="faq-heading">
+          <h2 id="faq-heading">Frequently Asked Questions</h2>
+          <div class="faq-item">
+            <h3>What makes Explora Journeys unique?</h3>
+            <p>Explora Journeys is the newest luxury cruise brand from MSC Group, launched in 2023. Every suite is ocean-front with a private terrace, and the experience includes 18 dining venues, inclusive pricing covering drinks, Wi-Fi, and gratuities, plus refined European design throughout — all aboard intimate 922-guest ships.</p>
+          </div>
+          <div class="faq-item">
+            <h3>What is included in an Explora Journeys fare?</h3>
+            <p>Explora Journeys uses inclusive pricing that covers dining across all 18 onboard restaurants, premium beverages, unlimited Wi-Fi, gratuities, and access to wellness facilities. This all-inclusive approach means fewer surprise charges and a seamless luxury experience from embarkation to disembarkation.</p>
+          </div>
+          <div class="faq-item">
+            <h3>Where does Explora Journeys sail?</h3>
+            <p>Explora Journeys offers itineraries across the Mediterranean, Northern Europe, the Caribbean, and Transatlantic crossings. With a focus on European elegance, Mediterranean voyages are a signature strength, complemented by seasonal repositioning cruises and destination-rich sailings worldwide.</p>
+          </div>
+          <div class="faq-item">
+            <h3>Which Explora ship is best for first-timers?</h3>
+            <p>Explora I is the ideal choice for first-timers. As the inaugural vessel, it has the most refined service team and established onboard routines. Mediterranean itineraries on Explora I offer a quintessential introduction to the brand's European luxury philosophy, with 18 dining experiences, inclusive pricing, and intimate 922-guest capacity that ensures personal attention.</p>
+          </div>
+          <div class="faq-item">
+            <h3>What are Explora Journeys' ship generations?</h3>
+            <p>Explora Journeys has three ship generations planned. Generation I (Explora I and II) are 63K GT, 922-guest all-suite ocean residences sailing now. Generation II (Explora III and IV) will be LNG-powered with enhanced sustainability features and expanded public spaces. Generation III (Explora V and VI) will be hydrogen-ready vessels representing the brand's long-term vision for sustainable luxury cruising.</p>
+          </div>
+        </section>
+      </div>
+
+      <!-- Right column: Dress Code -->
+      <aside>
+        <section class="card">
+          <h2>Dress Code</h2>
+
+          <h3>Ocean Casual (Daytime)</h3>
+          <p>Resort chic, linen, sundresses, smart shorts. Swimwear is welcome at pools and the Helios Pool &amp; Bar but not in restaurants.</p>
+
+          <h3>Evening Chic (Most Evenings)</h3>
+          <p>Smart separates, dresses, blazers optional. Think polished but relaxed — a collared shirt and trousers, a chic dress, or elegant separates.</p>
+
+          <h3>Gala Evening (Select Nights)</h3>
+          <p>Cocktail attire, dark suits, evening dresses. These are the nights to dress your best — Explora's signature evenings of refined celebration.</p>
+
+          <p class="tiny">Explora Journeys embraces modern European elegance — stylish but never stuffy. The atmosphere encourages guests to express personal style with sophistication.</p>
+        </section>
+
+        <section class="card">
+          <h3>Quick Links</h3>
+          <ul>
+            <li><a href="/ships.html">All Ships (full fleet)</a></li>
+            <li><a href="/restaurants.html">All Restaurants</a></li>
+            <li><a href="/cruise-lines.html">Compare Cruise Lines</a></li>
+            <li><a href="/planning.html">Planning Hub</a></li>
+          </ul>
+        </section>
+      </aside>
+    </div>
+
+    <!-- ICP-Lite FAQ Section -->
+    <section class="card faq" id="icp-faq" style="margin: 1.5rem 0; padding: 1rem;">
+      <h2 style="margin: 0 0 1rem; font-size: 1.25rem;">About This Page</h2>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What information does this page provide?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and information about Explora Journeys. Use it alongside official cruise line resources when planning your trip.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides community insights and planning resources. Always confirm details with your cruise line or travel advisor before making final decisions.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How can I get more help?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">For additional assistance, contact your cruise line directly or work with a travel advisor who specializes in cruises.</p>
+      </details>
+    </section>
+
+    <!-- Soli Deo Gloria -->
+    <section class="card center">
+      <p class="tiny">All pages are offered as a gift to God. <em>Soli Deo Gloria.</em></p>
     </section>
 
     <!-- Related Resources -->
@@ -270,23 +445,6 @@ All work on this project is offered as a gift to God.
           <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
           <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
         </a>
-      </div>
-    </section>
-
-    <!-- FAQ -->
-    <section class="card faq" aria-labelledby="faq-heading">
-      <h2 id="faq-heading">Frequently Asked Questions</h2>
-      <div class="faq-item">
-        <h3>What makes Explora Journeys unique?</h3>
-        <p>Explora Journeys is the newest luxury cruise brand from MSC Group, launched in 2023. Every suite is ocean-front with a private terrace, and the experience includes 18 dining venues, inclusive pricing covering drinks, Wi-Fi, and gratuities, plus refined European design throughout — all aboard intimate 922-guest ships.</p>
-      </div>
-      <div class="faq-item">
-        <h3>What is included in an Explora Journeys fare?</h3>
-        <p>Explora Journeys uses inclusive pricing that covers dining across all 18 onboard restaurants, premium beverages, unlimited Wi-Fi, gratuities, and access to wellness facilities. This all-inclusive approach means fewer surprise charges and a seamless luxury experience from embarkation to disembarkation.</p>
-      </div>
-      <div class="faq-item">
-        <h3>Where does Explora Journeys sail?</h3>
-        <p>Explora Journeys offers itineraries across the Mediterranean, Northern Europe, the Caribbean, and Transatlantic crossings. With a focus on European elegance, Mediterranean voyages are a signature strength, complemented by seasonal repositioning cruises and destination-rich sailings worldwide.</p>
       </div>
     </section>
   </div>

--- a/cruise-lines/oceania.html
+++ b/cruise-lines/oceania.html
@@ -6,7 +6,7 @@
      type: Cruise Line Guide
      parent: /cruise-lines.html
      category: Cruise Line Information
-     updated: 2026-01-30
+     updated: 2026-01-31
      expertise: Cruise line comparisons, fleet analysis, policy research, cruise planning
      target-audience: Cruise line comparison shoppers, foodies, experienced cruisers, travel planners
      answer-first: Oceania Cruises delivers "The Finest Cuisine at Sea" with intimate mid-size ships, destination-focused itineraries, and Jacques Pepin-inspired dining across 7 vessels.
@@ -30,7 +30,7 @@ All work on this project is offered as a gift to God.
 
   <!-- ICP-Lite v1.4: AI-First Metadata -->
   <meta name="ai-summary" content="Oceania Cruises guide: upper-premium line with 7 mid-size ships featuring Jacques Pepin-inspired culinary excellence, destination-focused itineraries, and country club casual atmosphere. Explore fleet and planning resources."/>
-  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="last-reviewed" content="2026-01-31"/>
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- Canonical / Social -->
@@ -65,7 +65,7 @@ All work on this project is offered as a gift to God.
     "name": "Oceania Cruises | In the Wake",
     "url": "https://cruisinginthewake.com/cruise-lines/oceania.html",
     "description": "Oceania Cruises guide: upper-premium line with 7 mid-size ships featuring Jacques Pepin-inspired culinary excellence, destination-focused itineraries, and country club casual atmosphere. Explore fleet and planning resources.",
-    "dateModified": "2026-01-30"
+    "dateModified": "2026-01-31"
   }
   </script>
 
@@ -97,6 +97,22 @@ All work on this project is offered as a gift to God.
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Oceania operates mid-size ships carrying 600-1200 guests, deliberately smaller than mainstream mega-ships. The R-class ships (Insignia, Nautica, Regatta, Sirena) carry around 670 guests, while the larger O-class (Marina, Riviera) and newest Allura-class (Allura, Vista) carry approximately 1,200 guests — still intimate by modern standards."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which Oceania ship is best for first-timers?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Marina or Riviera are the best choices for first-time Oceania cruisers. These Marina Class ships offer the full range of Oceania amenities — Jacques Bistro, Red Ginger, Polo Grill, Toscana, the Culinary Center cooking classes, and the Canyon Ranch SpaClub — in a midsize 1,250-guest package that feels intimate without sacrificing variety."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are Oceania's ship classes?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Oceania operates three ship classes: the Allura Class (Allura 2025, Vista 2023) — the newest 67K GT ships with 1,200 guests and the Aquamar Spa; the Marina Class (Marina 2011, Riviera 2012) — 66K GT ships with 1,250 guests that cemented 'Finest Cuisine at Sea'; and the Regatta Class or R-Class (Regatta, Insignia, Nautica, Sirena) — intimate 30K GT vessels with just 684 guests and a country club casual atmosphere."
         }
       }
     ]
@@ -229,25 +245,181 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
-    <section class="card" aria-labelledby="coming-soon-h">
-      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
-      <p>We're expanding our Oceania Cruises coverage with in-depth ship profiles, dining venue breakdowns, stateroom guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Oceania vessel — check back soon for comprehensive guides.</p>
-      <p>In the meantime, explore our <a href="/ships/oceania/">Oceania ship directory</a> for the fleet overview, or visit <a href="https://www.oceaniacruises.com" target="_blank" rel="noopener">OceaniaCruises.com</a> to browse current sailings.</p>
+    <!-- Ships by Class -->
+    <section class="card" id="ships" aria-labelledby="ships-h">
+      <h2 id="ships-h">Ships by Class</h2>
+      <p class="tiny">Explore each ship's page for dining venues, itinerary details, and planning guides. Classes ordered newest to oldest.</p>
+
+      <!-- Allura Class -->
+      <div class="class-section">
+        <h3>Allura Class</h3>
+        <p class="blurb">Oceania's newest flagships — 67,000 GT ships carrying just 1,200 guests. The Aquamar Spa + Vitality Center, Ember shore-side grill, redesigned Polo Grill, and Grand Dining Room set the standard. Oceania's most spacious ships with the highest staff-to-guest ratio in the fleet.</p>
+        <div class="ship-grid">
+          <a href="/ships/oceania/allura.html" class="ship-link">Allura <span class="year">2025</span></a>
+          <a href="/ships/oceania/vista.html" class="ship-link">Vista <span class="year">2023</span></a>
+        </div>
+      </div>
+
+      <!-- Marina Class (Oceania Class) -->
+      <div class="class-section">
+        <h3>Marina Class (Oceania Class)</h3>
+        <p class="blurb">The ships that cemented "Finest Cuisine at Sea." At 66,000 GT with 1,250 guests, Marina and Riviera feature Jacques Pepin's cuisine at Jacques Bistro, Red Ginger Asian, Polo Grill steakhouse, and Toscana Italian — all included in your fare.</p>
+        <div class="ship-grid">
+          <a href="/ships/oceania/marina.html" class="ship-link">Marina <span class="year">2011</span></a>
+          <a href="/ships/oceania/riviera.html" class="ship-link">Riviera <span class="year">2012</span></a>
+        </div>
+      </div>
+
+      <!-- Regatta Class (R-Class) -->
+      <div class="class-section">
+        <h3>Regatta Class (R-Class)</h3>
+        <p class="blurb">Intimate 30,000 GT vessels with just 684 guests. Country club casual atmosphere, exceptional cuisine-to-guest ratio, and the kind of personalized service that larger ships simply cannot match. Perfect for destination-intensive itineraries where the journey matters as much as the ports.</p>
+        <div class="ship-grid">
+          <a href="/ships/oceania/regatta.html" class="ship-link">Regatta <span class="year">2003</span></a>
+          <a href="/ships/oceania/insignia.html" class="ship-link">Insignia <span class="year">2002</span></a>
+          <a href="/ships/oceania/nautica.html" class="ship-link">Nautica <span class="year">2000</span></a>
+          <a href="/ships/oceania/sirena.html" class="ship-link">Sirena <span class="year">2016</span></a>
+        </div>
+      </div>
     </section>
 
-    <!-- Ships A-Z -->
-    <section id="ships" class="card" aria-labelledby="ships-h">
-      <h2 id="ships-h">Oceania Fleet</h2>
-      <ul>
-        <li><a href="/ships/oceania/allura.html">Allura</a></li>
-        <li><a href="/ships/oceania/insignia.html">Insignia</a></li>
-        <li><a href="/ships/oceania/marina.html">Marina</a></li>
-        <li><a href="/ships/oceania/nautica.html">Nautica</a></li>
-        <li><a href="/ships/oceania/regatta.html">Regatta</a></li>
-        <li><a href="/ships/oceania/riviera.html">Riviera</a></li>
-        <li><a href="/ships/oceania/sirena.html">Sirena</a></li>
-        <li><a href="/ships/oceania/vista.html">Vista</a></li>
-      </ul>
+    <!-- Gallery -->
+    <section class="card" aria-labelledby="gallery-h">
+      <h2 id="gallery-h">Gallery</h2>
+      <div class="grid two" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a9/Oceania_Marina_01.jpg/1200px-Oceania_Marina_01.jpg" alt="Oceania Marina cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Oceania_Marina_01.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Oceania_Riviera_04.JPG/1200px-Oceania_Riviera_04.JPG" alt="Oceania Riviera cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Oceania_Riviera_04.JPG" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <!-- Two-column: CTAs + Dress Code -->
+    <div class="two-col">
+      <div>
+        <!-- CTAs to Other Content -->
+        <section class="card">
+          <h2>Level Up Your Planning</h2>
+          <p>You've picked your ship class — now make your voyage unforgettable. These resources turn good cruises into great ones.</p>
+
+          <div class="cta-grid">
+            <a href="/restaurants.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Restaurants &amp; Menus</h3>
+              <p>Browse every dining venue — from the Grand Dining Room to Polo Grill — with menus, dress codes, and honest reviews. Know what to book before you board.</p>
+            </a>
+
+            <a href="/packing-lists.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Packing Lists</h3>
+              <p>Mediterranean or Alaska? Country club casual or elegant evening? Get ship-tested lists that fit your itinerary — nothing forgotten, nothing wasted.</p>
+            </a>
+
+            <a href="/ports.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Port Guides</h3>
+              <p>What to do when you dock. Honest snapshots, DIY options, and accessibility notes for every port of call.</p>
+            </a>
+
+            <a href="/solo.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Solo Cruising</h3>
+              <p>First time sailing alone? Learn how to own your itinerary, find your people, and love the freedom.</p>
+            </a>
+
+            <a href="/first-cruise.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>First Cruise Guide</h3>
+              <p>New to cruising? Our step-by-step guide covers everything from booking to disembarkation — no detail left behind.</p>
+            </a>
+
+            <a href="/cruise-lines.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Compare Lines</h3>
+              <p>How does Oceania stack up against Celebrity, Regent, or Viking? See all cruise lines side by side and find your perfect match.</p>
+            </a>
+          </div>
+        </section>
+
+        <!-- FAQs -->
+        <section class="card">
+          <h2>Frequently Asked Questions</h2>
+
+          <h3>What makes Oceania Cruises unique?</h3>
+          <p>Oceania Cruises occupies the upper-premium segment with intimate mid-size ships carrying just 600-1200 guests. Their hallmark is culinary excellence — branded as The Finest Cuisine at Sea — with Jacques Pepin as executive culinary director. Destination-focused itineraries feature longer port stays, and the country club casual atmosphere appeals to experienced cruisers.</p>
+
+          <h3>What dining does Oceania Cruises offer?</h3>
+          <p>Oceania's dining program is curated by legendary chef Jacques Pepin and includes multiple open-seating specialty restaurants at no extra charge. From French fine dining at Jacques to Italian at Toscana and steaks at Polo Grill, every venue emphasizes fresh ingredients and culinary artistry that rivals top shoreside restaurants.</p>
+
+          <h3>How big are Oceania cruise ships?</h3>
+          <p>Oceania operates mid-size ships carrying 600-1200 guests, deliberately smaller than mainstream mega-ships. The R-class ships (Insignia, Nautica, Regatta, Sirena) carry around 684 guests, while the larger Marina Class (Marina, Riviera) and newest Allura Class (Allura, Vista) carry approximately 1,200 guests — still intimate by modern standards.</p>
+
+          <h3>Which Oceania ship is best for first-timers?</h3>
+          <p>Marina or Riviera are the best choices for first-time Oceania cruisers. These Marina Class ships offer the full range of Oceania amenities — Jacques Bistro, Red Ginger, Polo Grill, Toscana, the Culinary Center cooking classes, and the Canyon Ranch SpaClub — in a midsize 1,250-guest package that feels intimate without sacrificing variety. See our <a href="/first-cruise.html">First Cruise Guide</a> for more tips.</p>
+
+          <h3>What are Oceania's ship classes?</h3>
+          <p>Oceania operates three ship classes: the <strong>Allura Class</strong> (Allura 2025, Vista 2023) — the newest 67K GT ships with 1,200 guests and the Aquamar Spa; the <strong>Marina Class</strong> (Marina 2011, Riviera 2012) — 66K GT ships with 1,250 guests that cemented "Finest Cuisine at Sea"; and the <strong>Regatta Class</strong> or R-Class (Regatta, Insignia, Nautica, Sirena) — intimate 30K GT vessels with just 684 guests and a country club casual atmosphere.</p>
+        </section>
+      </div>
+
+      <!-- Sidebar: Dress Code -->
+      <aside>
+        <section class="card">
+          <h2>Dress Code</h2>
+
+          <h3>Country Club Casual (Daytime)</h3>
+          <p>Resort wear, polos, sundresses, linen pants, and smart shorts. Think upscale resort — relaxed but polished. Swimwear stays at the pool deck.</p>
+
+          <h3>Smart Casual (Evenings)</h3>
+          <p>Collared shirts, blouses, dresses, slacks, or pantsuits. A step up from daytime but never stuffy. Jackets and blazers welcome but not required.</p>
+
+          <h3>No Formal Nights Required</h3>
+          <p>Oceania does not mandate formal nights — a welcome departure from traditional lines. Elegant attire is always welcomed and many guests dress up for special evenings, but you will never feel out of place in smart casual.</p>
+          <p class="tiny">Overall, Oceania's dress code is very relaxed compared to traditional premium and luxury lines. The emphasis is on comfort and understated elegance.</p>
+
+          <h3>Specialty Dining</h3>
+          <p class="tiny">Most specialty restaurants follow the smart casual standard. The Grand Dining Room and Polo Grill appreciate a slightly more polished look in the evening.</p>
+        </section>
+
+        <section class="card">
+          <h3>Quick Links</h3>
+          <ul>
+            <li><a href="/ships.html">All Ships (full fleet)</a></li>
+            <li><a href="/restaurants.html">All Restaurants</a></li>
+            <li><a href="/cruise-lines.html">Compare Cruise Lines</a></li>
+            <li><a href="/planning.html">Planning Hub</a></li>
+          </ul>
+        </section>
+      </aside>
+    </div>
+
+    <!-- ICP-Lite FAQ Section -->
+    <section class="card faq" id="icp-faq" style="margin: 1.5rem 0; padding: 1rem;">
+      <h2 style="margin: 0 0 1rem; font-size: 1.25rem;">Additional Information</h2>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What information does this page provide?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and information about Oceania Cruises. Use it alongside official cruise line resources when planning your trip.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides community insights and planning resources. Always confirm details with your cruise line or travel advisor before making final decisions.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How can I get more help?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">For additional assistance, contact your cruise line directly or work with a travel advisor who specializes in cruises.</p>
+      </details>
+    </section>
+
+    <!-- Soli Deo Gloria -->
+    <section class="card center">
+      <p class="tiny">All pages are offered as a gift to God. <em>Soli Deo Gloria.</em></p>
     </section>
 
     <!-- Related Resources -->
@@ -271,23 +443,6 @@ All work on this project is offered as a gift to God.
           <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
           <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
         </a>
-      </div>
-    </section>
-
-    <!-- FAQ -->
-    <section class="card faq" aria-labelledby="faq-heading">
-      <h2 id="faq-heading">Frequently Asked Questions</h2>
-      <div class="faq-item">
-        <h3>What makes Oceania Cruises unique?</h3>
-        <p>Oceania Cruises occupies the upper-premium segment with intimate mid-size ships carrying just 600-1200 guests. Their hallmark is culinary excellence — branded as The Finest Cuisine at Sea — with Jacques Pepin as executive culinary director. Destination-focused itineraries feature longer port stays, and the country club casual atmosphere appeals to experienced cruisers.</p>
-      </div>
-      <div class="faq-item">
-        <h3>What dining does Oceania Cruises offer?</h3>
-        <p>Oceania's dining program is curated by legendary chef Jacques Pepin and includes multiple open-seating specialty restaurants at no extra charge. From French fine dining at Jacques to Italian at Toscana and steaks at Polo Grill, every venue emphasizes fresh ingredients and culinary artistry that rivals top shoreside restaurants.</p>
-      </div>
-      <div class="faq-item">
-        <h3>How big are Oceania cruise ships?</h3>
-        <p>Oceania operates mid-size ships carrying 600-1200 guests, deliberately smaller than mainstream mega-ships. The R-class ships (Insignia, Nautica, Regatta, Sirena) carry around 670 guests, while the larger O-class (Marina, Riviera) and newest Allura-class (Allura, Vista) carry approximately 1,200 guests — still intimate by modern standards.</p>
       </div>
     </section>
   </div>

--- a/cruise-lines/regent.html
+++ b/cruise-lines/regent.html
@@ -30,7 +30,7 @@ All work on this project is offered as a gift to God.
 
   <!-- ICP-Lite v1.4: AI-First Metadata -->
   <meta name="ai-summary" content="Regent Seven Seas Cruises guide: ultra-luxury all-inclusive line with 7 all-suite ships (max 750 guests) featuring included shore excursions, fine dining, unlimited drinks, Wi-Fi, and gratuities. The Regent Suite is the most luxurious suite at sea."/>
-  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="last-reviewed" content="2026-01-31"/>
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- Canonical / Social -->
@@ -65,7 +65,7 @@ All work on this project is offered as a gift to God.
     "name": "Regent Seven Seas Cruises | In the Wake",
     "url": "https://cruisinginthewake.com/cruise-lines/regent.html",
     "description": "Regent Seven Seas Cruises guide: ultra-luxury all-inclusive line with 7 all-suite ships (max 750 guests) featuring included shore excursions, fine dining, unlimited drinks, Wi-Fi, and gratuities. The Regent Suite is the most luxurious suite at sea.",
-    "dateModified": "2026-01-30"
+    "dateModified": "2026-01-31"
   }
   </script>
 
@@ -97,6 +97,22 @@ All work on this project is offered as a gift to God.
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Regent Seven Seas offers itineraries across the Mediterranean, Northern Europe, Alaska, the Caribbean, Asia, South America, Australia, and Africa. They also operate annual World Cruises that circumnavigate the globe over several months."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which Regent ship is best for first-timers?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Seven Seas Splendor or Seven Seas Grandeur are ideal first Regent experiences. Both are Explorer Class ships with modern design, all-balcony suites, and the full range of Regent dining venues. They're large enough to offer variety but intimate enough (750 guests) that you'll feel personally attended to from embarkation."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are Regent's ship classes?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Regent operates four ship classes: Explorer Class (Seven Seas Explorer, Splendor, and Grandeur — 55K GT, 750 guests, the flagship trio), Voyager Class (Seven Seas Voyager — 42K GT, 700 guests, all-balcony pioneer), Navigator Class (Seven Seas Navigator — 28K GT, 490 guests, the most intimate vessel), and the upcoming Prestige Class (Prestige — 77K GT, expected 2027)."
         }
       }
     ]
@@ -228,24 +244,187 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
-    <section class="card" aria-labelledby="coming-soon-h">
-      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
-      <p>We're expanding our Regent Seven Seas Cruises coverage with in-depth ship profiles, dining venue breakdowns, suite guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Regent vessel — check back soon for comprehensive guides.</p>
-      <p>In the meantime, explore our <a href="/ships/regent/">Regent ship directory</a> for the fleet overview, or visit <a href="https://www.rssc.com" target="_blank" rel="noopener">RSSC.com</a> to browse current sailings.</p>
+    <!-- Ships by Class -->
+    <section id="ships" aria-labelledby="ships-h">
+      <h2 id="ships-h">Ships by Class</h2>
+
+      <div class="class-section">
+        <h3>Explorer Class</h3>
+        <p>55K GT, 750 guests. All-suite, all-balcony. The Regent Suite — the largest suite at sea at 4,443 sq ft. Compass Rose, Pacific Rim, Prime 7, Chartreuse. The pinnacle of inclusive luxury.</p>
+        <div class="ship-grid">
+          <a href="/ships/regent/seven-seas-explorer.html" class="ship-link">Seven Seas Explorer <span class="year">2016</span></a>
+          <a href="/ships/regent/seven-seas-splendor.html" class="ship-link">Seven Seas Splendor <span class="year">2020</span></a>
+          <a href="/ships/regent/seven-seas-grandeur.html" class="ship-link">Seven Seas Grandeur <span class="year">2023</span></a>
+        </div>
+      </div>
+
+      <div class="class-section">
+        <h3>Voyager Class</h3>
+        <p>42K GT, 700 guests. All-suite, all-balcony pioneer. Intimate, refined, with Compass Rose and Signatures French dining. Ideal for experienced luxury cruisers.</p>
+        <div class="ship-grid">
+          <a href="/ships/regent/seven-seas-voyager.html" class="ship-link">Seven Seas Voyager <span class="year">2003</span></a>
+        </div>
+      </div>
+
+      <div class="class-section">
+        <h3>Navigator Class</h3>
+        <p>28K GT, 490 guests. The fleet's most intimate vessel. All-suite with exceptional crew-to-guest ratio. Perfect for destination-intensive voyages where personal attention matters most.</p>
+        <div class="ship-grid">
+          <a href="/ships/regent/seven-seas-navigator.html" class="ship-link">Seven Seas Navigator <span class="year">1999</span></a>
+        </div>
+      </div>
+
+      <div class="class-section">
+        <h3>Prestige Class</h3>
+        <p>Next-generation 77K GT flagship. Details emerging — expected to redefine ultra-luxury at sea with expanded public spaces and new dining concepts.</p>
+        <div class="ship-grid">
+          <a href="/ships/regent/prestige.html" class="ship-link">Prestige <span class="year">2027 expected</span></a>
+        </div>
+      </div>
     </section>
 
-    <!-- Ships A-Z -->
-    <section id="ships" class="card" aria-labelledby="ships-h">
-      <h2 id="ships-h">Regent Seven Seas Fleet</h2>
-      <ul>
-        <li><a href="/ships/regent/prestige.html">Prestige</a></li>
-        <li><a href="/ships/regent/seven-seas-explorer.html">Seven Seas Explorer</a></li>
-        <li><a href="/ships/regent/seven-seas-grandeur.html">Seven Seas Grandeur</a></li>
-        <li><a href="/ships/regent/seven-seas-mariner.html">Seven Seas Mariner</a></li>
-        <li><a href="/ships/regent/seven-seas-navigator.html">Seven Seas Navigator</a></li>
-        <li><a href="/ships/regent/seven-seas-splendor.html">Seven Seas Splendor</a></li>
-        <li><a href="/ships/regent/seven-seas-voyager.html">Seven Seas Voyager</a></li>
-      </ul>
+    <!-- Gallery -->
+    <section class="card" aria-labelledby="gallery-h">
+      <h2 id="gallery-h">Gallery</h2>
+      <div class="grid-3">
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3c/Seven_Seas_Explorer_%28ship%2C_2016%29_001.jpg/1200px-Seven_Seas_Explorer_%28ship%2C_2016%29_001.jpg" alt="Seven Seas Explorer cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Seven_Seas_Explorer_(ship,_2016)_001.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ae/Seven_Seas_Splendor_01.jpg/1200px-Seven_Seas_Splendor_01.jpg" alt="Seven Seas Splendor cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Seven_Seas_Splendor_01.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <!-- Two-column: CTAs + Dress Code -->
+    <div class="two-col">
+      <div>
+        <!-- CTAs to Other Content -->
+        <section class="card">
+          <h2>Level Up Your Planning</h2>
+          <p>You've picked your line — now make your voyage unforgettable. These resources turn good cruises into great ones.</p>
+
+          <div class="cta-grid">
+            <a href="/restaurants.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Restaurants &amp; Menus</h3>
+              <p>Browse every dining venue — from Compass Rose to Prime 7 — with menus, dress codes, and honest reviews.</p>
+            </a>
+
+            <a href="/packing-lists.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Packing Lists</h3>
+              <p>Mediterranean or Alaska? Elegant casual or formal optional? Get ship-tested lists that fit your itinerary.</p>
+            </a>
+
+            <a href="/ports.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Port Guides</h3>
+              <p>What to do when you dock. Honest snapshots, DIY options, and accessibility notes for every port of call.</p>
+            </a>
+
+            <a href="/solo.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Solo Cruising</h3>
+              <p>First time sailing alone? Learn how to own your itinerary, find your people, and love the freedom.</p>
+            </a>
+
+            <a href="/first-cruise.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>First Cruise Guide</h3>
+              <p>New to cruising? Everything you need to know before you step aboard — from booking to disembarkation.</p>
+            </a>
+
+            <a href="/cruise-lines.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Compare Lines</h3>
+              <p>See how Regent stacks up against Silversea, Seabourn, Oceania, and other luxury lines.</p>
+            </a>
+          </div>
+        </section>
+      </div>
+
+      <!-- Right Rail: Dress Code -->
+      <aside>
+        <section class="card">
+          <h2>Dress Code</h2>
+
+          <h3>Casual Resort (Daytime)</h3>
+          <p>Resort wear, sundresses, polos, and smart shorts. Swimwear stays poolside; cover-ups for transitioning to indoor venues.</p>
+
+          <h3>Elegant Casual (Most Evenings)</h3>
+          <p>Open-collar dress shirts, slacks, dresses, blouses, and elegant separates. The standard for most evening dining across all restaurants.</p>
+
+          <h3>Optional Formal (Select Evenings)</h3>
+          <p>On longer voyages, select evenings invite dark suits, cocktail dresses, and evening gowns. These are optional — not mandatory — but guests tend to dress well.</p>
+          <p class="tiny">Regent is elegantly relaxed. There are no mandatory formal nights, but the atmosphere naturally encourages polished attire. Most guests appreciate the opportunity to dress up.</p>
+
+          <h3>Ashore</h3>
+          <p class="tiny">Modesty at churches and sacred sites is good seamanship. See local guidance on our <a href="/ports.html">Ports</a> pages.</p>
+        </section>
+
+        <section class="card">
+          <h3>Quick Links</h3>
+          <ul>
+            <li><a href="/ships/regent/">All Regent Ships</a></li>
+            <li><a href="/restaurants.html">All Restaurants</a></li>
+            <li><a href="/cruise-lines.html">Compare Cruise Lines</a></li>
+            <li><a href="/planning.html">Planning Hub</a></li>
+          </ul>
+        </section>
+      </aside>
+    </div>
+
+    <!-- FAQ -->
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <h3>What is included with Regent Seven Seas Cruises?</h3>
+        <p>Regent Seven Seas is the most inclusive luxury cruise line in the world. Every fare includes all-suite accommodations, unlimited shore excursions, specialty dining, unlimited beverages including fine wines and premium spirits, pre-paid gratuities, unlimited Wi-Fi, and roundtrip business-class airfare on select bookings.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What is the Regent Suite?</h3>
+        <p>The Regent Suite is widely regarded as the most luxurious suite at sea. Found aboard Seven Seas Explorer and Seven Seas Splendor, it spans over 4,443 square feet and features a private spa, grand living room, king-sized bed, and a sprawling private balcony with personal hot tub.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Where does Regent Seven Seas cruise?</h3>
+        <p>Regent Seven Seas offers itineraries across the Mediterranean, Northern Europe, Alaska, the Caribbean, Asia, South America, Australia, and Africa. They also operate annual World Cruises that circumnavigate the globe over several months.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Which Regent ship is best for first-timers?</h3>
+        <p>Seven Seas Splendor or Seven Seas Grandeur are ideal first Regent experiences. Both are Explorer Class ships with modern design, all-balcony suites, and the full range of Regent dining venues. They're large enough to offer variety but intimate enough (750 guests) that you'll feel personally attended to from embarkation. See our <a href="/first-cruise.html">First Cruise Guide</a> for more tips.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What are Regent's ship classes?</h3>
+        <p>Regent operates four ship classes: <strong>Explorer Class</strong> (Seven Seas Explorer, Splendor, and Grandeur — 55K GT, 750 guests, the flagship trio), <strong>Voyager Class</strong> (Seven Seas Voyager — 42K GT, 700 guests, all-balcony pioneer), <strong>Navigator Class</strong> (Seven Seas Navigator — 28K GT, 490 guests, the most intimate vessel), and the upcoming <strong>Prestige Class</strong> (Prestige — 77K GT, expected 2027).</p>
+      </div>
+    </section>
+
+    <!-- ICP-Lite FAQ Section -->
+    <section class="card faq" id="icp-faq" style="margin: 1.5rem 0; padding: 1rem;">
+      <h2 style="margin: 0 0 1rem; font-size: 1.25rem;">Additional Information</h2>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What information does this page provide?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and information about Regent Seven Seas Cruises. Use it alongside official cruise line resources when planning your trip.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides community insights and planning resources. Always confirm details with your cruise line or travel advisor before making final decisions.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How can I get more help?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">For additional assistance, contact your cruise line directly or work with a travel advisor who specializes in cruises.</p>
+      </details>
+    </section>
+
+    <!-- Soli Deo Gloria -->
+    <section class="card center">
+      <p class="tiny">All pages are offered as a gift to God. <em>Soli Deo Gloria.</em></p>
     </section>
 
     <!-- Related Resources -->
@@ -269,23 +448,6 @@ All work on this project is offered as a gift to God.
           <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
           <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
         </a>
-      </div>
-    </section>
-
-    <!-- FAQ -->
-    <section class="card faq" aria-labelledby="faq-heading">
-      <h2 id="faq-heading">Frequently Asked Questions</h2>
-      <div class="faq-item">
-        <h3>What is included with Regent Seven Seas Cruises?</h3>
-        <p>Regent Seven Seas is the most inclusive luxury cruise line in the world. Every fare includes all-suite accommodations, unlimited shore excursions, specialty dining, unlimited beverages including fine wines and premium spirits, pre-paid gratuities, unlimited Wi-Fi, and roundtrip business-class airfare on select bookings.</p>
-      </div>
-      <div class="faq-item">
-        <h3>What is the Regent Suite?</h3>
-        <p>The Regent Suite is widely regarded as the most luxurious suite at sea. Found aboard Seven Seas Explorer and Seven Seas Splendor, it spans over 4,000 square feet and features a private spa, grand living room, king-sized bed, and a sprawling private balcony with personal hot tub.</p>
-      </div>
-      <div class="faq-item">
-        <h3>Where does Regent Seven Seas cruise?</h3>
-        <p>Regent Seven Seas offers itineraries across the Mediterranean, Northern Europe, Alaska, the Caribbean, Asia, South America, Australia, and Africa. They also operate annual World Cruises that circumnavigate the globe over several months.</p>
       </div>
     </section>
   </div>

--- a/cruise-lines/seabourn.html
+++ b/cruise-lines/seabourn.html
@@ -30,7 +30,7 @@ All work on this project is offered as a gift to God.
 
   <!-- ICP-Lite v1.4: AI-First Metadata -->
   <meta name="ai-summary" content="Seabourn guide: ultra-luxury Carnival Corporation line with 7 intimate ships (450-600 guests), Thomas Keller dining, expedition vessels with submarines, and all-inclusive service. Explore fleet and planning resources."/>
-  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="last-reviewed" content="2026-01-31"/>
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- Canonical / Social -->
@@ -65,7 +65,7 @@ All work on this project is offered as a gift to God.
     "name": "Seabourn | In the Wake",
     "url": "https://cruisinginthewake.com/cruise-lines/seabourn.html",
     "description": "Seabourn guide: ultra-luxury Carnival Corporation line with 7 intimate ships (450-600 guests), Thomas Keller dining, expedition vessels with submarines, and all-inclusive service. Explore fleet and planning resources.",
-    "dateModified": "2026-01-30"
+    "dateModified": "2026-01-31"
   }
   </script>
 
@@ -97,6 +97,22 @@ All work on this project is offered as a gift to God.
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Seabourn sails the Mediterranean, Northern Europe, Antarctica, the Arctic, and Asia. The expedition ships (Venture and Pursuit) focus on polar and remote destinations, while the classic fleet covers luxury itineraries in the Mediterranean, Northern Europe, and Asia."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which Seabourn ship is best for first-timers?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The Ovation Class ships (Seabourn Ovation and Seabourn Encore) are the sweet spot for first-timers. At 604 guests they are Seabourn's largest vessels — still intimate by any standard — with the widest range of dining, the enhanced Retreat sundeck, and Adam D. Tihany interiors. They deliver the full Seabourn experience with the most variety onboard."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are Seabourn's ship classes?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Seabourn operates three ship classes: Expedition Class (Venture and Pursuit — purpose-built for polar cruising with submarines and Zodiacs), Odyssey Class (Odyssey, Sojourn, and Quest — all-suite, all-veranda ultra-luxury), and Ovation Class (Ovation and Encore — expanded designs with additional dining and The Retreat sundeck)."
         }
       }
     ]
@@ -228,24 +244,183 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
-    <section class="card" aria-labelledby="coming-soon-h">
-      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
-      <p>We're expanding our Seabourn coverage with in-depth ship profiles, dining venue breakdowns, stateroom guidance, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Seabourn vessel — check back soon for comprehensive guides.</p>
-      <p>In the meantime, explore our <a href="/ships/seabourn/">Seabourn ship directory</a> for the fleet overview, or visit <a href="https://www.seabourn.com" target="_blank" rel="noopener">Seabourn.com</a> to browse current sailings.</p>
+    <!-- Ships by Class -->
+    <section class="card" id="ships" aria-labelledby="ships-h">
+      <h2 id="ships-h">Ships by Class</h2>
+      <p class="tiny">Explore each ship's page for deck plans, dining venues, and stateroom guides. Classes ordered newest to oldest.</p>
+
+      <!-- Expedition Class -->
+      <div class="class-section">
+        <h3>Expedition Class</h3>
+        <p class="blurb">Purpose-built for polar and expedition cruising. 23K GT, 264 guests. PC6 ice-strengthened hull, two custom submarines, 24 Zodiac boats, kayaks, and a dedicated expedition team. Thomas Keller's The Grill by Thomas Keller onboard. These ships go where luxury has never gone before.</p>
+        <div class="ship-grid">
+          <a href="/ships/seabourn/seabourn-venture.html" class="ship-link">Seabourn Venture <span class="year">2022</span></a>
+          <a href="/ships/seabourn/seabourn-pursuit.html" class="ship-link">Seabourn Pursuit <span class="year">2023</span></a>
+        </div>
+      </div>
+
+      <!-- Odyssey Class -->
+      <div class="class-section">
+        <h3>Odyssey Class</h3>
+        <p class="blurb">All-suite, all-veranda intimate ultra-luxury. 32K GT, 458 guests. The Grill by Thomas Keller, Spa &amp; Wellness with Dr. Andrew Weil, and a Marina for water sports from the stern. The ships that defined modern Seabourn.</p>
+        <div class="ship-grid">
+          <a href="/ships/seabourn/seabourn-odyssey.html" class="ship-link">Seabourn Odyssey <span class="year">2009</span></a>
+          <a href="/ships/seabourn/seabourn-sojourn.html" class="ship-link">Seabourn Sojourn <span class="year">2010</span></a>
+          <a href="/ships/seabourn/seabourn-quest.html" class="ship-link">Seabourn Quest <span class="year">2011</span></a>
+        </div>
+      </div>
+
+      <!-- Ovation Class -->
+      <div class="class-section">
+        <h3>Ovation Class</h3>
+        <p class="blurb">The sweet spot of Seabourn luxury. 40K GT, 604 guests. Expanded Odyssey design with additional dining, The Retreat sundeck, and an enhanced spa. Adam D. Tihany interiors throughout. More space, same intimacy.</p>
+        <div class="ship-grid">
+          <a href="/ships/seabourn/seabourn-ovation.html" class="ship-link">Seabourn Ovation <span class="year">2018</span></a>
+          <a href="/ships/seabourn/seabourn-encore.html" class="ship-link">Seabourn Encore <span class="year">2016</span></a>
+        </div>
+      </div>
     </section>
 
-    <!-- Ships A-Z -->
-    <section id="ships" class="card" aria-labelledby="ships-h">
-      <h2 id="ships-h">Seabourn Fleet</h2>
-      <ul>
-        <li><a href="/ships/seabourn/seabourn-encore.html">Seabourn Encore</a></li>
-        <li><a href="/ships/seabourn/seabourn-odyssey.html">Seabourn Odyssey</a></li>
-        <li><a href="/ships/seabourn/seabourn-ovation.html">Seabourn Ovation</a></li>
-        <li><a href="/ships/seabourn/seabourn-pursuit.html">Seabourn Pursuit</a></li>
-        <li><a href="/ships/seabourn/seabourn-quest.html">Seabourn Quest</a></li>
-        <li><a href="/ships/seabourn/seabourn-sojourn.html">Seabourn Sojourn</a></li>
-        <li><a href="/ships/seabourn/seabourn-venture.html">Seabourn Venture</a></li>
-      </ul>
+    <!-- Gallery -->
+    <section class="card" aria-labelledby="gallery-h">
+      <h2 id="gallery-h">Gallery</h2>
+      <div class="grid two" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/Seabourn_Ovation_%28ship%2C_2018%29_001.jpg/1200px-Seabourn_Ovation_%28ship%2C_2018%29_001.jpg" alt="Seabourn Ovation cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Seabourn_Ovation_(ship,_2018)_001.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Seabourn_Quest_%28ship%2C_2011%29_001.jpg/1200px-Seabourn_Quest_%28ship%2C_2011%29_001.jpg" alt="Seabourn Quest cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Seabourn_Quest_(ship,_2011)_001.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <!-- Two-column: CTAs + Dress Code -->
+    <div class="two-col">
+      <div>
+        <!-- CTAs to Other Content -->
+        <section class="card">
+          <h2>Level Up Your Planning</h2>
+          <p>You've picked your ship class — now make your voyage unforgettable. These resources turn good cruises into great ones.</p>
+
+          <div class="cta-grid">
+            <a href="/restaurants.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Restaurants &amp; Menus</h3>
+              <p>Browse every dining venue with menus, dress codes, and honest reviews. Know what to book before you board.</p>
+            </a>
+
+            <a href="/packing-lists.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Packing Lists</h3>
+              <p>Mediterranean or Antarctica? Formal night or resort casual? Get ship-tested lists that fit your itinerary.</p>
+            </a>
+
+            <a href="/ports.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Port Guides</h3>
+              <p>What to do when you dock. Honest snapshots, DIY options, and accessibility notes for every port of call.</p>
+            </a>
+
+            <a href="/solo.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Solo Cruising</h3>
+              <p>First time sailing alone? Learn how to own your itinerary, find your people, and love the freedom.</p>
+            </a>
+
+            <a href="/first-cruise.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>First Cruise Guide</h3>
+              <p>New to cruising? Our step-by-step guide covers everything from booking to disembarkation.</p>
+            </a>
+
+            <a href="/cruise-lines.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Compare Lines</h3>
+              <p>See how Seabourn stacks up against Silversea, Regent, and other ultra-luxury lines.</p>
+            </a>
+          </div>
+        </section>
+      </div>
+
+      <!-- Right Rail: Dress Code -->
+      <aside>
+        <section class="card">
+          <h2>Dress Code</h2>
+
+          <h3>Resort Casual (Daytime)</h3>
+          <p>Elegant resort wear, sundresses, linen shirts, tailored shorts. Seabourn's daytime vibe is relaxed but polished — think upscale resort, not beach bar.</p>
+
+          <h3>Elegant Casual (Most Evenings)</h3>
+          <p>Dresses, smart separates, slacks with collared shirts. No jacket required. This is Seabourn's standard evening dress — guests dress well by choice, not obligation.</p>
+
+          <h3>Formal Optional (Select Evenings)</h3>
+          <p>On longer voyages, select evenings are designated Formal Optional. Cocktail dresses, suits, or tuxedos are welcomed but never enforced. Elegant Casual remains perfectly acceptable.</p>
+
+          <p class="tiny">Seabourn is relaxed luxury — the atmosphere naturally encourages guests to dress well without rigid enforcement. You'll feel the elegance in the room and want to match it.</p>
+        </section>
+
+        <section class="card">
+          <h3>Quick Links</h3>
+          <ul>
+            <li><a href="/ships.html">All Ships (full fleet)</a></li>
+            <li><a href="/restaurants.html">All Restaurants</a></li>
+            <li><a href="/cruise-lines.html">Compare Cruise Lines</a></li>
+            <li><a href="/planning.html">Planning Hub</a></li>
+          </ul>
+        </section>
+      </aside>
+    </div>
+
+    <!-- FAQ -->
+    <section class="card faq" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <h3>What makes Seabourn unique?</h3>
+        <p>Seabourn is an ultra-luxury cruise line offering intimate ships with just 450-600 guests. The experience is fully all-inclusive — complimentary drinks, gratuities, and premium dining including The Grill by Thomas Keller. Expedition ships feature submarines and Zodiacs for polar and remote voyages.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What are Seabourn's expedition ships?</h3>
+        <p>Seabourn Venture and Seabourn Pursuit are purpose-built expedition ships featuring custom submarines, a fleet of Zodiacs, and the "Ventures by Seabourn" program. They sail to Antarctica, the Arctic, and other remote destinations while maintaining Seabourn's ultra-luxury standards.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Where does Seabourn cruise?</h3>
+        <p>Seabourn sails the Mediterranean, Northern Europe, Antarctica, the Arctic, and Asia. The expedition ships (Venture and Pursuit) focus on polar and remote destinations, while the classic fleet covers luxury itineraries in the Mediterranean, Northern Europe, and Asia.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Which Seabourn ship is best for first-timers?</h3>
+        <p>The Ovation Class ships (Seabourn Ovation and Seabourn Encore) are the sweet spot for first-timers. At 604 guests they are Seabourn's largest vessels — still intimate by any standard — with the widest range of dining, the enhanced Retreat sundeck, and Adam D. Tihany interiors. They deliver the full Seabourn experience with the most variety onboard.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What are Seabourn's ship classes?</h3>
+        <p>Seabourn operates three ship classes: <strong>Expedition Class</strong> (Venture and Pursuit — purpose-built for polar cruising with submarines and Zodiacs, 264 guests), <strong>Odyssey Class</strong> (Odyssey, Sojourn, and Quest — all-suite, all-veranda ultra-luxury, 458 guests), and <strong>Ovation Class</strong> (Ovation and Encore — expanded designs with additional dining and The Retreat sundeck, 604 guests).</p>
+      </div>
+    </section>
+
+    <!-- ICP-Lite FAQ Section -->
+    <section class="card faq" id="faq" style="margin: 1.5rem 0; padding: 1rem;">
+      <h2 style="margin: 0 0 1rem; font-size: 1.25rem;">More Questions</h2>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What information does this page provide?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and information about Seabourn. Use it alongside official cruise line resources when planning your trip.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides community insights and planning resources. Always confirm details with Seabourn or your travel advisor before making final decisions.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How can I get more help?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">For additional assistance, contact Seabourn directly or work with a travel advisor who specializes in ultra-luxury cruises.</p>
+      </details>
+    </section>
+
+    <!-- Soli Deo Gloria -->
+    <section class="card center">
+      <p class="tiny">All pages are offered as a gift to God. <em>Soli Deo Gloria.</em></p>
     </section>
 
     <!-- Related Resources -->
@@ -269,23 +444,6 @@ All work on this project is offered as a gift to God.
           <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
           <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
         </a>
-      </div>
-    </section>
-
-    <!-- FAQ -->
-    <section class="card faq" aria-labelledby="faq-heading">
-      <h2 id="faq-heading">Frequently Asked Questions</h2>
-      <div class="faq-item">
-        <h3>What makes Seabourn unique?</h3>
-        <p>Seabourn is an ultra-luxury cruise line offering intimate ships with just 450-600 guests. The experience is fully all-inclusive — complimentary drinks, gratuities, and premium dining including The Grill by Thomas Keller. Expedition ships feature submarines and Zodiacs for polar and remote voyages.</p>
-      </div>
-      <div class="faq-item">
-        <h3>What are Seabourn's expedition ships?</h3>
-        <p>Seabourn Venture and Seabourn Pursuit are purpose-built expedition ships featuring custom submarines, a fleet of Zodiacs, and the "Ventures by Seabourn" program. They sail to Antarctica, the Arctic, and other remote destinations while maintaining Seabourn's ultra-luxury standards.</p>
-      </div>
-      <div class="faq-item">
-        <h3>Where does Seabourn cruise?</h3>
-        <p>Seabourn sails the Mediterranean, Northern Europe, Antarctica, the Arctic, and Asia. The expedition ships (Venture and Pursuit) focus on polar and remote destinations, while the classic fleet covers luxury itineraries in the Mediterranean, Northern Europe, and Asia.</p>
       </div>
     </section>
   </div>

--- a/cruise-lines/silversea.html
+++ b/cruise-lines/silversea.html
@@ -30,7 +30,7 @@ All work on this project is offered as a gift to God.
 
   <!-- ICP-Lite v1.4: AI-First Metadata -->
   <meta name="ai-summary" content="Silversea Cruises guide: ultra-luxury Royal Caribbean Group line with 12 ships (100-728 guests), all-suite with butler service, S.A.L.T. culinary program, and expedition voyages to all 7 continents including Antarctica."/>
-  <meta name="last-reviewed" content="2026-01-30"/>
+  <meta name="last-reviewed" content="2026-01-31"/>
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- Canonical / Social -->
@@ -65,7 +65,7 @@ All work on this project is offered as a gift to God.
     "name": "Silversea Cruises | In the Wake",
     "url": "https://cruisinginthewake.com/cruise-lines/silversea.html",
     "description": "Silversea Cruises guide: ultra-luxury Royal Caribbean Group line with 12 ships (100-728 guests), all-suite with butler service, S.A.L.T. culinary program, and expedition voyages to all 7 continents including Antarctica.",
-    "dateModified": "2026-01-30"
+    "dateModified": "2026-01-31"
   }
   </script>
 
@@ -97,6 +97,22 @@ All work on this project is offered as a gift to God.
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "Silversea sails to over 900 destinations across all 7 continents. Popular itineraries include Antarctica, the Arctic, the Mediterranean, the Galapagos, and annual World Cruises. The expedition fleet reaches some of the most remote places on Earth."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which Silversea ship is best for first-timers?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Silver Muse or Silver Dawn are excellent choices for first-time Silversea guests. As Muse Class ships, they offer the full S.A.L.T. culinary experience, butler service in every suite, and a refined atmosphere with 596 guests — large enough for variety but small enough for personal attention. Silver Moon and Silver Dawn also feature the S.A.L.T. Lab and Kitchen for hands-on culinary immersion."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are Silversea's ship classes?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Silversea operates six ship classes: Nova Class (Silver Nova, Silver Ray) — the newest flagships with asymmetric design; Muse Class (Silver Muse, Silver Moon, Silver Dawn) — refined contemporary luxury; Spirit Class (Silver Spirit) — classic elegance lengthened in 2018; Shadow/Whisper Class (Silver Shadow, Silver Whisper) — intimate traditional luxury; Wind Class (Silver Wind) — the fleet's most intimate ship; and Expedition Class (Silver Origin, Silver Endeavour, Silver Cloud) — purpose-built for expedition cruising."
         }
       }
     ]
@@ -228,29 +244,215 @@ All work on this project is offered as a gift to God.
       </div>
     </section>
 
-    <section class="card" aria-labelledby="coming-soon-h">
-      <h2 id="coming-soon-h">Comprehensive Guides Coming Soon</h2>
-      <p>We're expanding our Silversea Cruises coverage with in-depth ship profiles, suite breakdowns, S.A.L.T. dining guides, expedition itinerary details, and the kind of insider knowledge that transforms a good cruise into a great one. Our team is actively charting every Silversea vessel — check back soon for comprehensive guides.</p>
-      <p>In the meantime, explore our <a href="/ships/silversea/">Silversea ship directory</a> for the fleet overview, or visit <a href="https://www.silversea.com" target="_blank" rel="noopener">Silversea.com</a> to browse current sailings.</p>
+    <!-- Ships by Class -->
+    <section class="card" id="ships" aria-labelledby="ships-h">
+      <h2 id="ships-h">Ships by Class</h2>
+      <p class="tiny">Explore each ship's page for suite guides, dining venues, and itinerary details. Classes ordered newest to classic.</p>
+
+      <!-- Nova Class -->
+      <div class="class-section">
+        <h3>Nova Class</h3>
+        <p class="blurb">The future of Silversea. At 54,000 GT and 728 guests, these are the line's largest ships — featuring an asymmetric design, the flagship S.A.L.T. (Sea And Land Taste) culinary program, 8 restaurants, an expansive pool deck, and the Otium spa.</p>
+        <div class="ship-grid">
+          <a href="/ships/silversea/silver-nova.html" class="ship-link">Silver Nova <span class="year">2023</span></a>
+          <a href="/ships/silversea/silver-ray.html" class="ship-link">Silver Ray <span class="year">2024</span></a>
+        </div>
+      </div>
+
+      <!-- Muse Class -->
+      <div class="class-section">
+        <h3>Muse Class</h3>
+        <p class="blurb">Refined contemporary luxury at 40,000 GT and 596 guests. S.A.L.T. Lab and Kitchen (Moon/Dawn), La Dame, Kaiseki, Atlantide. Butler service in every suite — the heart of the modern Silversea experience.</p>
+        <div class="ship-grid">
+          <a href="/ships/silversea/silver-muse.html" class="ship-link">Silver Muse <span class="year">2017</span></a>
+          <a href="/ships/silversea/silver-moon.html" class="ship-link">Silver Moon <span class="year">2020</span></a>
+          <a href="/ships/silversea/silver-dawn.html" class="ship-link">Silver Dawn <span class="year">2022</span></a>
+        </div>
+      </div>
+
+      <!-- Spirit Class -->
+      <div class="class-section">
+        <h3>Spirit Class</h3>
+        <p class="blurb">Classic Silversea elegance at 39,000 GT and 540 guests. Lengthened in 2018 with an additional deck, expanded pool area, and new dining venues including Arts Cafe, La Terrazza, and Indochine.</p>
+        <div class="ship-grid">
+          <a href="/ships/silversea/silver-spirit.html" class="ship-link">Silver Spirit <span class="year">2009</span></a>
+        </div>
+      </div>
+
+      <!-- Shadow/Whisper Class -->
+      <div class="class-section">
+        <h3>Shadow/Whisper Class</h3>
+        <p class="blurb">Intimate, traditional luxury at 28,000 GT and 382 guests. The Restaurant, La Terrazza, and an exceptional staff-to-guest ratio. Ideal for destination-focused voyages where personal service is paramount.</p>
+        <div class="ship-grid">
+          <a href="/ships/silversea/silver-shadow.html" class="ship-link">Silver Shadow <span class="year">2000</span></a>
+          <a href="/ships/silversea/silver-whisper.html" class="ship-link">Silver Whisper <span class="year">2001</span></a>
+        </div>
+      </div>
+
+      <!-- Wind Class -->
+      <div class="class-section">
+        <h3>Wind Class</h3>
+        <p class="blurb">The fleet's most intimate ship at 17,000 GT and just 274 guests. Zodiac-equipped for expedition-style landings on select voyages. Classic small-ship luxury at its finest.</p>
+        <div class="ship-grid">
+          <a href="/ships/silversea/silver-wind.html" class="ship-link">Silver Wind <span class="year">1995</span></a>
+        </div>
+      </div>
+
+      <!-- Expedition Class -->
+      <div class="class-section">
+        <h3>Expedition Class</h3>
+        <p class="blurb">Purpose-built or converted for expedition cruising. Zodiacs, expert expedition teams, and polar-capable hulls. Silver Origin is Galapagos-dedicated; Silver Endeavour and Silver Cloud reach Antarctica, the Arctic, and beyond.</p>
+        <div class="ship-grid">
+          <a href="/ships/silversea/silver-origin.html" class="ship-link">Silver Origin <span class="year">2021</span></a>
+          <a href="/ships/silversea/silver-endeavour.html" class="ship-link">Silver Endeavour <span class="year">2021</span></a>
+          <a href="/ships/silversea/silver-cloud.html" class="ship-link">Silver Cloud <span class="year">1994</span></a>
+        </div>
+      </div>
     </section>
 
-    <!-- Ships A-Z -->
-    <section id="ships" class="card" aria-labelledby="ships-h">
-      <h2 id="ships-h">Silversea Fleet</h2>
-      <ul>
-        <li><a href="/ships/silversea/silver-cloud.html">Silver Cloud</a></li>
-        <li><a href="/ships/silversea/silver-dawn.html">Silver Dawn</a></li>
-        <li><a href="/ships/silversea/silver-endeavour.html">Silver Endeavour</a></li>
-        <li><a href="/ships/silversea/silver-moon.html">Silver Moon</a></li>
-        <li><a href="/ships/silversea/silver-muse.html">Silver Muse</a></li>
-        <li><a href="/ships/silversea/silver-nova.html">Silver Nova</a></li>
-        <li><a href="/ships/silversea/silver-origin.html">Silver Origin</a></li>
-        <li><a href="/ships/silversea/silver-ray.html">Silver Ray</a></li>
-        <li><a href="/ships/silversea/silver-shadow.html">Silver Shadow</a></li>
-        <li><a href="/ships/silversea/silver-spirit.html">Silver Spirit</a></li>
-        <li><a href="/ships/silversea/silver-whisper.html">Silver Whisper</a></li>
-        <li><a href="/ships/silversea/silver-wind.html">Silver Wind</a></li>
-      </ul>
+    <!-- Gallery -->
+    <section class="card" aria-labelledby="gallery-h">
+      <h2 id="gallery-h">Gallery</h2>
+      <div class="grid two" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Silver_Muse_%28ship%2C_2017%29_001.jpg/1200px-Silver_Muse_%28ship%2C_2017%29_001.jpg" alt="Silver Muse cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Silver_Muse_(ship,_2017)_001.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+        <figure style="margin: 0;">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Silver_Nova_01.jpg/1200px-Silver_Nova_01.jpg" alt="Silver Nova cruise ship" loading="lazy" decoding="async" style="width: 100%; border-radius: 8px;">
+          <figcaption class="tiny" style="margin-top: 0.5rem;">Photo: <a href="https://commons.wikimedia.org/wiki/File:Silver_Nova_01.jpg" target="_blank" rel="noopener">Dickelbers</a> / Wikimedia Commons, <a href="https://creativecommons.org/licenses/by-sa/4.0" target="_blank" rel="noopener">CC BY-SA 4.0</a></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <!-- Two-column: CTAs + Dress Code -->
+    <div class="two-col">
+      <div>
+        <!-- CTAs to Other Content -->
+        <section class="card">
+          <h2>Level Up Your Planning</h2>
+          <p>You've chosen ultra-luxury — now make your Silversea voyage truly unforgettable. These resources turn good cruises into great ones.</p>
+
+          <div class="cta-grid">
+            <a href="/restaurants.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Restaurants &amp; Menus</h3>
+              <p>Browse every dining venue — from S.A.L.T. Kitchen to La Dame — with menus, dress expectations, and honest insights.</p>
+            </a>
+
+            <a href="/packing-lists.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Packing Lists</h3>
+              <p>Mediterranean or Antarctica? Formal night or expedition gear? Get ship-tested lists that fit your itinerary.</p>
+            </a>
+
+            <a href="/ports.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Port Guides</h3>
+              <p>What to do when you dock. Honest snapshots, DIY options, and accessibility notes for every port of call.</p>
+            </a>
+
+            <a href="/solo.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Solo Cruising</h3>
+              <p>First time sailing alone? Learn how to own your itinerary, find your people, and love the freedom.</p>
+            </a>
+
+            <a href="/first-cruise.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>First Cruise Guide</h3>
+              <p>New to cruising? Our step-by-step guide covers everything from booking to disembarkation day.</p>
+            </a>
+
+            <a href="/cruise-lines.html" class="cta-card">
+              <span class="arrow">&rarr;</span>
+              <h3>Compare Lines</h3>
+              <p>See how Silversea stacks up against Regent, Seabourn, Oceania, and every other line we cover.</p>
+            </a>
+          </div>
+        </section>
+
+        <!-- FAQ -->
+        <section class="card faq" aria-labelledby="faq-heading">
+          <h2 id="faq-heading">Frequently Asked Questions</h2>
+          <div class="faq-item">
+            <h3>What makes Silversea Cruises unique?</h3>
+            <p>Silversea combines Italian heritage with ultra-luxury cruising across 12 intimate ships carrying just 100 to 728 guests. Every suite includes butler service, and the line's S.A.L.T. (Sea and Land Taste) culinary program immerses guests in destination-inspired cuisine. Silversea's expedition fleet visits all 7 continents, including Antarctica and the Galapagos.</p>
+          </div>
+          <div class="faq-item">
+            <h3>What is included on a Silversea cruise?</h3>
+            <p>Silversea is all-inclusive: fares cover butler service for every suite, premium beverages, dining across all onboard restaurants, gratuities, and Wi-Fi. Expedition voyages also include shore excursions, expert lectures, and specialized gear like parkas and rubber boots.</p>
+          </div>
+          <div class="faq-item">
+            <h3>Where does Silversea cruise?</h3>
+            <p>Silversea sails to over 900 destinations across all 7 continents. Popular itineraries include Antarctica, the Arctic, the Mediterranean, the Galapagos, and annual World Cruises. The expedition fleet reaches some of the most remote places on Earth.</p>
+          </div>
+          <div class="faq-item">
+            <h3>Which Silversea ship is best for first-timers?</h3>
+            <p>Silver Muse or Silver Dawn are excellent choices for first-time Silversea guests. As Muse Class ships, they offer the full S.A.L.T. culinary experience, butler service in every suite, and a refined atmosphere with 596 guests — large enough for variety but small enough for personal attention. Silver Moon and Silver Dawn also feature the S.A.L.T. Lab and Kitchen for hands-on culinary immersion.</p>
+          </div>
+          <div class="faq-item">
+            <h3>What are Silversea's ship classes?</h3>
+            <p>Silversea operates six ship classes: <strong>Nova Class</strong> (Silver Nova, Silver Ray) — the newest flagships with asymmetric design; <strong>Muse Class</strong> (Silver Muse, Silver Moon, Silver Dawn) — refined contemporary luxury; <strong>Spirit Class</strong> (Silver Spirit) — classic elegance; <strong>Shadow/Whisper Class</strong> (Silver Shadow, Silver Whisper) — intimate traditional luxury; <strong>Wind Class</strong> (Silver Wind) — the fleet's most intimate ship; and <strong>Expedition Class</strong> (Silver Origin, Silver Endeavour, Silver Cloud) — purpose-built for expedition cruising.</p>
+          </div>
+        </section>
+      </div>
+
+      <!-- Sidebar: Dress Code -->
+      <aside>
+        <section class="card">
+          <h2>Dress Code</h2>
+
+          <h3>Casual (Daytime)</h3>
+          <p>Resort wear — sundresses, linen, polos, and smart shorts. Silversea's daytime atmosphere is relaxed but polished. Pool deck attire stays poolside.</p>
+
+          <h3>Informal (Most Evenings)</h3>
+          <p>Open-collar shirts, blouses, dresses, and elegant separates. This is the standard evening dress code on most nights — think stylish but unstudied.</p>
+
+          <h3>Formal (Select Evenings)</h3>
+          <p>Dark suits, cocktail dresses, and evening gowns. Formal nights are fewer but cherished — Silversea guests rise to the occasion with grace.</p>
+
+          <p class="tiny">Butler service means your wardrobe travels effortlessly. Your butler will unpack, press, and organize — so bring what you love and let them handle the rest.</p>
+
+          <h3>Ashore</h3>
+          <p class="tiny">Modesty at churches and sacred sites is good seamanship. See local guidance on our <a href="/ports.html">Ports</a> pages.</p>
+        </section>
+
+        <section class="card">
+          <h3>Quick Links</h3>
+          <ul>
+            <li><a href="/ships.html">All Ships (full fleet)</a></li>
+            <li><a href="/restaurants.html">All Restaurants</a></li>
+            <li><a href="/cruise-lines.html">Compare Cruise Lines</a></li>
+            <li><a href="/planning.html">Planning Hub</a></li>
+          </ul>
+        </section>
+      </aside>
+    </div>
+
+    <!-- ICP-Lite FAQ Section -->
+    <section class="card faq" id="icp-faq" style="margin: 1.5rem 0; padding: 1rem;">
+      <h2 style="margin: 0 0 1rem; font-size: 1.25rem;">About This Page</h2>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What information does this page provide?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and information about Silversea Cruises. Use it alongside official cruise line resources when planning your trip.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides community insights and planning resources. Always confirm details with Silversea or your travel advisor before making final decisions.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How can I get more help?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">For additional assistance, contact Silversea directly or work with a travel advisor who specializes in ultra-luxury cruises.</p>
+      </details>
+    </section>
+
+    <!-- Soli Deo Gloria -->
+    <section class="card center">
+      <p class="tiny">All pages are offered as a gift to God. <em>Soli Deo Gloria.</em></p>
     </section>
 
     <!-- Related Resources -->
@@ -274,23 +476,6 @@ All work on this project is offered as a gift to God.
           <strong style="display: block; color: #0e6e8e; margin-bottom: 0.25rem;">Planning Hub</strong>
           <span class="tiny" style="color: #5a7a8a;">All planning tools</span>
         </a>
-      </div>
-    </section>
-
-    <!-- FAQ -->
-    <section class="card faq" aria-labelledby="faq-heading">
-      <h2 id="faq-heading">Frequently Asked Questions</h2>
-      <div class="faq-item">
-        <h3>What makes Silversea Cruises unique?</h3>
-        <p>Silversea combines Italian heritage with ultra-luxury cruising across 12 intimate ships carrying just 100 to 728 guests. Every suite includes butler service, and the line's S.A.L.T. (Sea and Land Taste) culinary program immerses guests in destination-inspired cuisine. Silversea's expedition fleet visits all 7 continents, including Antarctica and the Galapagos.</p>
-      </div>
-      <div class="faq-item">
-        <h3>What is included on a Silversea cruise?</h3>
-        <p>Silversea is all-inclusive: fares cover butler service for every suite, premium beverages, dining across all onboard restaurants, gratuities, and Wi-Fi. Expedition voyages also include shore excursions, expert lectures, and specialized gear like parkas and rubber boots.</p>
-      </div>
-      <div class="faq-item">
-        <h3>Where does Silversea cruise?</h3>
-        <p>Silversea sails to over 900 destinations across all 7 continents. Popular itineraries include Antarctica, the Arctic, the Mediterranean, the Galapagos, and annual World Cruises. The expedition fleet reaches some of the most remote places on Earth.</p>
       </div>
     </section>
   </div>

--- a/ships/costa/index.html
+++ b/ships/costa/index.html
@@ -17,8 +17,8 @@ Soli Deo Gloria
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <meta name="description" content="Explore all Costa Cruises ships. Detailed guides, specifications, and reviews."/>
-  <meta name="ai-summary" content="Complete guide to Costa Cruises ships including specifications, reviews, and comparisons.">
-  <meta name="last-reviewed" content="2026-01-02">
+  <meta name="ai-summary" content="Complete guide to Costa Cruises' 9-ship fleet organized by class: Excellence, Dream, Concordia, Musica, and Spirit classes with signature venues and ship comparisons.">
+  <meta name="last-reviewed" content="2026-01-31">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
@@ -147,25 +147,84 @@ Soli Deo Gloria
       <span>Costa Cruises</span>
     </nav>
 
-    <h1>Costa Cruises Ships</h1>
-    <p>Explore our guides to Costa Cruises cruise ships.</p>
+    <article class="card prose">
+      <h1>Costa Cruises Fleet</h1>
 
-    <section class="card">
-      <h2>Fleet</h2>
-      <ul class="ship-list">
-            <li><a href="costa-toscana.html">Costa Toscana</a></li>
-            <li><a href="costa-smeralda.html">Costa Smeralda</a></li>
-            <li><a href="costa-firenze.html">Costa Firenze</a></li>
-            <li><a href="costa-venezia.html">Costa Venezia</a></li>
-            <li><a href="costa-diadema.html">Costa Diadema</a></li>
-            <li><a href="costa-pacifica.html">Costa Pacifica</a></li>
-            <li><a href="costa-favolosa.html">Costa Favolosa</a></li>
-            <li><a href="costa-fascinosa.html">Costa Fascinosa</a></li>
-            <li><a href="costa-deliziosa.html">Costa Deliziosa</a></li>
-      </ul>
-    </section>
+      <p>Welcome aboard Costa Cruises! The fleet of 9 ships brings la dolce vita to every voyage — from the LNG-powered Excellence Class flagships to intimate Spirit Class vessels. Italian heritage, authentic cuisine, and Mediterranean itineraries define the Costa experience.</p>
 
-    <p><a href="/ships.html" class="btn">View All Ships</a> | <a href="/tools/ship-size-atlas.html" class="btn">Ship Size Atlas</a></p>
+      <!-- Navigation Links -->
+      <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0;">
+        <a href="/cruise-lines/costa.html" class="pill">Costa Cruises Guide</a>
+        <a href="/ships/quiz.html" class="pill">Ship Quiz</a>
+        <a href="/packing-lists.html" class="pill">Packing Lists</a>
+      </div>
+
+      <!-- Excellence Class -->
+      <section class="ship-class-section" style="margin-top: 2rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0057b8;">
+        <h2 style="margin-top: 0; color: #0057b8;">Excellence Class</h2>
+        <p>Costa's LNG-powered flagships at 185K GT. Colosseo atrium, 13 restaurants, Solemio Spa. Italian piazza concept at its grandest.</p>
+        <p><strong>Signature venues:</strong> Colosseo Atrium, Solemio Spa, Teppanyaki, Piazza Colosseo</p>
+        <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+          <li><a href="/ships/costa/costa-smeralda.html" class="pill">Costa Smeralda</a></li>
+          <li><a href="/ships/costa/costa-toscana.html" class="pill">Costa Toscana</a></li>
+        </ul>
+      </section>
+
+      <!-- Dream Class -->
+      <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0057b8;">
+        <h2 style="margin-top: 0; color: #0057b8;">Dream Class</h2>
+        <p>Italian-themed ships on a Vista-class platform at 135K GT. Piazza Colosseo, Mediterranean flair, vibrant entertainment.</p>
+        <p><strong>Signature venues:</strong> Piazza Colosseo, Samsara Spa, Pizzeria Pummid'Oro</p>
+        <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+          <li><a href="/ships/costa/costa-firenze.html" class="pill">Costa Firenze</a></li>
+          <li><a href="/ships/costa/costa-venezia.html" class="pill">Costa Venezia</a></li>
+        </ul>
+      </section>
+
+      <!-- Concordia Class -->
+      <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0057b8;">
+        <h2 style="margin-top: 0; color: #0057b8;">Concordia Class</h2>
+        <p>Mid-size 114K GT workhorses with Samsara Spa, grand piazzas, and classic Costa style. Reliable Mediterranean favorites.</p>
+        <p><strong>Signature venues:</strong> Samsara Spa, Grand Bar, Pizzeria Pummid'Oro, Lido Restaurant</p>
+        <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+          <li><a href="/ships/costa/costa-diadema.html" class="pill">Costa Diadema</a></li>
+          <li><a href="/ships/costa/costa-fascinosa.html" class="pill">Costa Fascinosa</a></li>
+          <li><a href="/ships/costa/costa-favolosa.html" class="pill">Costa Favolosa</a></li>
+        </ul>
+      </section>
+
+      <!-- Musica Class -->
+      <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0057b8;">
+        <h2 style="margin-top: 0; color: #0057b8;">Musica Class</h2>
+        <p>114K GT with music-themed decor and Mediterranean character.</p>
+        <p><strong>Signature venues:</strong> Samsara Spa, Grand Bar, Lido Restaurant</p>
+        <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+          <li><a href="/ships/costa/costa-pacifica.html" class="pill">Costa Pacifica</a></li>
+        </ul>
+      </section>
+
+      <!-- Spirit Class -->
+      <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #6b7280;">
+        <h2 style="margin-top: 0; color: #6b7280;">Spirit Class</h2>
+        <p>Intimate 92K GT vessel. Refined Italian atmosphere ideal for longer voyages.</p>
+        <p><strong>Signature venues:</strong> Samsara Spa, Aperitivo Bar</p>
+        <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+          <li><a href="/ships/costa/costa-deliziosa.html" class="pill">Costa Deliziosa</a></li>
+        </ul>
+      </section>
+
+      <!-- Bottom Navigation -->
+      <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb;">
+        <p><strong>Ready to choose your ship?</strong></p>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.75rem;">
+          <a href="/ships/quiz.html" class="pill" style="background: #0057b8; color: white;">Take the Ship Quiz</a>
+          <a href="/cruise-lines/costa.html" class="pill">Costa Cruises Guide</a>
+          <a href="/ships.html" class="pill">Browse All Cruise Lines</a>
+          <a href="/packing-lists.html" class="pill">Packing Lists</a>
+        </div>
+      </div>
+
+    </article>
   </main>
 
   <footer class="wrap">

--- a/ships/cunard/index.html
+++ b/ships/cunard/index.html
@@ -17,8 +17,8 @@ Soli Deo Gloria
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <meta name="description" content="Explore all Cunard ships. Detailed guides, specifications, and reviews."/>
-  <meta name="ai-summary" content="Complete guide to Cunard ships including specifications, reviews, and comparisons.">
-  <meta name="last-reviewed" content="2026-01-02">
+  <meta name="ai-summary" content="Complete guide to Cunard's 4-ship fleet organized by class: Ocean Liner (Queen Mary 2), Queen Anne Class, and Vista Class with signature venues and ship comparisons.">
+  <meta name="last-reviewed" content="2026-01-31">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
@@ -147,20 +147,61 @@ Soli Deo Gloria
       <span>Cunard</span>
     </nav>
 
-    <h1>Cunard Ships</h1>
-    <p>Explore our guides to Cunard cruise ships.</p>
+    <article class="card prose">
+      <h1>Cunard Fleet</h1>
 
-    <section class="card">
-      <h2>Fleet</h2>
-      <ul class="ship-list">
-            <li><a href="queen-mary-2.html">Queen Mary 2</a></li>
-            <li><a href="queen-anne.html">Queen Anne</a></li>
-            <li><a href="queen-elizabeth.html">Queen Elizabeth</a></li>
-            <li><a href="queen-victoria.html">Queen Victoria</a></li>
-      </ul>
-    </section>
+      <p>Four legendary Queens carry forward 185 years of ocean liner heritage. From the only true ocean liner still in service — Queen Mary 2 with her scheduled Transatlantic crossings — to the newest Queen Anne with her reimagined public spaces, Cunard delivers white-glove service, Grill-class dining, and the art of elegant sea travel.</p>
 
-    <p><a href="/ships.html" class="btn">View All Ships</a> | <a href="/tools/ship-size-atlas.html" class="btn">Ship Size Atlas</a></p>
+      <!-- Navigation Links -->
+      <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0;">
+        <a href="/cruise-lines/cunard.html" class="pill">Cunard Guide</a>
+        <a href="/ships/quiz.html" class="pill">Ship Quiz</a>
+        <a href="/packing-lists.html" class="pill">Packing Lists</a>
+      </div>
+
+      <!-- Ocean Liner -->
+      <section class="ship-class-section" style="margin-top: 2rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1a1a2e;">
+        <h2 style="margin-top: 0; color: #1a1a2e;">Ocean Liner</h2>
+        <p>The only true ocean liner in service. 148K GT, 2,691 guests. Scheduled Transatlantic crossings between New York and Southampton. Kennels, planetarium, largest ballroom at sea.</p>
+        <p><strong>Signature venues:</strong> Queens Grill, Princess Grill, Britannia Restaurant, Royal Court Theatre, Commodore Club, Planetarium</p>
+        <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+          <li><a href="/ships/cunard/queen-mary-2.html" class="pill">Queen Mary 2</a></li>
+        </ul>
+      </section>
+
+      <!-- Queen Anne Class -->
+      <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1a1a2e;">
+        <h2 style="margin-top: 0; color: #1a1a2e;">Queen Anne Class</h2>
+        <p>Newest Queen at 113K GT. Reimagined public spaces, Pavilion pool with retractable roof, Bright Lights Society.</p>
+        <p><strong>Signature venues:</strong> Queens Room, The Pavilion, Bright Lights Society, Chart Room</p>
+        <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+          <li><a href="/ships/cunard/queen-anne.html" class="pill">Queen Anne</a></li>
+        </ul>
+      </section>
+
+      <!-- Vista Class -->
+      <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1a1a2e;">
+        <h2 style="margin-top: 0; color: #1a1a2e;">Vista Class</h2>
+        <p>90K GT sisters with Royal Court Theatre, Queens Room ballroom, Garden Lounges. Classic Cunard elegance with modern comfort.</p>
+        <p><strong>Signature venues:</strong> Royal Court Theatre, Queens Room, Commodore Club, Garden Lounge, Grills Dining</p>
+        <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+          <li><a href="/ships/cunard/queen-victoria.html" class="pill">Queen Victoria</a></li>
+          <li><a href="/ships/cunard/queen-elizabeth.html" class="pill">Queen Elizabeth</a></li>
+        </ul>
+      </section>
+
+      <!-- Bottom Navigation -->
+      <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb;">
+        <p><strong>Ready to choose your ship?</strong></p>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.75rem;">
+          <a href="/ships/quiz.html" class="pill" style="background: #1a1a2e; color: white;">Take the Ship Quiz</a>
+          <a href="/cruise-lines/cunard.html" class="pill">Cunard Guide</a>
+          <a href="/ships.html" class="pill">Browse All Cruise Lines</a>
+          <a href="/packing-lists.html" class="pill">Packing Lists</a>
+        </div>
+      </div>
+
+    </article>
   </main>
 
   <footer class="wrap">

--- a/ships/explora-journeys/index.html
+++ b/ships/explora-journeys/index.html
@@ -17,16 +17,10 @@ Soli Deo Gloria
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <meta name="description" content="Explore all Explora Journeys ships. Detailed guides, specifications, and reviews."/>
-  <meta name="ai-summary" content="Complete guide to Explora Journeys ships including specifications, reviews, and comparisons.">
-  <meta name="last-reviewed" content="2026-01-02">
+  <meta name="ai-summary" content="Complete guide to Explora Journeys' fleet organized by 3 generations: Generation I (active), Generation II (LNG-powered), and Generation III (hydrogen-ready), with signature venues and ship links.">
+  <meta name="last-reviewed" content="2026-01-31">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <link rel="stylesheet" href="/assets/styles.css"/>
-  <style>
-    .ship-list { list-style: none; padding: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
-    .ship-list li a { display: block; padding: 1rem; background: var(--bg-alt, #f5f5f5); border-radius: 6px; text-decoration: none; transition: background .2s; }
-    .ship-list li a:hover { background: var(--bg-hover, #e0e0e0); }
-  </style>
-
   <!-- JSON-LD: WebPage (ICP-Lite v1.4) -->
   <script type="application/ld+json">
   {
@@ -34,8 +28,8 @@ Soli Deo Gloria
     "@type": "WebPage",
     "name": "Explora Journeys Ships",
     "url": "https://cruisinginthewake.com/ships/explora-journeys/",
-    "description": "Complete guide to Explora Journeys ships including specifications, reviews, and comparisons.",
-    "dateModified": "2026-01-02",
+    "description": "Complete guide to Explora Journeys' fleet organized by 3 generations with signature venues and ship links.",
+    "dateModified": "2026-01-31",
     "isPartOf": {
       "@type": "WebSite",
       "name": "In the Wake",
@@ -147,22 +141,60 @@ Soli Deo Gloria
       <span>Explora Journeys</span>
     </nav>
 
-    <h1>Explora Journeys Ships</h1>
-    <p>Explore our guides to Explora Journeys cruise ships.</p>
+    <article class="card prose">
+    <h1>Explora Journeys Fleet</h1>
 
-    <section class="card">
-      <h2>Fleet</h2>
-      <ul class="ship-list">
-            <li><a href="explora-v.html">Explora V</a></li>
-            <li><a href="explora-vi.html">Explora VI</a></li>
-            <li><a href="explora-i.html">Explora I</a></li>
-            <li><a href="explora-ii.html">Explora II</a></li>
-            <li><a href="explora-iii.html">Explora III</a></li>
-            <li><a href="explora-iv.html">Explora IV</a></li>
+    <p>Explora Journeys is redefining luxury at sea — a brand-new line from the MSC Group delivering all-suite ocean residences with 18 dining experiences, butler service, and European sophistication. Six ships are planned across three generations, from the active Generation I vessels to future hydrogen-ready ships that will set new sustainability standards in luxury cruising.</p>
+
+    <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0;">
+      <a href="/cruise-lines/explora-journeys.html" class="pill">Explora Journeys Guide</a>
+      <a href="/ships/quiz.html" class="pill">Ship Quiz</a>
+      <a href="/packing-lists.html" class="pill">Packing Lists</a>
+    </div>
+
+    <!-- Generation I -->
+    <section class="ship-class-section" style="margin-top: 2rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1a1a2e;">
+      <h2 style="margin-top: 0; color: #1a1a2e;">Generation I</h2>
+      <p>63K GT, 922 guests. All-suite ocean residences with private terraces. 18 dining experiences. First ships from MSC Group's luxury brand.</p>
+      <p><strong>Signature venues:</strong> Sakura, Fil Rouge, Anthology, Emporium Marketplace, Helios Pool &amp; Bar, Ocean Wellness Spa</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/explora-journeys/explora-i.html" class="pill">Explora I</a></li>
+        <li><a href="/ships/explora-journeys/explora-ii.html" class="pill">Explora II</a></li>
       </ul>
     </section>
 
-    <p><a href="/ships.html" class="btn">View All Ships</a> | <a href="/tools/ship-size-atlas.html" class="btn">Ship Size Atlas</a></p>
+    <!-- Generation II (LNG-powered) -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1a1a2e;">
+      <h2 style="margin-top: 0; color: #1a1a2e;">Generation II (LNG-powered)</h2>
+      <p>Next-generation LNG-powered ships. Expected 63K GT with expanded public spaces and new dining concepts.</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/explora-journeys/explora-iii.html" class="pill">Explora III</a></li>
+        <li><a href="/ships/explora-journeys/explora-iv.html" class="pill">Explora IV</a></li>
+      </ul>
+    </section>
+
+    <!-- Generation III (Hydrogen-ready) -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #6b7280;">
+      <h2 style="margin-top: 0; color: #6b7280;">Generation III (Hydrogen-ready)</h2>
+      <p>Future hydrogen-ready vessels. Details emerging as the brand's long-term vision unfolds.</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/explora-journeys/explora-v.html" class="pill">Explora V</a></li>
+        <li><a href="/ships/explora-journeys/explora-vi.html" class="pill">Explora VI</a></li>
+      </ul>
+    </section>
+
+    <!-- Bottom Navigation -->
+    <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb;">
+      <p><strong>Ready to choose your ship?</strong></p>
+      <div style="display: flex; flex-wrap: wrap; gap: 0.75rem;">
+        <a href="/ships/quiz.html" class="pill" style="background: #1a1a2e; color: white;">Take the Ship Quiz</a>
+        <a href="/cruise-lines/explora-journeys.html" class="pill">Explora Journeys Guide</a>
+        <a href="/ships.html" class="pill">Browse All Cruise Lines</a>
+        <a href="/packing-lists.html" class="pill">Packing Lists</a>
+      </div>
+    </div>
+
+    </article>
   </main>
 
   <footer class="wrap">

--- a/ships/oceania/index.html
+++ b/ships/oceania/index.html
@@ -17,14 +17,13 @@ Soli Deo Gloria
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <meta name="description" content="Explore all Oceania Cruises ships. Detailed guides, specifications, and reviews."/>
-  <meta name="ai-summary" content="Complete guide to Oceania Cruises ships including specifications, reviews, and comparisons.">
-  <meta name="last-reviewed" content="2026-01-02">
+  <meta name="ai-summary" content="Complete guide to Oceania Cruises' 8-ship fleet organized by class: Allura, Marina, and Regatta (R-Class) with signature venues, dining highlights, and ship comparisons.">
+  <meta name="last-reviewed" content="2026-01-31">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
-    .ship-list { list-style: none; padding: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
-    .ship-list li a { display: block; padding: 1rem; background: var(--bg-alt, #f5f5f5); border-radius: 6px; text-decoration: none; transition: background .2s; }
-    .ship-list li a:hover { background: var(--bg-hover, #e0e0e0); }
+    .ship-class-section { margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; }
+    .ship-class-section:first-of-type { margin-top: 2rem; }
   </style>
 
   <!-- JSON-LD: WebPage (ICP-Lite v1.4) -->
@@ -148,23 +147,61 @@ Soli Deo Gloria
     </nav>
 
     <h1>Oceania Cruises Ships</h1>
-    <p>Explore our guides to Oceania Cruises cruise ships.</p>
 
-    <section class="card">
-      <h2>Fleet</h2>
-      <ul class="ship-list">
-            <li><a href="vista.html">Vista</a></li>
-            <li><a href="allura.html">Allura</a></li>
-            <li><a href="marina.html">Marina</a></li>
-            <li><a href="riviera.html">Riviera</a></li>
-            <li><a href="insignia.html">Insignia</a></li>
-            <li><a href="nautica.html">Nautica</a></li>
-            <li><a href="regatta.html">Regatta</a></li>
-            <li><a href="sirena.html">Sirena</a></li>
+    <p>Oceania Cruises proves that the finest things come in elegant packages. With 8 ships ranging from intimate 684-guest R-Class gems to the new 1,200-guest Allura Class, every vessel delivers the "Finest Cuisine at Sea" — including Jacques Pepin's signature dishes, Polo Grill steaks, and Toscana Italian. No mega-ship crowds, no formal nights required — just extraordinary dining and destination-rich itineraries.</p>
+
+    <!-- Navigation Links -->
+    <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0;">
+      <a href="/cruise-lines/oceania.html" class="pill">Oceania Guide</a>
+      <a href="/ships/quiz.html" class="pill">Ship Quiz</a>
+      <a href="/packing-lists.html" class="pill">Packing Lists</a>
+    </div>
+
+    <!-- Allura Class -->
+    <section class="ship-class-section" style="margin-top: 2rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1a5276;">
+      <h2 style="margin-top: 0; color: #1a5276;">Allura Class</h2>
+      <p>Newest 67K GT ships with 1,200 guests. Aquamar Spa + Vitality Center, redesigned dining. Oceania's most spacious vessels.</p>
+      <p><strong>Signature venues:</strong> Grand Dining Room, Polo Grill, Toscana, Jacques Bistro, Ember, Aquamar Spa</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/oceania/allura.html" class="pill">Allura</a></li>
+        <li><a href="/ships/oceania/vista.html" class="pill">Vista</a></li>
       </ul>
     </section>
 
-    <p><a href="/ships.html" class="btn">View All Ships</a> | <a href="/tools/ship-size-atlas.html" class="btn">Ship Size Atlas</a></p>
+    <!-- Marina Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1a5276;">
+      <h2 style="margin-top: 0; color: #1a5276;">Marina Class</h2>
+      <p>66K GT, 1,250 guests. Jacques Pepin's cuisine, Red Ginger, Polo Grill. The ships that cemented "Finest Cuisine at Sea."</p>
+      <p><strong>Signature venues:</strong> Jacques Bistro, Red Ginger, Polo Grill, Toscana, Grand Dining Room, Baristas</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/oceania/marina.html" class="pill">Marina</a></li>
+        <li><a href="/ships/oceania/riviera.html" class="pill">Riviera</a></li>
+      </ul>
+    </section>
+
+    <!-- Regatta Class (R-Class) -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1a5276;">
+      <h2 style="margin-top: 0; color: #1a5276;">Regatta Class (R-Class)</h2>
+      <p>Intimate 30K GT with 684 guests. Country club casual atmosphere, exceptional cuisine-to-guest ratio. Perfect for destination-intensive itineraries.</p>
+      <p><strong>Signature venues:</strong> Grand Dining Room, Polo Grill, Toscana, Terrace Cafe, Horizons</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/oceania/regatta.html" class="pill">Regatta</a></li>
+        <li><a href="/ships/oceania/insignia.html" class="pill">Insignia</a></li>
+        <li><a href="/ships/oceania/nautica.html" class="pill">Nautica</a></li>
+        <li><a href="/ships/oceania/sirena.html" class="pill">Sirena</a></li>
+      </ul>
+    </section>
+
+    <!-- Bottom Navigation -->
+    <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb;">
+      <p><strong>Ready to choose your ship?</strong></p>
+      <div style="display: flex; flex-wrap: wrap; gap: 0.75rem;">
+        <a href="/ships/quiz.html" class="pill" style="background: #1a5276; color: white;">Take the Ship Quiz</a>
+        <a href="/cruise-lines/oceania.html" class="pill">Oceania Guide</a>
+        <a href="/ships.html" class="pill">Browse All Cruise Lines</a>
+        <a href="/packing-lists.html" class="pill">Packing Lists</a>
+      </div>
+    </div>
   </main>
 
   <footer class="wrap">

--- a/ships/rcl/index.html
+++ b/ships/rcl/index.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+<html lang="en" class="no-js">
+<head>
+<!-- ai-breadcrumbs
+     entity: Royal Caribbean Fleet
+     type: Ship Information Page
+     parent: /ships.html
+     category: Royal Caribbean Fleet
+     cruise-line: Royal Caribbean
+     updated: 2026-01-31
+     expertise: Royal Caribbean ship reviews, deck plans, dining analysis, cabin comparisons
+     target-audience: Royal Caribbean cruisers, ship comparison researchers, first-time cruisers
+     answer-first: Complete guide to Royal Caribbean's fleet organized by class: Icon, Oasis, Quantum Ultra, Quantum, Freedom, Voyager, Radiance, and Vision classes with ship links and class descriptions.
+     -->
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Royal Caribbean Fleet Guide — All Ships by Class | In the Wake</title>
+  <meta name="description" content="Complete guide to Royal Caribbean's fleet organized by class: Icon, Oasis, Quantum Ultra, Quantum, Freedom, Voyager, Radiance, and Vision classes with signature features and ship comparisons."/>
+  <meta name="ai-summary" content="Complete guide to Royal Caribbean's fleet organized by 8 ship classes from Icon (250K GT) to Vision (78K GT), with signature features, ship links, and class comparisons."/>
+  <meta name="last-reviewed" content="2026-01-31"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4"/>
+
+  <link rel="canonical" href="https://cruisinginthewake.com/ships/rcl/"/>
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Royal Caribbean Fleet Guide — In the Wake"/>
+  <meta property="og:description" content="Explore Royal Caribbean's fleet organized by class with signature features and ship comparisons."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/ships/rcl/"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Royal Caribbean Fleet Guide — In the Wake"/>
+  <meta name="twitter:description" content="Complete guide to Royal Caribbean's fleet organized by class with signature features and ship comparisons."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
+
+  <!-- JSON-LD: Person (E-E-A-T) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ken Baker",
+    "url": "https://cruisinginthewake.com/about/ken-baker.html",
+    "jobTitle": "Cruise Research Analyst & Data Specialist",
+    "description": "Cruise industry analyst specializing in ship comparisons, deck plan analysis, and dining venue research.",
+    "knowsAbout": ["Cruise Ship Analysis","Deck Plans","Royal Caribbean","Cruise Dining","Ship Comparisons"]
+  }
+  </script>
+
+  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Royal Caribbean Fleet Guide — In the Wake",
+    "url": "https://cruisinginthewake.com/ships/rcl/",
+    "description": "Complete guide to Royal Caribbean's fleet organized by 8 ship classes from Icon (250K GT) to Vision (78K GT), with signature features, ship links, and class comparisons.",
+    "dateModified": "2026-01-31",
+    "mainEntity": {
+      "@type": "Product",
+      "name": "Royal Caribbean Fleet",
+      "category": "Cruise Ship",
+      "manufacturer": {
+        "@type": "Organization",
+        "name": "Royal Caribbean International"
+      }
+    }
+  }
+  </script>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+
+  <!-- LCP Optimization -->
+  <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
+  <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
+
+  <!-- Service Worker -->
+  <script>if('serviceWorker' in navigator){addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));}</script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+</head>
+
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <header class="site-header hero-header">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Tools <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Onboard <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+
+    <div class="hero" role="img" aria-label="Ship wake at sunrise">
+      <div class="latlon-grid" aria-hidden="true"></div>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.300" width="180" height="180" alt="" aria-hidden="true"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo &copy; Flickers of Majesty</a>
+      </div>
+    </div>
+  </header>
+
+<main id="main-content" class="wrap">
+  <article class="card prose">
+    <h1>Royal Caribbean Fleet</h1>
+
+    <p>The vacation revolution spans 28 active ships across 8 distinct classes — from the record-breaking Icon Class (the world's largest cruise ships at 250,800 GT) to the glass-wrapped Radiance Class vessels purpose-built for Alaska's glaciers. Whether you're chasing adrenaline on the FlowRider, exploring seven neighborhoods on an Oasis-class giant, or savoring intimate sea days on a Vision-class explorer, Royal Caribbean delivers experiences that make you say "I can't believe this is on a cruise ship."</p>
+
+    <p>Below you'll find every ship organized by class, from the newest flagships to the beloved classics. Each class has its own personality, signature venues, and sweet spots for different travelers.</p>
+
+    <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0;">
+      <a href="/cruise-lines/royal-caribbean.html" class="pill">Royal Caribbean Guide</a>
+      <a href="/ships/quiz.html" class="pill">Ship Quiz</a>
+      <a href="/packing-lists.html" class="pill">Packing Lists</a>
+    </div>
+
+    <!-- Icon Class -->
+    <section class="ship-class-section" style="margin-top: 2rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0e6e8e;">
+      <h2 style="margin-top: 0; color: #0e6e8e;">Icon Class</h2>
+      <p><strong>The newest flagships — floating cities with neighborhoods in the sky.</strong> At 250,800 GT and 7,600 guests, these are the world's largest cruise ships. AquaDome shows, Surfside family zones, Category 6 waterpark, Central Park with real trees, and 40+ dining and drinking options. The pinnacle of Royal Caribbean innovation.</p>
+      <p><strong>Signature venues:</strong> AquaDome, Central Park, Surfside, Category 6 Waterpark, The Pearl, Thrill Island</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/icon-of-the-seas.html" class="pill">Icon of the Seas</a></li>
+        <li><a href="/ships/rcl/star-of-the-seas.html" class="pill">Star of the Seas</a></li>
+        <li><a href="/ships/rcl/legend-of-the-seas-icon-class-entering-service-in-2026.html" class="pill">Legend of the Seas (2026)</a></li>
+        <li><a href="/ships/rcl/icon-class-ship-tbn-2027.html" class="pill">Icon Class TBN (2027)</a></li>
+        <li><a href="/ships/rcl/icon-class-ship-tbn-2028.html" class="pill">Icon Class TBN (2028)</a></li>
+      </ul>
+    </section>
+
+    <!-- Oasis Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0e6e8e;">
+      <h2 style="margin-top: 0; color: #0e6e8e;">Oasis Class</h2>
+      <p><strong>The original gamechangers that redefined cruising.</strong> Seven neighborhoods, AquaTheater diving shows, and the Boardwalk's hand-carved carousel. At 225,000+ GT and 5,400–6,600 guests, these mega-ships deliver jaw-dropping variety without feeling crowded. Perfect for families who want "wow" with their wake.</p>
+      <p><strong>Signature venues:</strong> AquaTheater, Boardwalk, Central Park, Royal Promenade, Ultimate Abyss, FlowRider</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/utopia-of-the-seas.html" class="pill">Utopia of the Seas</a></li>
+        <li><a href="/ships/rcl/wonder-of-the-seas.html" class="pill">Wonder of the Seas</a></li>
+        <li><a href="/ships/rcl/symphony-of-the-seas.html" class="pill">Symphony of the Seas</a></li>
+        <li><a href="/ships/rcl/harmony-of-the-seas.html" class="pill">Harmony of the Seas</a></li>
+        <li><a href="/ships/rcl/allure-of-the-seas.html" class="pill">Allure of the Seas</a></li>
+        <li><a href="/ships/rcl/oasis-of-the-seas.html" class="pill">Oasis of the Seas</a></li>
+        <li><a href="/ships/rcl/oasis-class-ship-tbn-2028.html" class="pill">Oasis Class TBN (2028)</a></li>
+      </ul>
+    </section>
+
+    <!-- Quantum Ultra Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0e6e8e;">
+      <h2 style="margin-top: 0; color: #0e6e8e;">Quantum Ultra Class</h2>
+      <p><strong>Quantum evolved for tropics and nightlife.</strong> SeaPlex glow parties, iFly skydiving, and North Star pods — same tech-forward DNA with warmer itineraries. At 169,000 GT and 4,900 guests, these ships bring Quantum innovation to Caribbean and Mediterranean routes.</p>
+      <p><strong>Signature venues:</strong> SeaPlex, North Star, Sky Pad, Playmakers Sports Bar, Music Hall</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/odyssey-of-the-seas.html" class="pill">Odyssey of the Seas</a></li>
+        <li><a href="/ships/rcl/spectrum-of-the-seas.html" class="pill">Spectrum of the Seas</a></li>
+        <li><a href="/ships/rcl/quantum-ultra-class-ship-tbn-2028.html" class="pill">QU Class TBN (2028)</a></li>
+        <li><a href="/ships/rcl/quantum-ultra-class-ship-tbn-2029.html" class="pill">QU Class TBN (2029)</a></li>
+      </ul>
+    </section>
+
+    <!-- Quantum Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0e6e8e;">
+      <h2 style="margin-top: 0; color: #0e6e8e;">Quantum Class</h2>
+      <p><strong>Technology meets exploration.</strong> North Star observation pods, RipCord skydiving, robotic bartenders at Bionic Bar. At 168,000 GT and 4,900 guests, smart weather flexibility meets surprising serenity. These ships pioneered the tech-forward cruising revolution.</p>
+      <p><strong>Signature venues:</strong> North Star, RipCord by iFly, Bionic Bar, Two70, SeaPlex</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/ovation-of-the-seas.html" class="pill">Ovation of the Seas</a></li>
+        <li><a href="/ships/rcl/anthem-of-the-seas.html" class="pill">Anthem of the Seas</a></li>
+        <li><a href="/ships/rcl/quantum-of-the-seas.html" class="pill">Quantum of the Seas</a></li>
+      </ul>
+    </section>
+
+    <!-- Freedom Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0e6e8e;">
+      <h2 style="margin-top: 0; color: #0e6e8e;">Freedom Class</h2>
+      <p><strong>The bridge between classic and colossal.</strong> FlowRider, promenade parades, and family-friendly scale without mega-ship crowds. At 154,000 GT and 3,600 guests, these proven favorites deliver spirited decks and excellent value.</p>
+      <p><strong>Signature venues:</strong> FlowRider, Royal Promenade, H2O Zone, Sabor, Giovanni's Table</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/independence-of-the-seas.html" class="pill">Independence of the Seas</a></li>
+        <li><a href="/ships/rcl/liberty-of-the-seas.html" class="pill">Liberty of the Seas</a></li>
+        <li><a href="/ships/rcl/freedom-of-the-seas.html" class="pill">Freedom of the Seas</a></li>
+      </ul>
+    </section>
+
+    <!-- Voyager Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0e6e8e;">
+      <h2 style="margin-top: 0; color: #0e6e8e;">Voyager Class</h2>
+      <p><strong>The trailblazers.</strong> First to skate at sea and stroll a true promenade. At 137,000 GT and 3,100 guests, these ships deliver a condensed mega-ship experience with warmth. Perfect for first-timers who want ice shows without overwhelming scale.</p>
+      <p><strong>Signature venues:</strong> Royal Promenade, Ice Skating Rink, Rock Climbing Wall, Studio B, Schooner Bar</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/mariner-of-the-seas.html" class="pill">Mariner of the Seas</a></li>
+        <li><a href="/ships/rcl/navigator-of-the-seas.html" class="pill">Navigator of the Seas</a></li>
+        <li><a href="/ships/rcl/adventure-of-the-seas.html" class="pill">Adventure of the Seas</a></li>
+        <li><a href="/ships/rcl/explorer-of-the-seas.html" class="pill">Explorer of the Seas</a></li>
+        <li><a href="/ships/rcl/voyager-of-the-seas.html" class="pill">Voyager of the Seas</a></li>
+      </ul>
+    </section>
+
+    <!-- Radiance Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0e6e8e;">
+      <h2 style="margin-top: 0; color: #0e6e8e;">Radiance Class</h2>
+      <p><strong>Glass-wrapped and purpose-built for scenery.</strong> Excels on Alaska glaciers and coastal itineraries. At 90,000 GT and 2,100 guests, bright atriums, Solarium calm, and excellent service meet smaller crowds and larger windows.</p>
+      <p><strong>Signature venues:</strong> Solarium, Chops Grille, Izumi, Viking Crown Lounge, Rock Climbing Wall</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/jewel-of-the-seas.html" class="pill">Jewel of the Seas</a></li>
+        <li><a href="/ships/rcl/serenade-of-the-seas.html" class="pill">Serenade of the Seas</a></li>
+        <li><a href="/ships/rcl/brilliance-of-the-seas.html" class="pill">Brilliance of the Seas</a></li>
+        <li><a href="/ships/rcl/radiance-of-the-seas.html" class="pill">Radiance of the Seas</a></li>
+      </ul>
+    </section>
+
+    <!-- Vision Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #0e6e8e;">
+      <h2 style="margin-top: 0; color: #0e6e8e;">Vision Class</h2>
+      <p><strong>The fleet's explorers — smaller, older, deeply loved.</strong> At 78,000 GT and 2,400 guests, intimacy and itinerary matter more than bells and whistles. Ideal for port-intensive voyages where connection matters most.</p>
+      <p><strong>Signature venues:</strong> Viking Crown Lounge, Schooner Bar, Solarium, Centrum</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/vision-of-the-seas.html" class="pill">Vision of the Seas</a></li>
+        <li><a href="/ships/rcl/enchantment-of-the-seas.html" class="pill">Enchantment of the Seas</a></li>
+        <li><a href="/ships/rcl/grandeur-of-the-seas.html" class="pill">Grandeur of the Seas</a></li>
+      </ul>
+    </section>
+
+    <!-- Discovery Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #6b7280;">
+      <h2 style="margin-top: 0; color: #6b7280;">Star Class (Future)</h2>
+      <p><strong>Details emerging.</strong> Royal Caribbean's next frontier in ship design, expected to push boundaries once again.</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/star-class-ship-tbn-2028.html" class="pill">Star Class TBN (2028)</a></li>
+        <li><a href="/ships/rcl/discovery-class-ship-tbn.html" class="pill">Discovery Class TBN</a></li>
+      </ul>
+    </section>
+
+    <!-- Heritage Fleet -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #6b7280;">
+      <h2 style="margin-top: 0; color: #6b7280;">Heritage Fleet</h2>
+      <p><strong>The ships that built a legacy.</strong> No longer sailing with Royal Caribbean, but their stories live on. These vessels pioneered innovations that define modern cruising.</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/rcl/sovereign-of-the-seas.html" class="pill">Sovereign of the Seas</a></li>
+        <li><a href="/ships/rcl/monarch-of-the-seas.html" class="pill">Monarch of the Seas</a></li>
+        <li><a href="/ships/rcl/majesty-of-the-seas.html" class="pill">Majesty of the Seas</a></li>
+        <li><a href="/ships/rcl/legend-of-the-seas-1995-built.html" class="pill">Legend of the Seas (1995)</a></li>
+        <li><a href="/ships/rcl/legend-of-the-seas.html" class="pill">Legend of the Seas</a></li>
+        <li><a href="/ships/rcl/splendour-of-the-seas.html" class="pill">Splendour of the Seas</a></li>
+        <li><a href="/ships/rcl/rhapsody-of-the-seas.html" class="pill">Rhapsody of the Seas</a></li>
+        <li><a href="/ships/rcl/nordic-empress.html" class="pill">Nordic Empress</a></li>
+        <li><a href="/ships/rcl/nordic-prince.html" class="pill">Nordic Prince</a></li>
+        <li><a href="/ships/rcl/song-of-america.html" class="pill">Song of America</a></li>
+        <li><a href="/ships/rcl/song-of-norway.html" class="pill">Song of Norway</a></li>
+        <li><a href="/ships/rcl/sun-viking.html" class="pill">Sun Viking</a></li>
+        <li><a href="/ships/rcl/viking-serenade.html" class="pill">Viking Serenade</a></li>
+      </ul>
+    </section>
+
+    <!-- Bottom Navigation -->
+    <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb;">
+      <p><strong>Ready to choose your ship?</strong></p>
+      <div style="display: flex; flex-wrap: wrap; gap: 0.75rem;">
+        <a href="/ships/quiz.html" class="pill" style="background: #0e6e8e; color: white;">Take the Ship Quiz</a>
+        <a href="/cruise-lines/royal-caribbean.html" class="pill">Royal Caribbean Guide</a>
+        <a href="/ships.html" class="pill">Browse All Cruise Lines</a>
+        <a href="/packing-lists.html" class="pill">Packing Lists</a>
+      </div>
+    </div>
+
+  </article>
+</main>
+
+  <footer class="wrap" role="contentinfo">
+    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p class="tiny" style="margin-top: 0.5rem;">
+      <a href="/privacy.html">Privacy</a> &middot;
+      <a href="/terms.html">Terms</a> &middot;
+      <a href="/about-us.html">About</a> &middot;
+      <a href="/accessibility.html">Accessibility &amp; WCAG 2.1 AA Commitment</a>
+    </p>
+    <p class="tiny center" style="opacity:0;position:absolute;pointer-events:none;" aria-hidden="true">Soli Deo Gloria &#10013;</p>
+    <p class="trust-badge">&#10003; No ads. Minimal analytics. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+  <script src="/assets/js/in-app-browser-escape.js"></script>
+  <script src="/assets/js/ship-port-links.js" defer></script>
+</body>
+</html>

--- a/ships/regent/index.html
+++ b/ships/regent/index.html
@@ -17,14 +17,13 @@ Soli Deo Gloria
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <meta name="description" content="Explore all Regent Seven Seas Cruises ships. Detailed guides, specifications, and reviews."/>
-  <meta name="ai-summary" content="Complete guide to Regent Seven Seas Cruises ships including specifications, reviews, and comparisons.">
-  <meta name="last-reviewed" content="2026-01-02">
+  <meta name="ai-summary" content="Complete guide to Regent Seven Seas Cruises' 5-ship fleet organized by class: Explorer, Voyager, Navigator, and Prestige (future) with signature venues, all-inclusive luxury details, and ship comparisons.">
+  <meta name="last-reviewed" content="2026-01-31">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
-    .ship-list { list-style: none; padding: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
-    .ship-list li a { display: block; padding: 1rem; background: var(--bg-alt, #f5f5f5); border-radius: 6px; text-decoration: none; transition: background .2s; }
-    .ship-list li a:hover { background: var(--bg-hover, #e0e0e0); }
+    .ship-class-section { margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; }
+    .ship-class-section:first-of-type { margin-top: 2rem; }
   </style>
 
   <!-- JSON-LD: WebPage (ICP-Lite v1.4) -->
@@ -148,22 +147,67 @@ Soli Deo Gloria
     </nav>
 
     <h1>Regent Seven Seas Cruises Ships</h1>
-    <p>Explore our guides to Regent Seven Seas Cruises cruise ships.</p>
 
-    <section class="card">
-      <h2>Fleet</h2>
-      <ul class="ship-list">
-            <li><a href="seven-seas-grandeur.html">Seven Seas Grandeur</a></li>
-            <li><a href="seven-seas-splendor.html">Seven Seas Splendor</a></li>
-            <li><a href="seven-seas-explorer.html">Seven Seas Explorer</a></li>
-            <li><a href="prestige.html">Prestige</a></li>
-            <li><a href="seven-seas-mariner.html">Seven Seas Mariner</a></li>
-            <li><a href="seven-seas-voyager.html">Seven Seas Voyager</a></li>
-            <li><a href="seven-seas-navigator.html">Seven Seas Navigator</a></li>
+    <p>Regent Seven Seas Cruises defines "all-inclusive luxury" — and means it. Every suite has a balcony. Every meal is included. Every shore excursion in every port is part of the fare. From the intimate 490-guest Seven Seas Navigator to the flagship Explorer Class with the largest suite at sea (4,443 sq ft Regent Suite), these 5 ships deliver an unmatched combination of space, cuisine, and genuine inclusion.</p>
+
+    <!-- Navigation Links -->
+    <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0;">
+      <a href="/cruise-lines/regent.html" class="pill">Regent Guide</a>
+      <a href="/ships/quiz.html" class="pill">Ship Quiz</a>
+      <a href="/packing-lists.html" class="pill">Packing Lists</a>
+    </div>
+
+    <!-- Explorer Class -->
+    <section class="ship-class-section" style="margin-top: 2rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1c2951;">
+      <h2 style="margin-top: 0; color: #1c2951;">Explorer Class</h2>
+      <p>55K GT, 750 guests. All-suite, all-balcony. Regent Suite (4,443 sq ft — largest at sea). The pinnacle of inclusive luxury.</p>
+      <p><strong>Signature venues:</strong> Compass Rose, Pacific Rim, Prime 7, Chartreuse, Coffee Connection, Pool Grill</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/regent/seven-seas-explorer.html" class="pill">Seven Seas Explorer</a></li>
+        <li><a href="/ships/regent/seven-seas-splendor.html" class="pill">Seven Seas Splendor</a></li>
+        <li><a href="/ships/regent/seven-seas-grandeur.html" class="pill">Seven Seas Grandeur</a></li>
       </ul>
     </section>
 
-    <p><a href="/ships.html" class="btn">View All Ships</a> | <a href="/tools/ship-size-atlas.html" class="btn">Ship Size Atlas</a></p>
+    <!-- Voyager Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1c2951;">
+      <h2 style="margin-top: 0; color: #1c2951;">Voyager Class</h2>
+      <p>42K GT, 700 guests. All-suite, all-balcony pioneer. Intimate and refined.</p>
+      <p><strong>Signature venues:</strong> Compass Rose, Signatures French, Prime 7, La Veranda, Pool Bar Grill</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/regent/seven-seas-voyager.html" class="pill">Seven Seas Voyager</a></li>
+      </ul>
+    </section>
+
+    <!-- Navigator Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #1c2951;">
+      <h2 style="margin-top: 0; color: #1c2951;">Navigator Class</h2>
+      <p>28K GT, 490 guests. The fleet's most intimate vessel. Exceptional crew-to-guest ratio.</p>
+      <p><strong>Signature venues:</strong> Compass Rose, Prime 7, La Veranda, Galileo's Lounge</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/regent/seven-seas-navigator.html" class="pill">Seven Seas Navigator</a></li>
+      </ul>
+    </section>
+
+    <!-- Prestige Class (Future) -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #6b7280;">
+      <h2 style="margin-top: 0; color: #6b7280;">Prestige Class (Future)</h2>
+      <p>Next-generation 77K GT flagship expected 2027. Details emerging — expected to redefine ultra-luxury.</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/regent/prestige.html" class="pill">Prestige</a></li>
+      </ul>
+    </section>
+
+    <!-- Bottom Navigation -->
+    <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb;">
+      <p><strong>Ready to choose your ship?</strong></p>
+      <div style="display: flex; flex-wrap: wrap; gap: 0.75rem;">
+        <a href="/ships/quiz.html" class="pill" style="background: #1c2951; color: white;">Take the Ship Quiz</a>
+        <a href="/cruise-lines/regent.html" class="pill">Regent Guide</a>
+        <a href="/ships.html" class="pill">Browse All Cruise Lines</a>
+        <a href="/packing-lists.html" class="pill">Packing Lists</a>
+      </div>
+    </div>
   </main>
 
   <footer class="wrap">

--- a/ships/seabourn/index.html
+++ b/ships/seabourn/index.html
@@ -17,16 +17,10 @@ Soli Deo Gloria
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <meta name="description" content="Explore all Seabourn ships. Detailed guides, specifications, and reviews."/>
-  <meta name="ai-summary" content="Complete guide to Seabourn ships including specifications, reviews, and comparisons.">
-  <meta name="last-reviewed" content="2026-01-02">
+  <meta name="ai-summary" content="Complete guide to Seabourn's fleet organized by 3 ship classes: Expedition (264 guests), Ovation (604 guests), and Odyssey (458 guests), with signature venues and ship links.">
+  <meta name="last-reviewed" content="2026-01-31">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <link rel="stylesheet" href="/assets/styles.css"/>
-  <style>
-    .ship-list { list-style: none; padding: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
-    .ship-list li a { display: block; padding: 1rem; background: var(--bg-alt, #f5f5f5); border-radius: 6px; text-decoration: none; transition: background .2s; }
-    .ship-list li a:hover { background: var(--bg-hover, #e0e0e0); }
-  </style>
-
   <!-- JSON-LD: WebPage (ICP-Lite v1.4) -->
   <script type="application/ld+json">
   {
@@ -34,8 +28,8 @@ Soli Deo Gloria
     "@type": "WebPage",
     "name": "Seabourn Ships",
     "url": "https://cruisinginthewake.com/ships/seabourn/",
-    "description": "Complete guide to Seabourn ships including specifications, reviews, and comparisons.",
-    "dateModified": "2026-01-02",
+    "description": "Complete guide to Seabourn's fleet organized by 3 ship classes: Expedition, Ovation, and Odyssey, with signature venues and ship links.",
+    "dateModified": "2026-01-31",
     "isPartOf": {
       "@type": "WebSite",
       "name": "In the Wake",
@@ -147,23 +141,63 @@ Soli Deo Gloria
       <span>Seabourn</span>
     </nav>
 
-    <h1>Seabourn Ships</h1>
-    <p>Explore our guides to Seabourn cruise ships.</p>
+    <article class="card prose">
+    <h1>Seabourn Fleet</h1>
 
-    <section class="card">
-      <h2>Fleet</h2>
-      <ul class="ship-list">
-            <li><a href="seabourn-ovation.html">Seabourn Ovation</a></li>
-            <li><a href="seabourn-encore.html">Seabourn Encore</a></li>
-            <li><a href="seabourn-quest.html">Seabourn Quest</a></li>
-            <li><a href="seabourn-sojourn.html">Seabourn Sojourn</a></li>
-            <li><a href="seabourn-odyssey.html">Seabourn Odyssey</a></li>
-            <li><a href="seabourn-venture.html">Seabourn Venture</a></li>
-            <li><a href="seabourn-pursuit.html">Seabourn Pursuit</a></li>
+    <p>Seabourn delivers ultra-luxury at an intimate scale — from expedition voyages with personal submarines to Mediterranean cruises with Thomas Keller dining. Seven ships across three classes serve just 264 to 604 guests each, with all-suite accommodations, open bars, and the kind of personalized service where the crew remembers your name and your drink.</p>
+
+    <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0;">
+      <a href="/cruise-lines/seabourn.html" class="pill">Seabourn Guide</a>
+      <a href="/ships/quiz.html" class="pill">Ship Quiz</a>
+      <a href="/packing-lists.html" class="pill">Packing Lists</a>
+    </div>
+
+    <!-- Expedition Class -->
+    <section class="ship-class-section" style="margin-top: 2rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #2c3e50;">
+      <h2 style="margin-top: 0; color: #2c3e50;">Expedition Class</h2>
+      <p>23K GT, 264 guests. Purpose-built for polar and expedition cruising. Two custom submarines, 24 Zodiacs, PC6 ice-strengthened hull.</p>
+      <p><strong>Signature venues:</strong> The Grill by Thomas Keller, The Restaurant, Earth &amp; Ocean, Sushi, Expedition Lounge</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/seabourn/seabourn-venture.html" class="pill">Seabourn Venture</a></li>
+        <li><a href="/ships/seabourn/seabourn-pursuit.html" class="pill">Seabourn Pursuit</a></li>
       </ul>
     </section>
 
-    <p><a href="/ships.html" class="btn">View All Ships</a> | <a href="/tools/ship-size-atlas.html" class="btn">Ship Size Atlas</a></p>
+    <!-- Ovation Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #2c3e50;">
+      <h2 style="margin-top: 0; color: #2c3e50;">Ovation Class</h2>
+      <p>40K GT, 604 guests. Expanded Odyssey design with The Retreat sundeck, enhanced spa. Adam D. Tihany interiors.</p>
+      <p><strong>Signature venues:</strong> The Grill by Thomas Keller, The Restaurant, Sushi, The Colonnade, Sky Bar, The Retreat</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/seabourn/seabourn-ovation.html" class="pill">Seabourn Ovation</a></li>
+        <li><a href="/ships/seabourn/seabourn-encore.html" class="pill">Seabourn Encore</a></li>
+      </ul>
+    </section>
+
+    <!-- Odyssey Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #2c3e50;">
+      <h2 style="margin-top: 0; color: #2c3e50;">Odyssey Class</h2>
+      <p>32K GT, 458 guests. All-suite, all-veranda. The Grill by Thomas Keller, Marina water sports platform.</p>
+      <p><strong>Signature venues:</strong> The Grill by Thomas Keller, The Restaurant, Earth &amp; Ocean, The Patio, Marina</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/seabourn/seabourn-odyssey.html" class="pill">Seabourn Odyssey</a></li>
+        <li><a href="/ships/seabourn/seabourn-sojourn.html" class="pill">Seabourn Sojourn</a></li>
+        <li><a href="/ships/seabourn/seabourn-quest.html" class="pill">Seabourn Quest</a></li>
+      </ul>
+    </section>
+
+    <!-- Bottom Navigation -->
+    <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb;">
+      <p><strong>Ready to choose your ship?</strong></p>
+      <div style="display: flex; flex-wrap: wrap; gap: 0.75rem;">
+        <a href="/ships/quiz.html" class="pill" style="background: #2c3e50; color: white;">Take the Ship Quiz</a>
+        <a href="/cruise-lines/seabourn.html" class="pill">Seabourn Guide</a>
+        <a href="/ships.html" class="pill">Browse All Cruise Lines</a>
+        <a href="/packing-lists.html" class="pill">Packing Lists</a>
+      </div>
+    </div>
+
+    </article>
   </main>
 
   <footer class="wrap">

--- a/ships/silversea/index.html
+++ b/ships/silversea/index.html
@@ -17,16 +17,10 @@ Soli Deo Gloria
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
   <meta name="description" content="Explore all Silversea Cruises ships. Detailed guides, specifications, and reviews."/>
-  <meta name="ai-summary" content="Complete guide to Silversea Cruises ships including specifications, reviews, and comparisons.">
-  <meta name="last-reviewed" content="2026-01-02">
+  <meta name="ai-summary" content="Complete guide to Silversea's fleet organized by 6 ship classes: Nova, Muse, Spirit, Shadow/Whisper, Wind, and Expedition, with signature venues and ship links.">
+  <meta name="last-reviewed" content="2026-01-31">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <link rel="stylesheet" href="/assets/styles.css"/>
-  <style>
-    .ship-list { list-style: none; padding: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
-    .ship-list li a { display: block; padding: 1rem; background: var(--bg-alt, #f5f5f5); border-radius: 6px; text-decoration: none; transition: background .2s; }
-    .ship-list li a:hover { background: var(--bg-hover, #e0e0e0); }
-  </style>
-
   <!-- JSON-LD: WebPage (ICP-Lite v1.4) -->
   <script type="application/ld+json">
   {
@@ -34,8 +28,8 @@ Soli Deo Gloria
     "@type": "WebPage",
     "name": "Silversea Cruises Ships",
     "url": "https://cruisinginthewake.com/ships/silversea/",
-    "description": "Complete guide to Silversea Cruises ships including specifications, reviews, and comparisons.",
-    "dateModified": "2026-01-02",
+    "description": "Complete guide to Silversea's fleet organized by 6 ship classes: Nova, Muse, Spirit, Shadow/Whisper, Wind, and Expedition, with signature venues and ship links.",
+    "dateModified": "2026-01-31",
     "isPartOf": {
       "@type": "WebSite",
       "name": "In the Wake",
@@ -147,28 +141,95 @@ Soli Deo Gloria
       <span>Silversea Cruises</span>
     </nav>
 
-    <h1>Silversea Cruises Ships</h1>
-    <p>Explore our guides to Silversea Cruises cruise ships.</p>
+    <article class="card prose">
+    <h1>Silversea Cruises Fleet</h1>
 
-    <section class="card">
-      <h2>Fleet</h2>
-      <ul class="ship-list">
-            <li><a href="silver-nova.html">Silver Nova</a></li>
-            <li><a href="silver-ray.html">Silver Ray</a></li>
-            <li><a href="silver-moon.html">Silver Moon</a></li>
-            <li><a href="silver-dawn.html">Silver Dawn</a></li>
-            <li><a href="silver-muse.html">Silver Muse</a></li>
-            <li><a href="silver-spirit.html">Silver Spirit</a></li>
-            <li><a href="silver-whisper.html">Silver Whisper</a></li>
-            <li><a href="silver-shadow.html">Silver Shadow</a></li>
-            <li><a href="silver-endeavour.html">Silver Endeavour</a></li>
-            <li><a href="silver-wind.html">Silver Wind</a></li>
-            <li><a href="silver-cloud.html">Silver Cloud</a></li>
-            <li><a href="silver-origin.html">Silver Origin</a></li>
+    <p>Silversea's 12 ships span the full spectrum of luxury cruising — from the cutting-edge Nova Class with its S.A.L.T. culinary program to the expedition fleet exploring Antarctica and the Galapagos. Butler service in every suite, open bars, and included gratuities are standard across the fleet. Whether you're drawn to the newest Nova Class innovations or the intimate 274-guest Silver Wind, Silversea delivers refined exploration.</p>
+
+    <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0;">
+      <a href="/cruise-lines/silversea.html" class="pill">Silversea Guide</a>
+      <a href="/ships/quiz.html" class="pill">Ship Quiz</a>
+      <a href="/packing-lists.html" class="pill">Packing Lists</a>
+    </div>
+
+    <!-- Nova Class -->
+    <section class="ship-class-section" style="margin-top: 2rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #4a4a4a;">
+      <h2 style="margin-top: 0; color: #4a4a4a;">Nova Class</h2>
+      <p>54K GT, 728 guests. Asymmetric design, S.A.L.T. culinary program, 8 restaurants. The future of Silversea.</p>
+      <p><strong>Signature venues:</strong> S.A.L.T. Kitchen, S.A.L.T. Lab, La Dame, Kaiseki, Atlantide, La Terrazza, Silver Note</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/silversea/silver-nova.html" class="pill">Silver Nova</a></li>
+        <li><a href="/ships/silversea/silver-ray.html" class="pill">Silver Ray</a></li>
       </ul>
     </section>
 
-    <p><a href="/ships.html" class="btn">View All Ships</a> | <a href="/tools/ship-size-atlas.html" class="btn">Ship Size Atlas</a></p>
+    <!-- Muse Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #4a4a4a;">
+      <h2 style="margin-top: 0; color: #4a4a4a;">Muse Class</h2>
+      <p>40K GT, 596 guests. Butler service in every suite. S.A.L.T. Lab and Kitchen on Moon/Dawn.</p>
+      <p><strong>Signature venues:</strong> La Dame, Kaiseki, Atlantide, La Terrazza, Silver Note, Indochine, S.A.L.T.</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/silversea/silver-muse.html" class="pill">Silver Muse</a></li>
+        <li><a href="/ships/silversea/silver-moon.html" class="pill">Silver Moon</a></li>
+        <li><a href="/ships/silversea/silver-dawn.html" class="pill">Silver Dawn</a></li>
+      </ul>
+    </section>
+
+    <!-- Spirit Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #4a4a4a;">
+      <h2 style="margin-top: 0; color: #4a4a4a;">Spirit Class</h2>
+      <p>39K GT, 540 guests. Lengthened in 2018 with additional deck and venues.</p>
+      <p><strong>Signature venues:</strong> La Terrazza, Indochine, Arts Cafe, The Restaurant, Pool Deck Grill</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/silversea/silver-spirit.html" class="pill">Silver Spirit</a></li>
+      </ul>
+    </section>
+
+    <!-- Shadow/Whisper Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #4a4a4a;">
+      <h2 style="margin-top: 0; color: #4a4a4a;">Shadow/Whisper Class</h2>
+      <p>28K GT, 382 guests. Intimate, traditional luxury with exceptional staff-to-guest ratio.</p>
+      <p><strong>Signature venues:</strong> The Restaurant, La Terrazza, The Bar, Panorama Lounge</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/silversea/silver-shadow.html" class="pill">Silver Shadow</a></li>
+        <li><a href="/ships/silversea/silver-whisper.html" class="pill">Silver Whisper</a></li>
+      </ul>
+    </section>
+
+    <!-- Wind Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #6b7280;">
+      <h2 style="margin-top: 0; color: #6b7280;">Wind Class</h2>
+      <p>17K GT, 274 guests. The fleet's most intimate ship. Classic small-ship luxury.</p>
+      <p><strong>Signature venues:</strong> The Restaurant, La Terrazza, The Bar</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/silversea/silver-wind.html" class="pill">Silver Wind</a></li>
+      </ul>
+    </section>
+
+    <!-- Expedition Class -->
+    <section class="ship-class-section" style="margin-top: 1.5rem; padding: 1.5rem; background: #f8fafc; border-radius: 12px; border-left: 4px solid #4a4a4a;">
+      <h2 style="margin-top: 0; color: #4a4a4a;">Expedition Class</h2>
+      <p>Purpose-built or converted for expedition cruising. Zodiacs, expedition teams, polar-capable.</p>
+      <p><strong>Signature venues:</strong> The Restaurant, La Terrazza, The Grill, Expedition Lounge</p>
+      <ul style="list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+        <li><a href="/ships/silversea/silver-origin.html" class="pill">Silver Origin</a></li>
+        <li><a href="/ships/silversea/silver-endeavour.html" class="pill">Silver Endeavour</a></li>
+        <li><a href="/ships/silversea/silver-cloud.html" class="pill">Silver Cloud</a></li>
+      </ul>
+    </section>
+
+    <!-- Bottom Navigation -->
+    <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #e5e7eb;">
+      <p><strong>Ready to choose your ship?</strong></p>
+      <div style="display: flex; flex-wrap: wrap; gap: 0.75rem;">
+        <a href="/ships/quiz.html" class="pill" style="background: #4a4a4a; color: white;">Take the Ship Quiz</a>
+        <a href="/cruise-lines/silversea.html" class="pill">Silversea Guide</a>
+        <a href="/ships.html" class="pill">Browse All Cruise Lines</a>
+        <a href="/packing-lists.html" class="pill">Packing Lists</a>
+      </div>
+    </div>
+
+    </article>
   </main>
 
   <footer class="wrap">


### PR DESCRIPTION
…index, upgrade 7 fleet indexes

Phase 2 of the ship page audit:

- Upgraded 7 cruise-lines pages (Costa, Cunard, Oceania, Regent, Seabourn, Silversea, Explora Journeys) from "Coming Soon" stubs to full content matching established pages — ship class organization, gallery sections, Level Up CTAs, dress code sidebars, expanded FAQs, ICP-Lite FAQ sections
- Created ships/rcl/index.html — RCL was the only line without a fleet index page. 10 class sections covering all 49 ship pages
- Upgraded 7 fleet index pages from flat ship lists to class-based organization matching Carnival's pattern
- Updated audit report with Phase 2 changes and remaining work items

16 files changed, 2346 insertions, 522 deletions

https://claude.ai/code/session_012FatAD4A6vdvKv4HpssbHu