### PR TITLE
feat: Expand 11 thin active-fleet ship pages with full content

### DIFF
--- a/ships/celebrity-cruises/celebrity-constellation.html
+++ b/ships/celebrity-cruises/celebrity-constellation.html
@@ -98,7 +98,7 @@ All work on this project is offered as a gift to God.
       "name": "What dining options are available on Celebrity Constellation?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Celebrity Constellation offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship class."
+        "text": "Celebrity Constellation features the two-story Metropolitan Restaurant (complimentary main dining), Luminae at The Retreat (suite-class exclusive), Blu (AquaClass exclusive), Tuscan Grille, Sushi on Five, Café al Bacio, and the Ocean View Café buffet."
       }
     },
     {
@@ -106,7 +106,7 @@ All work on this project is offered as a gift to God.
       "name": "How do I find the deck plans for Celebrity Constellation?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Deck plans are available through the links on this page or on the Unknown website."
+        "text": "Deck plans are available through the links on this page or on the Celebrity Cruises website."
       }
     },
     {
@@ -114,7 +114,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Celebrity Constellation sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Celebrity Constellation typically sails Mediterranean itineraries from Rome and Athens in summer, plus Northern Europe, Transatlantic repositioning, and Indian Ocean voyages seasonally. Check the Celebrity Cruises website for current schedules."
       }
     }
   ]
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Celebrity Constellation</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Constellation is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Constellation is a Millennium-class ship from Celebrity Cruises, carrying around 2,170 guests. Launched in 2002 at 90,940 GT, she was revolutionized during a 2019 bow-to-stern modernization that added the rooftop Retreat Sundeck, restyled Tuscan Grille, and new suite categories. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Celebrity Constellation or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers who want Celebrity's modern luxury on a mid-size ship. Constellation's intimate 2,170-guest capacity and Millennium-class layout make her ideal for Mediterranean, Northern Europe, and repositioning voyages.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
+          <li><strong>Class:</strong> Millennium Class (2002, modernized 2019)</li>
+          <li><strong>Size:</strong> 90,940 GT · 2,170 guests · 999 crew</li>
+          <li><strong>Decks:</strong> 11 passenger decks</li>
+          <li><strong>Home Ports:</strong> Rome (Civitavecchia), Athens (Piraeus), Fort Lauderdale</li>
+          <li><strong>Sister Ships:</strong> <a href="celebrity-millennium.html">Millennium</a>, <a href="celebrity-infinity.html">Infinity</a>, <a href="celebrity-summit.html">Summit</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Celebrity Constellation offers a memorable cruise experience with Celebrity Cruises. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Celebrity Constellation debuted in 2002 as the fourth Millennium-class ship and received a bow-to-stern Revolution makeover in 2019. The refresh brought The Retreat — an exclusive suite-class area with its own sundeck, lounge, and dedicated restaurant — plus redesigned staterooms throughout. At 965 feet long and 105 feet wide, she strikes a balance between spacious public areas and the intimate feel that sets mid-size ships apart.</p>
+          <p>Dining highlights include the redesigned Tuscan Grille for Italian-inspired steakhouse fare, Sushi on Five for fresh rolls at sea, and the beloved Blu restaurant exclusive to AquaClass guests. The two-story main dining room, Luminae at The Retreat, and the Ocean View Café round out a lineup that punches above her tonnage. The Canyon Ranch SpaClub, resort-style pool deck, and Celebrity's signature lawn-club–inspired open spaces give Constellation a distinct personality among her sisters.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>
@@ -320,7 +323,7 @@ All work on this project is offered as a gift to God.
 
   <section class="meta">
     <div><strong>Status</strong><br>Active</div>
-    <div><strong>Notes</strong><br>Millennium class, renovated 2013.</div>
+    <div><strong>Notes</strong><br>Millennium Class · Entered service 2002 · Revolution refit 2019 · 90,940 GT</div>
   </section>
 
     <footer class="wrap" role="contentinfo">
@@ -368,22 +371,27 @@ All work on this project is offered as a gift to God.
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Celebrity Constellation?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Constellation offers complimentary dining including the <a href="/restaurants/mdr.html">main dining room</a> and buffet. Specialty restaurants vary by ship class. Check the dining section above for specific venues.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Constellation features the two-story Metropolitan Restaurant (complimentary main dining), Luminae at The Retreat (suite-class exclusive), Blu (AquaClass exclusive), Tuscan Grille, Sushi on Five, Café al Bacio, and the Ocean View Café buffet. Specialty dining carries a cover charge or is included with certain suite categories.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I find the deck plans for Celebrity Constellation?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Unknown website or in the cruise planner app.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Celebrity Cruises website or in the cruise planner app.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Celebrity Constellation sail?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Celebrity Constellation.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Constellation typically sails Mediterranean itineraries from Rome and Athens in summer, plus Northern Europe, Transatlantic repositioning, and Indian Ocean voyages seasonally. Check the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> for current schedules.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Unknown or your travel advisor before booking.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Celebrity Cruises or your travel advisor before booking.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What was the Celebrity Revolution refit?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">In 2019, Constellation received a $500M+ fleet-wide modernization called Celebrity Revolution. Changes included redesigned staterooms, new suite categories with The Retreat, updated restaurants (Tuscan Grille, Le Petit Chef), refreshed pool areas, and enhanced technology throughout the ship.</p>
       </details>
     </section>
       </div>

--- a/ships/celebrity-cruises/celebrity-flora.html
+++ b/ships/celebrity-cruises/celebrity-flora.html
@@ -98,7 +98,7 @@ All work on this project is offered as a gift to God.
       "name": "What dining options are available on Celebrity Flora?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Celebrity Flora offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship class."
+        "text": "Celebrity Flora features all-inclusive dining with a single elegant restaurant serving Ecuadorian and internationally inspired cuisine, a pool grill for casual lunch, and the Ocean View Café. All meals, snacks, and non-alcoholic beverages are included in the fare."
       }
     },
     {
@@ -106,7 +106,7 @@ All work on this project is offered as a gift to God.
       "name": "How do I find the deck plans for Celebrity Flora?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Deck plans are available through the links on this page or on the Unknown website."
+        "text": "Deck plans are available through the links on this page or on the Celebrity Cruises website."
       }
     },
     {
@@ -114,7 +114,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Celebrity Flora sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Celebrity Flora sails year-round 7-night Galápagos itineraries from Baltra Island, alternating between inner-loop and outer-loop routes to cover different islands."
       }
     }
   ]
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Celebrity Flora</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Flora is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Flora is a purpose-built Galápagos expedition ship from Celebrity Cruises, carrying just 100 guests. Launched in 2019 at 5,739 GT, she was designed from the keel up for the Galápagos Islands with an outward-facing design, all-suite accommodations, and naturalist-led excursions. This page covers deck plans, dining, live tracking, and everything you need to plan your expedition.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Celebrity Flora or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Expedition-minded cruisers seeking a luxury Galápagos experience. Flora's 100-guest capacity and purpose-built design deliver intimate wildlife encounters with Celebrity's signature modern-luxury service and all-inclusive pricing.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises (Galápagos fleet)</li>
+          <li><strong>Class:</strong> Flora Class — purpose-built expedition (2019)</li>
+          <li><strong>Size:</strong> 5,739 GT · 100 guests · 102 crew (1:1 ratio)</li>
+          <li><strong>Decks:</strong> 5 passenger decks</li>
+          <li><strong>Home Port:</strong> Baltra, Galápagos Islands (year-round)</li>
+          <li><strong>Sister Ships:</strong> <a href="celebrity-xpedition.html">Xpedition</a>, <a href="celebrity-xploration.html">Xploration</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Celebrity Flora offers a memorable cruise experience with Celebrity Cruises. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Celebrity Flora is the first ship in the cruise industry designed from scratch specifically for the Galápagos Islands. Launched in 2019, her outward-facing design maximizes wildlife viewing with floor-to-ceiling windows in every suite, an open-air Observatory, and a unique "glamping" experience on the top deck under the stars. At just 100 guests with a remarkable 1:1 guest-to-crew ratio, she delivers an intimate expedition experience wrapped in Celebrity's modern-luxury polish.</p>
+          <p>All accommodations are suites with infinite veranda-style balconies — the same design philosophy later adopted by the Edge class. Dining is all-inclusive with a single open-seating restaurant serving locally inspired cuisine, a pool grill, and an Ocean View Café. The real highlight is the expedition program: two daily excursions led by certified Galápagos National Park naturalists via Zodiac pangas, glass-bottom boat, kayaks, snorkeling gear, and wet/dry landings. The onboard Discovery Lounge hosts naturalist lectures and wildlife briefings each evening.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>
@@ -320,7 +323,7 @@ All work on this project is offered as a gift to God.
 
   <section class="meta">
     <div><strong>Status</strong><br>Active</div>
-    <div><strong>Notes</strong><br>Galapagos expedition.</div>
+    <div><strong>Notes</strong><br>Flora Class (expedition) · Entered service 2019 · 5,739 GT · Galápagos year-round</div>
   </section>
 
     <footer class="wrap" role="contentinfo">
@@ -368,22 +371,27 @@ All work on this project is offered as a gift to God.
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Celebrity Flora?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Flora offers complimentary dining including the <a href="/restaurants/mdr.html">main dining room</a> and buffet. Specialty restaurants vary by ship class. Check the dining section above for specific venues.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Flora features all-inclusive dining with a single elegant restaurant serving Ecuadorian and internationally inspired cuisine, a pool grill for casual lunch, and the Ocean View Café. All meals, snacks, and non-alcoholic beverages are included in the fare. A premium beverage package is also included.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I find the deck plans for Celebrity Flora?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Unknown website or in the cruise planner app.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> or in the cruise planner app.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Celebrity Flora sail?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Celebrity Flora.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Flora sails year-round 7-night Galápagos itineraries from Baltra Island, alternating between inner-loop and outer-loop routes to cover different islands. Check the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> for specific departure dates and routing.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Unknown or your travel advisor before booking.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Celebrity Cruises or your travel advisor before booking.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is Celebrity Flora all-inclusive?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Yes. Celebrity Flora's Galápagos fare includes all meals, beverages (including alcohol), twice-daily naturalist-led excursions, snorkeling equipment, wetsuits, kayaks, and glass-bottom boat tours. Gratuities and Galápagos National Park fees are additional. It's one of Celebrity's few truly all-inclusive products.</p>
       </details>
     </section>
       </div>

--- a/ships/celebrity-cruises/celebrity-infinity.html
+++ b/ships/celebrity-cruises/celebrity-infinity.html
@@ -98,7 +98,7 @@ All work on this project is offered as a gift to God.
       "name": "What dining options are available on Celebrity Infinity?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Celebrity Infinity offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship class."
+        "text": "Celebrity Infinity features the two-story Metropolitan Restaurant, Luminae at The Retreat (suite-class), Blu (AquaClass), Tuscan Grille, Sushi on Five, Café al Bacio, and Ocean View Café. Specialty dining carries a cover charge or is included with certain suite categories."
       }
     },
     {
@@ -106,7 +106,7 @@ All work on this project is offered as a gift to God.
       "name": "How do I find the deck plans for Celebrity Infinity?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Deck plans are available through the links on this page or on the Unknown website."
+        "text": "Deck plans are available through the links on this page or on the Celebrity Cruises website."
       }
     },
     {
@@ -114,7 +114,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Celebrity Infinity sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Celebrity Infinity typically sails Alaska from Vancouver/Seward in summer, plus Panama Canal, South America, and Caribbean itineraries seasonally. Check the Celebrity Cruises website for current schedules."
       }
     }
   ]
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Celebrity Infinity</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Infinity is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Infinity is a Millennium-class ship from Celebrity Cruises, carrying around 2,170 guests. Launched in 2001 at 90,940 GT, she received a complete Revolution modernization in 2019 that added The Retreat suite-class experience, redesigned staterooms, and refreshed dining venues. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Celebrity Infinity or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers seeking Celebrity's modern-luxury experience on an intimate mid-size ship. Infinity's 2,170-guest capacity is perfect for Alaska glacier cruising, Panama Canal transits, and South American voyages.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
+          <li><strong>Class:</strong> Millennium Class (2001, modernized 2019)</li>
+          <li><strong>Size:</strong> 90,940 GT · 2,170 guests · 999 crew</li>
+          <li><strong>Decks:</strong> 11 passenger decks</li>
+          <li><strong>Home Ports:</strong> Fort Lauderdale, San Juan, Buenos Aires (seasonal)</li>
+          <li><strong>Sister Ships:</strong> <a href="celebrity-millennium.html">Millennium</a>, <a href="celebrity-constellation.html">Constellation</a>, <a href="celebrity-summit.html">Summit</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Celebrity Infinity offers a memorable cruise experience with Celebrity Cruises. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Celebrity Infinity entered service in 2001 as the second Millennium-class vessel and underwent Celebrity's fleet-wide Revolution modernization in 2019. The refit introduced The Retreat — a ship-within-a-ship suite-class enclave with dedicated sundeck, lounge, and restaurant — along with completely reimagined staterooms, updated public spaces, and a refreshed pool deck. At 965 feet long, she carries 2,170 guests with a 2.2:1 guest-to-crew ratio.</p>
+          <p>Dining standouts include the glamorous two-story main dining room, Tuscan Grille (Italian steakhouse), Sushi on Five, and the exclusive Blu restaurant for AquaClass guests. Luminae at The Retreat serves suite-class guests with a bespoke menu. The Canyon Ranch SpaClub, Persian Garden thermal suite, rooftop terrace, and Martini Bar round out her public spaces. Infinity is particularly beloved for Alaska glacier routes where her mid-size profile allows closer approach to tidewater glaciers.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>
@@ -320,7 +323,7 @@ All work on this project is offered as a gift to God.
 
   <section class="meta">
     <div><strong>Status</strong><br>Active</div>
-    <div><strong>Notes</strong><br>Millennium class, renovated 2013.</div>
+    <div><strong>Notes</strong><br>Millennium Class · Entered service 2001 · Revolution refit 2019 · 90,940 GT</div>
   </section>
 
     <footer class="wrap" role="contentinfo">
@@ -368,22 +371,27 @@ All work on this project is offered as a gift to God.
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Celebrity Infinity?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Infinity offers complimentary dining including the <a href="/restaurants/mdr.html">main dining room</a> and buffet. Specialty restaurants vary by ship class. Check the dining section above for specific venues.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Infinity features the two-story Metropolitan Restaurant, Luminae at The Retreat (suite-class), Blu (AquaClass), Tuscan Grille, Sushi on Five, Café al Bacio, and Ocean View Café. Specialty dining carries a cover charge or is included with certain suite categories.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I find the deck plans for Celebrity Infinity?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Unknown website or in the cruise planner app.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> or in the cruise planner app.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Celebrity Infinity sail?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Celebrity Infinity.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Infinity typically sails Alaska from Vancouver/Seward in summer, plus Panama Canal, South America, and Caribbean itineraries seasonally. Check the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> for current schedules.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Unknown or your travel advisor before booking.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Celebrity Cruises or your travel advisor before booking.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is Celebrity Infinity good for Alaska?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Infinity is one of the top-rated ships for Alaska itineraries. Her mid-size Millennium-class profile allows closer glacier approaches, and the ship's floor-to-ceiling windows in the dining room and observation areas provide exceptional views of the Inside Passage and Glacier Bay.</p>
       </details>
     </section>
       </div>

--- a/ships/celebrity-cruises/celebrity-millennium.html
+++ b/ships/celebrity-cruises/celebrity-millennium.html
@@ -106,7 +106,7 @@ All work on this project is offered as a gift to God.
       "name": "How do I find the deck plans for Celebrity Millennium?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Deck plans are available through the links on this page or on the Unknown website."
+        "text": "Deck plans are available through the links on this page or on the Celebrity Cruises website."
       }
     },
     {
@@ -114,7 +114,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Celebrity Millennium sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Celebrity Millennium frequently sails Asia-Pacific from Yokohama (Tokyo) and Alaska from Vancouver or Seattle. Check the Celebrity Cruises website for current schedules."
       }
     }
   ]
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Celebrity Millennium</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Millennium is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Millennium is the name-ship of the Millennium class from Celebrity Cruises, carrying around 2,138 guests. Launched in 2000 at 90,940 GT, she was the first in her class to receive the Revolution modernization in 2019, introducing The Retreat suite-class experience and completely refreshed interiors. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Celebrity Millennium or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers looking for Celebrity's modern-luxury style on a mid-size ship with strong Asia-Pacific and Alaska deployments. Millennium's intimate 2,138-guest size is ideal for scenic itineraries where a smaller ship enhances the experience.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
+          <li><strong>Class:</strong> Millennium Class (2000, modernized 2019)</li>
+          <li><strong>Size:</strong> 90,940 GT · 2,138 guests · 999 crew</li>
+          <li><strong>Decks:</strong> 11 passenger decks</li>
+          <li><strong>Home Ports:</strong> Tokyo (Yokohama), Vancouver, Seattle (seasonal)</li>
+          <li><strong>Sister Ships:</strong> <a href="celebrity-constellation.html">Constellation</a>, <a href="celebrity-infinity.html">Infinity</a>, <a href="celebrity-summit.html">Summit</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Celebrity Millennium offers a memorable cruise experience with Celebrity Cruises. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Celebrity Millennium made history in 2000 as the first ship in a class that redefined premium cruising. Her gas-turbine propulsion system was groundbreaking at launch, and the 2019 Revolution refit brought her firmly into the modern era with The Retreat — a dedicated suite-class sanctuary featuring private sundeck, lounge, and Luminae restaurant — plus fully redesigned staterooms and refreshed public areas throughout all 11 passenger decks.</p>
+          <p>Dining highlights include the elegant two-story Metropolitan Restaurant, Tuscan Grille for Italian steakhouse fare, Sushi on Five, and Blu for AquaClass guests. The Sunset Bar at the aft offers one of the best open-air cocktail spots at sea. Millennium frequently deploys to Asia-Pacific from Yokohama and Alaska from Vancouver or Seattle, making her a favorite for destination-focused cruisers. The Canyon Ranch SpaClub, Persian Garden thermal suite, and adults-only Solarium round out her well-balanced public spaces.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>
@@ -320,7 +323,7 @@ All work on this project is offered as a gift to God.
 
   <section class="meta">
     <div><strong>Status</strong><br>Active</div>
-    <div><strong>Notes</strong><br>Millennium class, renovated 2019.</div>
+    <div><strong>Notes</strong><br>Millennium Class · Entered service 2000 · Revolution refit 2019 · 90,940 GT</div>
   </section>
 
     <footer class="wrap" role="contentinfo">
@@ -415,22 +418,27 @@ Location : Ketchikan, Alaska"
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Celebrity Millennium?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Millennium offers complimentary dining including the <a href="/restaurants/mdr.html">main dining room</a> and buffet. Specialty restaurants vary by ship class. Check the dining section above for specific venues.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Millennium features the Metropolitan Restaurant (complimentary main dining), Luminae at The Retreat (suite-class), Blu (AquaClass), Tuscan Grille, Sushi on Five, Café al Bacio, and Ocean View Café. Specialty dining carries a cover charge or is included with certain suite categories.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I find the deck plans for Celebrity Millennium?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Unknown website or in the cruise planner app.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> or in the cruise planner app.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Celebrity Millennium sail?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Celebrity Millennium.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Millennium frequently sails Asia-Pacific from Yokohama (Tokyo) and Alaska from Vancouver or Seattle. She also offers Transpacific repositioning voyages. Check the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> for current schedules.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Unknown or your travel advisor before booking.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Celebrity Cruises or your travel advisor before booking.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Does Celebrity Millennium sail to Japan?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Yes, Celebrity Millennium is regularly deployed to Japan and broader Asia-Pacific itineraries from Yokohama (Tokyo). Sailings typically visit ports across Japan, South Korea, and sometimes Southeast Asia. These Asia deployments are among the most popular for the Millennium class.</p>
       </details>
     </section>
       </div>

--- a/ships/celebrity-cruises/celebrity-summit.html
+++ b/ships/celebrity-cruises/celebrity-summit.html
@@ -98,7 +98,7 @@ All work on this project is offered as a gift to God.
       "name": "What dining options are available on Celebrity Summit?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Celebrity Summit offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship class."
+        "text": "Celebrity Summit features the Cosmopolitan Restaurant (complimentary main dining), Luminae at The Retreat (suite-class), Blu (AquaClass), Tuscan Grille, Sushi on Five, Café al Bacio, and Ocean View Café. Specialty dining carries a cover charge or is included with certain suite categories."
       }
     },
     {
@@ -106,7 +106,7 @@ All work on this project is offered as a gift to God.
       "name": "How do I find the deck plans for Celebrity Summit?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Deck plans are available through the links on this page or on the Unknown website."
+        "text": "Deck plans are available through the links on this page or on the Celebrity Cruises website."
       }
     },
     {
@@ -114,7 +114,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Celebrity Summit sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Celebrity Summit typically sails Bermuda and Canada/New England from Cape Liberty (NJ) in summer, then repositions to Caribbean itineraries from Fort Lauderdale in winter. Check the Celebrity Cruises website for current schedules."
       }
     }
   ]
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Celebrity Summit</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Summit is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Summit is a Millennium-class ship from Celebrity Cruises, carrying around 2,158 guests. Launched in 2001 at 90,940 GT, she was transformed during a 2019 Revolution modernization that added The Retreat suite-class experience, redesigned staterooms, and refreshed restaurants. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Celebrity Summit or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers who appreciate Celebrity's modern-luxury style on a mid-size ship. Summit's 2,158-guest capacity is well suited for Bermuda round-trips, Caribbean, and Canada/New England itineraries from the U.S. East Coast.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
+          <li><strong>Class:</strong> Millennium Class (2001, modernized 2019)</li>
+          <li><strong>Size:</strong> 90,940 GT · 2,158 guests · 999 crew</li>
+          <li><strong>Decks:</strong> 11 passenger decks</li>
+          <li><strong>Home Ports:</strong> Cape Liberty (Bayonne, NJ), Fort Lauderdale</li>
+          <li><strong>Sister Ships:</strong> <a href="celebrity-millennium.html">Millennium</a>, <a href="celebrity-constellation.html">Constellation</a>, <a href="celebrity-infinity.html">Infinity</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Celebrity Summit offers a memorable cruise experience with Celebrity Cruises. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Celebrity Summit launched in 2001 as the third Millennium-class ship and received her Revolution makeover in 2019. The modernization introduced The Retreat — Celebrity's ship-within-a-ship suite-class area featuring a private sundeck, exclusive lounge, and Luminae restaurant — plus fully redesigned staterooms and updated public spaces throughout. At 965 feet and 90,940 GT, she delivers a guest-to-crew ratio of roughly 2.2:1.</p>
+          <p>Dining is a highlight, with the elegant two-story Cosmopolitan Restaurant, the Italian-inspired Tuscan Grille, Sushi on Five, and Blu for AquaClass guests. The Sunset Bar, Martini Bar & Crush, and Passport Bar anchor the evening social scene. Summit is a favorite for East Coast departures — she regularly sails Bermuda round-trips from Cape Liberty (New Jersey) in summer and repositions to Caribbean itineraries in winter. The Canyon Ranch SpaClub and Solarium adults-only retreat add polish to sea days.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>
@@ -320,7 +323,7 @@ All work on this project is offered as a gift to God.
 
   <section class="meta">
     <div><strong>Status</strong><br>Active</div>
-    <div><strong>Notes</strong><br>Millennium class, renovated 2019.</div>
+    <div><strong>Notes</strong><br>Millennium Class · Entered service 2001 · Revolution refit 2019 · 90,940 GT</div>
   </section>
 
     <footer class="wrap" role="contentinfo">
@@ -368,22 +371,27 @@ All work on this project is offered as a gift to God.
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Celebrity Summit?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Summit offers complimentary dining including the <a href="/restaurants/mdr.html">main dining room</a> and buffet. Specialty restaurants vary by ship class. Check the dining section above for specific venues.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Summit features the Cosmopolitan Restaurant (complimentary main dining), Luminae at The Retreat (suite-class), Blu (AquaClass), Tuscan Grille, Sushi on Five, Café al Bacio, and Ocean View Café. Specialty dining carries a cover charge or is included with certain suite categories.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I find the deck plans for Celebrity Summit?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Unknown website or in the cruise planner app.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> or in the cruise planner app.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Celebrity Summit sail?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Celebrity Summit.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Summit typically sails Bermuda and Canada/New England from Cape Liberty (NJ) in summer, then repositions to Caribbean itineraries from Fort Lauderdale in winter. Check the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> for current schedules.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Unknown or your travel advisor before booking.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Celebrity Cruises or your travel advisor before booking.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Can I sail Celebrity Summit from New York?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Summit sails from Cape Liberty cruise port in Bayonne, New Jersey — the closest cruise terminal to Manhattan. She offers convenient round-trip Bermuda sailings (typically 5–7 nights) and Canada/New England itineraries from this port during the summer and fall seasons.</p>
       </details>
     </section>
       </div>

--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -98,7 +98,7 @@ All work on this project is offered as a gift to God.
       "name": "What dining options are available on Celebrity Xcel?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Celebrity Xcel offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship class."
+        "text": "Celebrity Xcel offers over 30 dining venues including the main restaurants, Eden, Fine Cut Steakhouse, Le Voyage by Daniel Boulud, Raw on Five, the Magic Carpet restaurant experience, Café al Bacio, and Ocean View Café."
       }
     },
     {
@@ -106,7 +106,7 @@ All work on this project is offered as a gift to God.
       "name": "How do I find the deck plans for Celebrity Xcel?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Deck plans are available through the links on this page or on the Unknown website."
+        "text": "Deck plans are available through the links on this page or on the Celebrity Cruises website."
       }
     },
     {
@@ -114,7 +114,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Celebrity Xcel sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Celebrity Xcel is expected to sail Caribbean itineraries from Fort Lauderdale and Mediterranean voyages seasonally. Check the Celebrity Cruises website for her maiden season schedule."
       }
     }
   ]
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Celebrity Xcel</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Xcel is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Xcel is the fifth Edge-class ship from Celebrity Cruises, debuting in 2025 at approximately 140,600 GT with capacity for 3,250 guests. She features Celebrity's signature outward-facing design with the Magic Carpet cantilevered platform, infinite veranda staterooms, and the rooftop garden. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Celebrity Xcel or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers wanting Celebrity's newest and most innovative ship. Xcel's Edge-class design delivers a resort-at-sea experience ideal for Caribbean and Mediterranean itineraries with cutting-edge dining and entertainment.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
+<li><strong>Class:</strong> Edge Class (2025)</li>
+<li><strong>Size:</strong> ~140,600 GT · 3,250 guests · 1,400 crew</li>
+<li><strong>Decks:</strong> 16 passenger decks</li>
+<li><strong>Home Ports:</strong> Fort Lauderdale, Rome (seasonal)</li>
+<li><strong>Sister Ships:</strong> <a href="celebrity-edge.html">Edge</a>, <a href="celebrity-apex.html">Apex</a>, <a href="celebrity-beyond.html">Beyond</a>, <a href="celebrity-ascent.html">Ascent</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Celebrity Xcel offers a memorable cruise experience with Celebrity Cruises. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Celebrity Xcel joins the fleet in 2025 as the fifth and potentially final Edge-class ship. Building on the design revolution that started with Celebrity Edge in 2018, Xcel continues the outward-facing philosophy with floor-to-ceiling windows throughout, the Magic Carpet — a cantilevered platform that moves between decks to serve as a bar, restaurant, and tender embarkation point — and Celebrity's signature Infinite Veranda staterooms where the balcony integrates seamlessly with the living space.</p>
+          <p>Dining spans over 30 options including Fine Cut Steakhouse, Le Voyage by Daniel Boulud, Raw on Five, and the multi-story Eden restaurant and lounge — a three-deck space blending performance art with nature-inspired cuisine. The Rooftop Garden offers open-air movies and live music, while the two-story Martini Bar and craft cocktail venues keep the evening scene lively. The Resort Deck features an asymmetric pool layout, Solarium adults-only retreat, and The Retreat for suite-class guests with private pool, sundeck, and exclusive restaurant.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>
@@ -320,7 +323,7 @@ All work on this project is offered as a gift to God.
 
   <section class="meta">
     <div><strong>Status</strong><br>Active</div>
-    <div><strong>Notes</strong><br>Edge class, entering Nov 2025.</div>
+    <div><strong>Notes</strong><br>Edge Class · Entered service 2025 · ~140,600 GT</div>
   </section>
 
     <footer class="wrap" role="contentinfo">
@@ -368,23 +371,28 @@ All work on this project is offered as a gift to God.
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Celebrity Xcel?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Xcel offers complimentary dining including the <a href="/restaurants/mdr.html">main dining room</a> and buffet. Specialty restaurants vary by ship class. Check the dining section above for specific venues.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Xcel offers over 30 dining venues including the main restaurants (Cosmopolitan, Normandie, Tuscan, Cyprus), Eden, Fine Cut Steakhouse, Le Voyage by Daniel Boulud, Raw on Five, the Magic Carpet restaurant experience, Café al Bacio, and Ocean View Café. Many specialty venues carry a cover charge.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I find the deck plans for Celebrity Xcel?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Unknown website or in the cruise planner app.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> or in the cruise planner app.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Celebrity Xcel sail?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Celebrity Xcel.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Celebrity Xcel is expected to sail Caribbean itineraries from Fort Lauderdale and Mediterranean voyages seasonally. Check the <a href="https://www.celebritycruises.com">Celebrity Cruises website</a> for her maiden season schedule and deployment.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Unknown or your travel advisor before booking.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Celebrity Cruises or your travel advisor before booking.</p>
       </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+  <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What is the Magic Carpet on Celebrity Xcel?</summary>
+  <p style="margin: 0.5rem 0; padding-left: 1rem;">The Magic Carpet is a cantilevered platform on the ship's starboard side that moves between Decks 2 and 16. It serves as a restaurant (Raw on Five), an open-air bar, a tender boarding station, and an extension of The Retreat sundeck depending on which deck it's positioned at. It's one of the most distinctive features of the Edge class.</p>
+</details>
     </section>
       </div>
 

--- a/ships/holland-america-line/eurodam.html
+++ b/ships/holland-america-line/eurodam.html
@@ -13,12 +13,12 @@ All work on this project is offered as a gift to God.
      entity: Ship
      type: Ship Information Page
      parent: /ships.html
-     category: Royal Caribbean Fleet
-     cruise-line: Royal Caribbean
+     category: Holland America Fleet
+     cruise-line: Holland America
      ship-class: Signature Class
      siblings: /ships/holland-america-line/nieuw-amsterdam.html
      updated: 2025-11-15
-     expertise: Royal Caribbean ship reviews, deck plans, dining analysis, cabin comparisons
+     expertise: Holland America Line ship reviews, deck plans, dining analysis, cabin comparisons
      target-audience: EurodamActive cruisers, ship comparison researchers, first-time cruisers
      answer-first: If a venue list does not appear, it means this ship’s dining has not been verified yet.
      -->
@@ -98,7 +98,7 @@ All work on this project is offered as a gift to God.
       "name": "What dining options are available on Eurodam?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Eurodam offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship class."
+        "text": "Eurodam features the two-story main dining room, Pinnacle Grill (premium steakhouse), Tamarind (pan-Asian), Canaletto (Italian), Dive-In poolside grill, and the Lido Market buffet. Pinnacle Grill and Tamarind carry a cover charge; all other dining is included."
       }
     },
     {
@@ -106,7 +106,7 @@ All work on this project is offered as a gift to God.
       "name": "How do I find the deck plans for Eurodam?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Deck plans are available through the links on this page or on the Unknown website."
+        "text": "Deck plans are available through the links on this page or on the Holland America Line website."
       }
     },
     {
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Eurodam</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Eurodam is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Eurodam is a Signature-class ship from Holland America Line, carrying around 2,104 guests. Launched in 2008 at 86,273 GT, she introduced many features that became HAL staples — including the innovative Loft suites, the pan-Asian Tamarind restaurant, and the Billboard Onboard live music venue. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Eurodam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers who appreciate Holland America's classic mid-size ship experience with contemporary upgrades. Eurodam's 2,104-guest capacity delivers a refined atmosphere ideal for Caribbean, Alaska, and European itineraries.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Holland America Line</li>
+          <li><strong>Class:</strong> Signature Class (2008)</li>
+          <li><strong>Size:</strong> 86,273 GT · 2,104 guests · 929 crew</li>
+          <li><strong>Decks:</strong> 11 passenger decks</li>
+          <li><strong>Home Ports:</strong> Fort Lauderdale, Seattle (Alaska season)</li>
+          <li><strong>Sister Ship:</strong> <a href="nieuw-amsterdam.html">Nieuw Amsterdam</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Eurodam offers a memorable cruise experience with Holland America Line. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Eurodam debuted in 2008 as the lead ship of Holland America's Signature class — a design evolution that introduced several firsts for the line. She was HAL's first ship with the Loft suites (two-story penthouses on the Navigation Deck), the first with Tamarind pan-Asian restaurant, and the first to feature Billboard Onboard — a live music venue with dueling pianos and band performances that became one of HAL's most popular entertainment innovations. At 936 feet and 86,273 GT, she was also the largest HAL ship when built.</p>
+          <p>Dining options span the classic two-story main dining room, the elegant Pinnacle Grill steakhouse, Tamarind for pan-Asian cuisine, Canaletto for Italian fare, and the Lido Market buffet. The Explorations Café (powered by The New York Times) offers a library-lounge atmosphere with specialty coffees, while the Crow's Nest observation lounge provides panoramic sea views. The Greenhouse Spa & Salon, thermal suite, two pool areas, and the signature HAL promenade deck round out the public spaces.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>
@@ -320,7 +323,7 @@ All work on this project is offered as a gift to God.
 
   <section class="meta">
     <div><strong>Status</strong><br>Active</div>
-    <div><strong>Notes</strong><br>Signature-class.</div>
+    <div><strong>Notes</strong><br>Signature Class · Entered service 2008 · 86,273 GT</div>
   </section>
 
     <footer class="wrap" role="contentinfo">
@@ -368,22 +371,27 @@ All work on this project is offered as a gift to God.
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Eurodam?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Eurodam offers complimentary dining including the <a href="/restaurants/mdr.html">main dining room</a> and buffet. Specialty restaurants vary by ship class. Check the dining section above for specific venues.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Eurodam features the two-story main dining room, Pinnacle Grill (premium steakhouse), Tamarind (pan-Asian), Canaletto (Italian), Dive-In poolside grill, and the Lido Market buffet. Pinnacle Grill and Tamarind carry a cover charge; all other dining is included.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I find the deck plans for Eurodam?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Unknown website or in the cruise planner app.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.hollandamerica.com">Holland America Line website</a> or in the cruise planner app.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Eurodam sail?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Eurodam.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Eurodam typically sails Caribbean from Fort Lauderdale in winter and Alaska from Seattle in summer. She also offers occasional European and Transatlantic repositioning voyages. Check the <a href="https://www.hollandamerica.com">Holland America Line website</a> for current schedules.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Unknown or your travel advisor before booking.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Holland America Line or your travel advisor before booking.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What makes Eurodam different from Nieuw Amsterdam?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Eurodam and Nieuw Amsterdam are Signature-class sisters with nearly identical layouts. The key differences are cosmetic — Nieuw Amsterdam (2010) received updated interior design and artwork reflecting New York themes, while Eurodam's décor is more classically European. Both have received similar fleet-wide upgrades over the years.</p>
       </details>
     </section>
       </div>

--- a/ships/holland-america-line/noordam.html
+++ b/ships/holland-america-line/noordam.html
@@ -13,12 +13,12 @@ All work on this project is offered as a gift to God.
      entity: Ship
      type: Ship Information Page
      parent: /ships.html
-     category: Royal Caribbean Fleet
-     cruise-line: Royal Caribbean
+     category: Holland America Fleet
+     cruise-line: Holland America
      ship-class: Vista Class
      siblings: /ships/holland-america-line/oosterdam.html, /ships/holland-america-line/westerdam.html, /ships/holland-america-line/zuiderdam.html
      updated: 2025-11-15
-     expertise: Royal Caribbean ship reviews, deck plans, dining analysis, cabin comparisons
+     expertise: Holland America Line ship reviews, deck plans, dining analysis, cabin comparisons
      target-audience: NoordamHistorical cruisers, ship comparison researchers, first-time cruisers
      answer-first: If a venue list does not appear, it means this ship’s dining has not been verified yet.
      -->
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Noordam</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Noordam is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Noordam is a Vista-class ship from Holland America Line, carrying around 1,918 guests. Launched in 2006 at 82,318 GT, she is the fourth and final Vista-class vessel, known for her extensive art collection and refined public spaces. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Noordam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers who value Holland America's classic ocean-liner heritage with modern comforts. Noordam's 1,918-guest capacity and Vista-class design are well suited for Mediterranean, Caribbean, and Australia/New Zealand itineraries.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Holland America Line</li>
+          <li><strong>Class:</strong> Vista Class (2006)</li>
+          <li><strong>Size:</strong> 82,318 GT · 1,918 guests · 842 crew</li>
+          <li><strong>Decks:</strong> 11 passenger decks</li>
+          <li><strong>Home Ports:</strong> Fort Lauderdale, Sydney (seasonal)</li>
+          <li><strong>Sister Ships:</strong> <a href="zuiderdam.html">Zuiderdam</a>, <a href="oosterdam.html">Oosterdam</a>, <a href="westerdam.html">Westerdam</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Noordam offers a memorable cruise experience with Holland America Line. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Noordam entered service in 2006 as the fourth and final Vista-class ship, completing a quartet that became the backbone of Holland America's fleet for nearly two decades. At 82,318 GT and 936 feet, she carries 1,918 guests with the uncrowded, spacious feel that defines HAL's mid-size premium experience. Her multi-million-dollar art collection spans Dutch Golden Age paintings to contemporary sculptures, continuing HAL's tradition as one of the cruise industry's most significant floating art galleries.</p>
+          <p>Dining anchors include the two-story main dining room, Pinnacle Grill steakhouse, Canaletto Italian restaurant, and the Lido Market buffet. The Explorations Caf&eacute; combines a well-stocked library with specialty coffees and ocean views. Entertainment features the Vista Show Lounge, Billboard Onboard with live musicians, and B.B. King's Blues Club. The Greenhouse Spa &amp; Salon, thermal suite, full wrap-around promenade deck, and retractable-roof Lido pool round out the public spaces that make the Vista class a perennial favorite among repeat HAL cruisers.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>
@@ -368,17 +371,17 @@ All work on this project is offered as a gift to God.
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Noordam?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Noordam offers complimentary dining including the <a href="/restaurants/mdr.html">main dining room</a> and buffet. Specialty restaurants vary by ship class. Check the dining section above for specific venues.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Noordam features the two-story main dining room, Pinnacle Grill (premium steakhouse), Canaletto (Italian), Dive-In poolside grill, and the Lido Market buffet. Pinnacle Grill carries a cover charge; all other dining is complimentary.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I find the deck plans for Noordam?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Unknown website or in the cruise planner app.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.hollandamerica.com">Holland America Line website</a> or in the cruise planner app.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Noordam sail?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Noordam.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Noordam sails a variety of itineraries including Caribbean, Mediterranean, and Australia/New Zealand voyages. She frequently repositions between hemispheres for seasonal deployments. Check the <a href="https://www.hollandamerica.com">Holland America Line website</a> for current schedules.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/oosterdam.html
+++ b/ships/holland-america-line/oosterdam.html
@@ -13,12 +13,12 @@ All work on this project is offered as a gift to God.
      entity: Ship
      type: Ship Information Page
      parent: /ships.html
-     category: Royal Caribbean Fleet
-     cruise-line: Royal Caribbean
+     category: Holland America Fleet
+     cruise-line: Holland America
      ship-class: Vista Class
      siblings: /ships/holland-america-line/noordam.html, /ships/holland-america-line/westerdam.html, /ships/holland-america-line/zuiderdam.html
      updated: 2025-11-15
-     expertise: Royal Caribbean ship reviews, deck plans, dining analysis, cabin comparisons
+     expertise: Holland America Line ship reviews, deck plans, dining analysis, cabin comparisons
      target-audience: OosterdamActive cruisers, ship comparison researchers, first-time cruisers
      answer-first: If a venue list does not appear, it means this ship’s dining has not been verified yet.
      -->
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Oosterdam</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Oosterdam is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Oosterdam is a Vista-class ship from Holland America Line, carrying around 1,848 guests. Launched in 2003 at 82,305 GT, she is part of the four-ship Vista class that defined HAL's mid-size premium experience for a generation. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Oosterdam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers who want Holland America's signature blend of classic ocean-liner tradition and modern comfort on a mid-size ship. Oosterdam's 1,848-guest capacity provides an intimate, refined atmosphere.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Holland America Line</li>
+          <li><strong>Class:</strong> Vista Class (2003)</li>
+          <li><strong>Size:</strong> 82,305 GT · 1,848 guests · 842 crew</li>
+          <li><strong>Decks:</strong> 11 passenger decks</li>
+          <li><strong>Home Ports:</strong> Fort Lauderdale, San Diego (seasonal)</li>
+          <li><strong>Sister Ships:</strong> <a href="zuiderdam.html">Zuiderdam</a>, <a href="westerdam.html">Westerdam</a>, <a href="noordam.html">Noordam</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Oosterdam offers a memorable cruise experience with Holland America Line. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Oosterdam launched in 2003 as the second Vista-class ship, following sister Zuiderdam. The Vista class introduced a larger hull design for Holland America that would serve as the foundation for nearly two decades of shipbuilding. At 936 feet and 82,305 GT, she carries 1,848 guests with a guest-to-crew ratio of about 2.2:1 — maintaining the uncrowded feel that HAL loyalists appreciate. She has received multiple upgrades over the years including the addition of Billboard Onboard, enhanced dining options, and refreshed staterooms.</p>
+          <p>Dining highlights include the two-story main dining room with its classic ocean-liner ambiance, the Pinnacle Grill steakhouse, Canaletto Italian restaurant, and the Lido Market buffet. The Explorations Café offers a library atmosphere with premium coffees and panoramic views. Entertainment centers on the Vista Show Lounge, Billboard Onboard music venue, and B.B. King's Blues Club. The Greenhouse Spa & Salon, full promenade deck for walking, and two pool areas — including a retractable-roof Lido pool — complete the public space lineup.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>
@@ -320,7 +323,7 @@ All work on this project is offered as a gift to God.
 
   <section class="meta">
     <div><strong>Status</strong><br>Active</div>
-    <div><strong>Notes</strong><br>Signature-class.</div>
+    <div><strong>Notes</strong><br>Vista Class · Entered service 2003 · 82,305 GT</div>
   </section>
 
     <footer class="wrap" role="contentinfo">
@@ -368,22 +371,27 @@ All work on this project is offered as a gift to God.
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What dining options are available on Oosterdam?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Oosterdam offers complimentary dining including the <a href="/restaurants/mdr.html">main dining room</a> and buffet. Specialty restaurants vary by ship class. Check the dining section above for specific venues.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Oosterdam features the two-story main dining room, Pinnacle Grill (premium steakhouse), Canaletto (Italian), Dive-In poolside grill, and the Lido Market buffet. Pinnacle Grill carries a cover charge; all other dining is complimentary.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">How do I find the deck plans for Oosterdam?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the Unknown website or in the cruise planner app.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.hollandamerica.com">Holland America Line website</a> or in the cruise planner app.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Where does Oosterdam sail?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Oosterdam.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">Oosterdam sails a variety of itineraries including Caribbean, Mexico, Hawaii, and Pacific Coast from West Coast ports, plus occasional European deployments. Check the <a href="https://www.hollandamerica.com">Holland America Line website</a> for current schedules.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">Is this information official?</summary>
-        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Unknown or your travel advisor before booking.</p>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">This page provides planning resources and community insights. Always confirm details with Holland America Line or your travel advisor before booking.</p>
+      </details>
+
+      <details style="margin: 0.5rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+        <summary style="cursor: pointer; font-weight: 600; padding: 0.5rem 0;">What is the Vista class?</summary>
+        <p style="margin: 0.5rem 0; padding-left: 1rem;">The Vista class is Holland America's four-ship series built between 2002–2006: Zuiderdam, Oosterdam, Westerdam, and Noordam. At 82,000+ GT and ~1,848 guests, they represent HAL's signature mid-size ship design with emphasis on art collections, spacious promenade decks, and a classic cruising atmosphere updated for modern tastes.</p>
       </details>
     </section>
       </div>

--- a/ships/holland-america-line/zaandam.html
+++ b/ships/holland-america-line/zaandam.html
@@ -13,12 +13,12 @@ All work on this project is offered as a gift to God.
      entity: Ship
      type: Ship Information Page
      parent: /ships.html
-     category: Royal Caribbean Fleet
-     cruise-line: Royal Caribbean
+     category: Holland America Fleet
+     cruise-line: Holland America
      ship-class: Rotterdam Class
      siblings: /ships/holland-america-line/volendam.html
      updated: 2025-11-15
-     expertise: Royal Caribbean ship reviews, deck plans, dining analysis, cabin comparisons
+     expertise: Holland America Line ship reviews, deck plans, dining analysis, cabin comparisons
      target-audience: ZaandamActive cruisers, ship comparison researchers, first-time cruisers
      answer-first: If a venue list does not appear, it means this ship’s dining has not been verified yet.
      -->
@@ -275,19 +275,22 @@ All work on this project is offered as a gift to God.
       <h1>Zaandam</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Zaandam is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Zaandam is an R-class (Rotterdam class) ship from Holland America Line, carrying around 1,432 guests. Launched in 2000 at 61,396 GT, she is famous for her music-themed décor featuring instruments from rock legends and a Baroque-style pipe organ in the atrium. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Zaandam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers who prefer a smaller, classic ship with Holland America's traditional ocean-liner ambiance. Zaandam's 1,432-guest capacity delivers an intimate, unhurried experience ideal for longer voyages, South America, and repositioning itineraries.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
-          <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
-          <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
+          <li><strong>Cruise Line:</strong> Holland America Line</li>
+<li><strong>Class:</strong> R Class / Rotterdam Class (2000)</li>
+<li><strong>Size:</strong> 61,396 GT · 1,432 guests · 615 crew</li>
+<li><strong>Decks:</strong> 10 passenger decks</li>
+<li><strong>Home Ports:</strong> Fort Lauderdale, varies by season</li>
+<li><strong>Sister Ships:</strong> <a href="volendam.html">Volendam</a>, <a href="rotterdam.html">Rotterdam</a></li>
         </ul>
       </div>
     </section>
@@ -297,8 +300,8 @@ All work on this project is offered as a gift to God.
       <h2 id="first-look">A First Look</h2>
       <div class="grid-2" style="gap: 1.5rem;">
         <div>
-          <p>Zaandam offers a memorable cruise experience with Holland America Line. This ship features modern amenities, diverse dining options, and entertainment for all ages.</p>
-          <p>Explore the deck plans below to familiarize yourself with the ship's layout, or check out the dining section to see available restaurants and venues.</p>
+          <p>Zaandam entered service in 2000 as part of Holland America's R class (also called the Rotterdam class), a series of ships that epitomize HAL's traditional ocean-liner philosophy. At 61,396 GT and 780 feet, she's notably smaller than modern mega-ships — carrying just 1,432 guests — which gives her an intimate, country-club atmosphere. Her signature feature is a music theme woven throughout the ship: a Baroque-style pipe organ in the three-story atrium, guitars signed by rock legends including Queen and the Rolling Stones, and music memorabilia in public spaces.</p>
+          <p>Dining includes the classic two-story main dining room, Pinnacle Grill steakhouse, Canaletto Italian restaurant, and the Lido buffet. The Explorations Café offers a library-lounge atmosphere, while the Crow's Nest observation lounge provides sweeping forward views — perfect for scenic cruising. The Greenhouse Spa, full wrap-around promenade deck, and two pool areas maintain the spacious feel. Zaandam frequently sails longer itineraries including South America, Transatlantic crossings, and world cruise segments — voyages where her smaller size and classic ambiance are particularly appreciated by seasoned travelers.</p>
         </div>
         <div id="ship-stats" class="stats-grid" data-slug=""></div>
       </div>

--- a/ships/msc/msc-world-america.html
+++ b/ships/msc/msc-world-america.html
@@ -13,12 +13,12 @@ All work on this project is offered as a gift to God.
      entity: Ship
      type: Ship Information Page
      parent: /ships.html
-     category: Royal Caribbean Fleet
-     cruise-line: Royal Caribbean
+     category: MSC Cruises Fleet
+     cruise-line: MSC
      ship-class: World Class
      siblings: /ships/msc/msc-world-asia.html, /ships/msc/msc-world-europa.html
      updated: 2025-11-15
-     expertise: Royal Caribbean ship reviews, deck plans, dining analysis, cabin comparisons
+     expertise: MSC Cruises ship reviews, deck plans, dining analysis, cabin comparisons
      target-audience: Msc World America cruisers, ship comparison researchers, first-time cruisers
      answer-first: Study the ship’s layout—pin your stateroom, elevators, dining, and venues before you sail.
      -->
@@ -325,11 +325,11 @@ All work on this project is offered as a gift to God.
       <h1>Msc World America</h1>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Msc World America is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> MSC World America is MSC Cruises' newest World-class mega-ship, debuting in April 2025 at 215,863 GT with capacity for 6,762 guests. She features the revolutionary multi-level Europa promenade, seven distinct districts, and MSC's largest Yacht Club suite-class enclave. This page covers deck plans, dining venues, live tracking, and everything you need to plan your sailing.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Msc World America or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers wanting MSC's most innovative ship with a distinctly American focus. World America's seven themed districts, 18 decks, and massive water park make her ideal for Caribbean sailings from Miami with families and groups of all sizes.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">


### PR DESCRIPTION
Upgraded ship pages from ~600 words to 800+ with ship-specific content replacing generic "Unknown" placeholders:

Celebrity (6): Constellation, Infinity, Summit, Xcel, Millennium, Flora
- Added Revolution refit details, real dining venues, sister ship links
- Ship-specific FAQ (Alaska, Bermuda, Galapagos, Japan, Magic Carpet)
- Fixed key facts with GT, guest count, crew, home ports

Holland America (4): Eurodam, Oosterdam, Noordam, Zaandam
- Fixed incorrect "Royal Caribbean" metadata to "Holland America"
- Added class-specific content (Signature, Vista, R-class details)
- Music theme (Zaandam), Billboard Onboard, wrap-around promenade

MSC (1): World America
- Fixed "Royal Caribbean" metadata to "MSC Cruises"
- Added World-class details, seven districts, Europa promenade

https://claude.ai/code/session_012FatAD4A6vdvKv4HpssbHu