### PR TITLE
feat: Add "From the Pier" distance component to 10 Caribbean ports

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -80,6 +80,24 @@ h3 { font-size: 1.25rem; line-height: 1.4; }
 .answer-line { margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px; }
 .cta-highlight { background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%); border-left: 4px solid var(--accent, #0e6e8e); }
 
+/* "From the Pier" Distance Component (Competitor Gap P1) */
+.pier-distances { margin: 1.25rem 0; padding: 1rem 1.25rem; background: #fdf8f0; border-radius: 10px; border: 1px solid #e8dcc8; }
+.pier-distances h3 { font-size: 1.1rem; margin: 0 0 0.15rem; color: var(--sea, #0a3d62); }
+.pier-distances .pier-note-from { font-size: 0.82rem; color: var(--text-muted, #2a4a5a); margin: 0 0 0.75rem; font-style: italic; }
+.pier-distances-table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+.pier-distances-table th { text-align: left; padding: 0.5rem 0.6rem; border-bottom: 2px solid var(--rope, #d9b382); color: var(--sea, #0a3d62); font-weight: 600; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.03em; }
+.pier-distances-table td { padding: 0.45rem 0.6rem; border-bottom: 1px solid #e8dcc8; color: var(--ink, #083041); }
+.pier-distances-table tr:last-child td { border-bottom: none; }
+.pier-distances-table tr:hover td { background: rgba(255,255,255,.5); }
+.pier-distances .walkable { color: #2a7a3a; font-weight: 600; }
+.pier-distances .taxi-needed { color: var(--text-muted, #2a4a5a); }
+.pier-distances .pier-tip { margin: 0.6rem 0 0; font-size: 0.82rem; color: var(--text-muted, #2a4a5a); font-style: italic; }
+@media (max-width: 600px) {
+  .pier-distances { padding: 0.75rem; }
+  .pier-distances-table { font-size: 0.85rem; }
+  .pier-distances-table th, .pier-distances-table td { padding: 0.35rem 0.4rem; }
+}
+
 /* Transport Cost Component (Competitor Gap P2) */
 .transport-costs { margin: 1.25rem 0; padding: 1rem 1.25rem; background: var(--foam, #e6f4f8); border-radius: 10px; border: 1px solid #cde8f0; }
 .transport-costs h3 { font-size: 1.1rem; margin: 0 0 0.75rem; color: var(--sea, #0a3d62); }

--- a/ports/aruba.html
+++ b/ports/aruba.html
@@ -262,6 +262,24 @@ Soli Deo Gloria
           <p>Car and UTV rentals give maximum flexibility for island exploration. Compact cars start around $50-70 per day from agencies near the cruise port, with UTVs running $150-200 for half-day rentals. Aruba drives on the right side (American convention), and roads are well-maintained. Gas stations accept credit cards and US dollars. I recommend UTVs specifically for Arikok National Park and the Natural Pool, where rough roads require high clearance. Standard rental cars work fine for beaches and general exploration.</p>
         </details>
 
+        <!-- FROM THE PIER DISTANCES -->
+        <div class="pier-distances" id="pier-distances" aria-label="Walking distances from Aruba cruise terminal to attractions">
+          <h3>From the Pier</h3>
+          <p class="pier-note-from">Distances from Aruba Cruise Terminal, Oranjestad</p>
+          <table class="pier-distances-table">
+            <thead><tr><th>Destination</th><th>Distance</th><th>Walk Time</th><th>Taxi</th></tr></thead>
+            <tbody>
+              <tr><td>Downtown Oranjestad</td><td class="walkable">0.3 mi</td><td class="walkable">5 min</td><td>—</td></tr>
+              <tr><td>Fort Zoutman / Museum</td><td class="walkable">0.4 mi</td><td class="walkable">8 min</td><td>—</td></tr>
+              <tr><td>Surfside Beach</td><td class="walkable">0.8 mi</td><td class="walkable">15 min</td><td>—</td></tr>
+              <tr><td>Eagle Beach</td><td class="taxi-needed">3 mi</td><td class="taxi-needed">Not practical</td><td>~$10</td></tr>
+              <tr><td>Palm Beach resorts</td><td class="taxi-needed">6 mi</td><td class="taxi-needed">Not walkable</td><td>~$25</td></tr>
+              <tr><td>Baby Beach</td><td class="taxi-needed">18 mi</td><td class="taxi-needed">Not walkable</td><td>~$40</td></tr>
+            </tbody>
+          </table>
+          <p class="pier-tip">Surfside Beach is the closest beach on foot (15 min). Downtown Oranjestad is less than 5 minutes' walk. Arubus L10A to beaches costs $5 RT.</p>
+        </div>
+
         <!-- TRANSPORT COSTS -->
         <div class="transport-costs" id="transport-costs" aria-label="Transport costs from Aruba cruise terminal">
           <h3>Transport Costs from the Pier</h3>

--- a/ports/belize.html
+++ b/ports/belize.html
@@ -219,6 +219,24 @@ Soli Deo Gloria
         <p><strong>Excursion Timing:</strong> Most tours meet at Fort Street Tourism Village right after you tender ashore. Look for guides holding signs with your tour company name. Arrive early to find your group. Tours typically depart 15-30 minutes after the first tenders arrive.</p>
       </details>
 
+      <!-- FROM THE PIER DISTANCES -->
+      <div class="pier-distances" id="pier-distances" aria-label="Distances from Belize City tender landing to attractions">
+        <h3>From the Pier</h3>
+        <p class="pier-note-from">Distances from Fort Street Tourism Village tender landing (tender port)</p>
+        <table class="pier-distances-table">
+          <thead><tr><th>Destination</th><th>Distance</th><th>Walk/Drive</th><th>Getting There</th></tr></thead>
+          <tbody>
+            <tr><td>Tourism Village shops</td><td class="walkable">Adjacent</td><td class="walkable">0 min</td><td>Walk</td></tr>
+            <tr><td>Cave tubing (Caves Branch)</td><td class="taxi-needed">40 mi</td><td class="taxi-needed">45 min drive</td><td>Excursion $60–100</td></tr>
+            <tr><td>Altun Ha Mayan Ruins</td><td class="taxi-needed">31 mi</td><td class="taxi-needed">1 hr drive</td><td>Excursion $50–80</td></tr>
+            <tr><td>Lamanai Ruins</td><td class="taxi-needed">60+ mi</td><td class="taxi-needed">2+ hr (road + boat)</td><td>Excursion $100–150</td></tr>
+            <tr><td>Barrier Reef snorkeling</td><td class="taxi-needed">Offshore</td><td class="taxi-needed">Boat only</td><td>Excursion $80–120</td></tr>
+            <tr><td>Great Blue Hole (scenic flight)</td><td class="taxi-needed">60 mi offshore</td><td class="taxi-needed">Scenic flight</td><td>Flight $250–350</td></tr>
+          </tbody>
+        </table>
+        <p class="pier-tip">Belize is an excursion port — attractions are in the jungle and on the water, not in town. Pre-book tours; independent city exploration not recommended.</p>
+      </div>
+
       <!-- TRANSPORT COSTS -->
       <div class="transport-costs" id="transport-costs" aria-label="Transport costs from Belize City cruise tender landing">
         <h3>Transport Costs from the Pier</h3>

--- a/ports/cozumel.html
+++ b/ports/cozumel.html
@@ -432,6 +432,24 @@ Soli Deo Gloria
           </details>
         </details>
 
+        <!-- FROM THE PIER DISTANCES -->
+        <div class="pier-distances" id="pier-distances" aria-label="Walking distances from Cozumel cruise piers to attractions">
+          <h3>From the Pier</h3>
+          <p class="pier-note-from">Distances from Punta Langosta (downtown) &amp; International/Puerta Maya (south) piers</p>
+          <table class="pier-distances-table">
+            <thead><tr><th>Destination</th><th>Distance</th><th>Walk Time</th><th>Taxi</th></tr></thead>
+            <tbody>
+              <tr><td>Downtown San Miguel</td><td class="walkable">Adjacent (Punta Langosta)</td><td class="walkable">0 min</td><td>—</td></tr>
+              <tr><td>Downtown San Miguel</td><td class="taxi-needed">3 mi from southern piers</td><td class="taxi-needed">~45 min</td><td>$8–10</td></tr>
+              <tr><td>Beach clubs (south end)</td><td class="taxi-needed">1–5 mi</td><td class="taxi-needed">Not practical</td><td>$15–25</td></tr>
+              <tr><td>San Gervasio Mayan Ruins</td><td class="taxi-needed">Interior, 45 min drive</td><td class="taxi-needed">Not walkable</td><td>$50–60 RT</td></tr>
+              <tr><td>Punta Sur Eco Park</td><td class="taxi-needed">Southern tip</td><td class="taxi-needed">Not walkable</td><td>$40–50 RT</td></tr>
+              <tr><td>Cozumel Museum</td><td class="walkable">Downtown (Punta Langosta)</td><td class="walkable">5 min</td><td>—</td></tr>
+            </tbody>
+          </table>
+          <p class="pier-tip">Punta Langosta is right downtown — walk off and explore. Southern piers require taxi to reach San Miguel.</p>
+        </div>
+
         <!-- TRANSPORT COSTS -->
         <div class="transport-costs" id="transport-costs" aria-label="Transport costs from Cozumel cruise pier">
           <h3>Transport Costs from the Pier</h3>

--- a/ports/grand-cayman.html
+++ b/ports/grand-cayman.html
@@ -387,6 +387,24 @@ Soli Deo Gloria
           </ul>
             </details>
 
+        <!-- FROM THE PIER DISTANCES -->
+        <div class="pier-distances" id="pier-distances" aria-label="Walking distances from Grand Cayman tender pier to attractions">
+          <h3>From the Pier</h3>
+          <p class="pier-note-from">Distances from George Town tender landing (tender port)</p>
+          <table class="pier-distances-table">
+            <thead><tr><th>Destination</th><th>Distance</th><th>Walk Time</th><th>Taxi</th></tr></thead>
+            <tbody>
+              <tr><td>George Town shops &amp; restaurants</td><td class="walkable">Adjacent</td><td class="walkable">5–10 min</td><td>—</td></tr>
+              <tr><td>National Museum</td><td class="walkable">0.2 mi</td><td class="walkable">5 min</td><td>—</td></tr>
+              <tr><td>Smith Cove (beach)</td><td class="walkable">0.5 mi</td><td class="walkable">10 min</td><td>—</td></tr>
+              <tr><td>Seven Mile Beach</td><td class="taxi-needed">3 mi</td><td class="taxi-needed">Not practical</td><td>$2.50–12/pp</td></tr>
+              <tr><td>Rum Point / Kaibo</td><td class="taxi-needed">25 mi</td><td class="taxi-needed">Not walkable</td><td>Water taxi $30–40 RT</td></tr>
+              <tr><td>Stingray City sandbar</td><td class="taxi-needed">Offshore</td><td class="taxi-needed">Boat only</td><td>Excursion $40–60</td></tr>
+            </tbody>
+          </table>
+          <p class="pier-tip">George Town is flat and fully walkable. Smith Cove is the closest beach on foot with good snorkeling.</p>
+        </div>
+
         <!-- TRANSPORT COSTS -->
         <div class="transport-costs" id="transport-costs" aria-label="Transport costs from Grand Cayman cruise tender landing">
           <h3>Transport Costs from the Pier</h3>

--- a/ports/montego-bay.html
+++ b/ports/montego-bay.html
@@ -267,6 +267,24 @@ Soli Deo Gloria
           </ul>
         </section>
 
+        <!-- FROM THE PIER DISTANCES -->
+        <div class="pier-distances" id="pier-distances" aria-label="Walking distances from Montego Bay cruise pier to attractions">
+          <h3>From the Pier</h3>
+          <p class="pier-note-from">Distances from Montego Bay Freeport cruise terminal</p>
+          <table class="pier-distances-table">
+            <thead><tr><th>Destination</th><th>Distance</th><th>Walk/Drive</th><th>Taxi</th></tr></thead>
+            <tbody>
+              <tr><td>Hip Strip (Gloucester Ave)</td><td class="taxi-needed">2.8 mi</td><td class="taxi-needed">10–15 min drive</td><td>$10–15</td></tr>
+              <tr><td>Doctor's Cave Beach</td><td class="taxi-needed">2.8 mi (on Hip Strip)</td><td class="taxi-needed">10–15 min drive</td><td>$10–15</td></tr>
+              <tr><td>Sam Sharpe Square (downtown)</td><td class="taxi-needed">2 mi</td><td class="taxi-needed">10 min drive</td><td>$8–12</td></tr>
+              <tr><td>Rose Hall Great House</td><td class="taxi-needed">9 mi</td><td class="taxi-needed">15 min drive</td><td>$15–20</td></tr>
+              <tr><td>Martha Brae River Rafting</td><td class="taxi-needed">20 mi</td><td class="taxi-needed">30 min drive</td><td>Excursion $60–80</td></tr>
+              <tr><td>Dunn's River Falls (Ocho Rios)</td><td class="taxi-needed">56 mi</td><td class="taxi-needed">1.5 hr drive</td><td>Full-day excursion</td></tr>
+            </tbody>
+          </table>
+          <p class="pier-tip">The cruise port is NOT walkable to town — taxi or shuttle required for all attractions. Hip Strip is the closest hub for beaches and dining.</p>
+        </div>
+
         <!-- TRANSPORT COSTS -->
         <div class="transport-costs" id="transport-costs" aria-label="Transport costs from Montego Bay cruise pier">
           <h3>Transport Costs from the Pier</h3>

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -382,6 +382,24 @@ Soli Deo Gloria
           </ul>
             </details>
 
+        <!-- FROM THE PIER DISTANCES -->
+        <div class="pier-distances" id="pier-distances" aria-label="Walking distances from Nassau cruise pier to attractions">
+          <h3>From the Pier</h3>
+          <p class="pier-note-from">Distances from Prince George Wharf cruise terminal</p>
+          <table class="pier-distances-table">
+            <thead><tr><th>Destination</th><th>Distance</th><th>Walk Time</th><th>Taxi</th></tr></thead>
+            <tbody>
+              <tr><td>Straw Market</td><td class="walkable">0.2 mi</td><td class="walkable">3 min</td><td>—</td></tr>
+              <tr><td>Downtown (Bay Street shops)</td><td class="walkable">0.3 mi</td><td class="walkable">5 min</td><td>—</td></tr>
+              <tr><td>Junkanoo Beach</td><td class="walkable">0.7 mi</td><td class="walkable">15 min</td><td>—</td></tr>
+              <tr><td>Fort Charlotte</td><td class="walkable">1 mi</td><td class="walkable">20 min</td><td>—</td></tr>
+              <tr><td>Paradise Island / Atlantis</td><td class="taxi-needed">2 mi</td><td class="taxi-needed">Not practical</td><td>$9/pp + $2 toll</td></tr>
+              <tr><td>Cabbage Beach</td><td class="taxi-needed">2.5 mi</td><td class="taxi-needed">Not practical</td><td>$12–15/pp</td></tr>
+            </tbody>
+          </table>
+          <p class="pier-tip">Downtown is compact and walkable — 12 blocks long by 6 wide. Junkanoo Beach is the closest free beach on foot.</p>
+        </div>
+
         <!-- TRANSPORT COSTS -->
         <div class="transport-costs" id="transport-costs" aria-label="Transport costs from Nassau cruise pier">
           <h3>Transport Costs from the Pier</h3>

--- a/ports/roatan.html
+++ b/ports/roatan.html
@@ -448,6 +448,24 @@ All work on this project is offered as a gift to God.
           <p>Taxis in Roatán operate on fixed routes rather than meters, and prices are somewhat negotiable depending on group size and whether you're sharing with other passengers. U.S. dollars are the expected currency, and drivers are accustomed to working with cruise schedules — they'll typically tell you what time you need to be back and can arrange pickup times.</p>
         </section>
 
+        <!-- FROM THE PIER DISTANCES -->
+        <div class="pier-distances" id="pier-distances" aria-label="Walking distances from Roatan cruise piers to attractions">
+          <h3>From the Pier</h3>
+          <p class="pier-note-from">Distances from Mahogany Bay &amp; Coxen Hole (Town Center) piers</p>
+          <table class="pier-distances-table">
+            <thead><tr><th>Destination</th><th>Distance</th><th>Walk/Drive</th><th>Taxi</th></tr></thead>
+            <tbody>
+              <tr><td>Mahogany Bay Beach</td><td class="walkable">Adjacent (chairlift)</td><td class="walkable">5 min chairlift</td><td>Free</td></tr>
+              <tr><td>Coxen Hole town</td><td class="walkable">Adjacent (Town Center pier)</td><td class="walkable">5 min</td><td>—</td></tr>
+              <tr><td>West Bay Beach</td><td class="taxi-needed">7 mi</td><td class="taxi-needed">15–20 min drive</td><td>$10–12/pp</td></tr>
+              <tr><td>West End Village</td><td class="taxi-needed">5 mi</td><td class="taxi-needed">20 min drive</td><td>$8–10/pp</td></tr>
+              <tr><td>Gumbalimba Park</td><td class="taxi-needed">7 mi</td><td class="taxi-needed">15–20 min drive</td><td>$10–12/pp</td></tr>
+              <tr><td>Carambola Botanical Gardens</td><td class="taxi-needed">10 mi</td><td class="taxi-needed">25 min drive</td><td>~$15/pp</td></tr>
+            </tbody>
+          </table>
+          <p class="pier-tip">From Mahogany Bay, the free chairlift goes straight to the beach. West Bay Beach is the top destination — 15–20 min by taxi from either port.</p>
+        </div>
+
         <!-- TRANSPORT COSTS -->
         <div class="transport-costs" id="transport-costs" aria-label="Transport costs from Roatan cruise pier">
           <h3>Transport Costs from the Pier</h3>

--- a/ports/san-juan.html
+++ b/ports/san-juan.html
@@ -258,6 +258,24 @@ Soli Deo Gloria
           <p>Note: Those blue cobblestones look beautiful but can be slippery when wet and uneven. Wear comfortable, sturdy walking shoes — save the sandals for the beach. The hills throughout Old San Juan add to the workout.</p>
             </details>
 
+        <!-- FROM THE PIER DISTANCES -->
+        <div class="pier-distances" id="pier-distances" aria-label="Walking distances from San Juan cruise piers to attractions">
+          <h3>From the Pier</h3>
+          <p class="pier-note-from">Distances from Old San Juan Piers (3, 4, 6) — colonial district is steps away</p>
+          <table class="pier-distances-table">
+            <thead><tr><th>Destination</th><th>Distance</th><th>Walk Time</th><th>Taxi</th></tr></thead>
+            <tbody>
+              <tr><td>Old San Juan colonial streets</td><td class="walkable">Adjacent</td><td class="walkable">0 min</td><td>—</td></tr>
+              <tr><td>San Cristóbal fortress</td><td class="walkable">0.4 mi</td><td class="walkable">10–15 min</td><td>—</td></tr>
+              <tr><td>El Morro fortress</td><td class="walkable">0.7 mi</td><td class="walkable">15–20 min</td><td>—</td></tr>
+              <tr><td>La Fortaleza (Governor's mansion)</td><td class="walkable">0.3 mi</td><td class="walkable">7 min</td><td>—</td></tr>
+              <tr><td>Condado Beach</td><td class="taxi-needed">3 mi</td><td class="taxi-needed">Not practical</td><td>$15–20</td></tr>
+              <tr><td>Bacardi Distillery</td><td class="taxi-needed">6 mi</td><td class="taxi-needed">Not walkable</td><td>$20–25 each way</td></tr>
+            </tbody>
+          </table>
+          <p class="pier-tip">Old San Juan Piers put you right in the colonial district — 0.6 sq mi of walkable history. Pan American Pier requires $10–15 taxi to Old San Juan.</p>
+        </div>
+
         <!-- TRANSPORT COSTS -->
         <div class="transport-costs" id="transport-costs" aria-label="Transport costs from San Juan cruise pier">
           <h3>Transport Costs from the Pier</h3>

--- a/ports/st-maarten.html
+++ b/ports/st-maarten.html
@@ -381,6 +381,24 @@ All work on this project is offered as a gift to God.
           <p>For most cruise visitors, a combination of walking downtown and shared taxis to Maho Beach or the French side offers the best value. Book ahead through your ship's shore excursion desk for guaranteed transportation if visiting multiple destinations.</p>
         </details>
 
+      <!-- FROM THE PIER DISTANCES -->
+      <div class="pier-distances" id="pier-distances" aria-label="Walking distances from St. Maarten cruise pier to attractions">
+        <h3>From the Pier</h3>
+        <p class="pier-note-from">Distances from Dr. A.C. Wathey Cruise Facility, Philipsburg</p>
+        <table class="pier-distances-table">
+          <thead><tr><th>Destination</th><th>Distance</th><th>Walk Time</th><th>Taxi</th></tr></thead>
+          <tbody>
+            <tr><td>Front Street (Philipsburg shopping)</td><td class="walkable">0.5 mi</td><td class="walkable">10–15 min</td><td>$3/pp</td></tr>
+            <tr><td>Great Bay Beach</td><td class="walkable">0.5 mi</td><td class="walkable">10–15 min</td><td>—</td></tr>
+            <tr><td>Fort Amsterdam</td><td class="walkable">0.8 mi</td><td class="walkable">15 min</td><td>—</td></tr>
+            <tr><td>Maho Beach (planes)</td><td class="taxi-needed">9 mi</td><td class="taxi-needed">Not walkable</td><td>$20/pp</td></tr>
+            <tr><td>Orient Beach (French side)</td><td class="taxi-needed">10 mi</td><td class="taxi-needed">Not walkable</td><td>$25/pp</td></tr>
+            <tr><td>Marigot (French capital)</td><td class="taxi-needed">11 mi</td><td class="taxi-needed">Not walkable</td><td>$20–25/pp</td></tr>
+          </tbody>
+        </table>
+        <p class="pier-tip">Flat boardwalk connects the pier to Philipsburg and Great Bay Beach. Maho Beach and French side require taxi.</p>
+      </div>
+
       <!-- TRANSPORT COSTS -->
       <div class="transport-costs" id="transport-costs" aria-label="Transport costs from St. Maarten cruise pier">
         <h3>Transport Costs from the Pier</h3>

--- a/ports/st-thomas.html
+++ b/ports/st-thomas.html
@@ -347,6 +347,24 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <p>For accessibility, Havensight terminal is fully accessible with ramps and accessible restrooms. Safari taxis can be challenging for wheelchairs; request a regular accessible taxi at the pier. Most downtown streets are flat for comfortable walking, though the famous 99 Steps and hilly neighborhoods require climbing. Beach wheelchairs may be available at Magens Bay — ask at the entrance.</p>
       </details>
 
+      <!-- FROM THE PIER DISTANCES -->
+      <div class="pier-distances" id="pier-distances" aria-label="Walking distances from St. Thomas cruise piers to attractions">
+        <h3>From the Pier</h3>
+        <p class="pier-note-from">Distances from Havensight Cruise Terminal (primary) &amp; Crown Bay Marina</p>
+        <table class="pier-distances-table">
+          <thead><tr><th>Destination</th><th>Distance</th><th>Walk Time</th><th>Taxi</th></tr></thead>
+          <tbody>
+            <tr><td>Havensight shops</td><td class="walkable">Adjacent</td><td class="walkable">2 min</td><td>—</td></tr>
+            <tr><td>Paradise Point Skyride</td><td class="walkable">0.2 mi (from Havensight)</td><td class="walkable">5 min</td><td>—</td></tr>
+            <tr><td>Downtown Charlotte Amalie</td><td class="walkable">1 mi (from Havensight)</td><td class="walkable">15–20 min</td><td>$5/pp</td></tr>
+            <tr><td>Downtown Charlotte Amalie</td><td class="taxi-needed">2 mi (from Crown Bay)</td><td class="taxi-needed">Not practical</td><td>$5/pp</td></tr>
+            <tr><td>Magens Bay Beach</td><td class="taxi-needed">5 mi</td><td class="taxi-needed">Not walkable</td><td>~$10/pp each way</td></tr>
+            <tr><td>Coral World Ocean Park</td><td class="taxi-needed">5 mi</td><td class="taxi-needed">Not walkable</td><td>$10–15/pp</td></tr>
+          </tbody>
+        </table>
+        <p class="pier-tip">From Havensight, the waterfront walk to downtown Charlotte Amalie is scenic and flat. Crown Bay requires taxi for everything.</p>
+      </div>
+
       <!-- TRANSPORT COSTS -->
       <div class="transport-costs" id="transport-costs" aria-label="Transport costs from St. Thomas cruise pier">
         <h3>Transport Costs from the Pier</h3>


### PR DESCRIPTION
Design and deploy .pier-distances CSS component addressing WhatsInPort's core competitive strength — scannable walking distances from cruise pier to key attractions.

Component features:
- Warm-toned callout box (distinct from blue transport-costs component)
- Scannable table: Destination | Distance | Walk Time | Taxi cost
- Green .walkable class highlights easy walking destinations
- Muted .taxi-needed class for destinations requiring transport
- Pier-specific notes identifying which pier (when multiple exist)
- Responsive mobile layout at 600px breakpoint
- ARIA labels for accessibility

Piloted on 10 Caribbean ports:
- Cozumel (multi-pier: Punta Langosta vs southern piers)
- Nassau (Prince George Wharf)
- Grand Cayman (George Town tender landing)
- St. Thomas (Havensight vs Crown Bay)
- St. Maarten (Philipsburg cruise facility)
- San Juan (Old San Juan Piers vs Pan American)
- Aruba (Oranjestad terminal)
- Roatan (Mahogany Bay vs Coxen Hole)
- Montego Bay (Freeport — not walkable to town)
- Belize City (Fort Street Tourism Village tender)

Competitor gap item P1 — closes key gap vs WhatsInPort.