### PR TITLE
CSS: Remove redundant inline <style> blocks from 68 restaurant pages

### DIFF
--- a/restaurants/carnival/alchemy-bar.html
+++ b/restaurants/carnival/alchemy-bar.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/big-chicken.html
+++ b/restaurants/carnival/big-chicken.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/blue-iguana-cantina.html
+++ b/restaurants/carnival/blue-iguana-cantina.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/bonsai-sushi.html
+++ b/restaurants/carnival/bonsai-sushi.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/bonsai-teppanyaki.html
+++ b/restaurants/carnival/bonsai-teppanyaki.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/chefs-table.html
+++ b/restaurants/carnival/chefs-table.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/chibang.html
+++ b/restaurants/carnival/chibang.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/cucina-del-capitano.html
+++ b/restaurants/carnival/cucina-del-capitano.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/emerils-bistro.html
+++ b/restaurants/carnival/emerils-bistro.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/fahrenheit-555.html
+++ b/restaurants/carnival/fahrenheit-555.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/guys-burger-joint.html
+++ b/restaurants/carnival/guys-burger-joint.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/guys-pig-and-anchor.html
+++ b/restaurants/carnival/guys-pig-and-anchor.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/il-viaggio.html
+++ b/restaurants/carnival/il-viaggio.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/javablue-cafe.html
+++ b/restaurants/carnival/javablue-cafe.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/jiji-asian-kitchen.html
+++ b/restaurants/carnival/jiji-asian-kitchen.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/lido-marketplace.html
+++ b/restaurants/carnival/lido-marketplace.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/main-dining-room.html
+++ b/restaurants/carnival/main-dining-room.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/mongolian-wok.html
+++ b/restaurants/carnival/mongolian-wok.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/pizzeria-del-capitano.html
+++ b/restaurants/carnival/pizzeria-del-capitano.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/room-service.html
+++ b/restaurants/carnival/room-service.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/rudis-seagrill.html
+++ b/restaurants/carnival/rudis-seagrill.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/seafood-shack.html
+++ b/restaurants/carnival/seafood-shack.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/carnival/the-deli.html
+++ b/restaurants/carnival/the-deli.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/atelier-bistrot.html
+++ b/restaurants/msc/atelier-bistrot.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/butchers-cut.html
+++ b/restaurants/msc/butchers-cut.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/caffe-san-marco.html
+++ b/restaurants/msc/caffe-san-marco.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/calumet-manitoba-buffet.html
+++ b/restaurants/msc/calumet-manitoba-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/chefs-garden-kitchen.html
+++ b/restaurants/msc/chefs-garden-kitchen.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/eataly.html
+++ b/restaurants/msc/eataly.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/galaxy-restaurant.html
+++ b/restaurants/msc/galaxy-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/gelateria-italiana.html
+++ b/restaurants/msc/gelateria-italiana.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/gli-archi-buffet.html
+++ b/restaurants/msc/gli-archi-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/hola-tacos-cantina.html
+++ b/restaurants/msc/hola-tacos-cantina.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/il-covo-restaurant.html
+++ b/restaurants/msc/il-covo-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/inca-maya-buffet.html
+++ b/restaurants/msc/inca-maya-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/indochine.html
+++ b/restaurants/msc/indochine.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/jean-philippe-chocolat.html
+++ b/restaurants/msc/jean-philippe-chocolat.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/kaito-sushi-bar.html
+++ b/restaurants/msc/kaito-sushi-bar.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/kaito-teppanyaki.html
+++ b/restaurants/msc/kaito-teppanyaki.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/la-boca-grill.html
+++ b/restaurants/msc/la-boca-grill.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/la-bussola-restaurant.html
+++ b/restaurants/msc/la-bussola-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/la-cantina-di-bacco.html
+++ b/restaurants/msc/la-cantina-di-bacco.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/la-caravella-restaurant.html
+++ b/restaurants/msc/la-caravella-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/la-pergola-buffet.html
+++ b/restaurants/msc/la-pergola-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/la-pescaderia.html
+++ b/restaurants/msc/la-pescaderia.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/la-reggia-restaurant.html
+++ b/restaurants/msc/la-reggia-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/lapprodo-restaurant.html
+++ b/restaurants/msc/lapprodo-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/le-bistrot.html
+++ b/restaurants/msc/le-bistrot.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/le-grill.html
+++ b/restaurants/msc/le-grill.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/lighthouse-restaurant.html
+++ b/restaurants/msc/lighthouse-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/lippocampo-restaurant.html
+++ b/restaurants/msc/lippocampo-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/luna-park-pizza-burger.html
+++ b/restaurants/msc/luna-park-pizza-burger.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/main-dining-room.html
+++ b/restaurants/msc/main-dining-room.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/marco-polo-restaurant.html
+++ b/restaurants/msc/marco-polo-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/marketplace-buffet.html
+++ b/restaurants/msc/marketplace-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/ocean-cay.html
+++ b/restaurants/msc/ocean-cay.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/oriental-plaza.html
+++ b/restaurants/msc/oriental-plaza.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/promenade-bites.html
+++ b/restaurants/msc/promenade-bites.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/sahara-buffet.html
+++ b/restaurants/msc/sahara-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/sea-pavilion.html
+++ b/restaurants/msc/sea-pavilion.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/shanghai-chinese-restaurant.html
+++ b/restaurants/msc/shanghai-chinese-restaurant.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/surf-and-turf.html
+++ b/restaurants/msc/surf-and-turf.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/terrazza-buffet.html
+++ b/restaurants/msc/terrazza-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/the-harbour-bar-bites.html
+++ b/restaurants/msc/the-harbour-bar-bites.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/venchi-1878.html
+++ b/restaurants/msc/venchi-1878.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/villa-pompeiana-buffet.html
+++ b/restaurants/msc/villa-pompeiana-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/villa-verde-buffet.html
+++ b/restaurants/msc/villa-verde-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {

--- a/restaurants/msc/zanzibar-buffet.html
+++ b/restaurants/msc/zanzibar-buffet.html
@@ -57,11 +57,6 @@ All work on this project is offered as a gift to God.
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 
-  <style>
-    .card{position:relative;overflow:hidden}
-    .card>img[aria-hidden]{position:absolute;inset:0;margin:auto;opacity:.08;max-width:60%;pointer-events:none;z-index:0}
-    .card .card__content{position:relative;z-index:1}
-  </style>
 
 <script type="application/ld+json">
 {


### PR DESCRIPTION
The 3 card CSS rules (.card, .card>img[aria-hidden], .card .card__content) already exist in assets/styles.css (lines 386-624). Removes identical inline duplicates from 23 Carnival + 45 MSC venue pages for consistency with NCL, Virgin, and RCL pages that were already consolidated.

Zero visual change — rules are inherited from the shared stylesheet.

https://claude.ai/code/session_014YvvbeoRt2xRLwHnZ4JttD