### PR TITLE
feat: Add From the Pier, Real Talk, and DIY vs. Excursion to 22 ports

### DIFF
--- a/UNFINISHED_TASKS.md
+++ b/UNFINISHED_TASKS.md
@@ -136,12 +136,12 @@ The following items were **explicitly started** in previous threads. Each has be
 - [x] Accessibility on port pages — **376 of 380** ports have accessibility content
 - [x] Transport cost data — present on **10 port pages** (partial, not 0)
 - [x] Print CSS — exists in `port-map.css`, `calculator.css`, `item-cards.css`, `ships-dynamic.css`
-**What remains (9/16+ done = ~56%):**
-- [ ] "From the Pier" walking distance component (0 ports)
-- [ ] "Add to My Logbook" button on port pages (0 ports)
-- [ ] Region completion achievements (0 implemented)
-- [ ] DIY vs. Excursion comparison callouts (0 ports)
-- [ ] "Real Talk" honest assessment callouts (0 ports)
+**What remains (13/16+ done = ~81%):**
+- [x] "From the Pier" walking distance component — **30 ports** (10 Caribbean + 10 Mediterranean + 6 Alaska + 4 Hawaii)
+- [x] "Add to My Logbook" button on port pages — **377 ports** (universal via `port-logbook-btn.js`)
+- [x] Region completion achievements — **8 regions** implemented in Port Tracker
+- [x] DIY vs. Excursion comparison callouts — **30 ports** (10 Caribbean + 10 Mediterranean + 6 Alaska + 4 Hawaii)
+- [x] "Real Talk" honest assessment callouts — **30 ports** (10 Caribbean + 10 Mediterranean + 6 Alaska + 4 Hawaii)
 - [ ] Transport cost expansion (10/380 — needs 370 more ports)
 - [ ] Comprehensive Print CSS for port pages (partial, not complete)
 

--- a/ports/athens.html
+++ b/ports/athens.html
@@ -298,7 +298,67 @@ Soli Deo Gloria
 
           <h4>Corinth Canal and Ancient Corinth</h4>
           <p>Head west to see the narrow, steep-walled Corinth Canal and explore Ancient Corinth's archaeological site. Half-day ship excursions run €70-100 per person. The canal itself is a 19th-century engineering marvel worth a photo stop. Ancient Corinth features impressive Temple of Apollo ruins and fortress-crowned Acrocorinth hill. Independent visits are possible with rental car but timing is tight for cruise schedules.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Acropolis Visit</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Metro + Ticket (€25-35/person)</h5>
+                <ul>
+                  <li>Metro from Piraeus to Akropoli station €1.20, 35 min</li>
+                  <li>Acropolis combined ticket €30 (covers 7 sites)</li>
+                  <li>Visit the Acropolis Museum next door at your pace</li>
+                  <li>Metro is clean, air-conditioned, and reliable</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion (€80-120/person)</h5>
+                <ul>
+                  <li>Air-conditioned bus from Piraeus to Acropolis</li>
+                  <li>Licensed guide explains 2,500 years of history</li>
+                  <li>Often includes Plaka neighborhood walking tour</li>
+                  <li>Guaranteed return to ship on schedule</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Piraeus is 10 km from central Athens — not walkable. The metro is cheap and fast (€1.20, 35 min to Monastiraki). In summer the Acropolis hill is brutally hot with zero shade — go first thing in the morning. The €30 combined ticket covers the Acropolis plus six other ancient sites and is valid for 5 days, so it is the best deal even for a single day.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Piraeus cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Piraeus Metro Station</span><div class="pier-detail">Walk from cruise terminal</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:12%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Monastiraki (Plaka)</span><div class="pier-detail">Metro Line 1 from Piraeus</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚇</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:25%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Acropolis</span><div class="pier-detail">Metro to Akropoli + uphill walk</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚇</span> 40 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:35%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">National Archaeological Museum</span><div class="pier-detail">Metro to Omonia + walk</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚇</span> 45 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:38%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Cape Sounion (Temple of Poseidon)</span><div class="pier-detail">Bus or excursion along coast</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 90 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:75%"></div></div>
+            </li>
+          </ul>
+        </div>
 
         <section id="food">
           <details class="section-collapse" open>

--- a/ports/barcelona.html
+++ b/ports/barcelona.html
@@ -335,7 +335,67 @@ Soli Deo Gloria
 
         <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Montserrat Day Trip ($50-90)</h4>
         <p>The Benedictine abbey atop a dramatic mountain 50 kilometers northwest offers spectacular scenery and the revered Black Madonna statue. Full-day ship excursions ($80-100) or independent visits via train from Plaça Espanya ($25-30 round trip including cable car). The mountain views alone justify the journey. Requires 5-6 hours minimum—only feasible with extended port time or as part of pre/post cruise stays.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: La Sagrada Familia Visit</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Independent (€30-40/person)</h5>
+                <ul>
+                  <li>Book timed-entry at sagradafamilia.org (€26 + €10 tower)</li>
+                  <li>Metro from port €2.55 or T-Casual card shared</li>
+                  <li>Combine with Gothic Quarter walk at your own pace</li>
+                  <li>Must book weeks ahead in peak season</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion (€80-120/person)</h5>
+                <ul>
+                  <li>Skip-the-line entry and guided tour included</li>
+                  <li>Air-conditioned bus from terminal to door</li>
+                  <li>Often bundled with Park Güell or Gothic Quarter</li>
+                  <li>Higher cost but logistics fully handled</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Which terminal you dock at changes everything. World Trade Center terminals let you walk into the city in 10 minutes. Moll Adossat adds 30-45 minutes each way by shuttle. Check your terminal assignment and plan accordingly — it can make the difference between seeing three attractions or one.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Barcelona cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Las Ramblas</span><div class="pier-detail">Walk from WTC terminals</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:12%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Gothic Quarter</span><div class="pier-detail">Walk from WTC / shuttle + walk from Moll Adossat</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">La Sagrada Familia</span><div class="pier-detail">Taxi or metro from port area</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚕</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:25%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Park Güell</span><div class="pier-detail">Taxi recommended — uphill location</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚕</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:35%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Montserrat</span><div class="pier-detail">Train from Plaça Espanya or ship excursion</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚂</span> 90 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:80%"></div></div>
+            </li>
+          </ul>
+        </div>
 
       <!-- Depth Soundings Section -->
       <details class="port-section" id="depth-soundings" open>

--- a/ports/civitavecchia.html
+++ b/ports/civitavecchia.html
@@ -337,7 +337,67 @@ Soli Deo Gloria
 
         <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Trastevere Neighborhood Lunch ($30-50)</h4>
         <p>Cross the Tiber to this authentic Roman neighborhood where locals actually dine. Family trattorias serve cacio e pepe, carbonara, and amatriciana—Rome's signature pasta dishes—in settings tourists rarely find. Combine with a Vatican morning or an afternoon wandering nearby. Genuine Roman food memories often outshine monument visits.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Rome Day Trip</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY by Train (€25-40/person)</h5>
+                <ul>
+                  <li>Regional train €5 each way, 75-80 minutes</li>
+                  <li>Book Vatican tickets at museivaticani.va months ahead</li>
+                  <li>Total freedom to choose Vatican OR Colosseum focus</li>
+                  <li>Must manage your own return timing carefully</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion (€100-180/person)</h5>
+                <ul>
+                  <li>Motorcoach transport with guaranteed ship return</li>
+                  <li>Skip-the-line tickets and guided commentary</li>
+                  <li>No stress about train schedules or delays</li>
+                  <li>Higher cost but eliminates Rome logistics anxiety</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Rome is 80 km away — three hours of your port day disappear just getting there and back. Pick ONE focus: Vatican or Colosseum, not both. If all-aboard is 5 PM, leave Rome by 2:30 PM at the latest. The train is reliable and cheap but demands time discipline. Missing the ship is not theoretical here.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Civitavecchia cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Fort Michelangelo</span><div class="pier-detail">Walk from port gate</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:8%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Civitavecchia Old Town</span><div class="pier-detail">Walk along waterfront</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:12%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Train Station</span><div class="pier-detail">Walk or shuttle from port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:16%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Vatican City (Rome)</span><div class="pier-detail">Train + metro from Civitavecchia</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚂</span> 90 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:75%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Colosseum (Rome)</span><div class="pier-detail">Train to Termini + metro</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚂</span> 95 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:80%"></div></div>
+            </li>
+          </ul>
+        </div>
 
       <!-- Depth Soundings Section -->
       <details class="port-section" id="depth-soundings" open>

--- a/ports/dubrovnik.html
+++ b/ports/dubrovnik.html
@@ -417,7 +417,67 @@ Soli Deo Gloria
 
         <h3>Lokrum Island</h3>
         <p>A 15-minute ferry ride from the Old Harbor brings you to this forested island nature reserve with botanical gardens, a small saltwater lake called the Dead Sea, and peacocks wandering the paths. It's a wonderful escape from the crowded Old Town, though it gets busy by midday. The monastery ruins date to the 11th century, and the swimming spots around the rocky coastline are excellent.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: City Walls Walk</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Walk the Walls (€35/person)</h5>
+                <ul>
+                  <li>Buy ticket at Pile Gate entrance (€35)</li>
+                  <li>Walk at your own pace — 2 km circuit, 1.5-2 hours</li>
+                  <li>Go early morning to beat the heat and crowds</li>
+                  <li>Combine with Old Town exploration on your schedule</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion (€70-100/person)</h5>
+                <ul>
+                  <li>Guided tour with historical context at every viewpoint</li>
+                  <li>Often includes Old Town walking tour after</li>
+                  <li>Skip-the-line entry during peak season</li>
+                  <li>Fixed schedule — less time for independent wandering</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">When multiple ships are in port, the Old Town becomes shoulder-to-shoulder. Start at the walls the moment they open (8 AM in summer) — by 10 AM the heat and crowds make the walk miserable. The €35 wall ticket is steep but non-negotiable, and it is the single best thing to do here. Bring water.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Dubrovnik cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Old Town (Pile Gate)</span><div class="pier-detail">Shuttle bus from Gruž port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">City Walls Entrance</span><div class="pier-detail">Shuttle + short walk to Pile Gate</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:14%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Lokrum Island</span><div class="pier-detail">Shuttle to Old Town + ferry from Old Harbor</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Banje Beach</span><div class="pier-detail">Walk from Old Town east gate</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Cavtat</span><div class="pier-detail">Boat from Old Harbor or bus from Gruž</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 45 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:40%"></div></div>
+            </li>
+          </ul>
+        </div>
 
       <!-- Depth Soundings Section -->
       <details class="port-section" id="depth_soundings" open>

--- a/ports/hilo.html
+++ b/ports/hilo.html
@@ -316,6 +316,66 @@ Soli Deo Gloria
         <p>Look for authentic Hawaiian and Polynesian fabric prints, a specialty of the area. Keep in mind that numerous shops close their doors on Sundays.</p>
       </section>
 
+        <!-- DIY vs. Excursion -->
+        <div class="diy-vs-excursion">
+          <h4>DIY vs. Ship Excursion: Hawaii Volcanoes National Park</h4>
+          <div class="diy-compare">
+            <div class="diy-option">
+              <h5>DIY Rental Car ($45-70/person)</h5>
+              <ul>
+                <li>Rent car near port, drive 45 min to Kilauea</li>
+                <li>Park entry $30/vehicle (valid 7 days)</li>
+                <li>Explore Crater Rim Drive and Thurston Lava Tube</li>
+                <li>Your pace — stop at waterfalls on the way back</li>
+              </ul>
+            </div>
+            <div class="excursion-option">
+              <h5>Ship Excursion ($100-150/person)</h5>
+              <ul>
+                <li>Bus transport with guide narrating volcanic geology</li>
+                <li>Stops at key viewpoints and visitor center</li>
+                <li>Often includes Rainbow Falls and Macadamia Farm</li>
+                <li>No driving — just enjoy the scenery</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Hilo is the rainy side of the Big Island — 130 inches per year. Bring a rain jacket no matter what. Hawaii Volcanoes National Park is the only must-do here and it is 45 minutes away. A rental car is the best option; the downtown area is small and can be walked in an hour. The Farmer's Market (Wed/Sat) is genuinely good if your timing lines up.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Hilo cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Downtown Hilo</span><div class="pier-detail">Taxi or bus from port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚕</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Rainbow Falls</span><div class="pier-detail">Short drive from downtown</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Botanical Gardens</span><div class="pier-detail">Drive north along coast</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:14%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Hawaii Volcanoes National Park</span><div class="pier-detail">Drive south on Highway 11</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 45 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:40%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Akaka Falls</span><div class="pier-detail">Drive north — stunning 442-ft waterfall</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 25 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:22%"></div></div>
+            </li>
+          </ul>
+        </div>
+
       <section class="port-section">
         <h3>Depth Soundings Ashore</h3>
         <p class="tiny" style="margin-bottom: 0.5rem; font-style: italic; color: #678;">Practical tips before you step off the ship.</p>

--- a/ports/honolulu.html
+++ b/ports/honolulu.html
@@ -290,7 +290,68 @@ Soli Deo Gloria
           <p>Just blocks from the cruise pier, Honolulu's Chinatown has thrived for over a century with authentic markets, herbal shops, dim sum restaurants, and lei stands. Free to wander; allow 2 hours. The Maunakea Marketplace offers local lunch options. Safe during daylight hours; pairs perfectly with downtown historic walking.</p>
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Waikiki Surfing Lesson</h4>
           <p>Waikiki's gentle waves make it ideal for first-time surfers. Two-hour group lessons run $80-100 and include all equipment. Multiple operators along the beach; Aloha Beach Services and Hans Hedemann are well-regarded. No advance booking needed for most operators — just walk up to the beach kiosks. Stand-up paddleboard rentals also widely available.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Pearl Harbor</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY TheBus + Free Tickets ($5-40/person)</h5>
+                <ul>
+                  <li>Arizona Memorial tickets free at recreation.gov (book 60 days ahead)</li>
+                  <li>TheBus #42 from Aloha Tower to Pearl Harbor $3</li>
+                  <li>USS Missouri battleship tour $35 additional</li>
+                  <li>Your pace — spend as long as the memorial deserves</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion ($80-130/person)</h5>
+                <ul>
+                  <li>Round-trip transport from pier with narrated drive</li>
+                  <li>Guaranteed Arizona Memorial tickets included</li>
+                  <li>Often bundles Missouri and Pacific Aviation Museum</li>
+                  <li>Structured schedule — less time at each stop</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Pearl Harbor Arizona Memorial tickets are free but book out 60 days in advance — this is not optional, you must plan ahead. TheBus costs $3 and goes everywhere, including Waikiki and Pearl Harbor. Skip the $40 Waikiki trolley tourist buses. Chinatown is walkable from the pier and has better food than Waikiki at half the price.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Honolulu cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Chinatown</span><div class="pier-detail">Walk from Aloha Tower</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">ʻIolani Palace</span><div class="pier-detail">Walk through downtown</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:14%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Waikiki Beach</span><div class="pier-detail">TheBus or taxi</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Diamond Head Trailhead</span><div class="pier-detail">Bus or taxi via Waikiki</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Pearl Harbor</span><div class="pier-detail">TheBus #42 or taxi</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 35 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:32%"></div></div>
+            </li>
+          </ul>
+        </div>
+
         <details class="port-section" id="food" open>
             <summary><h2>Where to Eat and Drink</h2></summary>
           <p>Honolulu's dining scene blends Hawaiian, Asian, and Pacific Rim influences:</p>

--- a/ports/icy-strait-point.html
+++ b/ports/icy-strait-point.html
@@ -513,7 +513,67 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
       <h3>Booking Tips</h3>
       <p>Whale watching and ZipRider sell out quickly — book as early as possible through your cruise line when booking opens. Ship excursion prices are typically 10-15% higher than booking direct, but include guaranteed return to ship. For independent exploration, the cannery complex, beach walks, and forest trails are free and don't require booking. Compare ship excursion costs with Huna Totem's direct offerings at icystraitpoint.com — you may save money booking ahead independently, but ship tours guarantee return even if schedules run late.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Whale Watching</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>Book Direct at icystraitpoint.com ($150-180/person)</h5>
+                <ul>
+                  <li>Same tours, often 10-15% less than ship price</li>
+                  <li>Departs from the cannery pier — steps from the ship</li>
+                  <li>Guaranteed whale sightings or refund</li>
+                  <li>No return guarantee if tour runs late</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion ($170-210/person)</h5>
+                <ul>
+                  <li>Same Huna Totem operators and boats</li>
+                  <li>Ship will wait if excursion runs late</li>
+                  <li>One-stop booking through cruise line</li>
+                  <li>Higher cost for schedule guarantee</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">This is the only port in Alaska that is 100% Indigenous-owned — every dollar stays in the Huna Tlingit community. The ZipRider is genuinely thrilling (one of the world's longest zip lines) and books out fast. The free cannery museum is better than you expect. Hoonah village is worth the free shuttle ride for authentic Alaska that most ports cannot offer.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Icy Strait Point cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Cannery Complex</span><div class="pier-detail">Walk from pier</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 2 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:4%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">ZipRider Launch</span><div class="pier-detail">Shuttle from cannery</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Whale Watch Departure</span><div class="pier-detail">Walk to boat dock</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Hoonah Village</span><div class="pier-detail">Free shuttle from cannery</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Forest Trails</span><div class="pier-detail">Walk from cannery complex</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+          </ul>
+        </div>
 
     <!-- Depth Soundings Section -->
     <details class="port-section" id="depth_soundings" open>

--- a/ports/juneau.html
+++ b/ports/juneau.html
@@ -502,7 +502,67 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
       <h3>Booking Tips</h3>
       <p>Reserve helicopter and whale watching tours 60–90 days before your cruise — these popular excursions sell out quickly, so book ahead to secure your spot. Compare ship excursion prices with independent operators; you'll often save 20–30% booking direct, though cruise line tours offer guaranteed return to the ship even if tours run late. Check weather-related refund policies carefully. For budget travelers, the best free activities include hiking to Nugget Falls, exploring downtown galleries, and visiting the Alaska State Museum. Always confirm tour pickup locations relative to your ship's dock.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Mendenhall Glacier</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Shuttle + Self-Guided ($35-45/person)</h5>
+                <ul>
+                  <li>Round-trip shuttle from downtown $35-45</li>
+                  <li>Walk to Nugget Falls trail (free, 1.5 miles round trip)</li>
+                  <li>Glacier visitor center has exhibits and viewing areas</li>
+                  <li>Flexible timing — catch an earlier or later shuttle back</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Glacier Tour ($150-250/person)</h5>
+                <ul>
+                  <li>Guided ice trekking with crampons and expert guides</li>
+                  <li>Kayak tours paddle to the glacier face</li>
+                  <li>Transportation and gear included in price</li>
+                  <li>Deeper experience but significantly higher cost</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Juneau gets 62 inches of rain a year — bring a waterproof jacket regardless of the forecast. Helicopter tours are weather-dependent and cancel frequently; book a backup plan. Tracy's King Crab Shack has a line for a reason — the crab legs are spectacular, but go early. The Mount Roberts Tramway ($50) is the best quick activity if your time is limited.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Juneau cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Downtown Juneau</span><div class="pier-detail">Walk from AJ Dock</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Mount Roberts Tramway</span><div class="pier-detail">Walk from cruise dock</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 3 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:4%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Whale Watch Departure</span><div class="pier-detail">Walk to harbor</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Mendenhall Glacier</span><div class="pier-detail">Shuttle bus from downtown</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Auke Bay (Whale Watch)</span><div class="pier-detail">Shuttle or taxi</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+          </ul>
+        </div>
 
     <!-- Depth Soundings Section -->
     <details class="port-section" id="depth_soundings" open>

--- a/ports/ketchikan.html
+++ b/ports/ketchikan.html
@@ -501,7 +501,67 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
       <h3>Booking Tips</h3>
       <p>Reserve Misty Fjords flightseeing 60-90 days before your cruise — these popular excursions sell out quickly, and you should book ahead to secure your spot. Weather cancellations are common, so have a backup plan like the Lumberjack Show or totem tours that operate rain or shine. Compare ship excursion prices with independent operators; you'll often save 20-30% booking direct. The trade-off: ship excursions guarantee return even if tours run late, while independent tours don't. For budget travelers, Creek Street exploration, the Totem Heritage Center, and salmon watching at the fish ladder are free or low-cost alternatives.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Totem Poles &amp; Creek Street</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Walking Tour (free-$15/person)</h5>
+                <ul>
+                  <li>Creek Street is a 5-minute walk from the pier — free</li>
+                  <li>Totem Heritage Center $6 entry, Southeast Alaska Discovery Center $10</li>
+                  <li>Watch salmon at Deer Mountain Hatchery (free)</li>
+                  <li>Self-guided — spend as long as you want at each stop</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Cultural Tour ($60-90/person)</h5>
+                <ul>
+                  <li>Bus to Saxman or Totem Bight totem parks</li>
+                  <li>Expert guide explains Tlingit cultural significance</li>
+                  <li>Often includes carving demonstrations</li>
+                  <li>Covers sites too far to walk in limited port time</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Ketchikan averages 150 inches of rain per year — it is the rainiest city in Alaska. Bring a real rain jacket, not a poncho. Creek Street is charming but very short — you can see it in 20 minutes. The Great Alaskan Lumberjack Show is surprisingly entertaining and fills an hour well. Misty Fjords is spectacular but cancels often due to weather; have a backup plan.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Ketchikan cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Creek Street</span><div class="pier-detail">Walk from cruise berths</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Downtown / Shopping</span><div class="pier-detail">Walk from any berth</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Totem Heritage Center</span><div class="pier-detail">Walk through downtown</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:14%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Saxman Village Totem Park</span><div class="pier-detail">Taxi or excursion bus</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚕</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Misty Fjords (Floatplane)</span><div class="pier-detail">Floatplane from harbor</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">✈️</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+          </ul>
+        </div>
 
     <!-- Depth Soundings Section -->
     <details class="port-section" id="depth_soundings" open>

--- a/ports/kotor.html
+++ b/ports/kotor.html
@@ -382,6 +382,66 @@ Soli Deo Gloria
         </div>
       </div>
 
+        <!-- DIY vs. Excursion -->
+        <div class="diy-vs-excursion">
+          <h4>DIY vs. Ship Excursion: Bay of Kotor Tour</h4>
+          <div class="diy-compare">
+            <div class="diy-option">
+              <h5>DIY by Local Bus/Taxi (€15-30/person)</h5>
+              <ul>
+                <li>Local bus to Perast €2, 20 minutes</li>
+                <li>Water taxi to Our Lady of the Rocks €5</li>
+                <li>Walk the Old Town and fortress for free</li>
+                <li>Flexible timing — explore what interests you</li>
+              </ul>
+            </div>
+            <div class="excursion-option">
+              <h5>Ship Excursion (€50-80/person)</h5>
+              <ul>
+                <li>Bay boat cruise with Perast and island stops</li>
+                <li>Guide narrates centuries of Venetian history</li>
+                <li>Often includes Budva old town visit</li>
+                <li>Guaranteed return — no transport stress</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">The fortress climb is 1,350 steps with no shade and no water for sale along the way. Start before 9 AM or you will suffer in the heat. The official entrance charges €8, but early risers often find the gate unmanned. The view from the top is genuinely one of Europe's best — it is worth every step.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Kotor cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Old Town (Sea Gate)</span><div class="pier-detail">Walk from cruise berth</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 2 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:4%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Fortress Summit</span><div class="pier-detail">1,350 steps from Old Town</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 60 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:50%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Perast</span><div class="pier-detail">Local bus or taxi along the bay</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Our Lady of the Rocks</span><div class="pier-detail">Water taxi from Perast</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:25%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Budva Old Town</span><div class="pier-detail">Taxi or excursion over the mountain</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚕</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:25%"></div></div>
+            </li>
+          </ul>
+        </div>
+
       <section class="port-section">
         <h3>Getting Around Kotor</h3>
         <p>Ship docks 100 m from Sea Gate — literally walk off into 12th century.</p>

--- a/ports/marseille.html
+++ b/ports/marseille.html
@@ -369,6 +369,66 @@ All work on this project is offered as a gift to God.
           </details>
         </details>
 
+        <!-- DIY vs. Excursion -->
+        <div class="diy-vs-excursion">
+          <h4>DIY vs. Ship Excursion: Calanques Boat Tour</h4>
+          <div class="diy-compare">
+            <div class="diy-option">
+              <h5>DIY from Old Port (€20-30/person)</h5>
+              <ul>
+                <li>Shuttle to Old Port (free/small fee), then boat tour €20-30</li>
+                <li>Multiple operators with 2-3 hour departures</li>
+                <li>Combine with bouillabaisse lunch at the port</li>
+                <li>Flexible — choose your own departure time</li>
+              </ul>
+            </div>
+            <div class="excursion-option">
+              <h5>Ship Excursion (€70-100/person)</h5>
+              <ul>
+                <li>Transport from terminal to boat included</li>
+                <li>Guided commentary on geology and history</li>
+                <li>Often includes swimming stop in a calanque</li>
+                <li>Guaranteed return timing for the ship</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Marseille is grittier than the Riviera ports — that is its charm, not a flaw. The Old Port bouillabaisse restaurants range from tourist traps to genuine (ask where the locals eat, not where the menus are in English). The metro is cheap (€1.70) and gets you everywhere. Notre-Dame de la Garde is worth the climb for views, but take the bus up and walk down.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Marseille cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Old Port (Vieux-Port)</span><div class="pier-detail">Shuttle bus from cruise terminal</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:12%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Le Panier (Old Quarter)</span><div class="pier-detail">Walk from Old Port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:16%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Notre-Dame de la Garde</span><div class="pier-detail">Bus #60 or taxi from Old Port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 25 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:22%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Calanques (Boat Tour)</span><div class="pier-detail">Boat from Old Port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:25%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Aix-en-Provence</span><div class="pier-detail">Train from Gare Saint-Charles</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚂</span> 45 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:38%"></div></div>
+            </li>
+          </ul>
+        </div>
+
       <section class="port-section">
         <h3>Getting Around Marseille</h3>
         <p>Most ships dock at the modern cruise terminals north of the Old Port. From there:</p>

--- a/ports/maui.html
+++ b/ports/maui.html
@@ -287,7 +287,67 @@ Soli Deo Gloria
           <li><strong>Kanaha Beach Park:</strong> Renowned internationally as a premier windsurfing destination with excellent swimming conditions</li>
           <li><strong>Alexander & Baldwin Sugar Museum:</strong> Chronicles Maui's plantation heritage in old mill town of Puunene</li>
         </ul>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Haleakala Sunrise</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Rental Car ($50-80/person)</h5>
+                <ul>
+                  <li>Rent car at port, drive 38 miles to summit</li>
+                  <li>Reserve sunrise slot at recreation.gov ($1 + $30 park entry)</li>
+                  <li>Drive back via upcountry for coffee and farms</li>
+                  <li>Car gives you all-day freedom to explore the island</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion ($120-180/person)</h5>
+                <ul>
+                  <li>Van transport to summit with guide and blankets</li>
+                  <li>Hot coffee and breakfast included at the top</li>
+                  <li>No driving on winding mountain roads in the dark</li>
+                  <li>Return guaranteed — but leaves very early</li>
+                </ul>
+              </div>
+            </div>
+          </div>
       </section>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Maui requires a rental car — there is no way around it. The port is industrial with nothing walkable nearby. The Road to Hana takes a full day and is not feasible on a cruise port call unless you have 10+ hours. Rent a car, drive to Iao Valley (30 min) or Haleakala (90 min), and you will not regret it. Skip Waikiki-style tourist traps.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Kahului cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Kahului Town</span><div class="pier-detail">Drive from port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Iao Valley State Park</span><div class="pier-detail">Drive through Wailuku</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Lahaina Town</span><div class="pier-detail">Drive west coast highway</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 40 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:35%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Haleakala Summit</span><div class="pier-detail">Drive up mountain road</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 90 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:75%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Hana (Road to Hana)</span><div class="pier-detail">Full-day scenic drive — 620 curves</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 3+ hrs</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:95%"></div></div>
+            </li>
+          </ul>
+        </div>
 
       <section class="port-section">
         <h3>Depth Soundings Ashore</h3>

--- a/ports/montego-bay.html
+++ b/ports/montego-bay.html
@@ -252,6 +252,31 @@ Soli Deo Gloria
 
           <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Margaritaville</h4>
           <p>Beachfront restaurant/bar on the Hip Strip with waterslide into the sea, swim-up bar, loud music, party atmosphere. Touristy but fun if that's your vibe. Good jerk chicken. Frozen drinks. Spring break energy. Love it or avoid it — no middle ground.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Dunn's River Falls</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY via Private Driver ($40-50/person)</h5>
+                <ul>
+                  <li>Negotiate a round-trip with JUTA taxi (~$160-200 for 4 people)</li>
+                  <li>Stop at Ocho Rios shops or jerk stands on the way</li>
+                  <li>Pay $20 falls entry + $10 locker yourself</li>
+                  <li>Flexible timing — no group schedule</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion ($90-120/person)</h5>
+                <ul>
+                  <li>Air-conditioned bus, guide handles everything</li>
+                  <li>Often bundled with lunch or another stop</li>
+                  <li>Guaranteed return to ship on time</li>
+                  <li>Higher cost but zero logistics to manage</li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </section>
 
         <section class="port-section">

--- a/ports/mykonos.html
+++ b/ports/mykonos.html
@@ -418,7 +418,67 @@ Soli Deo Gloria
 
         <h3>Little Venice</h3>
         <p>This photogenic waterfront district features 18th-century fishing houses with colorful wooden balconies built right over the sea. Today the ground floors house bars and restaurants where you can sip cocktails while waves splash beneath your feet. Sunset brings magical light and crowds to match—arrive early for the best seats. Prices reflect the premium location, so expect to pay €10-15 for drinks, but the atmosphere is genuinely special.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Delos Archaeological Island</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Ferry + Ticket (€32-40/person)</h5>
+                <ul>
+                  <li>Ferry from Mykonos Old Port €20 round-trip, 30 min</li>
+                  <li>Archaeological site entry €12</li>
+                  <li>Explore the sacred island at your own pace</li>
+                  <li>Limited return ferries — check schedule carefully</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion (€70-100/person)</h5>
+                <ul>
+                  <li>Guided tour with expert archaeological commentary</li>
+                  <li>Transport from ship tender to Delos and back</li>
+                  <li>History comes alive with a knowledgeable guide</li>
+                  <li>Fixed time on island — usually 2-3 hours</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Mykonos is expensive — budget €10-15 for a basic coffee, €15-20 for a cocktail in Little Venice. The windmills and Chora are beautiful but small; you can walk the entire town in 90 minutes. If you want a beach day, Ornos is closest and cheapest to reach. Paradise Beach is a party scene, not a relaxation spot.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Mykonos cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Mykonos Town (Chora)</span><div class="pier-detail">Shuttle from new port or walk from old port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Windmills &amp; Little Venice</span><div class="pier-detail">Walk through Chora</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:14%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Ornos Beach</span><div class="pier-detail">Bus from Fabrika Square</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:14%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Paradise Beach</span><div class="pier-detail">Bus from Fabrika Square</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Delos Island</span><div class="pier-detail">Ferry from Old Port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+          </ul>
+        </div>
 
       <!-- Depth Soundings Section -->
       <details class="port-section" id="depth_soundings" open>

--- a/ports/naples.html
+++ b/ports/naples.html
@@ -335,7 +335,67 @@ Soli Deo Gloria
 
         <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Naples Pizza Walking Tour ($40-60)</h4>
         <p>Guided tours of Naples' legendary pizzerias introduce visitors to the city's culinary heart. Visit historic establishments like Da Michele, Sorbillo, or Di Matteo. Learn the difference between marinara and margherita, why Naples pizza is protected by law, and why the volcanic soil matters. A delicious alternative to archaeological overload, and a memorable way to experience authentic Neapolitan culture.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Pompeii</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY by Circumvesuviana (€15-25/person)</h5>
+                <ul>
+                  <li>Train to Pompei Scavi €3.60, 35 minutes</li>
+                  <li>Entry ticket €16 at ticketone.it</li>
+                  <li>Explore at your own pace — no group schedule</li>
+                  <li>Trains can be crowded and occasionally delayed</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion (€80-120/person)</h5>
+                <ul>
+                  <li>Air-conditioned bus direct to entrance</li>
+                  <li>Licensed guide brings the ruins to life</li>
+                  <li>Often combined with Vesuvius or lunch stop</li>
+                  <li>Guaranteed return — ship waits for their bus</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">The port area is chaotic when multiple ships dock. Ignore anyone approaching you with tour offers at the terminal gate — use the official taxi stand or walk to the Circumvesuviana station. For Pompeii, bring water and sunscreen — the site is massive with almost no shade, and summer heat is brutal.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Naples cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Spaccanapoli (Old Town)</span><div class="pier-detail">Walk from Stazione Marittima</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:12%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Archaeological Museum</span><div class="pier-detail">Walk or short taxi from port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 25 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:20%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Herculaneum</span><div class="pier-detail">Circumvesuviana to Ercolano Scavi</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚂</span> 25 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:22%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Pompeii</span><div class="pier-detail">Circumvesuviana train from Naples</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚂</span> 40 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:35%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Amalfi Coast</span><div class="pier-detail">Drive or excursion — winding coastal roads</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 90 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:75%"></div></div>
+            </li>
+          </ul>
+        </div>
 
       <!-- Depth Soundings Section -->
       <details class="port-section" id="depth-soundings" open>

--- a/ports/nawiliwili.html
+++ b/ports/nawiliwili.html
@@ -301,6 +301,66 @@ Soli Deo Gloria
         <p>Kukui Grove and Lihue Shopping Centers feature familiar mainland-style retail stores. Complimentary shuttle buses provide transportation to various shopping areas and strip malls around the island.</p>
       </section>
 
+        <!-- DIY vs. Excursion -->
+        <div class="diy-vs-excursion">
+          <h4>DIY vs. Ship Excursion: Na Pali Coast</h4>
+          <div class="diy-compare">
+            <div class="diy-option">
+              <h5>DIY Boat Tour ($150-200/person)</h5>
+              <ul>
+                <li>Book direct with Captain Andy's or Holo Holo Charters</li>
+                <li>Catamaran or Zodiac raft tours along Na Pali</li>
+                <li>Often includes snorkeling stop and lunch</li>
+                <li>Save 20-30% vs. ship excursion price</li>
+              </ul>
+            </div>
+            <div class="excursion-option">
+              <h5>Ship Excursion ($200-280/person)</h5>
+              <ul>
+                <li>Same operators and boats with ship guarantee</li>
+                <li>Transport from pier to departure point included</li>
+                <li>Ship waits if tour runs late — zero stress</li>
+                <li>Higher cost but all logistics handled</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Kauai is the "Garden Isle" and it is stunningly beautiful everywhere you look. A rental car opens up the entire island — Waimea Canyon ("Grand Canyon of the Pacific") is a 90-minute drive and absolutely worth it. The Na Pali Coast is only accessible by boat or helicopter; a boat tour is the highlight experience here. Poipu Beach on the south shore has the best swimming.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Nawiliwili cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Kalapaki Beach</span><div class="pier-detail">Walk from harbor</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Lihue Town</span><div class="pier-detail">Drive or taxi from port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Poipu Beach (South Shore)</span><div class="pier-detail">Drive south</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 25 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:22%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Na Pali Coast Boat Tours</span><div class="pier-detail">Drive to Port Allen departure</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Waimea Canyon Lookout</span><div class="pier-detail">Drive west and uphill</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚗</span> 90 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:75%"></div></div>
+            </li>
+          </ul>
+        </div>
+
       <section class="port-section">
         <h3>Depth Soundings Ashore</h3>
         <p class="tiny" style="margin-bottom: 0.5rem; font-style: italic; color: #678;">Practical tips before you step off the ship.</p>

--- a/ports/roatan.html
+++ b/ports/roatan.html
@@ -432,6 +432,31 @@ All work on this project is offered as a gift to God.
           <p><strong>Little French Key</strong> offers yet another approach — this is a private island just off Roatán's coast, marketed specifically to cruise passengers seeking an all-inclusive island experience. Day passes run $60-90 depending on what's included, but you get access to beaches, water sports equipment (kayaks, paddleboards, snorkeling gear), an animal sanctuary with sloths and iguanas, and usually a buffet lunch with drinks. Transportation is included from either cruise port. The snorkeling here is decent, the beaches pretty, and the setup family-friendly. It's more manufactured than West Bay's natural beauty, but for families wanting a single-price, no-decisions-required day with activities for kids, Little French Key packages convenience effectively.</p>
 
           <p><strong>Half Moon Bay</strong> and the West End village offer a quieter alternative for those seeking to escape the cruise ship crowds. Half Moon Bay's crescent of sand is more intimate than West Bay, backed by local guesthouses and small restaurants rather than organized beach clubs. The vibe here is decidedly more laid-back — this is where backpackers and long-term travelers congregate, where the bars serve cheap Salva Vida beer and the restaurants make fresh ceviche instead of pre-packaged cruise excursions. The snorkeling from Half Moon Bay is excellent, the water equally clear, and you're far more likely to have stretches of reef to yourself. West End itself has become Roatán's dive capital, with a main road lined with dive shops, budget hotels, seafood restaurants, and the kind of relaxed Caribbean atmosphere that feels authentic rather than manufactured for tourists. If you want to see how the island lives when the cruise ships aren't in port, spend your day in West End.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: West Bay Beach Day</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Independent ($25-40/person)</h5>
+                <ul>
+                  <li>Shared taxi to West Bay ($10-12 each way)</li>
+                  <li>Rent chair and umbrella on the beach ($10-15)</li>
+                  <li>Bring your own snorkel gear or rent ($10-15)</li>
+                  <li>Buy lunch and drinks as you go — total flexibility</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Beach Excursion ($60-80/person)</h5>
+                <ul>
+                  <li>Tabyana Beach Club day pass with lounger and gear</li>
+                  <li>Lunch voucher often included</li>
+                  <li>Organized return transport to the pier</li>
+                  <li>Higher cost but everything handled for you</li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </section>
 
         <section class="port-section">

--- a/ports/santorini.html
+++ b/ports/santorini.html
@@ -428,7 +428,67 @@ Soli Deo Gloria
 
         <h3>Volcano Hike at Nea Kameni</h3>
         <p>Boat excursions (typically €20-30 per person) take visitors to the volcanic island at the caldera's center, followed by a guided hike across the rocky lunar landscape to active crater areas where sulfur vents still emit heat and gases. The moon-like terrain fascinates geology enthusiasts, and most tours combine this with swimming at the nearby hot springs.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Oia Sunset &amp; Village Walk</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Independent (€15-25/person)</h5>
+                <ul>
+                  <li>Cable car €6 up, €6 down (or donkey ride €5)</li>
+                  <li>Bus from Fira to Oia €1.80, 25 minutes</li>
+                  <li>Wander the blue-domed churches at your own pace</li>
+                  <li>Cable car lines can exceed 45 minutes at peak</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion (€60-90/person)</h5>
+                <ul>
+                  <li>Tender + van transport bypasses cable car crowds</li>
+                  <li>Guided tour covers history and photo spots</li>
+                  <li>Often includes wine tasting or caldera views</li>
+                  <li>Fixed schedule limits free exploration time</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">The cable car is the bottleneck that can ruin your day. First tender off the ship means a 5-minute wait; by mid-morning you could wait an hour. Do NOT ride the donkeys if you care about animal welfare — the path is steep and the animals are overworked. Walking the 588 steps is free and takes 20 minutes if you are reasonably fit.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Santorini tender pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Fira (Cable Car)</span><div class="pier-detail">Cable car from tender port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚡</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:8%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Fira (Walking Steps)</span><div class="pier-detail">588 steps up from old port</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Oia</span><div class="pier-detail">Bus from Fira bus station</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Akrotiri Archaeological Site</span><div class="pier-detail">Bus from Fira, 30 min</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 35 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:32%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Red Beach / Perissa</span><div class="pier-detail">Bus from Fira to beach towns</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+          </ul>
+        </div>
 
       <!-- Depth Soundings Section -->
       <details class="port-section" id="depth_soundings" open>

--- a/ports/seward.html
+++ b/ports/seward.html
@@ -362,7 +362,67 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
       <h3>Booking Tips</h3>
       <p>The Kenai Fjords cruises are extremely popular — book ahead when your cruise opens reservations. Ship excursion prices include guaranteed return to ship, which matters on an embarkation/disembarkation day. For independent booking, Major Marine Tours and Kenai Fjords Tours offer similar experiences at competitive prices ($175-225 for the full day). Weather cancellations happen — the Gulf of Alaska is unpredictable. If your cruise only calls at Seward, the fjord cruise is the one must-do experience.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Kenai Fjords Cruise</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Book Direct ($175-225/person)</h5>
+                <ul>
+                  <li>Major Marine Tours or Kenai Fjords Tours — same boats</li>
+                  <li>Book at kenaifjords.com — often $30-50 less per person</li>
+                  <li>6-8 hour full-day cruise through the fjords</li>
+                  <li>No ship return guarantee on embarkation days</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion ($220-280/person)</h5>
+                <ul>
+                  <li>Guaranteed return for embarkation/disembarkation</li>
+                  <li>Same operators, same route and wildlife</li>
+                  <li>One booking through cruise line</li>
+                  <li>Worth the premium on sailing day for peace of mind</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Seward is often an embark/disembark port, not a port call — your time is limited. The Kenai Fjords day cruise is the single must-do experience and worth every dollar. Dress warmer than you think — it is cold on the water even in July. The Exit Glacier hike is free and spectacular if you have a few extra hours before boarding.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Seward cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Downtown Seward</span><div class="pier-detail">Walk from cruise terminal</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Alaska SeaLife Center</span><div class="pier-detail">Walk along waterfront</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:14%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Kenai Fjords Boat Dock</span><div class="pier-detail">Walk to small boat harbor</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Exit Glacier Trailhead</span><div class="pier-detail">Shuttle or taxi</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Anchorage</span><div class="pier-detail">Bus or transfer — scenic highway</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 150 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:90%"></div></div>
+            </li>
+          </ul>
+        </div>
 
     <details class="port-section" id="depth_soundings" open>
       <summary><h2>Depth Soundings</h2></summary>

--- a/ports/sitka.html
+++ b/ports/sitka.html
@@ -512,7 +512,67 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
       <h3>Booking Tips</h3>
       <p>With shorter port times, combination excursions maximize your Sitka experience. The "Best of Sitka" tours ($100-150) typically include whale watching, the Raptor Center, and a historical overview — excellent value compared to booking separately. For independent exploration, book ahead for popular wildlife tours since ships sometimes only stay 6 hours. Compare ship excursion prices with local operators — you can often save 20-30% booking direct, but ship tours guarantee return to the ship even if schedules run late. Most whale watching operators offer money-back guarantees if no whales are spotted, though sightings are nearly universal during peak season.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: Sitka Walking &amp; Wildlife</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Self-Guided ($12-40/person)</h5>
+                <ul>
+                  <li>Alaska Raptor Center $12, Sitka National Historical Park free</li>
+                  <li>Walk the totem trail through coastal rainforest</li>
+                  <li>St. Michael's Cathedral $5 donation suggested</li>
+                  <li>Compact town — all sites walkable from shuttle drop</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship "Best of Sitka" ($100-150/person)</h5>
+                <ul>
+                  <li>Covers whale watching, Raptor Center, and history</li>
+                  <li>Transport between spread-out attractions included</li>
+                  <li>Expert guides on Tlingit and Russian heritage</li>
+                  <li>Maximizes short port time with tight scheduling</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Sitka port times are often only 6-8 hours, and tendering eats 30-60 minutes each way. Get on the first tender. The Raptor Center is one of the best wildlife experiences in Alaska and costs only $12. The totem trail in the National Historical Park is free, beautiful, and walkable in an hour. Skip the jewelry shops and spend your time in nature.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Sitka cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Harrigan Centennial Hall</span><div class="pier-detail">Free shuttle from dock</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 15 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:14%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">St. Michael's Cathedral</span><div class="pier-detail">Walk from Centennial Hall</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Sitka National Historical Park</span><div class="pier-detail">Walk from downtown</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 25 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:22%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Alaska Raptor Center</span><div class="pier-detail">Shuttle or taxi from downtown</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚌</span> 25 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:22%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Whale Watch Departure</span><div class="pier-detail">Tour pickup from Centennial Hall</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 20 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:18%"></div></div>
+            </li>
+          </ul>
+        </div>
 
     <!-- Depth Soundings Section -->
     <details class="port-section" id="depth_soundings" open>

--- a/ports/skagway.html
+++ b/ports/skagway.html
@@ -503,7 +503,67 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
       <h3>Booking Tips</h3>
       <p>Reserve White Pass Railway 60-90 days before your cruise — these trains sell out quickly, so book ahead to secure your preferred departure time. Morning trains offer better light for photography. Compare ship excursion prices with independent booking; the railway operates its own ticket office at wpyr.com. Free alternatives include the National Park Service walking tours, exploring Broadway's historic buildings, and visiting the museum exhibits at the NPS visitor center.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: White Pass Railway</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Book Direct ($130-140/person)</h5>
+                <ul>
+                  <li>Book at wpyr.com — same train, often 20% cheaper</li>
+                  <li>Walk from ship to depot in 5 minutes</li>
+                  <li>Choose your preferred departure time</li>
+                  <li>No return guarantee if train runs late</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion ($160-190/person)</h5>
+                <ul>
+                  <li>Same White Pass train with ship guarantee</li>
+                  <li>Ship will wait if the excursion runs late</li>
+                  <li>Often bundled with Yukon border crossing</li>
+                  <li>Higher cost for the peace of mind</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Skagway has 1,100 residents and over a million cruise visitors a year — the town exists for tourists. Broadway Street shops are mostly jewelry stores, but the Klondike Gold Rush NPS visitor center is genuinely excellent and free. The White Pass Railway is the main event here and it deserves the hype. Book the earliest train for the best light and fewer crowds.</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Skagway cruise pier">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Broadway Street</span><div class="pier-detail">Walk from any dock</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 2 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:4%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">White Pass Railway Depot</span><div class="pier-detail">Walk from Railroad Dock</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">NPS Visitor Center</span><div class="pier-detail">Walk along Broadway</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 5 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:6%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Gold Rush Cemetery</span><div class="pier-detail">Walk north from town</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚶</span> 25 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:22%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Yukon Border (White Pass Summit)</span><div class="pier-detail">Railway or bus excursion</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚂</span> 90 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:75%"></div></div>
+            </li>
+          </ul>
+        </div>
 
     <!-- Depth Soundings Section -->
     <details class="port-section" id="depth_soundings" open>

--- a/ports/venice.html
+++ b/ports/venice.html
@@ -335,7 +335,67 @@ Soli Deo Gloria
 
         <h4 style="margin-top: 1rem; color: var(--ink, #1a2a3a);">Get Lost in Cannaregio or Dorsoduro (free)</h4>
         <p>Venice's quieter neighborhoods offer respite from St. Mark's crowds. Cannaregio, the northern sestiere, features the Jewish Ghetto (the world's first, giving us the word), local cafés, and authentic residential atmosphere. Dorsoduro houses the Accademia gallery and Peggy Guggenheim Collection. Simply wandering reveals hidden squares, neighborhood churches, and the everyday Venice tourists rarely see.</p>
+
+          <!-- DIY vs. Excursion -->
+          <div class="diy-vs-excursion">
+            <h4>DIY vs. Ship Excursion: St. Mark's &amp; Doge's Palace</h4>
+            <div class="diy-compare">
+              <div class="diy-option">
+                <h5>DIY Vaporetto + Tickets (€35-50/person)</h5>
+                <ul>
+                  <li>Vaporetto day pass €25 — unlimited rides all day</li>
+                  <li>Doge's Palace skip-the-line ticket €30 online</li>
+                  <li>St. Mark's Basilica free (reserve timeslot online)</li>
+                  <li>Explore at your own pace between sites</li>
+                </ul>
+              </div>
+              <div class="excursion-option">
+                <h5>Ship Excursion (€80-130/person)</h5>
+                <ul>
+                  <li>Water taxi from terminal to St. Mark's Square</li>
+                  <li>Guided tour with expert Venetian commentary</li>
+                  <li>Skip-the-line access to palace and basilica</li>
+                  <li>Often includes gondola ride or glass factory visit</li>
+                </ul>
+              </div>
+            </div>
+          </div>
             </details>
+
+        <!-- REAL TALK -->
+        <p class="real-talk">Venice charges a day-tripper entry fee (€5) during peak days — check comune.venezia.it before arrival. The Rialto Bridge and St. Mark's Square are packed from 10 AM to 4 PM when cruise ships are in. Get lost in Dorsoduro or Cannaregio for the real Venice. Sit-down coffee at St. Mark's costs €12-15 with the "music surcharge."</p>
+
+        <!-- FROM THE PIER -->
+        <div class="from-the-pier" id="from-the-pier" aria-label="Travel times from Venice cruise terminal">
+          <h3>From the Pier</h3>
+          <ul class="pier-distances">
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Piazzale Roma</span><div class="pier-detail">People Mover from Marghera terminal</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">🚋</span> 10 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:10%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Rialto Bridge</span><div class="pier-detail">Vaporetto Line 1 from Piazzale Roma</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 30 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:28%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">St. Mark's Square</span><div class="pier-detail">Vaporetto Line 1 full Grand Canal route</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 45 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:40%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Murano (Glass Island)</span><div class="pier-detail">Vaporetto from Fondamente Nove</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 50 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:45%"></div></div>
+            </li>
+            <li class="pier-distance-item">
+              <div><span class="pier-dest">Burano (Colorful Houses)</span><div class="pier-detail">Vaporetto via Murano</div></div>
+              <span class="pier-time"><span class="walk-icon" aria-hidden="true">⛴️</span> 75 min</span>
+              <div class="pier-bar"><div class="pier-bar-fill" style="width:65%"></div></div>
+            </li>
+          </ul>
+        </div>
 
       <!-- Depth Soundings Section -->
       <details class="port-section" id="depth-soundings" open>


### PR DESCRIPTION
Expand three competitor gap features from 10 Caribbean ports to 30 total:
- 10 Mediterranean: Barcelona, Civitavecchia, Naples, Santorini, Dubrovnik, Mykonos, Venice, Kotor, Marseille, Athens
- 6 Alaska: Juneau, Ketchikan, Skagway, Sitka, Icy Strait Point, Seward
- 4 Hawaii: Honolulu, Maui, Hilo, Nawiliwili
- 2 Caribbean completions: Montego Bay and Roatan (DIY vs. Excursion only)

Each port now has: walking distance visualization from the pier, honest "Real Talk" traveler advice, and DIY vs. Ship Excursion cost comparisons for the top experience at each destination.

https://claude.ai/code/session_014YvvbeoRt2xRLwHnZ4JttD