### PR TITLE
Fix documentation inconsistencies across 7 files

### DIFF
--- a/IN_PROGRESS_TASKS.md
+++ b/IN_PROGRESS_TASKS.md
@@ -1,7 +1,7 @@
 # In-Progress Tasks
 
 **Purpose:** Thread coordination file to prevent conflicts between concurrent Claude threads.
-**Last Updated:** 2026-01-31 (cleaned up by claude/identify-maintenance-tasks-FN2lh)
+**Last Updated:** 2026-02-05 (cleaned up by claude/onboard-and-audit-PvzvO)
 **Maintained by:** Claude AI (Thread tracking)
 
 ---
@@ -36,12 +36,12 @@ FORMAT:
 **Notes:** Any blockers or important context
 -->
 
-### Documentation Consistency, CSS Consolidation & Competitor Gap Features
-**Thread:** `claude/identify-maintenance-tasks-FN2lh`
-**Started:** 2026-01-31
-**Files:** admin/claude/CLAUDE.md, IN_PROGRESS_TASKS.md, ships/*/index.html (CSS consolidation), ports/ (competitor gap features)
-**Status:** Starting — Tier 1 doc fixes, then Tier 2 CSS + competitor gap work.
-**Notes:** Continuation of priorities from plan-implementation-priorities-2026-01-31.md.
+### Onboard, Audit & Backlog Execution
+**Thread:** `claude/onboard-and-audit-PvzvO`
+**Started:** 2026-02-05
+**Files:** UNFINISHED_TASKS.md, admin/claude/CLAUDE.md, claude.md, IN_PROGRESS_TASKS.md, ports/*.html
+**Status:** Active — From the Pier complete (376/376), full codebase audit complete, documentation consistency fixes in progress.
+**Notes:** PR #1139 merged. Continuing with remaining Green-lane backlog items.
 
 ---
 
@@ -65,7 +65,8 @@ FORMAT:
 
 | Thread ID | Task | Status | Date |
 |-----------|------|--------|------|
-| claude/identify-maintenance-tasks-FN2lh | Doc consistency, CSS consolidation, competitor gap features | IN PROGRESS | 2026-01-31 |
+| claude/identify-maintenance-tasks-FN2lh | Doc consistency, CSS consolidation, competitor gap features | COMPLETE (merged) | 2026-01-31 |
+| claude/onboard-and-audit-PvzvO | From the Pier (376 ports), codebase audit, doc fixes | IN PROGRESS | 2026-02-05 |
 | claude/audit-venues-gD9fq | Logbook enrichment — Gentle Truth reviews | COMPLETE | 2026-01-31 |
 | claude/review-previous-work-ZMk3b | Deep audit, JPG elimination, CSS consolidation, ship-page.css rollout, guardrail, docs | COMPLETE | 2026-01-31 |
 | claude/review-onboarding-setup-01JpVFgKzWRBKvXaxcS1pC9N | Onboarding review, schema fix | COMPLETE | 2025-12-01 |

--- a/MAINTENANCE_TASKS.md
+++ b/MAINTENANCE_TASKS.md
@@ -133,7 +133,7 @@ node admin/validate-ship-page.js --all-ships 2>&1 | grep -E "(FAQ|story|content)
 node admin/validate-ship-page.js --all-ships 2>&1 | grep "persona"
 ```
 
-**Reference:** `admin/UNFINISHED-TASKS.md` for current status
+**Reference:** `UNFINISHED_TASKS.md` for current status
 
 ---
 
@@ -729,7 +729,7 @@ node admin/batch-fix-lazy-images.js
 ./admin/update-unfinished-tasks.sh
 ```
 
-**Output:** Updates `admin/UNFINISHED-TASKS.md` with current validation status.
+**Output:** Updates `UNFINISHED_TASKS.md` with current validation status.
 
 ---
 
@@ -936,7 +936,7 @@ python3 -c "import json; d=json.load(open('assets/data/ship-deployments.json'));
 
 ### 10.2 Adding New Cruise Lines
 
-**Frequency:** As resources allow (see admin/UNFINISHED-TASKS.md for priority list)
+**Frequency:** As resources allow (see UNFINISHED_TASKS.md for priority list)
 
 **Remaining Cruise Lines (0):**
 All 15 cruise lines have been implemented. Disney is excluded per user preference.
@@ -1051,7 +1051,7 @@ const specialNames = {
 - **Theological Foundation:** `.claude/skills/standards/resources/theological-foundation.md`
 
 ### Task Tracking
-- **Unfinished Tasks:** `admin/UNFINISHED-TASKS.md`
+- **Unfinished Tasks:** `UNFINISHED_TASKS.md`
 - **Vanilla Stories:** `admin/VANILLA-STORIES.md`
 - **Port Disclaimer Registry:** `admin/port-disclaimer-registry.json`
 

--- a/MAINTENANCE_TASKS_IDENTIFIED.md
+++ b/MAINTENANCE_TASKS_IDENTIFIED.md
@@ -295,7 +295,7 @@ Tasks in UNFINISHED_TASKS.md use a lane system:
 | Document | Location | Purpose |
 |----------|----------|---------|
 | Maintenance Tasks | `MAINTENANCE_TASKS.md` | Routine maintenance guide |
-| Unfinished Tasks | `admin/UNFINISHED-TASKS.md` | Current work backlog |
+| Unfinished Tasks | `UNFINISHED_TASKS.md` | Current work backlog |
 | Onboarding | `.claude/ONBOARDING.md` | System overview |
 | ICP-Lite Protocol | `.claude/skills/standards/resources/icp-lite-protocol.md` | AI metadata spec |
 | Ship Page Standards | `new-standards/foundation/SHIP_PAGE_STANDARDS_v3.007.010.md` | Template |

--- a/UNFINISHED_TASKS.md
+++ b/UNFINISHED_TASKS.md
@@ -235,16 +235,18 @@ The following items were **explicitly started** in previous threads. Each has be
 
 ### Documentation Inconsistencies Discovered
 
-| Issue | Location | Fix Needed |
-|-------|----------|------------|
-| admin/claude/CLAUDE.md references ICP-Lite v1.0, not v1.4 | admin/claude/CLAUDE.md:392,424 | Update to v1.4 |
-| admin/claude/CLAUDE.md says 147 port pages; actual count is 374+ | admin/claude/CLAUDE.md:186,192,220 | Update counts |
-| admin/claude/CLAUDE.md says 28 RCL ships in Stateroom Checker; need verification | admin/claude/CLAUDE.md:1969 | Verify current count |
-| admin/claude/CLAUDE.md priorities section (line 709) is outdated (2025-11-23) | admin/claude/CLAUDE.md:709 | Update priorities |
-| claude.md (root) says 311 ship pages; may need verification | claude.md:181 | Verify count |
-| claude.md references `admin/UNFINISHED-TASKS.md` which doesn't exist | claude.md:33 | Should reference `UNFINISHED_TASKS.md` |
-| IN_PROGRESS_TASKS.md says "No tasks currently in progress" but multiple items are active | IN_PROGRESS_TASKS.md:39 | Update active work |
-| ONBOARDING.md version is v1.1.5 (2026-01-29) — cross-doc data mostly consistent | .claude/ONBOARDING.md | Minor updates only |
+| Issue | Location | Status |
+|-------|----------|--------|
+| ~~CLAUDE.md references ICP-Lite v1.0~~ | admin/claude/CLAUDE.md | ✅ Fixed in v1.2.0 (2026-01-31) |
+| ~~CLAUDE.md says 147 port pages~~ | admin/claude/CLAUDE.md | ✅ Fixed in v1.2.0 — now says 380 |
+| ~~CLAUDE.md says 28 RCL ships in Stateroom Checker~~ | admin/claude/CLAUDE.md | ✅ Already correct — says 270 exception files |
+| ~~CLAUDE.md priorities section outdated~~ | admin/claude/CLAUDE.md:708 | ✅ Fixed 2026-02-05 (v1.2.4) — all counts verified against codebase |
+| ~~claude.md says 297 ship pages~~ | claude.md:41,182 | ✅ Fixed 2026-02-05 — now says 292 (verified count in cruise line dirs) |
+| ~~claude.md says 404 restaurant pages~~ | claude.md:186 | ✅ Fixed 2026-02-05 — now says 472 (verified) |
+| ~~claude.md says ship-page.css 292/297~~ | claude.md:187 | ✅ Fixed 2026-02-05 — now says 292/292 (100%) |
+| ~~`admin/UNFINISHED-TASKS.md` wrong path~~ | MAINTENANCE_TASKS.md, MAINTENANCE_TASKS_IDENTIFIED.md, INTERIOR_NAMING_RIGHTS_PROMPT.md | ✅ Fixed 2026-02-05 — all 6 references corrected to `UNFINISHED_TASKS.md` |
+| ~~IN_PROGRESS_TASKS.md stale entry~~ | IN_PROGRESS_TASKS.md | ✅ Fixed 2026-02-05 — updated to current thread |
+| ONBOARDING.md version is v1.1.5 (2026-01-29) | .claude/ONBOARDING.md | Minor — cross-doc data mostly consistent |
 
 ---
 

--- a/admin/claude/CLAUDE.md
+++ b/admin/claude/CLAUDE.md
@@ -1,7 +1,7 @@
 # Claude AI Assistant Guide - In the Wake
 
-**Version:** 1.2.3
-**Last Updated:** 2026-02-01
+**Version:** 1.2.4
+**Last Updated:** 2026-02-05
 **Purpose:** Comprehensive onboarding and reference guide for Claude AI assistants working on the In the Wake codebase
 
 ---
@@ -705,7 +705,7 @@ JSON-LD schema. Reduces page weight and improves LCP scores.
 
 ---
 
-## 🎯 Current Priorities (Updated 2026-02-01)
+## 🎯 Current Priorities (Updated 2026-02-05)
 
 ### P0 - Critical (Do These First)
 1. ✅ ~~Port Logbook~~ COMPLETE
@@ -715,17 +715,17 @@ JSON-LD schema. Reduces page weight and improves LCP scores.
 5. ✅ ~~Port expansion~~ COMPLETE (380 pages, up from 147)
 6. ✅ ~~ICP-Lite rollout~~ COMPLETE (100% of pages)
 7. ✅ ~~Venue audit Phase 2~~ COMPLETE (0 generic text, 0 hotdog.webp, all have menus; validator in validate.js)
-8. ⏳ **CSS consolidation (remaining)** — 12 ship fleet index `.ship-list` inline blocks remain (class name conflict), ~12 misc page-specific styles
+8. ⏳ **CSS consolidation (remaining)** — 18 files with `<style>` blocks (tools/admin/templates only); 31,128 inline `style=` attributes need Phase 5 cleanup
 
 ### P1 - High Priority (Do These Soon)
-9. ✅ ~~Port map completion~~ ESSENTIALLY COMPLETE — 375/380 (99%) have Leaflet maps, only 5 remain
-10. ⏳ **Ship page CSS rollout** — `ship-page.css` linked on 292/309 ship pages (17 remaining: newer cruise line additions)
-11. ⏳ **Competitor gap remaining items** — ~56% done (9/16+). Key gaps: "From the Pier" distances, transport cost tables, port day planner, budget calculator
+9. ⏳ **Port map completion** — 334/380 (88%) have Leaflet maps, 46 remaining
+10. ✅ ~~Ship page CSS rollout~~ COMPLETE — `ship-page.css` linked on 292/292 ship pages in cruise line directories (100%)
+11. ✅ ~~Competitor gap: "From the Pier"~~ COMPLETE — 376/376 real port pages have distance/transport component (2026-02-05)
 12. ⏳ **Site-wide hero/logo standardization** — Inconsistent across hub pages
 
 ### P2 - Medium Priority
-13. ✅ ~~Service Worker v14 upgrade~~ COMPLETE — sw.js 13.2.0 → 14.0.0 (predictive prefetch, FX API stale cache, precache-manifest updated)
-14. ✅ ~~Port weather seasonal data~~ COMPLETE — `seasonal-guides.json` has Tier 1 data for 381 ports; SW caching optimized with staleWhileRevalidate + prefetch in sw-bridge.js
+13. ✅ ~~Service Worker v14 upgrade~~ COMPLETE — sw.js upgraded to v14.2.0
+14. ✅ ~~Port weather seasonal data~~ COMPLETE — `seasonal-guides.json` has Tier 1 data for 380 ports; port-weather.js deployed to all 380 pages; 375/376 real ports have weather guide section
 15. ✅ ~~Stateroom Checker~~ MASSIVELY EXPANDED — 270 exception JSON files across ALL cruise lines
 
 ### P3-P4 - Future / Requires User Decision
@@ -850,6 +850,7 @@ Before marking any task complete, verify:
 ---
 
 **Version History:**
+- v1.2.4 (2026-02-05) - Corrected priorities against codebase audit: Leaflet maps 375→334 (88%), ship-page.css 292/309→292/292 (100%), "From the Pier" marked COMPLETE (376/376), SW version 14.0.0→14.2.0, seasonal data 381→380 ports, CSS consolidation updated to verified counts (18 style blocks, 31,128 inline attributes)
 - v1.2.3 (2026-02-01) - Updated seasonal-guides.json status (1→381 ports), corrected ship-page.css count (292/309), updated site-wide page count (1,167→1,195), WebP count (2,906→2,345), fixed image alt text accessibility (356 instances), updated all port last-reviewed dates to 2026-02-01
 - v1.2.2 (2026-01-31) - Documentation consistency pass: fixed SW version 13.0.0→14.0.0, fixed ai:summary→ai-summary (ICP-Lite v1.4), updated trust badge text to match site, marked SW v14 upgrade complete in priorities
 - v1.2.1 (2026-01-31) - Documentation consistency pass: fixed page/image counts to ground-truth (port-tracker 147→380, ICP-Lite 544→1115, ship images 82→444, site pages 561→1167), marked ship-page.css rollout complete (292/297), updated CSS consolidation status, removed stale JPG references

--- a/admin/claude/INTERIOR_NAMING_RIGHTS_PROMPT.md
+++ b/admin/claude/INTERIOR_NAMING_RIGHTS_PROMPT.md
@@ -56,7 +56,7 @@ the Interior array.
 
 Before you touch a single file, you must read and internalize:
 
-1. `admin/UNFINISHED-TASKS.md` — the full project context doc. Read it
+1. `UNFINISHED_TASKS.md` — the full project context doc. Read it
    completely. It has iCruise WMPHShipCodes, cabin numbering conventions,
    class groupings, and the classification rules.
 

--- a/claude.md
+++ b/claude.md
@@ -38,7 +38,7 @@ This is a static HTML/CSS/JavaScript cruise planning website with an AI-first me
 
 ```
 InTheWake/
-├── ships/              # 297 ship pages across 15 cruise lines
+├── ships/              # 292 ship pages across 16 cruise lines
 ├── ports/              # 380 port guide pages
 ├── restaurants/        # Dining venue pages
 ├── assets/             # CSS, JS, images, data
@@ -179,13 +179,12 @@ All work on this project is offered as a gift to God.
 
 | Metric | Value |
 |--------|-------|
-| Ship Pages | 297 |
-| Passing Validation | 106 (34%) *(last measured — validator needs cheerio)* |
-| Blocking Errors | 981 *(last measured)* |
+| Ship Pages | 292 (in 16 cruise line directories) |
 | Port Pages | 380 |
-| Restaurant/Venue Pages | 404 |
-| Ship pages with ship-page.css | 292/297 |
-| Ship Deployments | 193 ships, 15 cruise lines, 380 ports |
+| Restaurant/Venue Pages | 472 |
+| Ship pages with ship-page.css | 292/292 (100%) |
+| Ship Deployments | 193 ships, 16 cruise lines, 380 ports |
+| From the Pier component | 376/376 real ports (100%) |
 | JPG/JPEG images | 0 (eliminated 2026-01-31) |
 
 See [UNFINISHED_TASKS.md](UNFINISHED_TASKS.md) for detailed status.


### PR DESCRIPTION
Verified all counts against actual codebase:
- CLAUDE.md priorities: Leaflet maps 375→334 (88%), ship-page.css→100%, From the Pier marked COMPLETE, SW v14.0.0→v14.2.0
- claude.md: ship pages 297→292, restaurants 404→472, ship-page.css 292/292
- MAINTENANCE_TASKS.md + 2 others: admin/UNFINISHED-TASKS.md → UNFINISHED_TASKS.md (6 stale path references corrected)
- IN_PROGRESS_TASKS.md: replaced stale thread entry with current work
- UNFINISHED_TASKS.md: marked 9/10 inconsistencies as resolved

https://claude.ai/code/session_01JcLahCnVUX95m44KViWy2f