### PR TITLE
Fix Recent Stories not loading on 27 pages

### DIFF
--- a/ports/lautoka.html
+++ b/ports/lautoka.html
@@ -790,7 +790,7 @@ Soli Deo Gloria
         if(n)n.onclick=()=>{page++;render();};
       }
       fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-        articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+        articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
         if(fb)fb.style.display='none';
         if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
       }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-ecstasy.html
+++ b/ships/carnival/carnival-ecstasy.html
@@ -390,7 +390,7 @@ Dining Venues</h2>
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-elation.html
+++ b/ships/carnival/carnival-elation.html
@@ -418,7 +418,7 @@ fetch('/assets/data/logbook/carnival/carnival-elation.json').then(r=>r.json()).t
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-encounter.html
+++ b/ships/carnival/carnival-encounter.html
@@ -901,7 +901,7 @@ Dining Venues</h2></header>
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-fantasy.html
+++ b/ships/carnival/carnival-fantasy.html
@@ -389,7 +389,7 @@ Dining Venues</h2>
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-fascination.html
+++ b/ships/carnival/carnival-fascination.html
@@ -390,7 +390,7 @@ Dining Venues</h2>
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-imagination.html
+++ b/ships/carnival/carnival-imagination.html
@@ -358,7 +358,7 @@ Dining Venues</h2>
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-inspiration.html
+++ b/ships/carnival/carnival-inspiration.html
@@ -390,7 +390,7 @@ Dining Venues</h2>
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-luminosa.html
+++ b/ships/carnival/carnival-luminosa.html
@@ -595,7 +595,7 @@ Dining Venues on Carnival Luminosa <a href="/restaurants.html" style="font-size:
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-paradise.html
+++ b/ships/carnival/carnival-paradise.html
@@ -470,7 +470,7 @@ fetch('/assets/data/logbook/carnival/carnival-paradise.json').then(r=>r.json()).
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-radiance.html
+++ b/ships/carnival/carnival-radiance.html
@@ -720,7 +720,7 @@ Features & Dining</h2>
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-sensation.html
+++ b/ships/carnival/carnival-sensation.html
@@ -389,7 +389,7 @@ Dining Venues</h2>
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-splendor.html
+++ b/ships/carnival/carnival-splendor.html
@@ -804,7 +804,7 @@ Features & Dining</h2>
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-sunrise.html
+++ b/ships/carnival/carnival-sunrise.html
@@ -726,7 +726,7 @@ Features & Dining</h2>
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -836,7 +836,7 @@ Dining Venues on Carnival Sunshine <a href="/restaurants.html" style="font-size:
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-tropicale.html
+++ b/ships/carnival/carnival-tropicale.html
@@ -760,7 +760,7 @@
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -882,7 +882,7 @@ Dining Venues on Carnival Venezia <a href="/restaurants.html" style="font-size: 
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnival-vista.html
+++ b/ships/carnival/carnival-vista.html
@@ -456,7 +456,7 @@ Dining Venues on Carnival Vista</h2>
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/carnivale-1956.html
+++ b/ships/carnival/carnivale-1956.html
@@ -329,7 +329,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/celebration-1987.html
+++ b/ships/carnival/celebration-1987.html
@@ -322,7 +322,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/festivale-1961.html
+++ b/ships/carnival/festivale-1961.html
@@ -322,7 +322,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/holiday-1985.html
+++ b/ships/carnival/holiday-1985.html
@@ -321,7 +321,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/jubilee-1986.html
+++ b/ships/carnival/jubilee-1986.html
@@ -321,7 +321,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/mardi-gras-1972.html
+++ b/ships/carnival/mardi-gras-1972.html
@@ -327,7 +327,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/ships/carnival/tropicale-1981.html
+++ b/ships/carnival/tropicale-1981.html
@@ -322,7 +322,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
     if(n)n.onclick=()=>{page++;render();};
   }
   fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-    articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+    articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
     if(fb)fb.style.display='none';
     if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
   }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/solo/solo-cruising-practical-guide.html
+++ b/solo/solo-cruising-practical-guide.html
@@ -679,7 +679,7 @@
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});

--- a/solo/why-i-started-solo-cruising.html
+++ b/solo/why-i-started-solo-cruising.html
@@ -344,7 +344,7 @@
       if(n)n.onclick=()=>{page++;render();};
     }
     fetch('/assets/data/articles/index.json').then(r=>r.json()).then(data=>{
-      articles=(data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
+      articles=(data.articles||data||[]).filter(a=>a.status==='published').sort((a,b)=>new Date(b.date)-new Date(a.date));
       if(fb)fb.style.display='none';
       if(articles.length)render();else rail.innerHTML='<p class="tiny">No articles yet.</p>';
     }).catch(()=>{if(fb)fb.textContent='Could not load articles.';});


### PR DESCRIPTION
Bug: articles/index.json returns {articles: [...]} object, but JS
was treating response as direct array: (data||[])

Fixed: Changed to (data.articles||data||[]) to handle both formats

Affected pages: solo articles, cruise-lines, ships, ports, and hub pages

https://claude.ai/code/session_01JcLahCnVUX95m44KViWy2f