### PR TITLE
Review all 33 cross-port duplicate sets and assign port ownership

### DIFF
--- a/admin/cross-port-image-allowlist.json
+++ b/admin/cross-port-image-allowlist.json
@@ -1,6 +1,240 @@
 {
-  "_comment": "Cross-port image duplicate allowlist. Human-reviewed entries are downgraded from BLOCKING to INFO. Add entries here after manually verifying that a shared image is intentional.",
-  "_format": "Each entry: hash (md5), ports (array of port slugs sharing the image), reason (why it's OK), reviewer, date",
-  "_usage": "The validator (validate-port-page-v2.js) reads this file. Unreviewed duplicates remain BLOCKING.",
-  "reviewed": []
+  "_comment": "Cross-port image duplicate allowlist. Each entry assigns a duplicate image to its correct port. The validator green-lights the approved port and keeps BLOCKING on all others.",
+  "_format": "Each entry: hash (md5), approvedPort (the one port that owns this image), description (what the image shows), reviewer, date",
+  "_usage": "The validator (validate-port-page-v2.js) reads this file. Images on the approved port get INFO; on other ports they stay BLOCKING.",
+  "reviewed": [
+    {
+      "hash": "059c87ee6c3c6618f552f7ddb705443d",
+      "approvedPort": "antarctic-peninsula",
+      "description": "Iceberg arch photographed from zodiac — Antarctic Peninsula excursion",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "c34e01bdadc5b65b67779e50078fa81f",
+      "approvedPort": "antarctic-peninsula",
+      "description": "Wind-sculpted iceberg with peninsula mountain backdrop",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "3104a32a36177150cebd7bc5b69f77ad",
+      "approvedPort": "antarctic-peninsula",
+      "description": "Leopard seal on ice — Antarctic wildlife",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "1a97bd046228fe3c675d62dea88a4493",
+      "approvedPort": "antarctic-peninsula",
+      "description": "Port Lockroy building (British station on Goudier Island, Antarctic Peninsula)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "4b9d69a96202f44cbca8a25d1181efc9",
+      "approvedPort": "cozumel",
+      "description": "Crystal clear Caribbean beach with umbrellas — part of Cozumel photo series",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "029e14d0478fdc132dbbfa5615b778cd",
+      "approvedPort": "cozumel",
+      "description": "Heart sculpture reading 'Punta Langosta COZUMEL'",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "26a6a85722f17d6edf577d1d3eba7f99",
+      "approvedPort": "cozumel",
+      "description": "Colorful 'COZUMEL' letters at Punta Langosta cruise terminal",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "4741a1ab51641aba424d50caa6d6ea75",
+      "approvedPort": "cozumel",
+      "description": "Welcome sign: 'Punta Langosta Cozumel México'",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "9b3a36826a1e0f735573c535af3c5a5c",
+      "approvedPort": "cozumel",
+      "description": "Compass rose embedded in Punta Langosta pier concrete",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "62950b86e712bc8c381a7fe076ee8bad",
+      "approvedPort": "cozumel",
+      "description": "Punta Langosta cruise terminal building with 'Welcome' banner",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "bf40387ac298a8ee1cdc7c4c1d550c5f",
+      "approvedPort": "cozumel",
+      "description": "Giant colorful 'COZUMEL' letters with Royal Caribbean Oasis-class ship",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "889d5feff302ff7f1f32c688e68cb92e",
+      "approvedPort": "costamaya",
+      "description": "Rocky limestone coastline with turquoise water — Yucatan Caribbean coast",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "db8e081f2a388c1d7dd78d971ad6ea2b",
+      "approvedPort": "costamaya",
+      "description": "Cruise ship docked at Mahahual pier (Costa Maya port town)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "43f8d7a5aaf2f57647f3458c63e4ac70",
+      "approvedPort": "costamaya",
+      "description": "Colorful fish sculpture with red 'Costa Maya' ball visible",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "f4fe6ec9fe4af7493d7e493c61760c52",
+      "approvedPort": "costamaya",
+      "description": "Jaguar head sculpture — Mayan-themed Costa Maya cruise port decor",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "f6b322cb409f892b2897f13154e1fe4e",
+      "approvedPort": "cannes",
+      "description": "1951 SS Independence Mediterranean cruise poster (American Export Lines) — used as Cannes hero",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "50e3c73a80e5269e0110d765fc02336a",
+      "approvedPort": "chilean-fjords",
+      "description": "Photo collage mosaic — not port-specific, assigned to first folder",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "23c7104d22498bd0387d8f3e37c82426",
+      "approvedPort": "fairbanks",
+      "description": "Fish wheel camp on Alaskan river — traditional Fairbanks/Tanana River fishing",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "02ab0f1c8a6cfc157040b0adb0378789",
+      "approvedPort": "endicott-arm",
+      "description": "SE Alaska fjord with icebergs and steep mountains (hero + image 1)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "536c2f5f6267c7e213b9df1626700a55",
+      "approvedPort": "endicott-arm",
+      "description": "SE Alaska fjord with icebergs, mountains, glacier visible (image 2)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "09e56190cbae939d1ba165754983e3a9",
+      "approvedPort": "endicott-arm",
+      "description": "SE Alaska fjord scene with icebergs and exposed rock (image 3)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "d5471deed6c8b578e5e955356d71697a",
+      "approvedPort": "endicott-arm",
+      "description": "Calm fjord with mountain reflection and small icebergs (image 4)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "807bb7befe88d49a2dd7ca66625e410f",
+      "approvedPort": "endicott-arm",
+      "description": "Fjord with dense floating ice and mountains (image 5)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "a55047c06a0007e088cf2b26069230b1",
+      "approvedPort": "endicott-arm",
+      "description": "Glacier tongue visible between mountains with small icebergs (image 6)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "705c89e421aa07190e14fffa840c77d5",
+      "approvedPort": "endicott-arm",
+      "description": "Narrow fjord entrance with glacier in distance (image 7)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "fa4b70550485007466bab680927653ea",
+      "approvedPort": "endicott-arm",
+      "description": "Ship wake in sunlit fjord waterway (image 8)",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "837e74b6adc4728c74d38364b606329a",
+      "approvedPort": "endicott-arm",
+      "description": "Same as hero but uncropped original version",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "2bd71eca5deefdd775a577ee559febe2",
+      "approvedPort": "glacier-bay",
+      "description": "Holland America Line ship in Glacier Bay with bare rocky mountains",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "aff5636938f91bdae06d2ac51e542f0f",
+      "approvedPort": "glacier-bay",
+      "description": "Panoramic glacier and mountain view — classic Glacier Bay scenery",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "ecb24d57695f49acf505b320cd6d957c",
+      "approvedPort": "seward",
+      "description": "Seward Small Boat Harbor with fishing vessels and mountain backdrop",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "6c5372a87ec60d2014b5cdef029b2cc0",
+      "approvedPort": "helsinki",
+      "description": "Cruise terminal pier with covered walkways — cannot distinguish Helsinki/Tallinn; assigned to Helsinki",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    },
+    {
+      "hash": "9ed89b8b58acae316e0e4295d191071e",
+      "approvedPort": "trinidad",
+      "description": "Indian Caribbean Museum of Trinidad & Tobago — physical building is in Trinidad",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    }
+  ],
+  "_unresolved": [
+    {
+      "hash": "9d2bcf49936a2907c84c419fc72dcd29",
+      "ports": ["glacier-bay", "virgin-gorda"],
+      "description": "US Airport enplanements map (2023) — not a port image at all. Does not belong on ANY port page. Stays BLOCKING on both.",
+      "reviewer": "Claude (visual inspection)",
+      "date": "2026-02-20"
+    }
+  ]
 }

--- a/admin/validate-port-page-v2.js
+++ b/admin/validate-port-page-v2.js
@@ -92,21 +92,22 @@ async function buildCrossPortHashMap() {
 }
 
 // Human-reviewed allowlist: cross-port duplicates that have been manually
-// verified as intentional. Loaded from admin/cross-port-image-allowlist.json.
-// Format: Set of hashes that a human has approved.
-let _allowedDuplicateHashes = null;
+// verified and assigned to a specific port. Loaded from
+// admin/cross-port-image-allowlist.json.
+// Format: Map of hash → approvedPort (the one port where this image belongs).
+let _allowedDuplicateMap = null;
 
 function loadAllowedDuplicates() {
-  if (_allowedDuplicateHashes) return _allowedDuplicateHashes;
+  if (_allowedDuplicateMap) return _allowedDuplicateMap;
 
-  _allowedDuplicateHashes = new Set();
+  _allowedDuplicateMap = new Map(); // hash → approvedPort
   const allowlistPath = join(dirname(fileURLToPath(import.meta.url)), 'cross-port-image-allowlist.json');
   try {
     const data = JSON.parse(readFileSync(allowlistPath, 'utf-8'));
     if (Array.isArray(data.reviewed)) {
       for (const entry of data.reviewed) {
-        if (entry.hash) {
-          _allowedDuplicateHashes.add(entry.hash);
+        if (entry.hash && entry.approvedPort) {
+          _allowedDuplicateMap.set(entry.hash, entry.approvedPort);
         }
       }
     }
@@ -114,7 +115,7 @@ function loadAllowedDuplicates() {
     // Allowlist missing or malformed — treat all duplicates as unreviewed
   }
 
-  return _allowedDuplicateHashes;
+  return _allowedDuplicateMap;
 }
 
 const __filename = fileURLToPath(import.meta.url);
@@ -1169,7 +1170,7 @@ async function validatePortImages(filepath) {
 
   // Build dynamic cross-port hash map (cached after first call)
   const crossPortMap = await buildCrossPortHashMap();
-  const allowedHashes = loadAllowedDuplicates();
+  const allowedMap = loadAllowedDuplicates();
 
   for (const imgFile of imageFiles) {
     const imgPath = join(portImgDir, imgFile);
@@ -1187,10 +1188,15 @@ async function validatePortImages(filepath) {
       if (dupePortMap) {
         const otherPorts = [...dupePortMap.keys()].filter(p => p !== filename);
         if (otherPorts.length > 0) {
-          if (allowedHashes.has(hash)) {
-            // Human-reviewed and approved — downgrade to info
+          const approvedPort = allowedMap.get(hash);
+          if (approvedPort === filename) {
+            // This port is the approved owner — downgrade to info
             allowedDupeCount++;
-            allowedDupeImages.push(`${imgFile} (shared with ${otherPorts.join(', ')})`);
+            allowedDupeImages.push(`${imgFile} (approved owner; also in ${otherPorts.join(', ')})`);
+          } else if (approvedPort && approvedPort !== filename) {
+            // Reviewed but belongs to a DIFFERENT port — BLOCKING (wrong port)
+            crossPortCount++;
+            crossPortImages.push(`${imgFile} (belongs to ${approvedPort}, not this port; also in ${otherPorts.join(', ')})`);
           } else {
             // Unreviewed — BLOCKING
             crossPortCount++;


### PR DESCRIPTION
Visual inspection of every duplicate image determined correct owner:
- 4 Antarctic images → antarctic-peninsula (Port Lockroy, icebergs, seal)
- 7 Cozumel images → cozumel (signs literally say "COZUMEL")
- 4 Costa Maya images → costamaya (fish sculpture says "Costa Maya")
- 9 Endicott Arm images → endicott-arm (batch-duped to tracy-arm)
- 2 Glacier Bay images → glacier-bay (HAL ship, glacier panorama)
- 1 Seward harbor → seward
- 1 Fairbanks fish wheel → fairbanks
- 1 Cannes hero poster → cannes
- 1 Chilean fjords collage → chilean-fjords
- 1 Helsinki terminal → helsinki
- 1 Trinidad museum → trinidad

1 image left BLOCKING on both ports: US Airport map on glacier-bay and virgin-gorda (not a port image at all).

Allowlist format upgraded to port-specific: each hash maps to exactly one approvedPort. Validator now shows three states:
- Approved owner: INFO ("approved owner; also in X")
- Wrong port: BLOCKING ("belongs to X, not this port")
- Unreviewed: BLOCKING ("also in X")

https://claude.ai/code/session_01HrDAiurBX69VTYbwCdSgzk