### PR TITLE
Resequence home page: motto first, duck last (Emotional Hook Test)

### DIFF
--- a/admin/EMOTIONAL_HOOK_TEST_PLAN.md
+++ b/admin/EMOTIONAL_HOOK_TEST_PLAN.md
@@ -1,0 +1,184 @@
+# Emotional Hook Test — Page Restructuring Plan
+
+**Version:** 1.0.0
+**Created:** 2026-03-07
+**Origin:** Curse of Knowledge analysis applied to ITW pages
+**Status:** Draft — approved for one-page pilot (home page)
+
+---
+
+## The Test
+
+The 30-Second Emotional Hook Test evaluates what a reader *feels* in their first 30 seconds on a page — not what's technically present. Five questions, timed:
+
+| Second | Question | Dimension |
+|--------|----------|-----------|
+| 0–5 | Can I tell what this page is for? | **Clarity** |
+| 5–10 | Does the first scroll feel calm or overwhelming? | **Calm** |
+| 10–15 | Does this feel like it was made for someone like me? | **Seen** |
+| 15–20 | Do I feel "I can do this" / "I'll be okay"? | **Confidence** |
+| 20–30 | Does this person actually know / actually care? | **Trust** |
+
+Grading: **Pass / Partial / Fail** per question.
+
+---
+
+## Baseline Scores (2026-03-07)
+
+| Dimension | Juneau (Port) | Allure (Ship) | Home Page |
+|-----------|:---:|:---:|:---:|
+| Clarity | Pass | Partial | **Fail** |
+| Calm | Pass | Partial | Partial |
+| Seen | Pass | Partial | Partial |
+| Confidence | Pass | Pass (late) | Partial |
+| Trust | Pass | Pass | Pass |
+| **Grade** | **A** | **B-** | **C+** |
+
+**Key finding:** Trust is the strongest dimension site-wide. Clarity and calm are weakest — not because content is missing, but because the emotional content is consistently behind the engineering content in visual hierarchy.
+
+---
+
+## Home Page Restructuring (index.html)
+
+### Problem
+The reader's first question — "What is this site and why should I care?" — is answered third. The motto and welcome section are behind a duck card and a first-timer callout.
+
+### Current visual hierarchy:
+1. Duck card (gold border, "Found a Duck?")
+2. First-timer callout ("New to Cruising?")
+3. Welcome + motto ("The calmest seas are found in another's wake")
+4. Intent selector ("What are you planning?")
+5. 10-tool dark grid
+6. 6-card explore grid
+7. Audience doorways (Solo / Accessibility)
+8. FAQ
+9. Works Offline callout
+
+### Proposed hierarchy:
+1. **Welcome + motto** — THE emotional hook. First thing every visitor sees.
+2. **Intent selector** — "What are you planning?" Self-routing for all visitors.
+3. **Featured logbook excerpt** — NEW. 3-4 sentences from a real story (Margaret, Juneau, etc.) that establish emotional tone.
+4. **First-timer callout** — Moved down; still prominent but not position #1.
+5. **Audience doorways** (Solo / Accessibility) — Promoted from position 7.
+6. **Explore grid** (6 cards) — Content directory for return visitors.
+7. **Planning tools** — Collapsed or reduced. The intent selector already routes to tools contextually. Consider showing top 4 instead of all 10.
+8. **FAQ**
+9. **Works Offline callout**
+10. **Duck card** — Moved to footer area or community section. Charming, but not the first impression for new visitors.
+
+### New section: Featured Logbook Excerpt
+A single card containing 3-4 sentences pulled from an existing logbook story. Purpose: show what ITW *feels like* before listing what it contains. Rotate periodically.
+
+Example pull from the grief article:
+> *On her bed sat a towel animal: A penguin. Tom loved penguins. It was so ridiculous and earnest that she laughed out loud — an involuntary, startled laugh. That laugh didn't erase grief. But it cracked open the smallest window of light.*
+
+### New section: Reader voice / testimonial
+A single sentence from a real reader. Purpose: social proof that feels personal, not statistical.
+
+### What moves:
+- Duck card → near footer or community section
+- First-timer callout → below intent selector
+- 10-tool grid → reduced to top 4-5 tools, or collapsed behind "See all tools"
+
+### What's NOT changing:
+- Right rail (Site Highlights, Search, Author card, Recent Stories, Authors) — these are fine
+- Footer — unchanged
+- Navigation — unchanged
+- All existing content preserved — this is resequencing, not removal
+
+---
+
+## Ship Page Restructuring (allure-of-the-seas.html as template)
+
+### Problem
+The reader's first question — "What's she like? Is she right for me?" — is answered by the logbook story, which is below the photo carousel, stats grid, sister ship pills, class explorer pills, AND the dining card.
+
+### Current section order:
+1. H1 + fact block (tonnage, year, capacity)
+2. Answer-line + content-text paragraph
+3. Photo carousel + stats grid
+4. Sister ship pills + class explorer pills
+5. Dining card (JSON-loaded)
+6. **Logbook story** ← emotional payoff is here
+7. Videos
+8. Deck plans + Live tracker
+9. FAQ
+
+### Proposed section order:
+1. H1 — Rewrite from "Deck Plans, Live Tracker, Dining & Videos" to personality-first
+2. **NEW: "Who She's For"** — 3-sentence personality assessment above everything else
+3. Photo carousel + stats grid (unchanged)
+4. **Logbook story** — MOVED UP from position 6 to position 4
+5. **NEW: "What She Feels Like"** — Sensory paragraph (what it's like to walk aboard)
+6. Sister ship pills + **NEW: "How She Compares"** quick reference
+7. Dining card
+8. Videos
+9. Deck plans + Live tracker
+10. FAQ
+
+### New section: "Who She's For" (per ship)
+3-sentence personality lead. Example for Allure:
+> **Who She's For**: Families and groups who want everything in one floating city — seven neighborhoods, Broadway shows, a Central Park with real trees. If you want intimate, she's not it. If you want "I'll never run out of things to do," she's perfect.
+
+### New section: "What She Feels Like" (per ship)
+Sensory paragraph describing the physical experience of being aboard. Not specs — feelings.
+
+### New section: "How She Compares" (per ship)
+Brief 3-4 line comparison with closest alternatives. Answers: "Why this ship instead of that one?"
+
+### Implementation note:
+These new sections require per-ship content that can't be auto-generated. They need to be written for each ship individually or pulled from logbook stories. Start with ships that have existing logbook entries.
+
+---
+
+## Port Page — Juneau (minimal changes)
+
+### Current grade: A
+Juneau is the emotional standard. Minimal changes needed.
+
+### Additions to consider:
+1. **"First Time in Alaska?" orientation box** — 3 sentences at the top for readers who don't know what Juneau is.
+2. **"Accessibility at This Port" subsection** — Dedicated section covering pier accessibility, shuttle accessibility, whale watching boat accessibility, tramway accessibility. Currently mentioned once in a Mendenhall paragraph.
+3. **Expanded logbook entry** — The Author's Note in the sidebar is brief. A full first-person narrative on the main column (like the grief article does) would push Trust from strong to extraordinary.
+
+### Implementation note:
+These are content additions that require author input. Flag for Ken Baker review.
+
+---
+
+## Applying the Test to Other Pages
+
+Once validated on these three pages, the Emotional Hook Test becomes a permanent quality gate:
+
+### Per page type, the feeling target:
+| Page Type | Reader's First Question | Feeling Target |
+|-----------|------------------------|----------------|
+| Ship | "What's she like? Is she right for me?" | "I understand her personality in 60 seconds" |
+| Port | "What should I do? Will I be okay?" | "I feel prepared stepping off the ship" |
+| Restaurant | "What will I eat? Is it worth paying?" | "I can see what I'll eat and decide fast" |
+| Disability | "Does anyone think about me?" | "Someone thought about me" |
+| Solo/Grief | "Am I alone in this?" | "I'm not alone" |
+| Tool | "Will this help or confuse me?" | "This makes something confusing feel manageable" |
+| Home | "What is this? Why should I care?" | "I know what this is and I trust it — in 5 seconds" |
+
+---
+
+## Implementation Order
+
+1. **Home page resequencing** — highest impact, no new content needed (just reorder)
+2. **Ship page template** — "Who She's For" + logbook promotion on Allure (template for other ships)
+3. **Port accessibility subsections** — starting with Juneau, then top-10 ports
+4. **Formalize the test** — Create a skill/hook that prompts the 5 questions before content commits
+
+---
+
+## Success Criteria
+
+After implementation, re-run the 30-Second Emotional Hook Test:
+- Home page: Clarity should move from Fail to Pass
+- Ship page: Clarity and Calm should move from Partial to Pass
+- All three pages should score B+ or higher
+
+---
+
+**Soli Deo Gloria** — The feeling is the product. The architecture is the mechanism.

--- a/index.html
+++ b/index.html
@@ -382,38 +382,6 @@
   <main id="main-content" class="wrap page-grid" role="main" aria-label="Main content">
     <!-- LEFT: welcome + top explore -->
     <section class="col-1" aria-label="Welcome and explore">
-      <!-- Duck Spotting Card - Special Callout (Dismissible) -->
-      <article id="duck-card" class="card" style="background: linear-gradient(135deg, #fff9e6 0%, #fffbf0 100%); border: 3px solid #ffd700; box-shadow: 0 4px 12px rgba(255, 215, 0, 0.2); position: relative;">
-        <button type="button" onclick="document.getElementById('duck-card').style.display=\'none\'; localStorage.setItem(\'duckCardDismissed\', \'true\');"
-                style="position: absolute; top: 0.75rem; right: 0.75rem; background: transparent; border: none; font-size: 1.5rem; cursor: pointer; color: #d4a017; padding: 0.25rem; line-height: 1; opacity: 0.6; transition: opacity 0.2s;"
-                onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.6'"
-                aria-label="Dismiss duck card">×</button>
-        <h2 style="margin: 0 0 0.5rem 0; color: #d4a017; font-size: 1.5rem; display: flex; align-items: center; gap: 0.5rem;">
-          🦆 Found a Duck?
-        </h2>
-        <p style="margin: 0.5rem 0; font-size: 1.05rem; line-height: 1.6;">
-          Spotted one of our signature yellow ducks on your cruise? We'd love to see it!
-          <strong>Send us a picture and be featured on our website and Instagram!</strong>
-        </p>
-        <div class="actions" style="margin-top: 1rem; display: flex; gap: 0.75rem; flex-wrap: wrap;">
-          <a class="pill" href="mailto:ken@cruisinginthewake.com?subject=I%20Found%20a%20Duck!&body=Hi!%20I%20found%20a%20duck%20on%20my%20cruise.%20Here's%20my%20photo%20(please%20attach).%0A%0AShip:%20%0ADate:%20%0ALocation%20where%20I%20found%20it:%20%0A%0A"
-             style="background: #ffd700; color: #333; border-color: #d4a017; font-weight: 600; font-size: 1.05rem; padding: 0.75rem 1.5rem;">
-            📧 Send Your Duck Photo!
-          </a>
-          <a class="pill" href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener"
-             style="background: #fff; color: #d4a017; border: 2px solid #ffd700; font-weight: 600; font-size: 1.05rem; padding: 0.75rem 1.5rem;">
-            📸 See Featured Ducks on Instagram
-          </a>
-        </div>
-      </article>
-
-      <!-- First-Timer Callout -->
-      <article class="card" style="background: linear-gradient(135deg, #e8f4f8 0%, #f0f9fb 100%); border-left: 4px solid #17a2b8;">
-        <h2 style="margin: 0 0 0.5rem; color: #0c5460; font-size: 1.25rem;">New to Cruising?</h2>
-        <p style="margin: 0 0 0.75rem; font-size: 0.95rem;">First voyage? We've got you covered with everything you need to know — from booking to disembarkation.</p>
-        <a class="pill" href="/first-cruise.html" style="background: #17a2b8; color: white; border-color: #138496;">Start Here: First Cruise Guide</a>
-      </article>
-
       <article class="card welcome">
         <h1>Welcome aboard</h1>
         <p class="motto"><em>The calmest seas are found in another's wake.</em></p>
@@ -481,6 +449,26 @@
         </div>
       </section>
 
+      <!-- First-Timer Callout (positioned after intent selector) -->
+      <article class="card" style="background: linear-gradient(135deg, #e8f4f8 0%, #f0f9fb 100%); border-left: 4px solid #17a2b8;">
+        <h2 style="margin: 0 0 0.5rem; color: #0c5460; font-size: 1.25rem;">New to Cruising?</h2>
+        <p style="margin: 0 0 0.75rem; font-size: 0.95rem;">First voyage? We've got you covered with everything you need to know — from booking to disembarkation.</p>
+        <a class="pill" href="/first-cruise.html" style="background: #17a2b8; color: white; border-color: #138496;">Start Here: First Cruise Guide</a>
+      </article>
+
+      <!-- Featured Logbook Excerpt — emotional hook -->
+      <article class="card" style="border-left: 4px solid var(--rope, #d9b382); background: #fffbf0;">
+        <h2 style="margin: 0 0 0.75rem; font-size: 1.1rem; color: #5a4a3a;">From the Logbook</h2>
+        <blockquote style="margin: 0; padding: 0; font-style: italic; line-height: 1.7; color: #3a3a3a;">
+          <p style="margin: 0 0 0.5rem;">On her bed sat a towel animal: a penguin. Tom loved penguins. It held a tiny "Merry Christmas" sign between its flippers.</p>
+          <p style="margin: 0 0 0.5rem;">It was so ridiculous and earnest that she laughed out loud — an involuntary, startled laugh. Then guilt slammed into her chest. "How can I laugh? Tom is gone."</p>
+          <p style="margin: 0;">But another thought followed — uninvited, but soft: <em>Tom would've laughed too.</em></p>
+        </blockquote>
+        <p class="tiny" style="margin-top: 0.75rem; color: #8a7a6a;">
+          From <a href="/solo/in-the-wake-of-grief.html" style="color: #0e6e8e;">In the Wake of Grief: When Loss Needs Water</a>
+        </p>
+      </article>
+
       <!-- Planning Tools Row -->
       <section class="card tools-section" aria-labelledby="tools-heading" style="background: linear-gradient(135deg, #083041 0%, #0e6e8e 100%); color: #fff;">
         <h2 id="tools-heading" style="color: #fff; margin-bottom: 0.5rem;">Planning Tools</h2>
@@ -535,6 +523,32 @@
             <span style="font-size: 2rem; margin-bottom: 0.5rem;">🧳</span>
             <strong style="font-size: 0.9rem;">Packing Lists</strong>
             <span class="tiny" style="color: rgba(255,255,255,0.7);">Bring less, enjoy more</span>
+          </a>
+        </div>
+      </section>
+
+      <!-- Audience Doorways: Solo & Accessibility (promoted for visibility) -->
+      <section class="card audience-doorways" aria-labelledby="audience-heading" style="background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
+        <h2 id="audience-heading" style="margin-bottom: 0.5rem;">Planning for...</h2>
+        <p class="tiny content-text mb-1" >Special resources for travelers with specific needs.</p>
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+          <!-- Solo Cruising -->
+          <a href="/solo.html" style="display: flex; align-items: flex-start; gap: 1rem; padding: 1rem; background: #fff; border: 1px solid #dce5ea; border-radius: 10px; text-decoration: none; color: inherit; transition: all 0.2s ease;">
+            <span style="font-size: 2rem; flex-shrink: 0;">🧭</span>
+            <div>
+              <strong style="display: block; color: #0e6e8e; font-size: 1.1rem; margin-bottom: 0.25rem;">Solo Cruisers</strong>
+              <p class="tiny" style="margin: 0; color: #5a7a8a; line-height: 1.4;">Courage, safety, and joy when sailing on your own terms. Includes real stories from our community.</p>
+              <span class="pill" style="display: inline-block; margin-top: 0.5rem; font-size: 0.75rem; padding: 0.25rem 0.5rem;">Read Tina's Story</span>
+            </div>
+          </a>
+          <!-- Accessibility -->
+          <a href="/accessibility.html" style="display: flex; align-items: flex-start; gap: 1rem; padding: 1rem; background: #fff; border: 1px solid #dce5ea; border-radius: 10px; text-decoration: none; color: inherit; transition: all 0.2s ease;">
+            <span style="font-size: 2rem; flex-shrink: 0;">♿</span>
+            <div>
+              <strong style="display: block; color: #0e6e8e; font-size: 1.1rem; margin-bottom: 0.25rem;">Accessibility Needs</strong>
+              <p class="tiny" style="margin: 0; color: #5a7a8a; line-height: 1.4;">Mobility, dining, and cabin access tips so every traveler can enjoy the ship with confidence and ease.</p>
+              <span class="pill" style="display: inline-block; margin-top: 0.5rem; font-size: 0.75rem; padding: 0.25rem 0.5rem;">View Accessibility Guide</span>
+            </div>
           </a>
         </div>
       </section>
@@ -600,31 +614,30 @@
         </article>
       </section>
 
-      <!-- Audience Doorways: Solo & Accessibility -->
-      <section class="card audience-doorways" aria-labelledby="audience-heading" style="background: linear-gradient(135deg, #f8f9fa 0%, #fff 100%); border: 2px solid #e8eef2;">
-        <h2 id="audience-heading" style="margin-bottom: 0.5rem;">Planning for...</h2>
-        <p class="tiny content-text mb-1" >Special resources for travelers with specific needs.</p>
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
-          <!-- Solo Cruising -->
-          <a href="/solo.html" style="display: flex; align-items: flex-start; gap: 1rem; padding: 1rem; background: #fff; border: 1px solid #dce5ea; border-radius: 10px; text-decoration: none; color: inherit; transition: all 0.2s ease;">
-            <span style="font-size: 2rem; flex-shrink: 0;">🧭</span>
-            <div>
-              <strong style="display: block; color: #0e6e8e; font-size: 1.1rem; margin-bottom: 0.25rem;">Solo Cruisers</strong>
-              <p class="tiny" style="margin: 0; color: #5a7a8a; line-height: 1.4;">Courage, safety, and joy when sailing on your own terms. Includes real stories from our community.</p>
-              <span class="pill" style="display: inline-block; margin-top: 0.5rem; font-size: 0.75rem; padding: 0.25rem 0.5rem;">Read Tina's Story</span>
-            </div>
+      <!-- Duck Spotting Card (positioned after main content for returning visitors) -->
+      <article id="duck-card" class="card" style="background: linear-gradient(135deg, #fff9e6 0%, #fffbf0 100%); border: 3px solid #ffd700; box-shadow: 0 4px 12px rgba(255, 215, 0, 0.2); position: relative;">
+        <button type="button" onclick="document.getElementById('duck-card').style.display='none'; localStorage.setItem('duckCardDismissed', 'true');"
+                style="position: absolute; top: 0.75rem; right: 0.75rem; background: transparent; border: none; font-size: 1.5rem; cursor: pointer; color: #d4a017; padding: 0.25rem; line-height: 1; opacity: 0.6; transition: opacity 0.2s;"
+                onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.6'"
+                aria-label="Dismiss duck card">×</button>
+        <h2 style="margin: 0 0 0.5rem 0; color: #d4a017; font-size: 1.5rem; display: flex; align-items: center; gap: 0.5rem;">
+          Found a Duck?
+        </h2>
+        <p style="margin: 0.5rem 0; font-size: 1.05rem; line-height: 1.6;">
+          Spotted one of our signature yellow ducks on your cruise? We'd love to see it!
+          <strong>Send us a picture and be featured on our website and Instagram!</strong>
+        </p>
+        <div class="actions" style="margin-top: 1rem; display: flex; gap: 0.75rem; flex-wrap: wrap;">
+          <a class="pill" href="mailto:ken@cruisinginthewake.com?subject=I%20Found%20a%20Duck!&body=Hi!%20I%20found%20a%20duck%20on%20my%20cruise.%20Here's%20my%20photo%20(please%20attach).%0A%0AShip:%20%0ADate:%20%0ALocation%20where%20I%20found%20it:%20%0A%0A"
+             style="background: #ffd700; color: #333; border-color: #d4a017; font-weight: 600; font-size: 1.05rem; padding: 0.75rem 1.5rem;">
+            Send Your Duck Photo!
           </a>
-          <!-- Accessibility -->
-          <a href="/accessibility.html" style="display: flex; align-items: flex-start; gap: 1rem; padding: 1rem; background: #fff; border: 1px solid #dce5ea; border-radius: 10px; text-decoration: none; color: inherit; transition: all 0.2s ease;">
-            <span style="font-size: 2rem; flex-shrink: 0;">♿</span>
-            <div>
-              <strong style="display: block; color: #0e6e8e; font-size: 1.1rem; margin-bottom: 0.25rem;">Accessibility Needs</strong>
-              <p class="tiny" style="margin: 0; color: #5a7a8a; line-height: 1.4;">Mobility, dining, and cabin access tips so every traveler can enjoy the ship with confidence and ease.</p>
-              <span class="pill" style="display: inline-block; margin-top: 0.5rem; font-size: 0.75rem; padding: 0.25rem 0.5rem;">View Accessibility Guide</span>
-            </div>
+          <a class="pill" href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener"
+             style="background: #fff; color: #d4a017; border: 2px solid #ffd700; font-weight: 600; font-size: 1.05rem; padding: 0.75rem 1.5rem;">
+            See Featured Ducks on Instagram
           </a>
         </div>
-      </section>
+      </article>
 
       <!-- FAQ Section (ICP-Lite) - Moved from right rail for better accessibility -->
       <section class="card mt-15" aria-labelledby="faq-heading">


### PR DESCRIPTION
Applied Curse of Knowledge analysis to the home page visual hierarchy. The reader's first question — "What is this site?" — was previously answered third, behind a duck card and a first-timer callout.

New section order:
1. Welcome + motto (was 3rd, now 1st)
2. Intent selector ("What are you planning?")
3. First-timer callout (moved down from position 1)
4. Featured logbook excerpt (NEW — Margaret's penguin moment from grief article)
5. Planning tools grid
6. Audience doorways — Solo & Accessibility (promoted from position 7)
7. Explore grid (6 cards)
8. Duck card (moved from position 1 to here)
9. FAQ
10. Works Offline

Also added admin/EMOTIONAL_HOOK_TEST_PLAN.md documenting the 30-Second Emotional Hook Test framework and restructuring plans for ship and port pages.

https://claude.ai/code/session_01LgHMKCGWUjfxsKtgH7R6vZ