### PR TITLE
Fix ship trackers: add basin lat/lon, guard retired/TBN, flag Conques…

### DIFF
--- a/ships/carnival/carnival-breeze.html
+++ b/ships/carnival/carnival-breeze.html
@@ -879,7 +879,7 @@ document.addEventListener('DOMContentLoaded',function(){
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/carnival/carnival-conquest.html
+++ b/ships/carnival/carnival-conquest.html
@@ -761,7 +761,7 @@ fetch('/assets/data/logbook/carnival/carnival-conquest.json').then(r=>r.json()).
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=26.0&lon=-90.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/carnival/carnival-dream.html
+++ b/ships/carnival/carnival-dream.html
@@ -820,7 +820,7 @@ fetch('/assets/data/logbook/carnival/carnival-dream.json').then(r=>r.json()).the
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/carnival/carnival-freedom.html
+++ b/ships/carnival/carnival-freedom.html
@@ -904,7 +904,7 @@ fetch('/assets/data/logbook/carnival/carnival-freedom.json').then(r=>r.json()).t
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=26.0&lon=-90.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/carnival/carnival-glory.html
+++ b/ships/carnival/carnival-glory.html
@@ -871,7 +871,7 @@ fetch('/assets/data/logbook/carnival/carnival-glory.json').then(r=>r.json()).the
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=26.0&lon=-90.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -1129,7 +1129,7 @@ Dining Venues</h2>
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/carnival/carnival-mardi-gras.html
+++ b/ships/carnival/carnival-mardi-gras.html
@@ -1043,7 +1043,7 @@ Dining Venues on Carnival Mardi Gras <a href="/restaurants.html" style="font-siz
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/adventure-of-the-seas.html
+++ b/ships/rcl/adventure-of-the-seas.html
@@ -1140,7 +1140,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=15.0&lon=-65.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/allure-of-the-seas.html
+++ b/ships/rcl/allure-of-the-seas.html
@@ -1065,7 +1065,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/ships/rcl/anthem-of-the-seas.html
+++ b/ships/rcl/anthem-of-the-seas.html
@@ -1113,7 +1113,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=40.0&lon=-70.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -1162,7 +1162,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=15.0&lon=-65.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/enchantment-of-the-seas.html
+++ b/ships/rcl/enchantment-of-the-seas.html
@@ -1111,7 +1111,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=40.0&lon=-70.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/explorer-of-the-seas.html
+++ b/ships/rcl/explorer-of-the-seas.html
@@ -1122,7 +1122,7 @@ The rope hanging from the bottom right is tangled i"
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=40.0&lon=-70.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/freedom-of-the-seas.html
+++ b/ships/rcl/freedom-of-the-seas.html
@@ -1080,7 +1080,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/grandeur-of-the-seas.html
+++ b/ships/rcl/grandeur-of-the-seas.html
@@ -1154,7 +1154,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=40.0&lon=-70.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/harmony-of-the-seas.html
+++ b/ships/rcl/harmony-of-the-seas.html
@@ -1098,7 +1098,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/ships/rcl/independence-of-the-seas.html
+++ b/ships/rcl/independence-of-the-seas.html
@@ -1122,7 +1122,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=40.0&lon=15.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/jewel-of-the-seas.html
+++ b/ships/rcl/jewel-of-the-seas.html
@@ -1092,7 +1092,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=40.0&lon=-70.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/liberty-of-the-seas.html
+++ b/ships/rcl/liberty-of-the-seas.html
@@ -1117,7 +1117,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/mariner-of-the-seas.html
+++ b/ships/rcl/mariner-of-the-seas.html
@@ -1087,7 +1087,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/navigator-of-the-seas.html
+++ b/ships/rcl/navigator-of-the-seas.html
@@ -1076,7 +1076,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=15.0&lon=-65.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/nordic-prince.html
+++ b/ships/rcl/nordic-prince.html
@@ -1057,7 +1057,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     if(!card) return;
     const imo=card.getAttribute('data-imo');
     const container=document.getElementById('vf-tracker-container');
-    if(!imo||!container) return;
+    if(!imo||imo==='TBD'||imo==='0000000'||!container) return;
     const wrapper = document.createElement('div');
     wrapper.style.cssText = 'width:100%;height:500px;position:relative;background:#f0f4f8;border-radius:8px;overflow:hidden;';
     const iframe = document.createElement('iframe');

--- a/ships/rcl/oasis-class-ship-tbn-2028.html
+++ b/ships/rcl/oasis-class-ship-tbn-2028.html
@@ -993,7 +993,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     if(!card) return;
     const imo=card.getAttribute('data-imo');
     const container=document.getElementById('vf-tracker-container');
-    if(!imo||!container) return;
+    if(!imo||imo==='TBD'||imo==='0000000'||!container) return;
     const wrapper = document.createElement('div');
     wrapper.style.cssText = 'width:100%;height:500px;position:relative;background:#f0f4f8;border-radius:8px;overflow:hidden;';
     const iframe = document.createElement('iframe');

--- a/ships/rcl/oasis-of-the-seas.html
+++ b/ships/rcl/oasis-of-the-seas.html
@@ -1135,7 +1135,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/ships/rcl/odyssey-of-the-seas.html
+++ b/ships/rcl/odyssey-of-the-seas.html
@@ -1068,7 +1068,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/ships/rcl/ovation-of-the-seas.html
+++ b/ships/rcl/ovation-of-the-seas.html
@@ -1171,7 +1171,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=-30.0&lon=148.0&zoom=5&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -1193,7 +1193,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=125.0&zoom=4&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -1175,7 +1175,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=15.0&lon=-65.0&zoom=5&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/ships/rcl/rhapsody-of-the-seas.html
+++ b/ships/rcl/rhapsody-of-the-seas.html
@@ -1206,7 +1206,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=40.0&lon=15.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/serenade-of-the-seas.html
+++ b/ships/rcl/serenade-of-the-seas.html
@@ -1245,7 +1245,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=15.0&lon=-65.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/song-of-america.html
+++ b/ships/rcl/song-of-america.html
@@ -996,7 +996,7 @@ Dining on Song of America</h2>
     if(!card) return;
     const imo=card.getAttribute('data-imo');
     const container=document.getElementById('vf-tracker-container');
-    if(!imo||!container) return;
+    if(!imo||imo==='TBD'||imo==='0000000'||!container) return;
     const wrapper = document.createElement('div');
     wrapper.style.cssText = 'width:100%;height:500px;position:relative;background:#f0f4f8;border-radius:8px;overflow:hidden;';
     const iframe = document.createElement('iframe');

--- a/ships/rcl/spectrum-of-the-seas.html
+++ b/ships/rcl/spectrum-of-the-seas.html
@@ -1068,7 +1068,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=125.0&zoom=4&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/ships/rcl/sun-viking.html
+++ b/ships/rcl/sun-viking.html
@@ -1087,7 +1087,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     if(!card) return;
     const imo=card.getAttribute('data-imo');
     const container=document.getElementById('vf-tracker-container');
-    if(!imo||!container) return;
+    if(!imo||imo==='TBD'||imo==='0000000'||!container) return;
     const wrapper = document.createElement('div');
     wrapper.style.cssText = 'width:100%;height:500px;position:relative;background:#f0f4f8;border-radius:8px;overflow:hidden;';
     const iframe = document.createElement('iframe');

--- a/ships/rcl/symphony-of-the-seas.html
+++ b/ships/rcl/symphony-of-the-seas.html
@@ -1103,7 +1103,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/ships/rcl/utopia-of-the-seas.html
+++ b/ships/rcl/utopia-of-the-seas.html
@@ -1173,7 +1173,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);

--- a/ships/rcl/viking-serenade.html
+++ b/ships/rcl/viking-serenade.html
@@ -1109,7 +1109,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     if(!card) return;
     const imo=card.getAttribute('data-imo');
     const container=document.getElementById('vf-tracker-container');
-    if(!imo||!container) return;
+    if(!imo||imo==='TBD'||imo==='0000000'||!container) return;
     const wrapper = document.createElement('div');
     wrapper.style.cssText = 'width:100%;height:500px;position:relative;background:#f0f4f8;border-radius:8px;overflow:hidden;';
     const iframe = document.createElement('iframe');

--- a/ships/rcl/vision-of-the-seas.html
+++ b/ships/rcl/vision-of-the-seas.html
@@ -1206,7 +1206,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=26.0&lon=-90.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/voyager-of-the-seas.html
+++ b/ships/rcl/voyager-of-the-seas.html
@@ -1112,7 +1112,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=-30.0&lon=148.0&zoom=5&track=true&names=true';
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);
   })();

--- a/ships/rcl/wonder-of-the-seas.html
+++ b/ships/rcl/wonder-of-the-seas.html
@@ -1067,7 +1067,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     iframe.style.cssText = 'width:100%;height:100%;border:0;';
     iframe.title = 'Live ship tracker for ' + card.getAttribute('data-name');
     iframe.setAttribute('loading', 'lazy');
-    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&zoom=10&track=true&names=true';
+    iframe.src = 'https://www.vesselfinder.com/aismap?imo=' + imo + '&lat=20.0&lon=-75.0&zoom=4&track=true&names=true';
 
     wrapper.appendChild(iframe);
     container.appendChild(wrapper);


### PR DESCRIPTION
…t IMO

ROOT CAUSE: VesselFinder aismap does not auto-center on imo= parameter. Without lat/lon, the embed defaults to 0,0 (Gulf of Guinea, Africa).

Step 1 — Guard fix (5 ships): Tighten initLiveTracker() guard from
  if(!imo||!container)
to
  if(!imo||imo==='TBD'||imo==='0000000'||!container)
Prevents iframe loading on retired/TBN pages with no valid IMO. Applies to: nordic-prince, sun-viking, viking-serenade, song-of-america,
  oasis-class-ship-tbn-2028. (discovery-class-ship-tbn already had guard.)

Step 2 — Basin coordinates (34 ships): Replace &zoom=10 with
  &lat=XX.X&lon=YY.Y&zoom=Z per ocean basin instead of per home port.
Basin approach avoids monthly maintenance as ships redeploy seasonally. Ships stay within their ocean basin even when switching home ports.
  Caribbean/US East (lat=20, lon=-75, zoom=4): 14 ships
  Gulf of Mexico (lat=26, lon=-90, zoom=5): 4 ships
  US Northeast (lat=40, lon=-70, zoom=5): 5 ships
  S Caribbean/Latin (lat=15, lon=-65, zoom=5): 5 ships
  Mediterranean (lat=40, lon=15, zoom=5): 2 ships
  Asia-Pacific (lat=20, lon=125, zoom=4): 2 ships
  Australia (lat=-30, lon=148, zoom=5): 2 ships

SKIPPED — Carnival Conquest IMO conflict: data-imo="9195200" is a duplicate of Brilliance of the Seas. Correct Conquest IMO could not be verified from internal data. Needs manual lookup before changing.

All 290 ship pages still PASS validator.

https://claude.ai/code/session_013x2k7XCQ6RZ7GFMCUqCk3T