### PR TITLE
Fix weather FAQ gaps: goa + halifax now PASS

### DIFF
--- a/ports/goa.html
+++ b/ports/goa.html
@@ -89,6 +89,22 @@ Soli Deo Gloria
           "@type": "Answer",
           "text": "Yes, very safe. Goa is India's wealthiest state with well-developed tourism infrastructure. Tourist areas are secure, English is widely spoken, and cruise passengers face minimal safety concerns."
         }
+      },
+      {
+        "@type": "Question",
+        "name": "Does Goa have a cyclone or storm season to be aware of?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. The Arabian Sea sees cyclone activity primarily from May–June and October–November. Cruise ships calling at Goa typically operate during the dry season (November–March), well outside the peak cyclone window."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Will afternoon rain ruin my port day in Goa?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Outside monsoon season (June–September), brief afternoon showers are rare during the dry season. If your cruise calls during the transitional months of April or October, pack a light rain layer. Most cruise lines avoid Goa during monsoon season entirely."
+        }
       }
     ]
   }
@@ -295,7 +311,7 @@ Soli Deo Gloria
           <noscript>
             <div class="seasonal-guide seasonal-guide-static">
               <details class="seasonal-section" open>
-                <summary class="seasonal-section-title">Overview</summary>
+                <summary class="seasonal-section-title">At a Glance</summary>
                 <div class="seasonal-at-glance">
                   <div class="seasonal-glance-grid">
                     <div class="seasonal-glance-item"><span class="glance-label">Temperature</span><span class="glance-value">Varies by season — check forecast</span></div>
@@ -477,6 +493,10 @@ Soli Deo Gloria
         <p><strong>Q: What's the best time of year to visit Goa (Mormugao)?</strong><br>A: Peak cruise season (November-February) offers the most reliable weather and best conditions for sightseeing — dry, pleasant 75-85 degrees. Avoid monsoon season (June-September) when heavy rains make outdoor touring difficult.</p>
 
         <p><strong>Q: What should I pack for Goa's weather?</strong><br>A: Essentials include sunscreen, comfortable walking shoes, and lightweight layers for variable conditions. A scarf or wrap is useful for church visits. Bring a refillable water bottle — the heat is significant.</p>
+
+        <p><strong>Q: Does Goa have a cyclone or storm season to be aware of?</strong><br>A: Yes. The Arabian Sea sees cyclone activity primarily from May–June and October–November. Cruise ships calling at Goa typically operate during the dry season (November–March), well outside the peak cyclone window. If your itinerary falls near the shoulder months, check weather forecasts and cruise line advisories before your voyage.</p>
+
+        <p><strong>Q: Will afternoon rain ruin my port day in Goa?</strong><br>A: Outside monsoon season (June–September), brief afternoon showers are rare — the dry season is genuinely dry. If your cruise calls during the transitional months of April or October, pack a light rain layer. Genuine monsoon visits are uncommon because most cruise lines avoid Goa during those months entirely.</p>
       </details>
 
       <!-- CRUISE PORT SECTION -->

--- a/ports/halifax.html
+++ b/ports/halifax.html
@@ -97,6 +97,22 @@ Soli Deo Gloria
           "@type": "Answer",
           "text": "4-5 hours round-trip including 50 minutes drive each way and time exploring the lighthouse, rocky coast, and de Garthe Monument. Most cruise lines offer half-day excursions."
         }
+      },
+      {
+        "@type": "Question",
+        "name": "When is the best time of year to visit Halifax on a cruise?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Late June through September offers the best combination of warm weather, long daylight hours, and full operation of seasonal attractions. October sailings catch spectacular autumn foliage. Spring cruises can be breezy and overcast — pack layers."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does Halifax get hurricanes or major storm season disruptions?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Halifax does not sit in the primary hurricane zone, but Atlantic hurricanes occasionally track northward as post-tropical storms by late August or September. The Atlantic storm season peaks September–October — pack a waterproof layer for fall sailings."
+        }
       }
     ]
   }
@@ -494,6 +510,10 @@ Soli Deo Gloria
             </div>
         </details><details class="port-section" id="faq" open="">
             <summary><h2>Frequently Asked Questions</h2></summary>
+          <p><strong>Q: When is the best time of year to visit Halifax on a cruise?</strong><br>A: Late June through September offers the best combination of warm weather (18–24°C / 65–75°F), long daylight hours, and full operation of seasonal attractions. October sailings catch spectacular autumn foliage but bring cooler, windier conditions. Spring cruises (May–June) can be breezy and overcast — pack layers.</p>
+
+          <p><strong>Q: Does Halifax get hurricanes or major storm season disruptions?</strong><br>A: Halifax does not sit in the primary hurricane zone, but Atlantic hurricanes occasionally track northward and arrive as post-tropical storms by late August or September. These can bring heavy rain and strong winds. Most cruise lines monitor conditions closely and will adjust itineraries if needed. The Atlantic storm season peaks September–October — pack a waterproof layer for fall sailings.</p>
+
           <p><strong>Q: Is Halifax worth visiting on a cruise?</strong><br>A: Absolutely — Halifax is one of the friendliest, most walkable ports in North America. The waterfront boardwalk, Citadel Hill, Maritime Museum with Titanic exhibits, and authentic local culture make it a rewarding port day. You can explore independently without any ship excursion for most attractions.</p>
 
           <p><strong>Q: What is the best attraction in Halifax?</strong><br>A: Peggy's Cove for scenery, the Maritime Museum for Titanic and Halifax Explosion history, and Citadel Hill for panoramic harbor views and the noon gun ceremony. Budget about $10 CAD for the museum and allow at least 90 minutes.</p>


### PR DESCRIPTION
goa.html:
- "Overview" → "At a Glance" seasonal section title (validator requires exact match)
- Add hurricane/storm season FAQ (Arabian Sea cyclone window May–Jun, Oct–Nov)
- Add rain concerns FAQ (dry season is genuinely dry; monsoon months avoided by cruise lines)
- Update FAQPage schema with 2 new questions (count now matches page)

halifax.html:
- Add best-time-of-year FAQ (late June–September peak; fall foliage October; spring breezy)
- Add hurricane/storm season FAQ (post-tropical storms can reach Nova Scotia Sep–Oct)
- Update FAQPage schema with 2 new questions

Both pages now score PERFECT (13/13 direct checks, 0 errors).

https://claude.ai/code/session_01QPeb2CeSs6Ag7hx3yLoo6r