### PR TITLE
Update Brilliance deployment info — Caribbean/Mediterranean 2026

### DIFF
--- a/ships/rcl/brilliance-of-the-seas.html
+++ b/ships/rcl/brilliance-of-the-seas.html
@@ -140,7 +140,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       "@type": "Person",
       "name": "In the Wake Editorial Team"
     },
-    "reviewBody": "Brilliance of the Seas delivers Royal Caribbean's signature ocean-view experience with glass walls, mid-size intimacy, and global itineraries spanning Alaska to Australia.",
+    "reviewBody": "Brilliance of the Seas delivers Royal Caribbean's signature ocean-view experience with glass walls, mid-size intimacy, and seasonal deployments from Caribbean to Mediterranean.",
     "itemReviewed": {
       "@type": "Cruise",
       "name": "Brilliance of the Seas",
@@ -223,7 +223,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         "name": "Where does Brilliance of the Seas typically sail?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Brilliance has sailed global itineraries including Alaska, the Caribbean, Australia, and Asia. Deployments vary by season."
+          "text": "In 2026, Brilliance sails the Southern Caribbean from San Juan (winter/spring) and the Mediterranean from Barcelona and Trieste (summer). She has previously sailed Alaska, Australia, and Asia. Deployments vary by season."
         }
       },
       {
@@ -805,7 +805,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
       <details class="faq-item">
         <summary>Where does Brilliance of the Seas typically sail?</summary>
-        <p class="faq-answer">Brilliance has sailed global itineraries including Alaska, the Caribbean, Australia, and Asia. Deployments vary by season — check the live tracker on this page or Royal Caribbean's official site for current and upcoming voyages.</p>
+        <p class="faq-answer">In 2026, Brilliance sails the Southern Caribbean from San Juan (winter/spring) and the Mediterranean from Barcelona and Trieste (summer). She has previously sailed Alaska, Australia, and Asia. Deployments vary by season — check the live tracker on this page or Royal Caribbean's official site for current and upcoming voyages.</p>
       </details>
 
       <details class="faq-item">


### PR DESCRIPTION
Brilliance of the Seas is NOT in Alaska in 2026. Updated:
- FAQ: "In 2026, Brilliance sails the Southern Caribbean from San Juan (winter/spring) and the Mediterranean from Barcelona and Trieste (summer)." Previously said Alaska/Caribbean/Australia/Asia generically.
- Review body: "seasonal deployments from Caribbean to Mediterranean" (was "spanning Alaska to Australia")

Data sourced from CruiseMapper, iCruise, CruiseHive, and VesselFinder (current position: Caribbean Sea, 12.47N 68.49W as of Apr 3 2026).

https://claude.ai/code/session_018pcWEaJCsNJ2As862ecW8i