### PR TITLE
Add carousel HTML structure check + mandatory pre-commit validation

### DIFF
--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -99,6 +99,25 @@ Before writing ANY page (new or merge), verify:
 3. **Sister ships completeness** — Cross-reference the investigation's class data against existing ship pages in `/ships/[line]/`. If a sister exists as a page but wasn't in the investigation output, include it anyway.
 4. **Skip link consistency** — Skip link `href` must match `<main>` element's `id`.
 
+### Step 4.5: Validate BEFORE Committing (MANDATORY)
+
+**After every edit — before `git add` — run the validator:**
+```bash
+bash admin/validate-ship-page.sh ships/[line]/[slug].html
+```
+
+**Do NOT commit if the validator reports errors.** Fix first, then commit.
+
+This catches:
+- Broken carousel HTML (missing `</div>` on slides, orphaned slides outside swiper-wrapper)
+- Swiper lazy:true conflicting with native loading="lazy"
+- Missing noscript fallbacks (AI crawlers see empty content)
+- Wrong skip link targets
+- Attributions outside col-1
+- Missing images, stale venue references, sister ship mismatches
+
+**The validator is the last gate.** No matter how confident you are in a regex/Python fix, the validator catches what you miss. A broken carousel that looks fine in the Edit tool will render as a wall of overlapping images in a browser.
+
 ### Step 4: Generate the Page
 
 **Ship pages** — follow `new-standards/v3.010/SHIP_PAGE_CHECKLIST_v3.010.md`:

--- a/admin/validate-ship-page.sh
+++ b/admin/validate-ship-page.sh
@@ -582,6 +582,25 @@ else
     check_fail "First Look carousel has NO images — carousel will render empty"
 fi
 
+# Check carousel HTML structure — every swiper-slide must have a closing </div>
+# Strategy: inside the firstlook carousel, count slide opens vs all </div> tags,
+# then subtract 2 for the swiper-wrapper close and the pagination self-close.
+CAROUSEL_HTML=$(echo "$CONTENT" | sed -n '/swiper firstlook/,/swiper-pagination/p')
+SLIDE_OPENS=$(echo "$CAROUSEL_HTML" | grep -c 'class="swiper-slide"' || echo "0")
+ALL_DIV_CLOSES=$(echo "$CAROUSEL_HTML" | grep -c '</div>' || echo "0")
+# Subtract: 1 for swiper-wrapper </div>, 1 for pagination <div.../></div>
+SLIDE_CLOSES=$((ALL_DIV_CLOSES - 2))
+if [ "$SLIDE_OPENS" -gt 0 ]; then
+    if [ "$SLIDE_OPENS" -eq "$SLIDE_CLOSES" ]; then
+        check_pass "Carousel HTML: $SLIDE_OPENS slides, all properly closed"
+    elif [ "$SLIDE_OPENS" -gt "$SLIDE_CLOSES" ]; then
+        MISSING=$((SLIDE_OPENS - SLIDE_CLOSES))
+        check_fail "Carousel HTML BROKEN: $SLIDE_OPENS slides opened but $MISSING missing </div> — slides will nest incorrectly"
+    else
+        check_warn "Carousel has more </div> ($SLIDE_CLOSES) than slides ($SLIDE_OPENS) — possible extra closing tags"
+    fi
+fi
+
 # ============================================================================
 # Section 9c: Sister Ships Completeness
 # ============================================================================


### PR DESCRIPTION
Validator (Section 9b):
- Count slide opens vs </div> closes inside the carousel
- Catches missing </div> tags that cause slides to nest inside each other, breaking Swiper rendering (the exact Brilliance bug)
- Reports: "8 slides opened but 1 missing </div> — slides will nest incorrectly"

SKILL.md (Step 4.5):
- Added mandatory "validate BEFORE committing" rule
- After every edit, run the validator before git add
- Do NOT commit if errors are reported
- Explains why: regex/Python fixes can silently break HTML structure in ways that look correct in a diff but render as garbage in a browser. The validator is the last gate.

https://claude.ai/code/session_018pcWEaJCsNJ2As862ecW8i