### PR TITLE
Batch-fix 24 MSC ship pages: template-level repairs

### DIFF
--- a/admin/batch-fix-msc.py
+++ b/admin/batch-fix-msc.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Batch fix for MSC-era ship pages. v2 — expanded coverage.
+
+Applies template-level fixes that don't require per-ship content research:
+1.  <html lang="en"> → <html lang="en" class="no-js"> + no-js removal script
+2.  ai-breadcrumbs HTML comment → removed
+3.  content-protocol ICP-Lite v1.4 → ICP-2
+4.  Skip link #content → #main-content
+5.  <main class="wrap" id="content"> → <main class="wrap page-grid" id="main-content" ... tabindex="-1">
+6.  Swiper @10 CSS stylesheet link → removed (JS loader already handles fallback)
+7.  Cordelia Empress Food Court image → removed
+8.  Static copyright 2025 → JS dynamic year
+9.  Dining heading → add Browse All link
+10. Add whimsical-ship-units.js script
+11. H1 bare ship name → with subtitle
+12. Empty stats heading → "Key Facts About [Ship Name]"
+13. Video carousel noscript
+14. Recent Articles noscript
+15. Whimsical Units noscript
+16. Dining noscript from venues-v2.json
+17. IMO "TBD" → leave alone (needs per-ship research)
+
+Does NOT touch:
+- FAQ boilerplate (per-ship content)
+- Duplicate stats sections (structural risk)
+- Placeholder 'coming soon' (per-ship content)
+- Fleet listing entries (manual)
+- Fact-block crew count (needs per-ship data)
+- page.json creation (needs per-ship stats)
+
+Idempotent — safe to run multiple times.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path('/home/user/inthewake')
+MSC_DIR = ROOT / 'ships' / 'msc'
+VENUES_FILE = ROOT / 'assets' / 'data' / 'venues-v2.json'
+
+with open(VENUES_FILE) as f:
+    venues_data = json.load(f)
+venues_idx = {v['slug']: v for v in venues_data.get('venues', [])}
+ships_data = venues_data.get('ships', {})
+
+
+def ship_name_from_slug(slug):
+    """Convert 'msc-divina' to 'MSC Divina'."""
+    parts = slug.split('-')
+    return ' '.join(p.upper() if p == 'msc' else p.title() for p in parts)
+
+
+def build_dining_noscript(slug, indent='          '):
+    """Build a dining noscript from the ship's venues."""
+    ship = ships_data.get(slug, {})
+    venue_slugs = ship.get('venues', [])
+    if not venue_slugs:
+        return ''
+
+    by_cat = {}
+    for vs in venue_slugs:
+        v = venues_idx.get(vs, {})
+        cat = v.get('category', 'other')
+        subcat = v.get('subcategory', '')
+        if cat == 'dining' and subcat == 'specialty':
+            cat = 'specialty'
+        elif cat == 'dining' and subcat == 'complimentary':
+            cat = 'mdr'
+        elif cat == 'dining':
+            cat = 'casual'
+        if cat not in by_cat:
+            by_cat[cat] = []
+        by_cat[cat].append(v.get('name', vs))
+
+    labels = {
+        'mdr': 'Complimentary Dining',
+        'specialty': 'Specialty Dining',
+        'casual': 'Casual Dining',
+        'bar': 'Bars & Lounges',
+        'bars': 'Bars & Lounges',
+        'entertainment': 'Entertainment',
+        'activities': 'Activities',
+        'neighborhoods': 'Other',
+        'other': 'Other'
+    }
+    order = ['mdr', 'specialty', 'casual', 'bars', 'bar', 'entertainment', 'activities', 'neighborhoods', 'other']
+
+    html = f'{indent}<noscript>\n'
+    for cat in order:
+        if cat in by_cat:
+            html += f'{indent}  <h3>{labels[cat]}</h3>\n{indent}  <ul>\n'
+            for name in by_cat[cat]:
+                html += f'{indent}    <li><strong>{name}</strong></li>\n'
+            html += f'{indent}  </ul>\n'
+    html += f'{indent}</noscript>'
+    return html
+
+
+def fix_page(path):
+    """Apply all fixes to a single ship page. Returns list of fix names applied."""
+    slug = path.stem
+    ship_name = ship_name_from_slug(slug)
+    fixes = []
+
+    with open(path) as f:
+        content = f.read()
+
+    original = content
+
+    # 1. no-js class + removal script
+    if '<html lang="en">' in content and 'class="no-js"' not in content:
+        content = content.replace(
+            '<html lang="en">\n<head>',
+            '<html lang="en" class="no-js">\n<head>\n<script>document.documentElement.classList.remove(\'no-js\');</script>'
+        )
+        fixes.append('no-js')
+
+    # 2. ai-breadcrumbs removal
+    ai_breadcrumbs_pattern = r'<!-- ai-breadcrumbs\s*\n(?:.*\n)*?\s*-->\s*\n'
+    if re.search(ai_breadcrumbs_pattern, content):
+        content = re.sub(ai_breadcrumbs_pattern, '', content)
+        fixes.append('ai-breadcrumbs-removed')
+
+    # 3. content-protocol ICP-Lite → ICP-2
+    if 'ICP-Lite v1.4' in content:
+        content = content.replace('ICP-Lite v1.4', 'ICP-2')
+        fixes.append('icp-2-upgrade')
+    if '<!-- ICP-Lite' in content or 'ICP-Lite v1.0' in content:
+        content = content.replace('ICP-Lite v1.0', 'ICP-2').replace('ICP-Lite', 'ICP-2')
+        fixes.append('icp-lite-comments')
+
+    # 4. Skip link #content → #main-content
+    if '<a href="#content" class="skip-link">' in content:
+        content = content.replace(
+            '<a href="#content" class="skip-link">',
+            '<a href="#main-content" class="skip-link">'
+        )
+        fixes.append('skip-link')
+
+    # 5. Main element (two common variants)
+    if '<main class="wrap" id="content" role="main">' in content:
+        content = content.replace(
+            '<main class="wrap" id="content" role="main">',
+            '<main class="wrap page-grid" id="main-content" role="main" tabindex="-1">'
+        )
+        fixes.append('main-page-grid')
+    # Variant B: class before role, id with data-ship
+    main_variant_b = re.compile(r'<main role="main" class="wrap page-grid" id="content"([^>]*)>')
+    if main_variant_b.search(content):
+        content = main_variant_b.sub(
+            r'<main role="main" class="wrap page-grid" id="main-content" tabindex="-1"\1>',
+            content
+        )
+        fixes.append('main-id-content-b')
+
+    # 6. Swiper @10 CSS removal
+    swiper10_pattern = r'\s*<link rel="stylesheet" href="https://unpkg\.com/swiper@10/[^"]+"/>\s*\n'
+    if re.search(swiper10_pattern, content):
+        content = re.sub(swiper10_pattern, '\n', content)
+        fixes.append('swiper-10-removed')
+
+    # 7. Cordelia Empress Food Court image removal (various patterns)
+    # Pattern A: in dining heading
+    cordelia_in_h2_pattern = r'<h2 id="diningHeading"><img id="dining-hero" class="card-hero"\s*src="/assets/img/Cordelia_Empress_Food_Court\.webp"\s*alt="[^"]*" loading="lazy"/>\s*Dining on'
+    if re.search(cordelia_in_h2_pattern, content):
+        content = re.sub(
+            cordelia_in_h2_pattern,
+            '<h2 id="diningHeading">Dining on',
+            content
+        )
+        fixes.append('cordelia-in-h2')
+    # Pattern B: standalone img tag
+    cordelia_standalone_pattern = r'<img id="dining-hero" class="card-hero"[^>]*Cordelia_Empress_Food_Court[^>]*/>'
+    if re.search(cordelia_standalone_pattern, content):
+        content = re.sub(cordelia_standalone_pattern, '', content)
+        fixes.append('cordelia-standalone')
+
+    # 8. Dynamic copyright year
+    if '&copy; 2025 In the Wake' in content:
+        content = content.replace(
+            '&copy; 2025 In the Wake',
+            '&copy; <script>document.write(new Date().getFullYear())</script> In the Wake'
+        )
+        fixes.append('dynamic-copyright')
+
+    # 9. Dining heading Browse All link
+    dining_heading_pattern = rf'<h2 id="diningHeading">Dining on {re.escape(ship_name)}</h2>'
+    dining_heading_replacement = f'<h2 id="diningHeading">Dining on {ship_name} <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>'
+    if re.search(dining_heading_pattern, content) and '→ Browse All' not in content:
+        content = re.sub(dining_heading_pattern, dining_heading_replacement, content)
+        fixes.append('browse-all-link')
+
+    # 10. whimsical-ship-units.js script
+    if 'whimsical-ship-units.js' not in content:
+        content = content.replace(
+            '</body>',
+            '<script src="/assets/js/whimsical-ship-units.js" defer></script>\n</body>'
+        )
+        fixes.append('whimsical-script')
+
+    # 11. H1 bare ship name enhancement
+    h1_pattern = rf'<h1>{re.escape(ship_name)}</h1>'
+    h1_replacement = f'<h1>{ship_name} — Deck Plans, Live Tracker, Dining &amp; Videos</h1>'
+    if re.search(h1_pattern, content):
+        content = re.sub(h1_pattern, h1_replacement, content)
+        fixes.append('h1-subtitle')
+
+    # 12. Empty stats heading
+    empty_stats_heading = '<h2 id="ship-stats-title">Ship Statistics</h2>'
+    if empty_stats_heading in content:
+        content = content.replace(
+            empty_stats_heading,
+            f'<h2 id="ship-stats-title">Key Facts About {ship_name}</h2>'
+        )
+        fixes.append('stats-heading')
+
+    # 13. Video noscript
+    video_empty = '<div class="swiper-wrapper" id="featuredVideos"></div>'
+    if video_empty in content:
+        content = content.replace(
+            video_empty,
+            f'<div class="swiper-wrapper" id="featuredVideos">\n          <noscript><p>Video tours for {ship_name} are available on YouTube.</p></noscript>\n        </div>'
+        )
+        fixes.append('video-noscript')
+
+    # 14. Recent Articles noscript
+    recent_empty = '<div id="recent-rail" class="rail-list" aria-live="polite"></div>'
+    if recent_empty in content:
+        content = content.replace(
+            recent_empty,
+            '<div id="recent-rail" class="rail-list" aria-live="polite">\n          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>\n        </div>'
+        )
+        fixes.append('recent-noscript')
+
+    # 15. Whimsical Units noscript
+    whim_empty_pattern = r'<section class="card"\s+id="whimsical-units-container"\s+style="background:#f7fdff;border-radius:12px;padding:1\.25rem;"></section>'
+    whim_replacement = f'<section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">{ship_name} offers MSC Cruises\' signature European elegance and multinational atmosphere.</p></noscript></section>'
+    if re.search(whim_empty_pattern, content):
+        content = re.sub(whim_empty_pattern, whim_replacement, content)
+        fixes.append('whimsical-noscript')
+
+    # 16. Dining noscript (from venues-v2.json)
+    dining_noscript_html = build_dining_noscript(slug)
+    if dining_noscript_html:
+        # Pattern: empty dining-content div
+        dining_pattern = r'<div class="dining-content" id="dining-content" aria-live="polite">\s*</div>'
+        if re.search(dining_pattern, content):
+            content = re.sub(
+                dining_pattern,
+                f'<div class="dining-content" id="dining-content" aria-live="polite">\n{dining_noscript_html}\n        </div>',
+                content
+            )
+            fixes.append('dining-noscript')
+
+    if content != original:
+        with open(path, 'w') as f:
+            f.write(content)
+
+    return fixes
+
+
+def main():
+    pages = sorted(MSC_DIR.glob('msc-*.html'))
+    print(f'Found {len(pages)} MSC ship pages')
+    print()
+
+    total_fixes = 0
+    for page in pages:
+        fixes = fix_page(page)
+        if fixes:
+            print(f'{page.stem}: {len(fixes)} fixes — {", ".join(fixes)}')
+            total_fixes += len(fixes)
+        else:
+            print(f'{page.stem}: (no changes)')
+
+    print()
+    print(f'Total fixes applied: {total_fixes}')
+
+
+if __name__ == '__main__':
+    main()

--- a/ships/msc/msc-armonia.html
+++ b/ships/msc/msc-armonia.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Armonia
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Lirica Class
-     siblings: /ships/msc/msc-lirica.html, /ships/msc/msc-opera.html, /ships/msc/msc-sinfonia.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Armonia cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Armonia: Lirica Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Armonia: A Lirica Class ship from MSC Cruises. 65,542 GT, 1,954 guests, built 2001. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Armonia: A Lirica Class ship from MSC Cruises. 65,542 GT, 1,954 guests, built 2001. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Lirica Class ship operated by MSC Cruises.","name":"MSC Armonia","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Armonia is a Lirica Class MSC Cruises ship measuring 65,542 GT with capacity for 1,954 guests. Originally built in 2001 by Fincantieri and extended in 2014, she features the elegant La Caravella main restaurant, Ristorante L'Ippocampo, the Sahara buffet, and the Aurea Spa. A classic mid-size ship ideal for Caribbean and Mediterranean itineraries."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Armonia</span>
     </nav>
 
-    <h1>MSC Armonia</h1>
+    <h1>MSC Armonia — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Armonia overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Armonia is a Lirica Class cruise ship operated by MSC Cruises. She entered service in 2004, measures 65,591 gross tons, and carries approximately 2,679 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Armonia dining venue" loading="lazy"/>
-Dining on MSC Armonia</h2>
+      <h2 id="diningHeading">Dining on MSC Armonia <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-armonia","aliases":["MSC Armonia"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Lirica Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Armonia</strong> is a <strong>Lirica Class</strong> ship from MSC Cruises.
@@ -488,7 +470,9 @@ Dining on MSC Armonia</h2>
       <h2 id="video-highlights">Watch: MSC Armonia Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Armonia are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -559,7 +543,7 @@ Dining on MSC Armonia</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Armonia</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-armonia">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">65,591 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">2,679</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Armonia</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Armonia offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Armonia</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Armonia</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-bellissima.html
+++ b/ships/msc/msc-bellissima.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Bellissima
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Meraviglia Class
-     siblings: /ships/msc/msc-meraviglia.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Bellissima cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Bellissima: Meraviglia Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Bellissima: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Bellissima: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2019. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Meraviglia Class ship operated by MSC Cruises.","name":"MSC Bellissima","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Bellissima is a Meraviglia Class MSC Cruises ship measuring 171,598 GT with capacity for 4,500 guests. Built in 2019, she features a 96-metre LED sky dome on the promenade, Cirque du Soleil at Sea, Eataly restaurant, and the MSC Yacht Club ship-within-a-ship upscale concept."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Bellissima</span>
     </nav>
 
-    <h1>MSC Bellissima</h1>
+    <h1>MSC Bellissima — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Bellissima overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Bellissima is a Meraviglia Class cruise ship operated by MSC Cruises. She entered service in 2019, measures 171,598 gross tons, and carries approximately 5,714 guests at double occupancy.</p>
@@ -424,17 +409,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Bellissima dining venue" loading="lazy"/>
-Dining on MSC Bellissima</h2>
+      <h2 id="diningHeading">Dining on MSC Bellissima <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-bellissima","aliases":["MSC Bellissima"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Meraviglia Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Bellissima</strong> is a <strong>Meraviglia Class</strong> ship from MSC Cruises.
@@ -489,7 +471,9 @@ Dining on MSC Bellissima</h2>
       <h2 id="video-highlights">Watch: MSC Bellissima Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Bellissima are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -560,7 +544,7 @@ Dining on MSC Bellissima</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Bellissima</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-bellissima">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">171,598 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">5,714</div></div>
@@ -682,10 +666,12 @@ Dining on MSC Bellissima</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Bellissima offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -707,7 +693,7 @@ Dining on MSC Bellissima</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -733,5 +719,6 @@ Dining on MSC Bellissima</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-divina.html
+++ b/ships/msc/msc-divina.html
@@ -60,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -129,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Fantasia Class ship operated by MSC Cruises.","name":"MSC Divina","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Divina is a Fantasia Class MSC Cruises ship measuring 139,400 GT with capacity for 3,502 guests. Built in 2012 and named after Sophia Loren, she features the MSC Yacht Club, Eataly, a 4D cinema, and the Aurea Spa with a snow room and thalassotherapy pool."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -357,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Divina</span>
     </nav>
 
-    <h1>MSC Divina</h1>
+    <h1>MSC Divina — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Divina overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Divina is a Fantasia Class cruise ship operated by MSC Cruises. She entered service in May 2012, was christened by Sophia Loren, measures 139,400 gross tons, carries approximately 3,502 guests at double occupancy with a crew of 1,388. She sails Caribbean from PortMiami (winter) and Mediterranean (summer). Features the MSC Yacht Club, Eataly restaurants, and Aurea Spa.</p>
@@ -409,14 +409,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading">Dining on MSC Divina</h2>
+      <h2 id="diningHeading">Dining on MSC Divina <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-divina","aliases":["MSC Divina"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Fantasia Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Divina</strong> is a <strong>Fantasia Class</strong> ship from MSC Cruises.
@@ -474,7 +474,9 @@ All work on this project is offered as a gift to God.
       <h2 id="video-highlights">Watch: MSC Divina Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Divina are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -522,7 +524,7 @@ All work on this project is offered as a gift to God.
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Divina</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-divina">
         <noscript>
           <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">139,400 GT</div></div>
@@ -689,10 +691,12 @@ All work on this project is offered as a gift to God.
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Divina offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -740,5 +744,6 @@ All work on this project is offered as a gift to God.
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-euribia.html
+++ b/ships/msc/msc-euribia.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Euribia
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Meraviglia Plus
-     siblings: /ships/msc/msc-grandiosa.html, /ships/msc/msc-virtuosa.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Euribia cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Euribia: Meraviglia Plus Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Euribia: A Meraviglia Plus Class ship from MSC Cruises. 184,011 GT, 4,888 guests, built 2023. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Euribia: A Meraviglia Plus Class ship from MSC Cruises. 184,011 GT, 4,888 guests, built 2023. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Meraviglia Plus ship operated by MSC Cruises.","name":"MSC Euribia","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Euribia is a Meraviglia Plus Class MSC Cruises ship measuring 184,011 GT with capacity for 4,888 guests. Built in 2023 with LNG propulsion, she features a striking hull art by Alex Filmer-Lorch, Cirque du Soleil at Sea, the MSC Yacht Club, and an innovative Luna Park adventure area."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Euribia</span>
     </nav>
 
-    <h1>MSC Euribia</h1>
+    <h1>MSC Euribia — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Euribia overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Euribia is a Meraviglia Plus cruise ship operated by MSC Cruises. She entered service in 2023, measures 183,500 gross tons, and carries approximately 6,327 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Euribia dining venue" loading="lazy"/>
-Dining on MSC Euribia</h2>
+      <h2 id="diningHeading">Dining on MSC Euribia <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-euribia","aliases":["MSC Euribia"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Meraviglia Plus Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Euribia</strong> is a <strong>Meraviglia Plus Class</strong> ship from MSC Cruises.
@@ -488,7 +470,9 @@ Dining on MSC Euribia</h2>
       <h2 id="video-highlights">Watch: MSC Euribia Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Euribia are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -559,7 +543,7 @@ Dining on MSC Euribia</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Euribia</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-euribia">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">183,500 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">6,327</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Euribia</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Euribia offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Euribia</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Euribia</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-fantasia.html
+++ b/ships/msc/msc-fantasia.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Fantasia
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Fantasia Class
-     siblings: /ships/msc/msc-divina.html, /ships/msc/msc-preziosa.html, /ships/msc/msc-splendida.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Fantasia cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Fantasia: Fantasia Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Fantasia: A Fantasia Class ship from MSC Cruises. 137,936 GT, 3,274 guests, built 2008. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Fantasia: A Fantasia Class ship from MSC Cruises. 137,936 GT, 3,274 guests, built 2008. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Fantasia Class ship operated by MSC Cruises.","name":"MSC Fantasia","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Fantasia is the lead ship of the Fantasia Class for MSC Cruises, measuring 137,936 GT with capacity for 3,274 guests. Built in 2008, she was the first MSC ship to feature the MSC Yacht Club upscale ship-within-a-ship concept, along with L'Etoile restaurant, the Aurea Spa, and a stunning Swarovski crystal staircase."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Fantasia</span>
     </nav>
 
-    <h1>MSC Fantasia</h1>
+    <h1>MSC Fantasia — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Fantasia overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Fantasia is a Fantasia Class cruise ship operated by MSC Cruises. She entered service in 2008, measures 137,936 gross tons, and carries approximately 4,363 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Fantasia dining venue" loading="lazy"/>
-Dining on MSC Fantasia</h2>
+      <h2 id="diningHeading">Dining on MSC Fantasia <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-fantasia","aliases":["MSC Fantasia"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Fantasia Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Fantasia</strong> is a <strong>Fantasia Class</strong> ship from MSC Cruises.
@@ -488,7 +470,9 @@ Dining on MSC Fantasia</h2>
       <h2 id="video-highlights">Watch: MSC Fantasia Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Fantasia are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -559,7 +543,7 @@ Dining on MSC Fantasia</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Fantasia</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-fantasia">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">137,936 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">4,363</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Fantasia</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Fantasia offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Fantasia</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Fantasia</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-grandiosa.html
+++ b/ships/msc/msc-grandiosa.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Grandiosa
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Meraviglia Plus
-     siblings: /ships/msc/msc-euribia.html, /ships/msc/msc-virtuosa.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Grandiosa cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Grandiosa: Meraviglia Plus Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Grandiosa: A Meraviglia Plus Class ship from MSC Cruises. 181,541 GT, 4,888 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Grandiosa: A Meraviglia Plus Class ship from MSC Cruises. 181,541 GT, 4,888 guests, built 2019. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Meraviglia Plus ship operated by MSC Cruises.","name":"MSC Grandiosa","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Grandiosa is a Meraviglia Plus Class MSC Cruises ship measuring 181,541 GT with capacity for 4,888 guests. Built in 2019, she features a 112-metre LED sky dome promenade, Cirque du Soleil at Sea, two Himalayan Bridge rope courses, the MSC Yacht Club, and a wide array of specialty dining."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Grandiosa</span>
     </nav>
 
-    <h1>MSC Grandiosa</h1>
+    <h1>MSC Grandiosa — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Grandiosa overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Grandiosa is a Meraviglia Plus cruise ship operated by MSC Cruises. She entered service in 2019, measures 181,541 gross tons, and carries approximately 6,334 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Grandiosa dining venue" loading="lazy"/>
-Dining on MSC Grandiosa</h2>
+      <h2 id="diningHeading">Dining on MSC Grandiosa <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-grandiosa","aliases":["MSC Grandiosa"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Meraviglia Plus Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Grandiosa</strong> is a <strong>Meraviglia Plus Class</strong> ship from MSC Cruises.
@@ -488,7 +470,9 @@ Dining on MSC Grandiosa</h2>
       <h2 id="video-highlights">Watch: MSC Grandiosa Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Grandiosa are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -559,7 +543,7 @@ Dining on MSC Grandiosa</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Grandiosa</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-grandiosa">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">181,541 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">6,334</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Grandiosa</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Grandiosa offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Grandiosa</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Grandiosa</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-lirica.html
+++ b/ships/msc/msc-lirica.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Lirica
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Lirica Class
-     siblings: /ships/msc/msc-armonia.html, /ships/msc/msc-opera.html, /ships/msc/msc-sinfonia.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Lirica cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Lirica: Lirica Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Lirica: A Lirica Class ship from MSC Cruises. 65,591 GT, 1,984 guests, built 2003. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Lirica: A Lirica Class ship from MSC Cruises. 65,591 GT, 1,984 guests, built 2003. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Lirica Class ship operated by MSC Cruises.","name":"MSC Lirica","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Lirica is the lead ship of the Lirica Class for MSC Cruises, measuring 65,591 GT with capacity for 1,984 guests. Built in 2003 and lengthened in 2015, she features an intimate mid-size design with La Brasserie restaurant, the Aurea Spa, a two-deck theatre, and frequently sails Asian and Middle Eastern itineraries."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Lirica</span>
     </nav>
 
-    <h1>MSC Lirica</h1>
+    <h1>MSC Lirica — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Lirica overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Lirica is a Lirica Class cruise ship operated by MSC Cruises. She entered service in 2003, measures 65,591 gross tons, and carries approximately 2,679 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Lirica dining venue" loading="lazy"/>
-Dining on MSC Lirica</h2>
+      <h2 id="diningHeading">Dining on MSC Lirica <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-lirica","aliases":["MSC Lirica"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Lirica Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Lirica</strong> is a <strong>Lirica Class</strong> ship from MSC Cruises.
@@ -488,7 +470,9 @@ Dining on MSC Lirica</h2>
       <h2 id="video-highlights">Watch: MSC Lirica Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Lirica are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -559,7 +543,7 @@ Dining on MSC Lirica</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Lirica</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-lirica">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">65,591 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">2,679</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Lirica</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Lirica offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Lirica</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Lirica</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-magnifica.html
+++ b/ships/msc/msc-magnifica.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Magnifica
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Musica Class
-     siblings: /ships/msc/msc-musica.html, /ships/msc/msc-orchestra.html, /ships/msc/msc-poesia.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Magnifica cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Magnifica: Musica Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Magnifica: A Musica Class ship from MSC Cruises. 95,128 GT, 2,518 guests, built 2010. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Magnifica: A Musica Class ship from MSC Cruises. 95,128 GT, 2,518 guests, built 2010. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Musica Class ship operated by MSC Cruises.","name":"MSC Magnifica","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Magnifica is a Musica Class MSC Cruises ship measuring 95,128 GT with capacity for 2,518 guests. Built in 2010, she features an elegant interior with the Royal Palm Casino, a panoramic Top Sail lounge, the Aurea Spa, and a varied specialty dining selection. Popular on world cruise and Grand Voyage itineraries."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Magnifica</span>
     </nav>
 
-    <h1>MSC Magnifica</h1>
+    <h1>MSC Magnifica — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Magnifica overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Magnifica is a Musica Class cruise ship operated by MSC Cruises. She entered service in 2010, measures 95,128 gross tons, and carries approximately 3,223 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Magnifica dining venue" loading="lazy"/>
-Dining on MSC Magnifica</h2>
+      <h2 id="diningHeading">Dining on MSC Magnifica <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-magnifica","aliases":["MSC Magnifica"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Musica Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Magnifica</strong> is a <strong>Musica Class</strong> ship from MSC Cruises.
@@ -491,7 +473,9 @@ Dining on MSC Magnifica</h2>
       <h2 id="video-highlights">Watch: MSC Magnifica Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Magnifica are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -539,7 +523,7 @@ Dining on MSC Magnifica</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Magnifica</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-magnifica">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">95,128 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">3,223</div></div>
@@ -701,10 +685,12 @@ Dining on MSC Magnifica</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Magnifica offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -726,7 +712,7 @@ Dining on MSC Magnifica</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -752,5 +738,6 @@ Dining on MSC Magnifica</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-meraviglia.html
+++ b/ships/msc/msc-meraviglia.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Meraviglia
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Meraviglia Class
-     siblings: /ships/msc/msc-bellissima.html
-     updated: 2026-02-21
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Meraviglia cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Meraviglia: Meraviglia Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Meraviglia: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2017. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Meraviglia: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2017. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Meraviglia Class ship operated by MSC Cruises.","name":"MSC Meraviglia","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Meraviglia is the lead ship of the Meraviglia Class for MSC Cruises, measuring 171,598 GT with capacity for 4,500 guests. Built in 2017, she was the first MSC ship to feature Cirque du Soleil at Sea, a 96-metre LED sky dome promenade, and an expansive MSC Yacht Club with butler service."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Meraviglia</span>
     </nav>
 
-    <h1>MSC Meraviglia</h1>
+    <h1>MSC Meraviglia — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Meraviglia overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Meraviglia is a Meraviglia Class cruise ship operated by MSC Cruises. She entered service in 2017, measures 171,598 gross tons, and carries approximately 5,714 guests at double occupancy.</p>
@@ -426,17 +411,14 @@ All work on this project is offered as a gift to God.
     </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Meraviglia dining venue" loading="lazy"/>
-Dining on MSC Meraviglia</h2>
+      <h2 id="diningHeading">Dining on MSC Meraviglia <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-meraviglia","aliases":["MSC Meraviglia"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Meraviglia Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Meraviglia</strong> is a <strong>Meraviglia Class</strong> ship from MSC Cruises.
@@ -494,7 +476,9 @@ Dining on MSC Meraviglia</h2>
       <h2 id="video-highlights">Watch: MSC Meraviglia Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Meraviglia are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -542,7 +526,7 @@ Dining on MSC Meraviglia</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Meraviglia</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-meraviglia">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">171,598 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">5,714</div></div>
@@ -704,10 +688,12 @@ Dining on MSC Meraviglia</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Meraviglia offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -729,7 +715,7 @@ Dining on MSC Meraviglia</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -755,5 +741,6 @@ Dining on MSC Meraviglia</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-musica.html
+++ b/ships/msc/msc-musica.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Musica
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Musica Class
-     siblings: /ships/msc/msc-magnifica.html, /ships/msc/msc-orchestra.html, /ships/msc/msc-poesia.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Musica cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Musica: Musica Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Musica: A Musica Class ship from MSC Cruises. 92,409 GT, 2,550 guests, built 2006. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Musica: A Musica Class ship from MSC Cruises. 92,409 GT, 2,550 guests, built 2006. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Musica Class ship operated by MSC Cruises.","name":"MSC Musica","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Musica is the lead ship of the Musica Class for MSC Cruises, measuring 92,409 GT with capacity for 2,550 guests. Built in 2006 at STX Europe, she features a three-deck waterfall in the atrium, the Kaito sushi bar, Il Galeone restaurant, and the Aurea Spa with a Balinese treatment room."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Musica</span>
     </nav>
 
-    <h1>MSC Musica</h1>
+    <h1>MSC Musica — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Musica overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Musica is a Musica Class cruise ship operated by MSC Cruises. She entered service in 2006, measures 92,409 gross tons, and carries approximately 3,223 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Musica dining venue" loading="lazy"/>
-Dining on MSC Musica</h2>
+      <h2 id="diningHeading">Dining on MSC Musica <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-musica","aliases":["MSC Musica"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Musica Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Musica</strong> is a <strong>Musica Class</strong> ship from MSC Cruises.
@@ -488,7 +470,9 @@ Dining on MSC Musica</h2>
       <h2 id="video-highlights">Watch: MSC Musica Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Musica are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -559,7 +543,7 @@ Dining on MSC Musica</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Musica</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-musica">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">92,409 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">3,223</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Musica</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Musica offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Musica</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Musica</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-opera.html
+++ b/ships/msc/msc-opera.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Opera
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Lirica Class
-     siblings: /ships/msc/msc-armonia.html, /ships/msc/msc-lirica.html, /ships/msc/msc-sinfonia.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Opera cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Opera: Lirica Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Opera: A Lirica Class ship from MSC Cruises. 65,591 GT, 1,984 guests, built 2004. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Opera: A Lirica Class ship from MSC Cruises. 65,591 GT, 1,984 guests, built 2004. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Lirica Class ship operated by MSC Cruises.","name":"MSC Opera","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Opera is a Lirica Class MSC Cruises ship measuring 65,591 GT with capacity for 1,984 guests. Built in 2004 and extended in 2015, she features intimate Italian-designed interiors, the La Caravella main restaurant, a panoramic Top Sail lounge, and the Aurea Spa. Popular for Mediterranean and South American sailings."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Opera</span>
     </nav>
 
-    <h1>MSC Opera</h1>
+    <h1>MSC Opera — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Opera overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Opera is a Lirica Class cruise ship operated by MSC Cruises. She entered service in 2004, measures 65,591 gross tons, and carries approximately 2,679 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Opera dining venue" loading="lazy"/>
-Dining on MSC Opera</h2>
+      <h2 id="diningHeading">Dining on MSC Opera <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-opera","aliases":["MSC Opera"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Lirica Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Opera</strong> is a <strong>Lirica Class</strong> ship from MSC Cruises.
@@ -488,7 +470,9 @@ Dining on MSC Opera</h2>
       <h2 id="video-highlights">Watch: MSC Opera Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Opera are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -559,7 +543,7 @@ Dining on MSC Opera</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Opera</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-opera">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">65,591 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">2,679</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Opera</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Opera offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Opera</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Opera</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-orchestra.html
+++ b/ships/msc/msc-orchestra.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Orchestra
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Musica Class
-     siblings: /ships/msc/msc-magnifica.html, /ships/msc/msc-musica.html, /ships/msc/msc-poesia.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Orchestra cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Orchestra: Musica Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Orchestra: A Musica Class ship from MSC Cruises. 92,409 GT, 2,550 guests, built 2007. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Orchestra: A Musica Class ship from MSC Cruises. 92,409 GT, 2,550 guests, built 2007. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Musica Class ship operated by MSC Cruises.","name":"MSC Orchestra","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Orchestra is a Musica Class MSC Cruises ship measuring 92,409 GT with capacity for 2,550 guests. Built in 2007, she features Shanghai Chinese restaurant, the Kaito sushi bar, Il Galeone main dining room, a panoramic Top Sail lounge, and the Aurea Spa. A mid-size ship popular for Mediterranean cruises."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Orchestra</span>
     </nav>
 
-    <h1>MSC Orchestra</h1>
+    <h1>MSC Orchestra — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Orchestra overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Orchestra is a Musica Class cruise ship operated by MSC Cruises. She entered service in 2007, measures 92,409 gross tons, and carries approximately 3,223 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Orchestra dining venue" loading="lazy"/>
-Dining on MSC Orchestra</h2>
+      <h2 id="diningHeading">Dining on MSC Orchestra <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-orchestra","aliases":["MSC Orchestra"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Musica Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Orchestra</strong> is a <strong>Musica Class</strong> ship from MSC Cruises.
@@ -488,7 +470,9 @@ Dining on MSC Orchestra</h2>
       <h2 id="video-highlights">Watch: MSC Orchestra Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Orchestra are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -559,7 +543,7 @@ Dining on MSC Orchestra</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Orchestra</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-orchestra">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">92,409 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">3,223</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Orchestra</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Orchestra offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Orchestra</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Orchestra</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-poesia.html
+++ b/ships/msc/msc-poesia.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Poesia
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Musica Class
-     siblings: /ships/msc/msc-magnifica.html, /ships/msc/msc-musica.html, /ships/msc/msc-orchestra.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Poesia cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Poesia: Musica Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Poesia: A Musica Class ship from MSC Cruises. 92,627 GT, 2,550 guests, built 2008. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Poesia: A Musica Class ship from MSC Cruises. 92,627 GT, 2,550 guests, built 2008. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -144,7 +129,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Musica Class ship operated by MSC Cruises.","name":"MSC Poesia","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Poesia is a Musica Class MSC Cruises ship measuring 92,627 GT with capacity for 2,550 guests. Built in 2008, she features the elegant Villa Verde Ristorante, Kaito sushi bar, a panoramic Top Sail lounge, and the Aurea Spa. A refined mid-size ship popular for Mediterranean and world cruise itineraries."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -267,7 +252,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -364,7 +349,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -372,9 +357,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Poesia</span>
     </nav>
 
-    <h1>MSC Poesia</h1>
+    <h1>MSC Poesia — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Poesia overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Poesia is a Musica Class cruise ship operated by MSC Cruises. She entered service in 2008, measures 92,627 gross tons, and carries approximately 3,223 guests at double occupancy.</p>
@@ -423,17 +408,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Poesia dining venue" loading="lazy"/>
-Dining on MSC Poesia</h2>
+      <h2 id="diningHeading">Dining on MSC Poesia <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-poesia","aliases":["MSC Poesia"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Musica Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Poesia</strong> is a <strong>Musica Class</strong> ship from MSC Cruises.
@@ -488,7 +470,9 @@ Dining on MSC Poesia</h2>
       <h2 id="video-highlights">Watch: MSC Poesia Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Poesia are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -559,7 +543,7 @@ Dining on MSC Poesia</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Poesia</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-poesia">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">92,627 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">3,223</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Poesia</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Poesia offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Poesia</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Poesia</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-preziosa.html
+++ b/ships/msc/msc-preziosa.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Preziosa
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Fantasia Class
-     siblings: /ships/msc/msc-divina.html, /ships/msc/msc-fantasia.html, /ships/msc/msc-splendida.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Preziosa cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Preziosa: Fantasia Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Preziosa: A Fantasia Class ship from MSC Cruises. 139,400 GT, 3,502 guests, built 2013. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Preziosa: A Fantasia Class ship from MSC Cruises. 139,400 GT, 3,502 guests, built 2013. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Fantasia Class ship operated by MSC Cruises.","name":"MSC Preziosa","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Preziosa is a Fantasia Class ship from MSC Cruises measuring 139,400 GT and hosting 3,502 guests since 2013. The last Fantasia Class vessel features the Infinity Pool, the longest waterslide at sea (at time of launch), MSC Yacht Club, Eataly partnership dining, and the Galaxy nightclub with Swarovski crystal details."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Preziosa</span>
     </nav>
 
-    <h1>MSC Preziosa</h1>
+    <h1>MSC Preziosa — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Preziosa overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Preziosa is a Fantasia Class cruise ship operated by MSC Cruises. She entered service in 2013, measures 139,072 gross tons, and carries approximately 4,345 guests at double occupancy.</p>
@@ -403,17 +388,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Preziosa dining venue" loading="lazy"/>
-Dining on MSC Preziosa</h2>
+      <h2 id="diningHeading">Dining on MSC Preziosa <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-preziosa","aliases":["MSC Preziosa"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Fantasia Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Preziosa</strong> is a <strong>Fantasia Class</strong> ship from MSC Cruises.
@@ -468,7 +450,9 @@ Dining on MSC Preziosa</h2>
       <h2 id="video-highlights">Watch: MSC Preziosa Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Preziosa are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -539,7 +523,7 @@ Dining on MSC Preziosa</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Preziosa</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-preziosa">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">139,072 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">4,345</div></div>
@@ -661,10 +645,12 @@ Dining on MSC Preziosa</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Preziosa offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -686,7 +672,7 @@ Dining on MSC Preziosa</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -712,5 +698,6 @@ Dining on MSC Preziosa</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-seascape.html
+++ b/ships/msc/msc-seascape.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Seascape
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Seaside EVO
-     siblings: /ships/msc/msc-seashore.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Seascape cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Seascape: Seaside EVO Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Seascape: A Seaside EVO Class ship from MSC Cruises. 170,412 GT, 4,540 guests, built 2022. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Seascape: A Seaside EVO Class ship from MSC Cruises. 170,412 GT, 4,540 guests, built 2022. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Seaside EVO ship operated by MSC Cruises.","name":"MSC Seascape","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Seascape is a Seaside EVO Class ship from MSC Cruises measuring 170,412 GT and hosting 4,540 guests since 2022. An evolution of the Seaside Class, she features a stunning six-deck outdoor promenade, the Robot Bar, Cliffhanger over-water swing ride, Cirque du Soleil at Sea, MSC Yacht Club, and Hola! Tacos & Cantina."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Seascape</span>
     </nav>
 
-    <h1>MSC Seascape</h1>
+    <h1>MSC Seascape — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Seascape overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Seascape is a Seaside EVO cruise ship operated by MSC Cruises. She entered service in 2022, measures 169,400 gross tons, and carries approximately 5,632 guests at double occupancy.</p>
@@ -403,17 +388,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Seascape dining venue" loading="lazy"/>
-Dining on MSC Seascape</h2>
+      <h2 id="diningHeading">Dining on MSC Seascape <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-seascape","aliases":["MSC Seascape"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Seaside EVO Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Seascape</strong> is a <strong>Seaside EVO Class</strong> ship from MSC Cruises.
@@ -471,7 +453,9 @@ Dining on MSC Seascape</h2>
       <h2 id="video-highlights">Watch: MSC Seascape Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Seascape are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -519,7 +503,7 @@ Dining on MSC Seascape</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Seascape</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-seascape">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">169,400 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">5,632</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Seascape</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Seascape offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Seascape</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Seascape</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-seashore.html
+++ b/ships/msc/msc-seashore.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Seashore
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Seaside EVO
-     siblings: /ships/msc/msc-seascape.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Seashore cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Seashore: Seaside EVO Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Seashore: A Seaside EVO Class ship from MSC Cruises. 170,412 GT, 4,540 guests, built 2021. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Seashore: A Seaside EVO Class ship from MSC Cruises. 170,412 GT, 4,540 guests, built 2021. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Seaside EVO ship operated by MSC Cruises.","name":"MSC Seashore","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Seashore is a Seaside EVO Class ship from MSC Cruises measuring 170,412 GT and hosting 4,540 guests since 2021. The first Seaside EVO vessel features an extended outdoor promenade, the Robot Bar, Cirque du Soleil at Sea, MSC Yacht Club with private sundeck, and Butcher's Cut steakhouse."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Seashore</span>
     </nav>
 
-    <h1>MSC Seashore</h1>
+    <h1>MSC Seashore — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Seashore overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Seashore is a Seaside EVO cruise ship operated by MSC Cruises. She entered service in 2021, measures 169,400 gross tons, and carries approximately 5,632 guests at double occupancy.</p>
@@ -403,17 +388,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Seashore dining venue" loading="lazy"/>
-Dining on MSC Seashore</h2>
+      <h2 id="diningHeading">Dining on MSC Seashore <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-seashore","aliases":["MSC Seashore"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Seaside EVO Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Seashore</strong> is a <strong>Seaside EVO Class</strong> ship from MSC Cruises.
@@ -471,7 +453,9 @@ Dining on MSC Seashore</h2>
       <h2 id="video-highlights">Watch: MSC Seashore Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Seashore are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -519,7 +503,7 @@ Dining on MSC Seashore</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Seashore</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-seashore">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">169,400 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">5,632</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Seashore</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Seashore offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Seashore</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Seashore</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-seaside.html
+++ b/ships/msc/msc-seaside.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Seaside
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Seaside Class
-     siblings: /ships/msc/msc-seaview.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Seaside cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Seaside: Seaside Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Seaside: A Seaside Class ship from MSC Cruises. 153,516 GT, 4,132 guests, built 2017. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Seaside: A Seaside Class ship from MSC Cruises. 153,516 GT, 4,132 guests, built 2017. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Seaside Class ship operated by MSC Cruises.","name":"MSC Seaside","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Seaside is the lead ship of the Seaside Class from MSC Cruises measuring 153,516 GT and hosting 4,132 guests since 2017. Designed by Fincantieri as a beach condo concept, she features a wraparound waterfront promenade, the Aquapark with waterslides, MSC Yacht Club, Butcher's Cut steakhouse, and an innovative aft pool area."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Seaside</span>
     </nav>
 
-    <h1>MSC Seaside</h1>
+    <h1>MSC Seaside — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Seaside overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Seaside is a Seaside Class cruise ship operated by MSC Cruises. She entered service in 2017, measures 153,516 gross tons, and carries approximately 5,179 guests at double occupancy.</p>
@@ -403,17 +388,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Seaside dining venue" loading="lazy"/>
-Dining on MSC Seaside</h2>
+      <h2 id="diningHeading">Dining on MSC Seaside <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-seaside","aliases":["MSC Seaside"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Seaside Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Seaside</strong> is a <strong>Seaside Class</strong> ship from MSC Cruises.
@@ -471,7 +453,9 @@ Dining on MSC Seaside</h2>
       <h2 id="video-highlights">Watch: MSC Seaside Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Seaside are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -519,7 +503,7 @@ Dining on MSC Seaside</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Seaside</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-seaside">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">153,516 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">5,179</div></div>
@@ -681,10 +665,12 @@ Dining on MSC Seaside</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Seaside offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -706,7 +692,7 @@ Dining on MSC Seaside</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -732,5 +718,6 @@ Dining on MSC Seaside</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-seaview.html
+++ b/ships/msc/msc-seaview.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Seaview
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Seaside Class
-     siblings: /ships/msc/msc-seaside.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Seaview cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Seaview: Seaside Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Seaview: A Seaside Class ship from MSC Cruises. 153,516 GT, 4,132 guests, built 2018. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Seaview: A Seaside Class ship from MSC Cruises. 153,516 GT, 4,132 guests, built 2018. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Seaside Class ship operated by MSC Cruises.","name":"MSC Seaview","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Seaview is a Seaside Class ship from MSC Cruises measuring 153,516 GT and hosting 4,132 guests since 2018. Sister to MSC Seaside, she features the wraparound waterfront promenade, panoramic glass-floored Bridge of Sighs, Aquapark with waterslides, MSC Yacht Club, and Butcher's Cut steakhouse."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Seaview</span>
     </nav>
 
-    <h1>MSC Seaview</h1>
+    <h1>MSC Seaview — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Seaview overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Seaview is a Seaside Class cruise ship operated by MSC Cruises. She entered service in 2018, measures 153,516 gross tons, and carries approximately 5,179 guests at double occupancy.</p>
@@ -404,17 +389,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Seaview dining venue" loading="lazy"/>
-Dining on MSC Seaview</h2>
+      <h2 id="diningHeading">Dining on MSC Seaview <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-seaview","aliases":["MSC Seaview"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Seaside Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Seaview</strong> is a <strong>Seaside Class</strong> ship from MSC Cruises.
@@ -469,7 +451,9 @@ Dining on MSC Seaview</h2>
       <h2 id="video-highlights">Watch: MSC Seaview Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Seaview are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -540,7 +524,7 @@ Dining on MSC Seaview</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Seaview</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-seaview">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">153,516 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">5,179</div></div>
@@ -662,10 +646,12 @@ Dining on MSC Seaview</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Seaview offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -687,7 +673,7 @@ Dining on MSC Seaview</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -713,5 +699,6 @@ Dining on MSC Seaview</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-sinfonia.html
+++ b/ships/msc/msc-sinfonia.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Sinfonia
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Lirica Class
-     siblings: /ships/msc/msc-armonia.html, /ships/msc/msc-lirica.html, /ships/msc/msc-opera.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Sinfonia cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Sinfonia: Lirica Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Sinfonia: A Lirica Class ship from MSC Cruises. 65,542 GT, 1,954 guests, built 2002. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Sinfonia: A Lirica Class ship from MSC Cruises. 65,542 GT, 1,954 guests, built 2002. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Lirica Class ship operated by MSC Cruises.","name":"MSC Sinfonia","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Sinfonia is a Lirica Class ship from MSC Cruises measuring 65,542 GT and hosting 1,954 guests since 2002. Extended in 2015 during the Renaissance Programme, she features La Caravella and Il Covo restaurants, the Aurea Spa, panoramic Top Sail lounge, and South African and Mediterranean itineraries."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Sinfonia</span>
     </nav>
 
-    <h1>MSC Sinfonia</h1>
+    <h1>MSC Sinfonia — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Sinfonia overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Sinfonia is a Lirica Class cruise ship operated by MSC Cruises. She entered service in 2005, measures 65,591 gross tons, and carries approximately 2,679 guests at double occupancy.</p>
@@ -403,17 +388,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Sinfonia dining venue" loading="lazy"/>
-Dining on MSC Sinfonia</h2>
+      <h2 id="diningHeading">Dining on MSC Sinfonia <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-sinfonia","aliases":["MSC Sinfonia"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Lirica Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Sinfonia</strong> is a <strong>Lirica Class</strong> ship from MSC Cruises.
@@ -468,7 +450,9 @@ Dining on MSC Sinfonia</h2>
       <h2 id="video-highlights">Watch: MSC Sinfonia Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Sinfonia are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -539,7 +523,7 @@ Dining on MSC Sinfonia</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Sinfonia</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-sinfonia">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">65,591 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">2,679</div></div>
@@ -661,10 +645,12 @@ Dining on MSC Sinfonia</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Sinfonia offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -686,7 +672,7 @@ Dining on MSC Sinfonia</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -712,5 +698,6 @@ Dining on MSC Sinfonia</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-splendida.html
+++ b/ships/msc/msc-splendida.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Splendida
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Fantasia Class
-     siblings: /ships/msc/msc-divina.html, /ships/msc/msc-fantasia.html, /ships/msc/msc-preziosa.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Splendida cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Splendida: Fantasia Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Splendida: A Fantasia Class ship from MSC Cruises. 137,936 GT, 3,274 guests, built 2009. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Splendida: A Fantasia Class ship from MSC Cruises. 137,936 GT, 3,274 guests, built 2009. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Fantasia Class ship operated by MSC Cruises.","name":"MSC Splendida","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Splendida is a Fantasia Class ship from MSC Cruises measuring 137,936 GT and hosting 3,274 guests since 2009. Sister to MSC Fantasia, she features the MSC Yacht Club ship-within-a-ship concept, L'Etoile restaurant, Aurea Spa, a Swarovski crystal staircase, and Mediterranean and Arabian Gulf itineraries."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Splendida</span>
     </nav>
 
-    <h1>MSC Splendida</h1>
+    <h1>MSC Splendida — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Splendida overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Splendida is a Fantasia Class cruise ship operated by MSC Cruises. She entered service in 2009, measures 137,936 gross tons, and carries approximately 4,363 guests at double occupancy.</p>
@@ -403,17 +388,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Splendida dining venue" loading="lazy"/>
-Dining on MSC Splendida</h2>
+      <h2 id="diningHeading">Dining on MSC Splendida <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-splendida","aliases":["MSC Splendida"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Fantasia Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Splendida</strong> is a <strong>Fantasia Class</strong> ship from MSC Cruises.
@@ -468,7 +450,9 @@ Dining on MSC Splendida</h2>
       <h2 id="video-highlights">Watch: MSC Splendida Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Splendida are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -539,7 +523,7 @@ Dining on MSC Splendida</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Splendida</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-splendida">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">137,936 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">4,363</div></div>
@@ -661,10 +645,12 @@ Dining on MSC Splendida</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Splendida offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -686,7 +672,7 @@ Dining on MSC Splendida</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -712,5 +698,6 @@ Dining on MSC Splendida</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-virtuosa.html
+++ b/ships/msc/msc-virtuosa.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC Virtuosa
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: Meraviglia Plus
-     siblings: /ships/msc/msc-euribia.html, /ships/msc/msc-grandiosa.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC Virtuosa cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC Virtuosa: Meraviglia Plus Class ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC Virtuosa: A Meraviglia Plus Class ship from MSC Cruises. 181,541 GT, 4,888 guests, built 2021. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC Virtuosa: A Meraviglia Plus Class ship from MSC Cruises. 181,541 GT, 4,888 guests, built 2021. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Meraviglia Plus ship operated by MSC Cruises.","name":"MSC Virtuosa","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Virtuosa is a Meraviglia Plus Class ship from MSC Cruises measuring 181,541 GT and hosting 4,888 guests since 2021. Sister to MSC Grandiosa, she features Rob the humanoid robot bartender, Cirque du Soleil at Sea, a 112-metre LED sky dome in the Galleria, two Himalayan Bridge rope courses, and MSC Yacht Club."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC Virtuosa</span>
     </nav>
 
-    <h1>MSC Virtuosa</h1>
+    <h1>MSC Virtuosa — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Virtuosa overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Virtuosa is a Meraviglia Plus cruise ship operated by MSC Cruises. She entered service in 2021, measures 181,541 gross tons, and carries approximately 6,334 guests at double occupancy.</p>
@@ -403,17 +388,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC Virtuosa dining venue" loading="lazy"/>
-Dining on MSC Virtuosa</h2>
+      <h2 id="diningHeading">Dining on MSC Virtuosa <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-virtuosa","aliases":["MSC Virtuosa"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Meraviglia Plus Class</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Virtuosa</strong> is a <strong>Meraviglia Plus Class</strong> ship from MSC Cruises.
@@ -468,7 +450,9 @@ Dining on MSC Virtuosa</h2>
       <h2 id="video-highlights">Watch: MSC Virtuosa Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC Virtuosa are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -539,7 +523,7 @@ Dining on MSC Virtuosa</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC Virtuosa</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-virtuosa">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">181,541 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">6,334</div></div>
@@ -661,10 +645,12 @@ Dining on MSC Virtuosa</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC Virtuosa offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -686,7 +672,7 @@ Dining on MSC Virtuosa</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -712,5 +698,6 @@ Dining on MSC Virtuosa</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-world-america.html
+++ b/ships/msc/msc-world-america.html
@@ -6,27 +6,14 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC World America
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC
-     ship-class: exceptional
-     siblings: /ships/msc/msc-world-asia.html, /ships/msc/msc-world-europa.html
-     updated: 2025-11-15
-     expertise: MSC Cruises ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC World America cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Study the ship’s layout—pin your stateroom, elevators, dining, and venues before you sail.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="ai-summary" content="MSC World America (v2.201). Deck plans, dining venues, stateroom tours, and live ship tracker. Plan your cruise with in-depth reviews.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
   <title>MSC World America — In the Wake (v2.201)</title>
 <meta name="description" content="MSC World America (v2.201)"/>
 <link rel="canonical" href="https://cruisinginthewake.com/ships/msc/msc-world-america.html"/>
@@ -126,9 +113,9 @@ All work on this project is offered as a gift to God.
 }
 </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"MSC World America","url":"https://cruisinginthewake.com/ships/msc/msc-world-america.html","description":"MSC World America (v2.201). Deck plans, dining venues, stateroom tours, and live ship tracker. Plan your cruise with in-depth reviews.","dateModified":"2026-02-21","mainEntity":{"@type":"Thing","name":"MSC World America","category":"Cruise Ship","manufacturer":{"@type":"Organization","name":"MSC Cruises"}}}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
   "@context": "https://schema.org",
@@ -294,7 +281,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-  <a href="#content" class="skip-link">Skip to main content</a>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <!-- ARIA Live Regions -->
   <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
   <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
@@ -389,14 +376,14 @@ All work on this project is offered as a gift to God.
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit"><a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Photo © Flickers of Majesty</a></div>
     </div></header>
-  <main role="main" class="wrap page-grid" id="content" data-ship="MSC World America">
+  <main role="main" class="wrap page-grid" id="main-content" tabindex="-1" data-ship="MSC World America">
 
     <!-- Main Content Column -->
     <section class="col-1" aria-label="Ship details">
 <div>
-    <!-- ICP-Lite Content Structure -->
+    <!-- ICP-2 Content Structure -->
     <section class="page-intro">
-      <h1>MSC World America</h1>
+      <h1>MSC World America — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC World America is a exceptional cruise ship operated by MSC Cruises. She entered service in 2025, measures 215,863 gross tons, and carries approximately 6,762 guests at double occupancy.</p>
@@ -450,13 +437,8 @@ All work on this project is offered as a gift to God.
 
     <!-- Dining Section -->
     <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading">Dining on MSC World America</h2>
-      <img id="dining-hero" class="card-hero"
-           src="/assets/img/Cordelia_Empress_Food_Court.webp"
-           alt="MSC World America dining venue with international cuisine options"
-           loading="lazy"
-           style="width:100%;border-radius:8px;margin:1rem 0;"
-           onerror="this.style.display='none'"/>
+      <h2 id="diningHeading">Dining on MSC World America <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
+      
       <p>MSC World America offers over <strong>30 dining venues</strong> across seven themed districts. Highlights include Butcher's Cut steakhouse, Kaito Teppanyaki & Sushi Bar, Hola! Tacos & Cantina, Chef's Garden Kitchen, La Pescadería seafood restaurant, and the exclusive Yacht Club Restaurant with 24-hour butler service.</p>
     </section>
 
@@ -465,7 +447,9 @@ All work on this project is offered as a gift to God.
       <h2 id="video-highlights">Watch: MSC World America Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC World America are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" aria-hidden="true"></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -527,7 +511,7 @@ All work on this project is offered as a gift to God.
   
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC World America</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-world-america">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">215,863 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">6,762</div></div>
@@ -568,7 +552,7 @@ All work on this project is offered as a gift to God.
   <p><em>Personal notes from recent sailings will appear here. This section is intentionally subjective and complements (not replaces) the objective overview.</em></p>
 </section>
 
-<!-- ICP-Lite FAQ Section -->
+<!-- ICP-2 FAQ Section -->
 
     <!-- Ken's Logbook Section -->
     <section class="card note-kens-logbook" aria-labelledby="logbook">
@@ -682,7 +666,9 @@ All work on this project is offered as a gift to God.
         <p class="tiny content-text">
           Real cruising experiences, practical guides, and heartfelt reflections.
         </p>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
         <p id="recent-rail-fallback" class="tiny hidden">Loading articles…</p>
       </section>
     
@@ -696,7 +682,7 @@ All work on this project is offered as a gift to God.
         </nav>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC World America offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
 
@@ -813,5 +799,6 @@ All work on this project is offered as a gift to God.
   })();
   </script>
 
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-world-asia.html
+++ b/ships/msc/msc-world-asia.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC World Asia
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: exceptional
-     siblings: /ships/msc/msc-world-america.html, /ships/msc/msc-world-europa.html
-     updated: 2026-01-02
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC World Asia cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC World Asia: exceptional ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC World Asia: A exceptional ship from MSC Cruises. 215,863 GT, 5,264 guests, built 2026. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC World Asia: A exceptional ship from MSC Cruises. 215,863 GT, 5,264 guests, built 2026. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A exceptional ship operated by MSC Cruises.","name":"MSC World Asia","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC World Asia is a exceptional ship from MSC Cruises measuring 215,863 GT and hosting 5,264 guests, launching in 2026. Third in the exceptional series, she features the distinctive Y-shaped aft design, an outdoor promenade spanning six decks, Cirque du Soleil at Sea, and MSC Yacht Club with dedicated sundeck and restaurant."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC World Asia</span>
     </nav>
 
-    <h1>MSC World Asia</h1>
+    <h1>MSC World Asia — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC World Asia overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC World Asia is a exceptional cruise ship operated by MSC Cruises. She entered service in 2026, measures 215,863 gross tons, and carries approximately 6,762 guests at double occupancy.</p>
@@ -404,17 +389,14 @@ All work on this project is offered as a gift to God.
         </section>
 
         <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC World Asia dining venue" loading="lazy"/>
-Dining on MSC World Asia</h2>
+      <h2 id="diningHeading">Dining on MSC World Asia <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
 <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-world-asia","aliases":["MSC World Asia"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; exceptional</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC World Asia</strong> is a <strong>exceptional</strong> ship from MSC Cruises.
@@ -469,7 +451,9 @@ Dining on MSC World Asia</h2>
       <h2 id="video-highlights">Watch: MSC World Asia Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC World Asia are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -540,7 +524,7 @@ Dining on MSC World Asia</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC World Asia</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-world-asia">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">215,863 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">6,762</div></div>
@@ -662,10 +646,12 @@ Dining on MSC World Asia</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
     
-      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"></section>
+      <section class="card" id="whimsical-units-container" style="background:#f7fdff;border-radius:12px;padding:1.25rem;"><noscript><h3 style="margin:0 0 0.5rem;">Ship Size</h3><p class="tiny">MSC World Asia offers MSC Cruises' signature European elegance and multinational atmosphere.</p></noscript></section>
     </aside>
   
     <!-- Planning Resources -->
@@ -687,7 +673,7 @@ Dining on MSC World Asia</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -713,5 +699,6 @@ Dining on MSC World Asia</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>

--- a/ships/msc/msc-world-europa.html
+++ b/ships/msc/msc-world-europa.html
@@ -6,22 +6,9 @@ All work on this project is offered as a gift to God.
 "Whatever you do, work heartily..." — Colossians 3:23
 -->
 
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     name: MSC World Europa
-     entity: Ship
-     type: Ship Information Page
-     parent: /ships.html
-     category: MSC Cruises Fleet
-     cruise-line: MSC Cruises
-     ship-class: exceptional
-     siblings: /ships/msc/msc-world-america.html, /ships/msc/msc-world-asia.html
-     updated: 2026-02-21
-     expertise: MSC ship reviews, deck plans, dining analysis, cabin comparisons
-     target-audience: MSC World Europa cruisers, ship comparison researchers, first-time cruisers
-     answer-first: Discover MSC World Europa: exceptional ship from MSC Cruises — dining highlights, crew warmth, live tracking, and planning tips inside.
-     -->
+<script>document.documentElement.classList.remove('no-js');</script>
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
 <script>
@@ -42,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="description" content="Discover MSC World Europa: A exceptional ship from MSC Cruises. 215,863 GT, 5,264 guests, built 2022. Dining, entertainment, deck plans, and planning tips."/>
   <meta name="ai-summary" content="Discover MSC World Europa: A exceptional ship from MSC Cruises. 215,863 GT, 5,264 guests, built 2022. Dining, entertainment, deck plans, and planning tips.">
   <meta name="last-reviewed" content="2026-02-21">
-  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
   <meta property="og:type" content="website"/>
@@ -73,7 +60,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <!-- JSON-LD: WebPage (ICP-Lite) -->
+  <!-- JSON-LD: WebPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -103,8 +90,6 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
-  <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
-
 <!-- JSON-LD: WebSite -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
 
@@ -124,7 +109,7 @@ All work on this project is offered as a gift to God.
 
   <!-- JSON-LD: Review -->
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A exceptional ship operated by MSC Cruises.","name":"MSC World Europa","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC World Europa is the lead ship of the exceptional from MSC Cruises measuring 215,863 GT and hosting 5,264 guests since 2022. The first LNG-powered cruise ship in the MSC fleet, she features a Y-shaped aft design, the Europa Promenade with LED sky ceiling, Cirque du Soleil at Sea, seven distinct districts, and MSC Yacht Club."}</script>
-  <!-- JSON-LD: FAQPage (ICP-Lite) -->
+  <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -247,7 +232,7 @@ All work on this project is offered as a gift to God.
 </script>
 </head>
 <body class="page" data-imo="9837582">
-<a href="#content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
 <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
 
@@ -344,7 +329,7 @@ All work on this project is offered as a gift to God.
     </div>
   </header>
 
-  <main class="wrap" id="content" role="main">
+  <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
@@ -352,9 +337,9 @@ All work on this project is offered as a gift to God.
       <span aria-current="page">MSC World Europa</span>
     </nav>
 
-    <h1>MSC World Europa</h1>
+    <h1>MSC World Europa — Deck Plans, Live Tracker, Dining &amp; Videos</h1>
 
-    <!-- ICP-Lite: Page Intro -->
+    <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC World Europa overview">
       
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC World Europa is a exceptional cruise ship operated by MSC Cruises. She entered service in 2022, measures 205,700 gross tons, and carries approximately 6,762 guests at double occupancy.</p>
@@ -444,7 +429,7 @@ All work on this project is offered as a gift to God.
     </section>
     <p class="subtitle">MSC Cruises &bull; exceptional</p>
 
-    <!-- ICP-Lite Quick Answer -->
+    <!-- ICP-2 Quick Answer -->
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC World Europa</strong> is a <strong>exceptional</strong> ship from MSC Cruises.
@@ -485,10 +470,7 @@ All work on this project is offered as a gift to God.
 
     <!-- Dining Section -->
     <section class="card" aria-labelledby="diningHeading">
-      <h2 id="diningHeading"><img id="dining-hero" class="card-hero"
-             src="/assets/img/Cordelia_Empress_Food_Court.webp"
-             alt="MSC World Europa dining venue" loading="lazy"/>
-Dining on MSC World Europa</h2>
+      <h2 id="diningHeading">Dining on MSC World Europa <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
       <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
     </section>
     <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-world-europa","aliases":["MSC World Europa"]}</script>
@@ -507,7 +489,9 @@ Dining on MSC World Europa</h2>
       <h2 id="video-highlights">Watch: MSC World Europa Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours.</p>
       <div class="swiper videos" aria-label="Featured video carousel">
-        <div class="swiper-wrapper" id="featuredVideos"></div>
+        <div class="swiper-wrapper" id="featuredVideos">
+          <noscript><p>Video tours for MSC World Europa are available on YouTube.</p></noscript>
+        </div>
         <div class="swiper-pagination" ></div>
         <div class="swiper-button-prev" aria-label="Previous slide"></div>
         <div class="swiper-button-next" aria-label="Next slide"></div>
@@ -577,7 +561,7 @@ Dining on MSC World Europa</h2>
       
     <!-- Ship Statistics -->
     <section class="card" aria-labelledby="ship-stats-title">
-      <h2 id="ship-stats-title">Ship Statistics</h2>
+      <h2 id="ship-stats-title">Key Facts About MSC World Europa</h2>
       <div id="ship-stats" class="stats-grid" data-slug="msc-world-europa">
         <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">205,700 GT</div></div>
         <div class="stat-item"><div class="label">Guests</div><div class="value">6,762</div></div>
@@ -699,7 +683,9 @@ Dining on MSC World Europa</h2>
 
       <section class="card" id="recent-rail-nav-bottom" aria-labelledby="recent-rail-title">
         <h3 id="recent-rail-title">Recent Stories</h3>
-        <div id="recent-rail" class="rail-list" aria-live="polite"></div>
+        <div id="recent-rail" class="rail-list" aria-live="polite">
+          <noscript><ul style="list-style:none;padding:0;"><li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising Guide</a></li></ul></noscript>
+        </div>
       </section>
 
       <!-- Whimsical Distance Units -->
@@ -726,7 +712,7 @@ Dining on MSC World Europa</h2>
 </main>
 
   <footer class="wrap" role="contentinfo">
-    <p>&copy; 2025 In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
+    <p>&copy; <script>document.write(new Date().getFullYear())</script> In the Wake &middot; A Cruise Traveler's Logbook &middot; All rights reserved.</p>
     <p class="tiny">
       <a href="/privacy.html">Privacy</a> &middot;
       <a href="/terms.html">Terms</a> &middot;
@@ -752,5 +738,6 @@ Dining on MSC World Europa</h2>
   <script src="/assets/js/dropdown.js"></script>
   <script src="/assets/js/in-app-browser-escape.js"></script>
   <script src="/assets/js/ship-port-links.js" defer></script>
+<script src="/assets/js/whimsical-ship-units.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Applied 373 fixes across 24 MSC-era template pages via admin/batch-fix-msc.py. Plan reviewed via multi-model pipeline (Gemini + Perplexity) before running.

Fixes applied per page (up to 16):
- no-js class + removal script on <html>
- ai-breadcrumbs HTML comment removed (ICP-2 v2.1)
- content-protocol ICP-Lite v1.4 to ICP-2
- Skip link #content to #main-content
- Main element: add page-grid, id to main-content, tabindex
- Swiper @10 CSS link removed (JS loader already has @11 fallback)
- Cordelia Empress Food Court image removed (two patterns)
- Static copyright 2025 to dynamic JS year
- Dining heading 'Browse All' link
- whimsical-ship-units.js script added
- H1 bare ship name to with subtitle
- Empty stats heading to 'Key Facts About [Ship Name]'
- Video carousel noscript fallback
- Recent Articles noscript fallback
- Whimsical Units noscript
- Dining noscript from venues-v2.json per ship

Results:
- Before: 20-26 warnings per page (template defaults)
- After: 9-15 warnings per page (~50% reduction)
- Remaining warnings are per-ship content (FAQ, deployment, crew), validator false positives (dynamic copyright, venues.json check), or pre-existing structural issues (duplicate sections)

Script is idempotent. Does not touch FAQ, duplicate stats sections, placeholder sections, fleet listing entries, or page.json creation.

https://claude.ai/code/session_018pcWEaJCsNJ2As862ecW8i