### PR TITLE
Repair MSC Armonia: 0 errors, data verified from MSC official deck pl…

### DIFF
--- a/assets/data/ships/msc/msc-armonia.page.json
+++ b/assets/data/ships/msc/msc-armonia.page.json
@@ -1,0 +1,66 @@
+{
+  "slug": "msc-armonia",
+  "line": "msc",
+  "class": "Lirica Class",
+  "imo": "9210141",
+  "tracker": {
+    "provider": "vesselfinder",
+    "embed_name": "MSC-ARMONIA",
+    "details_url": "https://www.vesselfinder.com/vessels/details/9210141"
+  },
+  "deck_plans": {
+    "official_url": "https://www.msccruises.com/en-us/cruise-ships/msc-armonia.aspx",
+    "official_pdf": "https://www.msccruises.co.uk/content/dam/msc-cruises/b2c-assets/fleet/msc-armonia/MSC_ARMONIA_DECKPLAN.pdf",
+    "preview_img": "/assets/ship-map.png"
+  },
+  "dining": {
+    "provider": "msc",
+    "json": "/assets/data/venues-v2.json",
+    "aliases": ["MSC Armonia"]
+  },
+  "stats_fallback": {
+    "entered_service": 2004,
+    "delivered": 2001,
+    "lengthened": 2014,
+    "gt": "65,542 GT",
+    "guests": "1,950 (double) / 2,658 (max)",
+    "crew": "721",
+    "length": "902 ft (274.9 m)",
+    "beam": "105 ft (32 m)",
+    "builder": "Chantiers de l'Atlantique, Saint-Nazaire, France",
+    "lengthening_yard": "Fincantieri, Palermo, Italy",
+    "registry": "Panama (Colón)",
+    "godmother": "unconfirmed"
+  },
+  "related": {
+    "sister_ships": [
+      "/ships/msc/msc-lirica.html",
+      "/ships/msc/msc-opera.html",
+      "/ships/msc/msc-sinfonia.html"
+    ]
+  },
+  "deployment": {
+    "summer_2026": "Eastern Mediterranean from Marghera (Venice)",
+    "winter_2026_27": "South Africa (Durban Nov 2026 - Cape Town Mar 2027)",
+    "notes": "Repositions from Marghera on 1 November 2026 via Suez Canal; first Durban sailing 27 November 2026; Cape Town from 8 March 2027; season ends 29 March 2027."
+  },
+  "history": {
+    "original_name": "MS European Vision",
+    "original_operator": "Festival Cruises",
+    "acquired_by_msc": 2004,
+    "lengthening": "25-metre midsection inserted at Fincantieri Palermo in 2014 (MSC Renaissance Program). Added 193 passenger cabins and 59 crew cabins."
+  },
+  "sources": {
+    "imo_verification": "https://www.vesselfinder.com/vessels/details/9210141",
+    "deck_plan_pdf": "https://www.msccruises.co.uk/content/dam/msc-cruises/b2c-assets/fleet/msc-armonia/MSC_ARMONIA_DECKPLAN.pdf",
+    "south_africa_itinerary": "https://www.msccruises.co.za/-/media/zaf/documents/2026-27-msc-armonia-itinerary18nov25.pdf",
+    "cruise_industry_news": "https://cruiseindustrynews.com/cruise-news/2025/09/msc-armonia-to-debut-in-south-africa-for-2026-27/",
+    "cruisemapper": "https://www.cruisemapper.com/ships/MSC-Armonia-607",
+    "cruisedeckplans": "https://www.cruisedeckplans.com/DP/deckplans/MSC-Armonia"
+  },
+  "compliance": {
+    "alt_text_required": true,
+    "loading_lazy": true,
+    "wcag": "2.1 AA"
+  }
+}

--- a/assets/data/ships/msc/msc-bellissima.page.json
+++ b/assets/data/ships/msc/msc-bellissima.page.json
@@ -1,0 +1,70 @@
+{
+  "slug": "msc-bellissima",
+  "line": "msc",
+  "class": "Meraviglia Class",
+  "imo": "9760524",
+  "mmsi": "248992000",
+  "call_sign": "9HA4902",
+  "tracker": {
+    "provider": "vesselfinder",
+    "embed_name": "MSC-BELLISSIMA",
+    "details_url": "https://www.vesselfinder.com/vessels/details/9760524"
+  },
+  "deck_plans": {
+    "official_url": "https://www.msccruises.com/int/our-cruises/ships/msc-bellissima",
+    "official_pdf": "https://www.msccruises.co.uk/content/dam/msc-cruises/b2c-assets/fleet/msc-bellissima/MSC_BELLISSIMA_DECKPLAN.pdf",
+    "ship_map_pdf": "https://service.msccruises.com/images/shipmap/pdfs/be_en-gb.pdf",
+    "preview_img": "/assets/ship-map.png"
+  },
+  "dining": {
+    "provider": "msc",
+    "json": "/assets/data/venues-v2.json",
+    "aliases": ["MSC Bellissima"]
+  },
+  "stats_fallback": {
+    "entered_service": 2019,
+    "delivered": "2019-02-28",
+    "gt": "171,598 GT",
+    "guests": "4,488 (double) / 5,654 (max)",
+    "cabins": 2217,
+    "crew": "1,536",
+    "length": "1,036 ft (315.83 m)",
+    "beam": "141 ft (43 m)",
+    "builder": "Chantiers de l'Atlantique, Saint-Nazaire, France",
+    "registry": "Malta (Valletta)",
+    "godmother": "Sophia Loren"
+  },
+  "related": {
+    "sister_ships": [
+      "/ships/msc/msc-meraviglia.html"
+    ],
+    "related_class": "Meraviglia-Plus: MSC Grandiosa, MSC Virtuosa"
+  },
+  "deployment": {
+    "summer_2026": "Year-round East Asia — Japan, Taiwan, China",
+    "winter_2026_27": "Year-round East Asia continues",
+    "homeports": ["Yokohama (Tokyo)", "Shanghai", "Keelung (Taipei)", "Naha"],
+    "notes": "First MSC ship permanently based in Asia. Sample 4-night Tokyo-Keelung and 7-night East Asia round-trips. Prep refit 27 November - 13 December 2023 at Shanghai Huarun Dadong Dockyard."
+  },
+  "history": {
+    "delivered": "28 February 2019",
+    "christened": "2 March 2019, Southampton (godmother Sophia Loren, ceremony moved indoors due to storm)",
+    "refits": "27 November - 13 December 2023 at Shanghai Huarun Dadong Dockyard (East Asia deployment prep)"
+  },
+  "sources": {
+    "imo_verification": "https://www.vesselfinder.com/vessels/details/9760524",
+    "vessel_tracker": "https://www.vesseltracker.com/en/Ships/Msc-Bellissima-9760524.html",
+    "ship_map_pdf": "https://service.msccruises.com/images/shipmap/pdfs/be_en-gb.pdf",
+    "deck_plan_pdf": "https://www.msccruises.co.uk/content/dam/msc-cruises/b2c-assets/fleet/msc-bellissima/MSC_BELLISSIMA_DECKPLAN.pdf",
+    "msc_official": "https://www.msccruises.com/int/our-cruises/ships/msc-bellissima",
+    "cruisemapper": "https://www.cruisemapper.com/ships/MSC-Bellissima-1359",
+    "cruisedeckplans": "https://www.cruisedeckplans.com/ships/MSC-Bellissima",
+    "builder": "https://chantiers-atlantique.com/en/references/msc-meraviglia-msc-bellissima-msc-grandiosa-and-msc-virtuosa/",
+    "naming_ceremony": "https://cruiseindustrynews.com/cruise-news/2019/03/msc-bellissima-is-officially-named/"
+  },
+  "compliance": {
+    "alt_text_required": true,
+    "loading_lazy": true,
+    "wcag": "2.1 AA"
+  }
+}

--- a/assets/data/venues-v2.json
+++ b/assets/data/venues-v2.json
@@ -1,9 +1,9 @@
 {
   "meta": {
     "version": "2.0.1",
-    "updated": "2026-02-01",
+    "updated": "2026-04-10",
     "source": "RCL v2.223 compilation with 3+ source agreement",
-    "note": "Expanded to 17 ships with Voyager complete + 2 Radiance class from Grok v2.223 | Consolidated MDR variations | Added entertainment, activity, and bar venues previously classified as unknown"
+    "note": "Expanded to 17 ships with Voyager complete + 2 Radiance class from Grok v2.223 | Consolidated MDR variations | Added entertainment, activity, and bar venues previously classified as unknown | 2026-04-10: MSC Armonia venues verified against MSC official deck plan PDF."
   },
   "venues": [
     {
@@ -33,7 +33,7 @@
     },
     {
       "slug": "park-cafe",
-      "name": "Park Caf\u00e9",
+      "name": "Park Café",
       "category": "dining",
       "subcategory": "complimentary",
       "description": "Made-to-order deli items and salads",
@@ -113,7 +113,7 @@
     },
     {
       "slug": "cafe-two70",
-      "name": "Caf\u00e9 @ Two70",
+      "name": "Café @ Two70",
       "category": "dining",
       "subcategory": "complimentary",
       "description": "Quick service breakfast and lunch",
@@ -493,7 +493,7 @@
     },
     {
       "slug": "latte-tudes",
-      "name": "Caf\u00e9 Latte-tudes",
+      "name": "Café Latte-tudes",
       "category": "bars",
       "subcategory": "coffee",
       "description": "Specialty coffee and pastries",
@@ -770,7 +770,7 @@
     },
     {
       "slug": "cafe-promenade",
-      "name": "Caf\u00e9 Promenade",
+      "name": "Café Promenade",
       "category": "dining",
       "subcategory": "complimentary",
       "description": "Snacks and quick bites on the Royal Promenade",
@@ -1265,7 +1265,7 @@
     },
     {
       "slug": "royal-railway",
-      "name": "Royal Railway \u2013 Utopia Station",
+      "name": "Royal Railway – Utopia Station",
       "category": "dining",
       "description": "Immersive train dining experience with multi-course American cuisine"
     },
@@ -1351,7 +1351,7 @@
       "slug": "leaf-and-bean",
       "name": "Leaf & Bean",
       "category": "dining",
-      "description": "Caf\u00e9 with Asian-inspired beverages and snacks"
+      "description": "Café with Asian-inspired beverages and snacks"
     },
     {
       "slug": "amber-and-oak",
@@ -1453,7 +1453,7 @@
     },
     {
       "slug": "solarium-cafe",
-      "name": "Solarium Caf\u00e9",
+      "name": "Solarium Café",
       "category": "dining",
       "description": "Light fare in the adults-only Solarium"
     },
@@ -1591,10 +1591,10 @@
     },
     {
       "slug": "vitality-cafe",
-      "name": "Vitality Caf\u00e9",
+      "name": "Vitality Café",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Complimentary healthy caf\u00e9 in the Spa area offering homemade granola bars, small muffins, fresh fruit, and juices. Smoothies available with Deluxe Beverage Package.",
+      "description": "Complimentary healthy café in the Spa area offering homemade granola bars, small muffins, fresh fruit, and juices. Smoothies available with Deluxe Beverage Package.",
       "premium": false
     },
     {
@@ -1661,17 +1661,17 @@
       "name": "Eataly",
       "category": "dining",
       "subcategory": "specialty",
-      "description": "First Eataly at sea, exclusively on MSC World America \u2014 Italian food marketplace with fresh pasta, wood-fired pizza, and gelato",
+      "description": "First Eataly at sea, exclusively on MSC World America — Italian food marketplace with fresh pasta, wood-fired pizza, and gelato",
       "cost": "A la carte",
       "premium": true,
       "line": "msc"
     },
     {
       "slug": "jean-philippe-chocolat",
-      "name": "Jean Philippe Chocolat & Caf\u00e9",
+      "name": "Jean Philippe Chocolat & Café",
       "category": "dining",
       "subcategory": "specialty",
-      "description": "Artisan chocolate and pastry caf\u00e9 by world-record-holding chocolatier Jean Philippe Maury",
+      "description": "Artisan chocolate and pastry café by world-record-holding chocolatier Jean Philippe Maury",
       "cost": "A la carte",
       "premium": true,
       "line": "msc"
@@ -1787,12 +1787,12 @@
     },
     {
       "slug": "caffe-san-marco",
-      "name": "Caff\u00e8 San Marco",
+      "name": "Caffè San Marco",
       "category": "dining",
-      "subcategory": "specialty",
-      "description": "Italian-style caf\u00e9 on MSC Armonia serving espresso, pastries, and gelato",
+      "subcategory": "cafe",
+      "description": "Italian-style café on MSC Armonia serving espresso, pastries, and light bites. À la carte.",
       "cost": "A la carte",
-      "premium": true,
+      "premium": false,
       "line": "msc"
     },
     {
@@ -1847,15 +1847,6 @@
       "category": "dining",
       "subcategory": "complimentary",
       "description": "MSC's complimentary buffet with international food stations on newer ships",
-      "premium": false,
-      "line": "msc"
-    },
-    {
-      "slug": "la-pergola-buffet",
-      "name": "La Pergola Buffet",
-      "category": "dining",
-      "subcategory": "complimentary",
-      "description": "Complimentary buffet on MSC Armonia",
       "premium": false,
       "line": "msc"
     },
@@ -1999,7 +1990,7 @@
       "name": "Marco Polo Restaurant",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Complimentary alternative dining room on MSC Armonia with maritime theme",
+      "description": "Main dining room on MSC Armonia (Deck 5 aft) serving multi-course complimentary dinners. Named after the Venetian explorer.",
       "premium": false,
       "line": "msc"
     },
@@ -2703,7 +2694,7 @@
       "name": "Main Dining Room",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Main dining room \u2014 multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
+      "description": "Main dining room — multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
       "consolidate_into": "mdr",
       "premium": false
     },
@@ -2712,7 +2703,7 @@
       "name": "Romeo & Juliet",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Main dining room \u2014 multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
+      "description": "Main dining room — multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
       "consolidate_into": "mdr",
       "premium": false
     },
@@ -2721,7 +2712,7 @@
       "name": "Macbeth",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Main dining room \u2014 multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
+      "description": "Main dining room — multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
       "consolidate_into": "mdr",
       "premium": false
     },
@@ -2730,7 +2721,7 @@
       "name": "King Lear",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Main dining room \u2014 multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
+      "description": "Main dining room — multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
       "consolidate_into": "mdr",
       "premium": false
     },
@@ -2739,7 +2730,7 @@
       "name": "Rembrandt",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Main dining room \u2014 multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
+      "description": "Main dining room — multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
       "consolidate_into": "mdr",
       "premium": false
     },
@@ -2748,7 +2739,7 @@
       "name": "Michelangelo",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Main dining room \u2014 multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
+      "description": "Main dining room — multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
       "consolidate_into": "mdr",
       "premium": false
     },
@@ -2757,7 +2748,7 @@
       "name": "Botticelli",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Main dining room \u2014 multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
+      "description": "Main dining room — multi-course dinner with rotating menus. Same menu as all Royal Caribbean MDRs.",
       "consolidate_into": "mdr",
       "premium": false
     },
@@ -3412,6 +3403,168 @@
       "name": "Teen Disco",
       "category": "activities",
       "subcategory": "kids"
+    },
+    {
+      "slug": "la-pergola-restaurant-armonia",
+      "name": "La Pergola Restaurant",
+      "category": "dining",
+      "subcategory": "complimentary",
+      "description": "Suite-exclusive restaurant on MSC Armonia (Deck 6), reserved for guests in Aurea and Fantastica suite categories. Added in the 2014 Renaissance lengthening refit.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "la-brasserie-buffet-armonia",
+      "name": "La Brasserie Buffet",
+      "category": "dining",
+      "subcategory": "complimentary",
+      "description": "Complimentary indoor buffet on MSC Armonia (Deck 11) serving breakfast, lunch, and casual evening meals.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "il-girasole-armonia",
+      "name": "Il Girasole",
+      "category": "dining",
+      "subcategory": "complimentary",
+      "description": "Alfresco complimentary eatery on MSC Armonia with Pizza & Pasta and Hamburger Paradise stations; the ship's outdoor cafeteria.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "italian-ice-cream-bar-armonia",
+      "name": "The Italian Ice Cream Bar",
+      "category": "dining",
+      "subcategory": "cafe",
+      "description": "Gelato and sorbetto counter on MSC Armonia. À la carte.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "vitamin-bar-armonia",
+      "name": "The Vitamin Bar",
+      "category": "dining",
+      "subcategory": "cafe",
+      "description": "Wellness juice and smoothie bar on MSC Armonia serving fresh-pressed drinks. À la carte.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "bar-del-duomo-armonia",
+      "name": "Bar del Duomo",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Main atrium bar on MSC Armonia, themed after Milan's cathedral piazza.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "white-lion-pub-armonia",
+      "name": "The White Lion Pub",
+      "category": "bars",
+      "subcategory": "pub",
+      "description": "English-style pub on MSC Armonia with draught beers and casual bar snacks.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "red-bar-armonia",
+      "name": "The Red Bar",
+      "category": "bars",
+      "subcategory": "piano-bar",
+      "description": "Piano bar and lounge on MSC Armonia for cocktails and live music.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "armonia-bar",
+      "name": "Armonia Bar",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Namesake lounge bar on MSC Armonia.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "il-lido-bar-armonia",
+      "name": "Il Lido Bar",
+      "category": "bars",
+      "subcategory": "pool-bar",
+      "description": "Poolside bar on MSC Armonia.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "cigar-club-armonia",
+      "name": "Cigar Club",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Dedicated cigar lounge on MSC Armonia.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "msc-voyagers-club-armonia",
+      "name": "MSC Voyagers Club",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Loyalty lounge on MSC Armonia for MSC Voyagers Club members.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "lounge-and-library-armonia",
+      "name": "Lounge & Library",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Quiet reading and lounge space on MSC Armonia with books and comfortable seating.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "teatro-la-fenice-armonia",
+      "name": "Teatro La Fenice",
+      "category": "entertainment",
+      "subcategory": "show",
+      "description": "Main theatre on MSC Armonia (Decks 6-7) hosting production shows, guest acts, and classical performances. Named after Venice's La Fenice opera house.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "starlight-disco-armonia",
+      "name": "Starlight Disco",
+      "category": "entertainment",
+      "subcategory": "nightclub",
+      "description": "Nightclub and disco on MSC Armonia's upper decks, also serving as the Young Club venue.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "palm-beach-casino-armonia",
+      "name": "Palm Beach Casino",
+      "category": "entertainment",
+      "subcategory": "casino",
+      "description": "Casino on MSC Armonia with table games and slot machines.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "msc-aurea-spa-armonia",
+      "name": "MSC Aurea Spa",
+      "category": "activities",
+      "subcategory": "spa",
+      "description": "Full-service spa and thermal area on MSC Armonia with treatment rooms, sauna, steam rooms, and fitness facilities.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "teen-club-armonia",
+      "name": "Teen Club",
+      "category": "activities",
+      "subcategory": "youth",
+      "description": "Dedicated teen lounge and programme on MSC Armonia, run by MSC's multilingual youth staff.",
+      "premium": false,
+      "line": "msc"
     }
   ],
   "ships": {
@@ -4798,14 +4951,29 @@
     "msc-armonia": {
       "name": "MSC Armonia",
       "class": "Lirica Class",
-      "gt": 65591,
+      "gt": 65542,
       "venues": [
-        "la-pergola-buffet",
-        "main-dining-room",
         "marco-polo-restaurant",
+        "la-pergola-restaurant-armonia",
+        "la-brasserie-buffet-armonia",
+        "il-girasole-armonia",
         "caffe-san-marco",
-        "gelateria-italiana",
-        "surf-and-turf"
+        "italian-ice-cream-bar-armonia",
+        "vitamin-bar-armonia",
+        "surf-and-turf",
+        "bar-del-duomo-armonia",
+        "white-lion-pub-armonia",
+        "red-bar-armonia",
+        "armonia-bar",
+        "il-lido-bar-armonia",
+        "cigar-club-armonia",
+        "msc-voyagers-club-armonia",
+        "lounge-and-library-armonia",
+        "teatro-la-fenice-armonia",
+        "starlight-disco-armonia",
+        "palm-beach-casino-armonia",
+        "msc-aurea-spa-armonia",
+        "teen-club-armonia"
       ]
     },
     "msc-bellissima": {

--- a/assets/data/venues-v2.json
+++ b/assets/data/venues-v2.json
@@ -3,7 +3,7 @@
     "version": "2.0.1",
     "updated": "2026-04-10",
     "source": "RCL v2.223 compilation with 3+ source agreement",
-    "note": "Expanded to 17 ships with Voyager complete + 2 Radiance class from Grok v2.223 | Consolidated MDR variations | Added entertainment, activity, and bar venues previously classified as unknown | 2026-04-10: MSC Armonia venues verified against MSC official deck plan PDF."
+    "note": "Expanded to 17 ships with Voyager complete + 2 Radiance class from Grok v2.223 | Consolidated MDR variations | Added entertainment, activity, and bar venues previously classified as unknown | 2026-04-10: MSC Armonia venues verified against MSC official deck plan PDF. | 2026-04-10: MSC Bellissima venues verified against MSC official ship map PDF."
   },
   "venues": [
     {
@@ -1855,7 +1855,7 @@
       "name": "Lighthouse Restaurant",
       "category": "dining",
       "subcategory": "complimentary",
-      "description": "Complimentary buffet on MSC Bellissima with panoramic ocean views",
+      "description": "Main dining room on MSC Bellissima (Deck 6). One of four complimentary MDRs on Bellissima. Also on MSC Meraviglia.",
       "premium": false,
       "line": "msc"
     },
@@ -3565,6 +3565,285 @@
       "description": "Dedicated teen lounge and programme on MSC Armonia, run by MSC's multilingual youth staff.",
       "premium": false,
       "line": "msc"
+    },
+    {
+      "slug": "il-ciliegio-bellissima",
+      "name": "Il Ciliegio",
+      "category": "dining",
+      "subcategory": "complimentary",
+      "description": "Complimentary main dining room on MSC Bellissima (Deck 6). One of four MDRs on the ship.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "le-cerisier-bellissima",
+      "name": "Le Cerisier",
+      "category": "dining",
+      "subcategory": "complimentary",
+      "description": "Complimentary main dining room on MSC Bellissima (Deck 6). French-named MDR, one of four on the ship.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "posidonia-restaurant-bellissima",
+      "name": "Posidonia Restaurant",
+      "category": "dining",
+      "subcategory": "complimentary",
+      "description": "Complimentary main dining room on MSC Bellissima (Deck 5). One of four MDRs on the ship.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "marketplace-buffet-bellissima",
+      "name": "Marketplace Buffet",
+      "category": "dining",
+      "subcategory": "complimentary",
+      "description": "Complimentary buffet on MSC Bellissima (Deck 15) serving breakfast, lunch, and casual evening meals.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "msc-yacht-club-restaurant-bellissima",
+      "name": "MSC Yacht Club Restaurant",
+      "category": "dining",
+      "subcategory": "complimentary",
+      "description": "Private fine-dining restaurant for MSC Yacht Club guests on MSC Bellissima (Deck 18).",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "jean-philippe-chocolat-bellissima",
+      "name": "Jean-Philippe Chocolat & Café",
+      "category": "dining",
+      "subcategory": "specialty",
+      "description": "Specialty chocolate and coffee café on MSC Bellissima (Deck 6) by celebrated pastry chef Jean-Philippe Maury. À la carte.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "jean-philippe-crepes-gelato-bellissima",
+      "name": "Jean-Philippe Crêpes & Gelato",
+      "category": "dining",
+      "subcategory": "specialty",
+      "description": "Specialty crêperie and gelato counter on MSC Bellissima (Deck 6) by Jean-Philippe Maury. À la carte.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "atmosphere-ice-cream-bar-bellissima",
+      "name": "Atmosphere Ice Cream Bar",
+      "category": "dining",
+      "subcategory": "cafe",
+      "description": "Poolside ice cream counter on MSC Bellissima (Deck 15). À la carte.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "bellissima-bar-lounge",
+      "name": "Bellissima Bar & Lounge",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Namesake bar and lounge on MSC Bellissima (Deck 6).",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "edge-cocktail-bar-bellissima",
+      "name": "Edge Cocktail Bar",
+      "category": "bars",
+      "subcategory": "cocktail-bar",
+      "description": "Cocktail bar on MSC Bellissima (Deck 6).",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "champagne-bar-bellissima",
+      "name": "Champagne Bar",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Champagne bar on MSC Bellissima (Deck 7).",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "carousel-lounge-bellissima",
+      "name": "Carousel Lounge",
+      "category": "entertainment",
+      "subcategory": "show",
+      "description": "Purpose-built Cirque du Soleil at Sea venue on MSC Bellissima (Deck 7) hosting exclusive Cirque shows developed for MSC.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "imperial-casino-bellissima",
+      "name": "Imperial Casino",
+      "category": "entertainment",
+      "subcategory": "casino",
+      "description": "Casino on MSC Bellissima (Deck 7) with table games and slot machines.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "masters-of-the-sea-bellissima",
+      "name": "Masters of the Sea",
+      "category": "bars",
+      "subcategory": "pub",
+      "description": "English-style pub on MSC Bellissima (Deck 7).",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "tv-studio-bar-bellissima",
+      "name": "TV Studio & Bar",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "TV studio and bar on MSC Bellissima (Deck 7) where MSC's onboard television programming is produced.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "infinity-bar-bellissima",
+      "name": "Infinity Bar",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Atrium bar on MSC Bellissima (Deck 5).",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "sky-lounge-bellissima",
+      "name": "Sky Lounge",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Upper-deck observation lounge on MSC Bellissima (Deck 18) with panoramic views.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "sports-bar-bellissima",
+      "name": "Sports Bar",
+      "category": "bars",
+      "subcategory": "sports-bar",
+      "description": "Sports bar on MSC Bellissima (Deck 16) screening live sport.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "horizon-bar-bellissima",
+      "name": "Horizon Bar",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "Outdoor bar on MSC Bellissima (Deck 18).",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "atmosphere-bar-bellissima",
+      "name": "Atmosphere Bar",
+      "category": "bars",
+      "subcategory": "pool-bar",
+      "description": "Pool bar on MSC Bellissima (Deck 15, with North and South counters).",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "grand-canyon-bar-bellissima",
+      "name": "Grand Canyon Bar",
+      "category": "bars",
+      "subcategory": "pool-bar",
+      "description": "Outdoor pool bar on MSC Bellissima (Deck 15) with views over the main pool area.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "arizona-bar-bellissima",
+      "name": "Arizona Bar",
+      "category": "bars",
+      "subcategory": "pool-bar",
+      "description": "Pool bar in the Arizona Aquapark on MSC Bellissima (Deck 19).",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "top-sail-lounge-bellissima",
+      "name": "Top Sail Lounge",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "MSC Yacht Club exclusive lounge on MSC Bellissima (Deck 16). Yacht Club guests only.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "msc-yacht-club-grill-bar-bellissima",
+      "name": "MSC Yacht Club Grill & Bar",
+      "category": "bars",
+      "subcategory": "lounge",
+      "description": "MSC Yacht Club exclusive grill and bar on MSC Bellissima (Deck 19). Yacht Club guests only.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "london-theatre-bellissima",
+      "name": "London Theatre",
+      "category": "entertainment",
+      "subcategory": "show",
+      "description": "Main production theatre on MSC Bellissima (Decks 5-6) hosting nightly production shows and guest acts.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "galleria-bellissima",
+      "name": "Galleria Bellissima",
+      "category": "neighborhoods",
+      "subcategory": "promenade",
+      "description": "Two-deck indoor promenade on MSC Bellissima (Decks 6-7) with an 80-metre LED dome ceiling cycling through skies, underwater scenes, and digital art. The ship's signature space.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "arizona-aquapark-bellissima",
+      "name": "Arizona Aquapark",
+      "category": "activities",
+      "subcategory": "waterslides",
+      "description": "Outdoor aquapark on MSC Bellissima (Deck 19) with waterslides and splash features.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "himalayan-bridge-bellissima",
+      "name": "Himalayan Bridge",
+      "category": "activities",
+      "subcategory": "ropes-course",
+      "description": "Elevated ropes course on MSC Bellissima (Deck 19) with suspended walkways.",
+      "premium": false,
+      "line": "msc"
+    },
+    {
+      "slug": "sportplex-bellissima",
+      "name": "Sportplex",
+      "category": "activities",
+      "subcategory": "sports",
+      "description": "Indoor sports and games complex on MSC Bellissima (Deck 16) with bowling, basketball, VR maze, XD Cinema, F1 racing simulator, and a video game arcade.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "msc-aurea-spa-bellissima",
+      "name": "MSC Aurea Spa",
+      "category": "activities",
+      "subcategory": "spa",
+      "description": "Full-service spa and thermal area on MSC Bellissima (Deck 7) with treatment rooms, sauna, steam rooms, and hammam.",
+      "premium": true,
+      "line": "msc"
+    },
+    {
+      "slug": "attic-club-bellissima",
+      "name": "Attic Club",
+      "category": "entertainment",
+      "subcategory": "nightclub",
+      "description": "Late-night club on MSC Bellissima (Deck 18).",
+      "premium": false,
+      "line": "msc"
     }
   ],
   "ships": {
@@ -4978,15 +5257,45 @@
     },
     "msc-bellissima": {
       "name": "MSC Bellissima",
-      "class": "Meraviglia Plus Class",
+      "class": "Meraviglia Class",
       "gt": 171598,
       "venues": [
         "lighthouse-restaurant",
-        "main-dining-room",
+        "il-ciliegio-bellissima",
+        "le-cerisier-bellissima",
+        "posidonia-restaurant-bellissima",
+        "marketplace-buffet-bellissima",
+        "atmosphere-ice-cream-bar-bellissima",
         "butchers-cut",
-        "hola-tacos-cantina",
         "kaito-sushi-bar",
-        "kaito-teppanyaki"
+        "kaito-teppanyaki",
+        "hola-tacos-cantina",
+        "jean-philippe-chocolat-bellissima",
+        "jean-philippe-crepes-gelato-bellissima",
+        "msc-yacht-club-restaurant-bellissima",
+        "bellissima-bar-lounge",
+        "edge-cocktail-bar-bellissima",
+        "champagne-bar-bellissima",
+        "masters-of-the-sea-bellissima",
+        "tv-studio-bar-bellissima",
+        "infinity-bar-bellissima",
+        "sky-lounge-bellissima",
+        "sports-bar-bellissima",
+        "horizon-bar-bellissima",
+        "atmosphere-bar-bellissima",
+        "grand-canyon-bar-bellissima",
+        "arizona-bar-bellissima",
+        "top-sail-lounge-bellissima",
+        "msc-yacht-club-grill-bar-bellissima",
+        "london-theatre-bellissima",
+        "carousel-lounge-bellissima",
+        "imperial-casino-bellissima",
+        "attic-club-bellissima",
+        "galleria-bellissima",
+        "arizona-aquapark-bellissima",
+        "himalayan-bridge-bellissima",
+        "sportplex-bellissima",
+        "msc-aurea-spa-bellissima"
       ]
     },
     "msc-divina": {

--- a/ships/msc/msc-armonia.html
+++ b/ships/msc/msc-armonia.html
@@ -26,9 +26,9 @@ All work on this project is offered as a gift to God.
   <!-- ===== SEO Meta ===== -->
   <title>MSC Armonia — MSC Cruises Ship Guide | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/msc/msc-armonia.html"/>
-  <meta name="description" content="MSC Armonia: Lirica Class ship (65,542 GT, 1,950 double occupancy / 2,679 max, entered MSC service 2004). Lengthened 24m in 2014. Marco Polo MDR, Surf &amp; Turf specialty. Sails Eastern Mediterranean from Venice; debuting South Africa Nov 2026."/>
-  <meta name="ai-summary" content="MSC Armonia is a Lirica Class ship (65,542 GT, 1,950 guests, originally European Vision 2001, MSC since 2004, lengthened 2014). Sails Eastern Mediterranean from Venice; debuting South Africa Nov 2026.">
-  <meta name="last-reviewed" content="2026-02-21">
+  <meta name="description" content="MSC Armonia: Lirica Class ship (65,542 GT, 1,950 double occupancy / 2,658 max, 721 crew). Originally MS European Vision 2001 for Festival Cruises, joined MSC 2004, lengthened 25m in 2014. Marco Polo and La Pergola dining. Sails Eastern Mediterranean from Venice; Durban-based Nov 2026 – Mar 2027."/>
+  <meta name="ai-summary" content="MSC Armonia: Lirica Class, 65,542 GT, 1,950 double / 2,658 max, 721 crew. Joined MSC 2004, lengthened 2014. Venice/Med summer 2026; debuts Durban Nov 2026 – Mar 2027.">
+  <meta name="last-reviewed" content="2026-04-10">
   <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
@@ -38,9 +38,9 @@ All work on this project is offered as a gift to God.
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:locale" content="en_US"/>
   <meta property="og:title" content="MSC Armonia — MSC Cruises Ship Guide"/>
-  <meta property="og:description" content="MSC Armonia: Lirica Class ship with 1,950 double-occupancy guests. Lengthened 2014. Mediterranean &amp; South Africa itineraries."/>
+  <meta property="og:description" content="MSC Armonia: Lirica Class ship (65,542 GT, 1,950 double / 2,658 max). Originally European Vision 2001, joined MSC 2004, lengthened 2014. Mediterranean summer 2026 and South Africa (Durban) Nov 2026 – Mar 2027."/>
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:description" content="MSC Armonia: Lirica Class, 65,542 GT, 1,950 guests, entered MSC service 2004, lengthened 2014. Venice-based Mediterranean itineraries."/>
+  <meta name="twitter:description" content="MSC Armonia: Lirica Class, 65,542 GT, 1,950 double / 2,658 max, 721 crew. Joined MSC 2004, lengthened 2014. Venice-based Mediterranean then Durban for 2026-27 South Africa season."/>
   <meta name="twitter:title" content="MSC Armonia — MSC Cruises Ship Guide"/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
@@ -56,7 +56,7 @@ All work on this project is offered as a gift to God.
       "name": "MSC Cruises",
       "url": "https://www.msccruises.com/"
     },
-    "description": "MSC Armonia is a Lirica Class cruise ship from MSC Cruises, accommodating 1,950 guests at double occupancy (2,679 max). Originally delivered 2001 as European Vision for Festival Cruises, joined MSC in 2004, lengthened 24m in 2014."
+    "description": "MSC Armonia is a Lirica Class cruise ship from MSC Cruises, 65,542 GT, accommodating 1,950 guests at double occupancy (2,658 maximum) with a crew of 721. Originally delivered 2001 as MS European Vision for Festival Cruises by Chantiers de l'Atlantique (Saint-Nazaire), joined MSC in 2004, and lengthened 25 metres in 2014 at Fincantieri Palermo (Renaissance Program)."
   }
   </script>
 
@@ -67,8 +67,8 @@ All work on this project is offered as a gift to God.
     "@type": "WebPage",
     "name": "MSC Armonia",
     "url": "https://cruisinginthewake.com/ships/msc/msc-armonia.html",
-    "description": "MSC Armonia: Lirica Class ship (65,542 GT, 1,950 double occupancy / 2,679 max, entered MSC service 2004). Lengthened 24m in 2014. Marco Polo MDR. Sails Eastern Mediterranean from Venice.",
-    "dateModified": "2026-02-21",
+    "description": "MSC Armonia: Lirica Class ship (65,542 GT, 1,950 double / 2,658 max, 721 crew). Originally MS European Vision 2001, joined MSC 2004, lengthened 25m in 2014. Marco Polo and La Pergola dining. Summer 2026 Eastern Mediterranean from Venice; South Africa (Durban) Nov 2026 – Mar 2027.",
+    "dateModified": "2026-04-10",
     "mainEntity": {
       "@type": "Thing",
       "name": "MSC Armonia",
@@ -128,7 +128,7 @@ All work on this project is offered as a gift to God.
 </script>
 
   <!-- JSON-LD: Review -->
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Lirica Class ship operated by MSC Cruises.","name":"MSC Armonia","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Armonia is a Lirica Class MSC Cruises ship measuring 65,542 GT with capacity for 1,950 guests at double occupancy (2,679 maximum). Originally delivered in 2001 by Chantiers de l'Atlantique as European Vision for Festival Cruises, she joined MSC in 2004 and was cut in half and lengthened by 24m at Fincantieri Palermo in 2014 (Renaissance Program). She features the Marco Polo main dining room, the suite-exclusive La Pergola restaurant, Surf & Turf specialty steakhouse, La Brasserie buffet, and the Aurea Spa. Currently sails Eastern Mediterranean from Venice; debuting South Africa November 2026."}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Lirica Class ship operated by MSC Cruises.","name":"MSC Armonia","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Armonia is a Lirica Class MSC Cruises ship measuring 65,542 GT with capacity for 1,950 guests at double occupancy (2,658 maximum) and a crew of 721. Originally delivered in 2001 by Chantiers de l'Atlantique (Saint-Nazaire) as MS European Vision for Festival Cruises, she joined MSC Cruises in 2004 following Festival's bankruptcy and was cut in half and lengthened by a 25-metre midsection at Fincantieri Palermo in 2014 under MSC's Renaissance Program. Dining is built around the Marco Polo Restaurant (main dining on Deck 5) and La Pergola Restaurant (Deck 6, reserved for Aurea and Fantastica suite guests), with La Brasserie buffet and the alfresco Il Girasole (pizza, pasta, and grill), Caffè San Marco, The Italian Ice Cream Bar, and The Vitamin Bar for casual meals. Entertainment centres on Teatro La Fenice, with bars and lounges including Bar del Duomo, The White Lion Pub, The Red Bar piano lounge, Armonia Bar, Il Lido Bar, Starlight Disco, Palm Beach Casino, Cigar Club, and the MSC Voyagers Club loyalty lounge. In summer 2026 she sails Eastern Mediterranean itineraries from Venice (Marghera); on 1 November 2026 she repositions via Suez for a debut South Africa season based in Durban, shifting to Cape Town for Walvis Bay cruises from 8 March 2027 before returning to Europe in April 2027."}</script>
   <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
@@ -137,42 +137,42 @@ All work on this project is offered as a gift to God.
     "mainEntity": [
       {
         "@type": "Question",
-        "name": "What dining options are available on MSC Armonia?",
+        "name": "What dining options are on MSC Armonia?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "MSC Armonia offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship and may require reservations or carry an additional charge. Check the dining section above for specific venues available on this ship."
+          "text": "MSC Armonia's complimentary dining centres on the Marco Polo Restaurant (main dining room on Deck 5) and La Pergola Restaurant (Deck 6, reserved for guests in Aurea and Fantastica suite categories). La Brasserie buffet and the alfresco Il Girasole (with pizza, pasta, and grill stations) handle casual meals. Caffè San Marco serves espresso and pastries, The Italian Ice Cream Bar handles gelato, and The Vitamin Bar offers wellness drinks. Cruise Critic and CruiseMapper also reference a Surf & Turf specialty room, though MSC's current deck plan does not list it as a fixed venue."
         }
       },
       {
         "@type": "Question",
-        "name": "How do I find the deck plans for MSC Armonia?",
+        "name": "Which ships are in the same class as MSC Armonia?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Deck plans are available through the links on this page. You can also find official deck plans on the MSC Cruises website or in the cruise planner app."
+          "text": "MSC Armonia is part of the Lirica Class, together with MSC Lirica, MSC Opera, and MSC Sinfonia. The four ships joined the MSC fleet between 2003 and 2005 (MSC Lirica 2003, MSC Opera 2004, MSC Armonia 2004 acquisition, MSC Sinfonia 2005) and all four were cut in half and lengthened by roughly 25 metres between 2014 and 2015 under MSC's Renaissance Program, adding cabins and public space while keeping the original Lirica-class footprint."
         }
       },
       {
         "@type": "Question",
-        "name": "Where does MSC Armonia sail?",
+        "name": "Where does MSC Armonia sail in 2026-2027?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Ship deployments vary by season. Check the MSC Cruises website for current itineraries and departure ports for MSC Armonia."
+          "text": "In summer 2026 MSC Armonia is deployed on Eastern Mediterranean itineraries from Marghera (Venice), typically calling at Split, Brindisi, and other Adriatic ports. On 1 November 2026 she repositions via the Suez Canal for her debut South Africa season, operating 3- to 5-night cruises from Durban (Portuguese Island, Pomene) starting 27 November 2026. From 8 March 2027 she shifts homeport to Cape Town for Walvis Bay cruises, and the season ends on 29 March 2027 before she repositions back to Europe in April 2027. She replaces MSC Opera in the South Africa market."
         }
       },
       {
         "@type": "Question",
-        "name": "How can I track MSC Armonia's current location?",
+        "name": "How big is MSC Armonia compared to the rest of the MSC fleet?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Use the live ship tracker section on this page to see the ship's current position, speed, and next port in real-time when available."
+          "text": "At 65,542 gross tons and 274.9 metres long, MSC Armonia is one of the smallest ships currently in the MSC fleet — about one-third the size of the World-class MSC World Europa (215,863 GT) and roughly half the size of the Meraviglia-class ships. She carries 1,950 guests at double occupancy (2,658 maximum) with a crew of 721. The smaller scale and 2014 midsection insertion give her the feel of a classic European cruise ship with modern public spaces."
         }
       },
       {
         "@type": "Question",
-        "name": "Is this information official?",
+        "name": "What is the history of MSC Armonia?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "This page provides planning resources and community insights. Always confirm details with MSC Cruises or your travel advisor before booking."
+          "text": "MSC Armonia was delivered in 2001 as MS European Vision, built by Chantiers de l'Atlantique in Saint-Nazaire, France, for the now-defunct Festival Cruises. When Festival went bankrupt in 2004 MSC Cruises acquired the ship and renamed her MSC Armonia. In 2014 she returned to the yard — this time Fincantieri in Palermo — where she was cut in half and a 25-metre midsection was inserted, adding 193 passenger cabins and 59 crew cabins. She is registered in Panama (Colón)."
         }
       }
     ]
@@ -196,8 +196,8 @@ All work on this project is offered as a gift to God.
     "@context": "https://schema.org",
     "@type": "Article",
     "headline": "MSC Armonia — MSC Cruises Ship Guide",
-    "description": "MSC Armonia: Lirica Class ship (65,542 GT, 1,950 double occupancy / 2,679 max, entered MSC service 2004). Lengthened 24m in 2014. Marco Polo MDR. Sails Eastern Mediterranean from Venice.",
-    "dateModified": "2026-02-21",
+    "description": "MSC Armonia: Lirica Class ship (65,542 GT, 1,950 double / 2,658 max, 721 crew). Originally MS European Vision 2001, joined MSC 2004, lengthened 25m in 2014. Marco Polo and La Pergola dining. Summer 2026 Eastern Mediterranean from Venice; South Africa (Durban) Nov 2026 – Mar 2027.",
+    "dateModified": "2026-04-10",
     "author": {
         "@type": "Person",
         "name": "Ken Baker",
@@ -362,40 +362,32 @@ All work on this project is offered as a gift to God.
     <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Armonia overview">
       
-      <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Armonia is a Lirica Class cruise ship operated by MSC Cruises. Originally delivered in 2001 as European Vision for Festival Cruises by Chantiers de l'Atlantique (Saint-Nazaire, France), she joined the MSC fleet in 2004. In 2014 she was cut in half and lengthened by 24 metres at Fincantieri Palermo (Renaissance Program), growing to 65,542 gross tons and 274.9 m length. She carries approximately 1,950 guests at double occupancy (2,679 maximum) with a crew of 721, and currently sails Eastern Mediterranean itineraries from Venice.</p>
+      <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Armonia is a Lirica Class cruise ship operated by MSC Cruises. Originally delivered in 2001 as MS European Vision for Festival Cruises by Chantiers de l'Atlantique (Saint-Nazaire, France), she was acquired by MSC in 2004 after Festival's bankruptcy. In 2014 she returned to the yard at Fincantieri Palermo and was cut in half and lengthened by a 25-metre midsection (MSC's Renaissance Program), growing to 65,542 gross tons and 274.9 metres in length. She carries 1,950 guests at double occupancy (2,658 maximum) with a crew of 721, and flies the Panamanian flag from Colón. Summer 2026 she sails Eastern Mediterranean itineraries from Marghera (Venice); from November 2026 through March 2027 she operates MSC's debut South Africa season based initially in Durban and later in Cape Town.</p>
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
           <li><strong>Class:</strong> Lirica Class</li>
-          <li><strong>Delivered:</strong> 2001 (joined MSC 2004; lengthened 2014)</li>
+          <li><strong>Delivered:</strong> 2001 (joined MSC 2004; lengthened 25m in 2014)</li>
           <li><strong>Tonnage:</strong> 65,542 GT</li>
-          <li><strong>Guests:</strong> 1,950 (double) / 2,679 (max)</li>
+          <li><strong>Guests:</strong> 1,950 (double) / 2,658 (max)</li>
           <li><strong>Crew:</strong> 721</li>
+          <li><strong>Length &times; Beam:</strong> 274.9 m &times; 32 m</li>
+          <li><strong>Registry:</strong> Panama (Colón)</li>
           <li><strong>IMO:</strong> 9210141</li>
         </ul>
       </div>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> MSC Armonia (65,542 GT, 1,950 double / 2,679 max, delivered 2001, joined MSC 2004) is a Lirica Class ship — MSC's most intimate size — cut in half and lengthened by 24 metres in 2014 at Fincantieri Palermo. She sails Eastern Mediterranean from Venice and debuts in South Africa November 2026.
+        <strong>Quick Answer:</strong> MSC Armonia (65,542 GT, 1,950 double / 2,658 max, 721 crew, delivered 2001, joined MSC 2004) is a Lirica Class ship — MSC's most intimate mid-size — cut in half and lengthened by a 25-metre midsection in 2014 at Fincantieri Palermo. She sails Eastern Mediterranean from Venice in summer 2026 and debuts in South Africa from Durban on 27 November 2026, moving to Cape Town on 8 March 2027.
       </p>
 
-      <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Budget-conscious European cruisers who prefer a smaller, less crowded ship with MSC's Italian-inspired dining and a European international atmosphere.
+      <p id="who-shes-for" class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
+        <strong>Who She's For:</strong> Budget-conscious cruisers who prefer a smaller, calmer ship to a modern megaship, families drawn to MSC's Italian-inspired dining at a lower price than newer MSC hardware, and travellers looking to join MSC's first Durban-based season in November 2026. Not for guests who expect waterslides, Broadway-style production shows, robot bars, or the full suite of features found on the Meraviglia or World classes.
       </p>
 
       <p class="content-text">
-        MSC Armonia is one of the four Lirica Class ships that pioneered MSC Cruises' modern fleet. She offers a classic mid-size cruise experience: the Marco Polo main dining room on Deck 5, the suite-exclusive La Pergola restaurant on Deck 6, the Surf &amp; Turf specialty steakhouse, Teatro La Fenice main theatre, and the Aurea Spa. Sister ships include MSC Sinfonia, MSC Lirica, and MSC Opera — all four underwent the 2014–2015 Renaissance lengthening program that added a 24-metre midsection.
+        MSC Armonia is one of four Lirica Class ships that established MSC Cruises' modern fleet. She offers a classic mid-size cruise experience: the Marco Polo main dining room on Deck 5, the suite-exclusive La Pergola restaurant on Deck 6, La Brasserie buffet and the alfresco Il Girasole (with pizza, pasta, and grill stations), Caffè San Marco, Teatro La Fenice, and the MSC Aurea Spa. Bars and lounges include Bar del Duomo, The White Lion Pub, The Red Bar piano lounge, Il Lido Bar, the Cigar Club, and Palm Beach Casino. Sister ships are MSC Lirica, MSC Opera, and MSC Sinfonia — all four received 25-metre midsection inserts under MSC's 2014–2015 Renaissance Program.
       </p>
-
-      <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
-        <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
-        <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Ship Class:</strong> Lirica Class — 65,542 GT, 1,950 double / 2,679 max</li>
-          <li><strong>2014 Renaissance:</strong> cut in half, 24m section inserted at Fincantieri Palermo; added La Pergola restaurant, Doremi Spray Park, expanded Aurea Spa, Chicco kids' clubs</li>
-          <li><strong>Itineraries:</strong> Eastern Mediterranean from Venice (Summer 2026), South Africa from Durban/Cape Town (Nov 2026 – Apr 2027)</li>
-          <li><strong>Delivered:</strong> 2001 as European Vision for Festival Cruises; joined MSC 2004</li>
-        </ul>
-      </div>
     </section>
 
     <!-- First Look Section -->
@@ -422,11 +414,50 @@ All work on this project is offered as a gift to God.
           </div>
         </section>
 
-        <section class="card" aria-labelledby="diningHeading">
+        <section id="dining-card" class="card" data-ship="MSC Armonia" aria-labelledby="diningHeading">
       <h2 id="diningHeading">Dining on MSC Armonia <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
-      <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
+      <div class="dining-content" id="dining-content" aria-live="polite">
+          <noscript>
+            <h3>Main Dining Rooms</h3>
+            <ul>
+              <li><strong>Marco Polo Restaurant</strong> (Deck 5, main dining room)</li>
+              <li><strong>La Pergola Restaurant</strong> (Deck 6, reserved for Aurea and Fantastica suite guests)</li>
+            </ul>
+            <h3>Buffet &amp; Casual</h3>
+            <ul>
+              <li><strong>La Brasserie Buffet</strong> (indoor, Deck 11)</li>
+              <li><strong>Il Girasole</strong> (alfresco buffet with Pizza &amp; Pasta and Hamburger Paradise stations)</li>
+              <li><strong>Caffè San Marco</strong> (espresso, pastries, light bites)</li>
+              <li><strong>The Italian Ice Cream Bar</strong> (gelato)</li>
+              <li><strong>The Vitamin Bar</strong> (wellness juices and smoothies)</li>
+            </ul>
+            <h3>Specialty Dining</h3>
+            <ul>
+              <li><strong>Surf &amp; Turf</strong> — steak and seafood restaurant. Noted by Cruise Critic and CruiseMapper; not listed on MSC's current official deck plan PDF, so availability should be confirmed before booking.</li>
+            </ul>
+            <h3>Bars &amp; Lounges</h3>
+            <ul>
+              <li><strong>Bar del Duomo</strong></li>
+              <li><strong>The White Lion Pub</strong></li>
+              <li><strong>The Red Bar</strong> (piano bar)</li>
+              <li><strong>Armonia Bar</strong></li>
+              <li><strong>Il Lido Bar</strong> (poolside)</li>
+              <li><strong>Cigar Club</strong></li>
+              <li><strong>MSC Voyagers Club</strong> (loyalty lounge)</li>
+              <li><strong>Lounge &amp; Library</strong></li>
+            </ul>
+            <h3>Entertainment &amp; Activities</h3>
+            <ul>
+              <li><strong>Teatro La Fenice</strong> (main theatre)</li>
+              <li><strong>Starlight Disco / Young Club</strong></li>
+              <li><strong>Palm Beach Casino</strong></li>
+              <li><strong>MSC Aurea Spa</strong></li>
+              <li><strong>Teen Club</strong></li>
+            </ul>
+          </noscript>
+        </div>
+      <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-armonia","aliases":["MSC Armonia"]}</script>
     </section>
-<script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-armonia","aliases":["MSC Armonia"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Lirica Class</p>
 
@@ -434,8 +465,8 @@ All work on this project is offered as a gift to God.
     <div class="quick-answer" role="region" aria-label="Quick answer">
       <h3>At a Glance</h3>
       <p><strong>MSC Armonia</strong> is a <strong>Lirica Class</strong> ship from MSC Cruises.
-      At <strong>65,542 gross tons</strong> with capacity for <strong>1,950 guests</strong> at double occupancy (2,679 max),
-      she was delivered in <strong>2001</strong> (originally European Vision for Festival Cruises; joined MSC 2004; lengthened 24m in 2014).</p>
+      At <strong>65,542 gross tons</strong> with capacity for <strong>1,950 guests</strong> at double occupancy (2,658 maximum) and a crew of 721,
+      she was delivered in <strong>2001</strong> as MS European Vision for Festival Cruises, joined MSC in <strong>2004</strong>, and was lengthened by a 25-metre midsection at Fincantieri Palermo in <strong>2014</strong>. Summer 2026 she sails Eastern Mediterranean itineraries from Venice; her 2026-27 winter season is MSC's debut South Africa deployment based in Durban.</p>
     </div>
 
 
@@ -446,9 +477,27 @@ All work on this project is offered as a gift to God.
     <section class="card note-kens-logbook" aria-labelledby="logbook">
       <h2 id="logbook">The Logbook: MSC Armonia</h2>
       <div id="logbook-container" data-ship="msc-armonia" data-line="msc">
-        <p class="placeholder">Stories and insights from cruisers who have sailed on MSC Armonia will appear here.</p>
+        <noscript>
+          <article class="story">
+            <h3>What to Expect Aboard MSC Armonia</h3>
+            <div class="story-body">
+              <p><strong>Q: Is MSC Armonia a good fit for a first MSC cruise?</strong></p>
+              <p>A: Yes, if you are drawn to a classic mid-size European ship rather than a modern megaship. At 65,542 GT and 1,950 guests at double occupancy she feels intimate compared with MSC World Europa or the Meraviglia class, and her Eastern Mediterranean itineraries out of Venice call at ports that larger ships often skip. Public rooms are laid out in a traditional single-atrium plan — no indoor promenade, no zipline — which many cruisers read as peaceful rather than dated.</p>
+              <p><strong>Q: What about the 2014 lengthening — does it show?</strong></p>
+              <p>A: The 25-metre midsection added under MSC's Renaissance Program brought new cabins, a larger buffet footprint, and the alfresco Il Girasole outdoor eatery. La Pergola, the suite-exclusive restaurant on Deck 6, was also added in the refit. Forward sections retain their 2001 Festival Cruises-era character; the midsection and aft are visibly newer.</p>
+              <p><strong>Q: What's the story with the South Africa season?</strong></p>
+              <p>A: November 2026 marks MSC Armonia's debut in South Africa, replacing MSC Opera. After a 26-night repositioning cruise from Marghera via the Suez Canal, she begins operating 3- to 5-night cruises out of Durban on 27 November 2026 (Portuguese Island and Pomene), transitions to Cape Town on 8 March 2027 for Walvis Bay sailings, and ends the season on 29 March 2027 before returning to Europe in April.</p>
+            </div>
+          </article>
+        </noscript>
       </div>
     </section>
+
+    <p class="mt-1">
+      <a href="https://www.msccruises.com/en-us/cruise-ships/msc-armonia.aspx" class="btn-deck-plans" target="_blank" rel="nofollow noopener">
+        View Official Deck Plans →
+      </a>
+    </p>
 
 
     <!-- Videos Section -->
@@ -518,50 +567,53 @@ All work on this project is offered as a gift to God.
     
 
     <!-- Placeholder sections -->
-        <script type="application/json" id="ship-stats-fallback">{"slug":"msc-armonia","name":"MSC Armonia","cruise_line":"MSC Cruises","class":"Lirica Class","entered_service":2004,"delivered":2001,"lengthened":2014,"gt":"65,542 GT","guests":"1,950 (double) / 2,679 (max)","crew":"721","length":"902 ft (274.9 m)","beam":"105 ft (32 m)","registry":"Panama","builder":"Chantiers de l'Atlantique, Saint-Nazaire, France"}</script>
+        <script type="application/json" id="ship-stats-fallback">{"slug":"msc-armonia","name":"MSC Armonia","cruise_line":"MSC Cruises","class":"Lirica Class","entered_service":2004,"delivered":2001,"lengthened":2014,"imo":"9210141","gt":"65,542 GT","guests":"1,950 (double) / 2,658 (max)","crew":"721","length":"902 ft (274.9 m)","beam":"105 ft (32 m)","registry":"Panama (Colón)","builder":"Chantiers de l'Atlantique, Saint-Nazaire, France"}</script>
 
     <section class="card" aria-labelledby="entertainmentHeading">
-      <h2 id="entertainmentHeading">Entertainment &amp; Activities</h2>
-      <p>Entertainment details coming soon. Explore shows, activities, and onboard experiences.</p>
+      <h2 id="entertainmentHeading">Entertainment &amp; Activities on MSC Armonia</h2>
+      <p>MSC Armonia's main entertainment venue is <strong>Teatro La Fenice</strong>, the ship's theatre on Decks 6 and 7, hosting nightly production shows, classical performances, and guest acts. Late-night life centres on <strong>Starlight Disco / Young Club</strong> on the upper decks and the <strong>Red Bar</strong> piano lounge, with the <strong>Palm Beach Casino</strong>, <strong>Cigar Club</strong>, and <strong>MSC Voyagers Club</strong> loyalty lounge as adult spaces. Daytime activities include two outdoor pools, jacuzzis, a jogging track, mini-golf, the <strong>MSC Aurea Spa</strong> thermal area, and a gym on Deck 11. Children and teens have a dedicated Mini Club and Teen Club programme run by MSC's multilingual youth staff.</p>
     </section>
 
     <section class="grid-2">
-      
+
     <!-- Ship Statistics -->
-    <section class="card" aria-labelledby="ship-stats-title">
+    <section class="card" aria-labelledby="statsHeading">
       <h3 id="statsHeading">Key Facts About MSC Armonia</h3>
       <div id="ship-stats" class="stats-grid" data-slug="msc-armonia">
         <noscript>
           <div class="stat-item"><div class="label">Class</div><div class="value">Lirica Class</div></div>
+          <div class="stat-item"><div class="label">Entered Service</div><div class="value">2001 (MSC 2004; lengthened 2014)</div></div>
           <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">65,542 GT</div></div>
-          <div class="stat-item"><div class="label">Guests</div><div class="value">1,950 (double) / 2,679 (max)</div></div>
+          <div class="stat-item"><div class="label">Guests</div><div class="value">1,950 (double) / 2,658 (max)</div></div>
           <div class="stat-item"><div class="label">Crew</div><div class="value">721</div></div>
-          <div class="stat-item"><div class="label">Delivered</div><div class="value">2001 (joined MSC 2004; lengthened 2014)</div></div>
           <div class="stat-item"><div class="label">Length</div><div class="value">902 ft (274.9 m)</div></div>
           <div class="stat-item"><div class="label">Beam</div><div class="value">105 ft (32 m)</div></div>
-          <div class="stat-item"><div class="label">Registry</div><div class="value">Panama</div></div>
+          <div class="stat-item"><div class="label">Registry</div><div class="value">Panama (Colón)</div></div>
+          <div class="stat-item"><div class="label">IMO</div><div class="value">9210141</div></div>
         </noscript>
       </div>
     </section>
+
     <section class="card" aria-labelledby="deck-plans">
       <h2 id="deck-plans">MSC Armonia Deck Plans</h2>
-      <p>View the official deck plans to explore cabin locations, dining venues, pools, and entertainment areas.</p>
-      <p><a href="https://www.msccruises.com/en-us/cruise-ships/msc-armonia.aspx" class="btn-deck-plans" target="_blank" rel="nofollow noopener">View Official Deck Plans →</a></p>
+      <p>MSC Armonia's deck plan after the 2014 Renaissance lengthening covers 13 decks with 976 cabins. Deck 5 houses the Marco Polo main dining room; Deck 6 holds La Pergola (suite-only) and Teatro La Fenice; public rooms, bars, and the Bar del Duomo atrium run through Decks 6 and 7; pools, Il Girasole alfresco dining, La Brasserie buffet, the MSC Aurea Spa, and the gym are on Decks 10–12.</p>
+      <figure>
+        <img src="/assets/ship-map.png" alt="MSC Armonia simplified deck plan preview" loading="lazy"/>
+        <figcaption class="tiny">Simplified deck layout overview</figcaption>
+      </figure>
+      <p><a href="https://www.msccruises.com/en-us/cruise-ships/msc-armonia.aspx" class="btn-deck-plans" target="_blank" rel="nofollow noopener">View Official MSC Armonia Deck Plans →</a></p>
     </section>
 
-<section class="card" aria-labelledby="deckPlansHeading">
-        <h2 id="deckPlansHeading">MSC Armonia Deck Plans</h2>
-        <p>View the official deck plans to explore MSC Armonia's layout.</p>
-        <figure>
-          <img src="/assets/ship-map.png" alt="MSC Armonia simplified deck plan preview" loading="lazy"/>
-          <figcaption class="tiny">Simplified deck layout overview</figcaption>
-        </figure>
-        <p><a class="btn" href="https://www.msccruises.com/" target="_blank" rel="noopener">Visit MSC Official Site</a></p>
-      </section>
-      <section class="card" aria-labelledby="liveTrackHeading" data-imo="9210141" data-name="MSC-ARMONIA">
-        <h2 id="liveTrackHeading">Where Is MSC Armonia?</h2>
-        <p>Track MSC Armonia's current position and upcoming itinerary.</p>
-        <p><a class="btn" href="https://www.vesselfinder.com/vessels/MSC-ARMONIA-IMO-9210141" target="_blank" rel="noopener">Open Live Tracker on VesselFinder</a></p>
+      <section class="card itinerary" aria-labelledby="liveTrackHeading" data-imo="9210141" data-name="MSC-ARMONIA">
+        <h2 id="liveTrackHeading">Where Is MSC Armonia Right Now?</h2>
+        <p>See MSC Armonia's current position, speed, heading, and next port on the live AIS tracker below.</p>
+        <div id="vf-tracker-container" class="tracker-container">
+          <iframe title="MSC Armonia live position tracker" src="https://www.vesselfinder.com/aismap?imo=9210141&amp;zoom=4&amp;names=true" width="100%" height="380" frameborder="0" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          <noscript>
+            <p>Live tracking requires JavaScript. You can track MSC Armonia (IMO 9210141) directly at <a href="https://www.vesselfinder.com/vessels/details/9210141" target="_blank" rel="noopener">VesselFinder</a> or <a href="https://www.cruisemapper.com/ships/MSC-Armonia-607" target="_blank" rel="noopener">CruiseMapper</a>.</p>
+          </noscript>
+        </div>
+        <p class="tiny">See <a href="/ports.html">ports</a> for more information about individual ports.</p>
       </section>
     </section>
 
@@ -582,35 +634,42 @@ All work on this project is offered as a gift to God.
     <section class="card faq" id="faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions About MSC Armonia</h2>
 
-      <details  class="section-divider">
-        <summary>What dining options are available on MSC Armonia?</summary>
-        <p  class="list-indent">MSC Armonia offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship and may require reservations or carry an additional charge. Check the dining section above for specific venues available on this ship.</p>
+      <details class="faq-item section-divider">
+        <summary>What dining options are on MSC Armonia?</summary>
+        <p class="faq-answer list-indent">MSC Armonia's complimentary dining centres on the <strong>Marco Polo Restaurant</strong> (main dining room on Deck 5) and <strong>La Pergola Restaurant</strong> (Deck 6, reserved for guests in Aurea and Fantastica suite categories). <strong>La Brasserie</strong> buffet and the alfresco <strong>Il Girasole</strong> (with Pizza &amp; Pasta and Hamburger Paradise stations) handle casual meals. <strong>Caffè San Marco</strong> serves espresso and pastries, <strong>The Italian Ice Cream Bar</strong> handles gelato, and <strong>The Vitamin Bar</strong> offers wellness drinks. Cruise Critic and CruiseMapper also reference a <strong>Surf &amp; Turf</strong> specialty room, though MSC's current official deck plan PDF does not list it as a fixed venue, so availability is worth confirming before you book. See the <a href="#dining-card">Dining section</a> above for the full list.</p>
       </details>
 
-      <details  class="section-divider">
-        <summary>How do I find the deck plans for MSC Armonia?</summary>
-        <p  class="list-indent">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.msccruises.com" target="_blank" rel="noopener">MSC Cruises</a> website or in the cruise planner app.</p>
+      <details class="faq-item section-divider">
+        <summary>Which ships are in the same class as MSC Armonia?</summary>
+        <p class="faq-answer list-indent">MSC Armonia is part of the <strong>Lirica Class</strong>, together with <a href="/ships/msc/msc-lirica.html">MSC Lirica</a>, <a href="/ships/msc/msc-opera.html">MSC Opera</a>, and <a href="/ships/msc/msc-sinfonia.html">MSC Sinfonia</a>. The four ships joined the MSC fleet between 2003 and 2005 (MSC Lirica 2003, MSC Opera 2004, MSC Armonia 2004 acquisition, MSC Sinfonia 2005) and all four were cut in half and lengthened by roughly 25 metres between 2014 and 2015 under MSC's Renaissance Program, adding cabins and public space while keeping the original Lirica-class silhouette.</p>
       </details>
 
-      <details  class="section-divider">
-        <summary>Where does MSC Armonia sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the <a href="https://www.msccruises.com" target="_blank" rel="noopener">MSC Cruises</a> website for current itineraries and departure ports for MSC Armonia.</p>
+      <details class="faq-item section-divider">
+        <summary>Where does MSC Armonia sail in 2026-2027?</summary>
+        <p class="faq-answer list-indent">In summer 2026 MSC Armonia is deployed on Eastern Mediterranean itineraries from <strong>Marghera (Venice)</strong>, typically calling at Split, Brindisi, and other Adriatic ports. On <strong>1 November 2026</strong> she repositions via the Suez Canal on a 26-night cruise to Durban for her debut South Africa season. The first Durban sailing departs <strong>27 November 2026</strong> (3-night cruise to Portuguese Island), and she operates 3- to 5-night cruises from Durban through early March 2027 — visiting Pomene, Portuguese Island, and Maputo. From <strong>8 March 2027</strong> she shifts homeport to <strong>Cape Town</strong> for Walvis Bay cruises, ending the season on <strong>29 March 2027</strong> before she repositions back to Europe in April 2027. She replaces MSC Opera in the South Africa market. Check the <a href="#liveTrackHeading">live tracker</a> above for current position and next port.</p>
       </details>
 
-      <details  class="section-divider">
-        <summary>How can I track MSC Armonia's current location?</summary>
-        <p  class="list-indent">Use the live ship tracker section on this page to see the ship's current position, speed, and next port in real-time when available.</p>
+      <details class="faq-item section-divider">
+        <summary>How big is MSC Armonia compared to the rest of the MSC fleet?</summary>
+        <p class="faq-answer list-indent">At <strong>65,542 gross tons</strong> and 274.9 metres long, MSC Armonia is one of the smallest ships currently in the MSC fleet — about one-third the size of the World-class <a href="/ships/msc/msc-world-europa.html">MSC World Europa</a> (215,863 GT) and roughly half the size of the Meraviglia-class ships. She carries <strong>1,950 guests at double occupancy</strong> (2,658 maximum) with a crew of 721. The smaller scale, 2014 midsection insertion, and classic single-atrium layout give her the feel of a traditional European cruise ship with modernised public spaces.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
-        <summary>Is this information official?</summary>
-        <p  class="list-indent">This page provides planning resources and community insights. Always confirm details with <a href="https://www.msccruises.com" target="_blank" rel="noopener">MSC Cruises</a> or your travel advisor before booking.</p>
+      <details class="faq-item">
+        <summary>What is the history of MSC Armonia?</summary>
+        <p class="faq-answer list-indent">MSC Armonia was delivered in <strong>2001</strong> as <strong>MS European Vision</strong>, built by <a href="https://chantiers-atlantique.com/en/" target="_blank" rel="noopener">Chantiers de l'Atlantique</a> in Saint-Nazaire, France, for the now-defunct Festival Cruises. When Festival went bankrupt in <strong>2004</strong> MSC Cruises acquired the ship and renamed her MSC Armonia. In <strong>2014</strong> she returned to the yard — this time Fincantieri in Palermo — where she was cut in half and a <strong>25-metre midsection</strong> was inserted, adding 193 passenger cabins and 59 crew cabins. She is registered in <strong>Panama (Colón)</strong> and carries IMO number <strong>9210141</strong>.</p>
       </details>
     </section>
 
     <section class="card attributions">
-      <h3>Sources & Attribution</h3>
-      <p class="small">Ship specifications from official cruise line materials. Photos credited where shown. Data verified against industry sources.</p>
+      <h3>Sources &amp; Attribution</h3>
+      <ul class="small">
+        <li>IMO, MMSI, live position, length, and beam verified against <a href="https://www.vesselfinder.com/vessels/details/9210141" target="_blank" rel="noopener">VesselFinder (IMO 9210141)</a>.</li>
+        <li>Venue names, deck plan, guest capacity (2,658 max / 976 cabins), and deck layout from the <a href="https://www.msccruises.co.uk/content/dam/msc-cruises/b2c-assets/fleet/msc-armonia/MSC_ARMONIA_DECKPLAN.pdf" target="_blank" rel="noopener">MSC Armonia official deck plan PDF</a>.</li>
+        <li>2026-27 South Africa itinerary from the <a href="https://www.msccruises.co.za/-/media/zaf/documents/2026-27-msc-armonia-itinerary18nov25.pdf" target="_blank" rel="noopener">MSC Cruises South Africa 2026/27 itinerary brochure</a>.</li>
+        <li>South Africa deployment context from <a href="https://cruiseindustrynews.com/cruise-news/2025/09/msc-armonia-to-debut-in-south-africa-for-2026-27/" target="_blank" rel="noopener">Cruise Industry News (September 2025)</a>.</li>
+        <li>Class history, Lirica sisters, and 2014 Renaissance lengthening details from <a href="https://www.cruisemapper.com/ships/MSC-Armonia-607" target="_blank" rel="noopener">CruiseMapper</a> and <a href="https://www.cruisedeckplans.com/DP/deckplans/MSC-Armonia" target="_blank" rel="noopener">CruiseDeckPlans</a>.</li>
+        <li>Ship photography credited in each carousel caption. No godmother is listed for MSC Armonia in primary sources; we list that field as unconfirmed rather than guess.</li>
+      </ul>
     </section>
   
 

--- a/ships/msc/msc-bellissima.html
+++ b/ships/msc/msc-bellissima.html
@@ -26,9 +26,9 @@ All work on this project is offered as a gift to God.
   <!-- ===== SEO Meta ===== -->
   <title>MSC Bellissima — MSC Cruises Ship Guide | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/msc/msc-bellissima.html"/>
-  <meta name="description" content="Discover MSC Bellissima: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
-  <meta name="ai-summary" content="Discover MSC Bellissima: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2019. Dining, entertainment, deck plans, and planning tips.">
-  <meta name="last-reviewed" content="2026-02-21">
+  <meta name="description" content="MSC Bellissima: Meraviglia Class, 171,598 GT, 4,488 double / 5,654 max guests, 1,536 crew. Built 2019 by Chantiers de l'Atlantique. Year-round East Asia from Tokyo, Yokohama, Shanghai, and Keelung. Galleria Bellissima LED dome, Carousel Lounge Cirque du Soleil, London Theatre."/>
+  <meta name="ai-summary" content="MSC Bellissima: Meraviglia Class, 171,598 GT, 4,488 double / 5,654 max, 1,536 crew. Built 2019, Malta flag. Year-round East Asia: Japan, Taiwan, China. Cirque du Soleil, 4 MDRs, LED dome.">
+  <meta name="last-reviewed" content="2026-04-10">
   <meta name="content-protocol" content="ICP-2">
 
   <!-- OpenGraph / Twitter -->
@@ -38,9 +38,9 @@ All work on this project is offered as a gift to God.
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:locale" content="en_US"/>
   <meta property="og:title" content="MSC Bellissima — MSC Cruises Ship Guide"/>
-  <meta property="og:description" content="Explore MSC Bellissima: Meraviglia Class ship with 4,500 guests. Dining, entertainment, and planning resources."/>
+  <meta property="og:description" content="MSC Bellissima: Meraviglia Class (171,598 GT), 4,488 double / 5,654 max guests, 1,536 crew. Built 2019, Malta flag. Year-round East Asia from Tokyo, Yokohama, Shanghai, and Keelung — the first MSC ship permanently based in Asia (as of 2026)."/>
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:description" content="Discover MSC Bellissima: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2019. Dining, entertainment, deck plans, and planning tips."/>
+  <meta name="twitter:description" content="MSC Bellissima: Meraviglia Class, 171,598 GT, 4,488 double / 5,654 max, 1,536 crew. Built 2019. Year-round East Asia from Tokyo and Shanghai. Cirque du Soleil in the Carousel Lounge."/>
   <meta name="twitter:title" content="MSC Bellissima — MSC Cruises Ship Guide"/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
 
@@ -56,7 +56,7 @@ All work on this project is offered as a gift to God.
       "name": "MSC Cruises",
       "url": "https://www.msccruises.com/"
     },
-    "description": "MSC Bellissima is a Meraviglia Class cruise ship from MSC Cruises, accommodating 4,500 guests."
+    "description": "MSC Bellissima is a Meraviglia Class cruise ship from MSC Cruises, 171,598 GT, accommodating 4,488 guests at double occupancy (5,654 maximum) with a crew of 1,536. Delivered 28 February 2019 by Chantiers de l'Atlantique (Saint-Nazaire), christened by Sophia Loren on 2 March 2019 in Southampton, and operating year-round in East Asia from homeports including Yokohama (Tokyo), Shanghai, Keelung, and Naha."
   }
   </script>
 
@@ -67,8 +67,8 @@ All work on this project is offered as a gift to God.
     "@type": "WebPage",
     "name": "MSC Bellissima",
     "url": "https://cruisinginthewake.com/ships/msc/msc-bellissima.html",
-    "description": "Discover MSC Bellissima: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2019. Dining, entertainment, deck plans, and planning tips.",
-    "dateModified": "2026-02-21",
+    "description": "MSC Bellissima: Meraviglia Class (171,598 GT), 4,488 double / 5,654 max guests, 1,536 crew. Delivered 2019, Malta flag. Galleria Bellissima 80m LED dome promenade, Cirque du Soleil at Sea in the Carousel Lounge, London Theatre, four main dining rooms (Lighthouse, Il Ciliegio, Le Cerisier, Posidonia) and MSC Yacht Club. Year-round East Asia from Tokyo, Yokohama, Shanghai, and Keelung.",
+    "dateModified": "2026-04-10",
     "mainEntity": {
       "@type": "Thing",
       "name": "MSC Bellissima",
@@ -128,7 +128,7 @@ All work on this project is offered as a gift to God.
 </script>
 
   <!-- JSON-LD: Review -->
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Meraviglia Class ship operated by MSC Cruises.","name":"MSC Bellissima","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Bellissima is a Meraviglia Class MSC Cruises ship measuring 171,598 GT with capacity for 4,500 guests. Built in 2019, she features a 96-metre LED sky dome on the promenade, Cirque du Soleil at Sea, Eataly restaurant, and the MSC Yacht Club ship-within-a-ship upscale concept."}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Meraviglia Class ship operated by MSC Cruises.","name":"MSC Bellissima","brand":{"@type":"Organization","name":"MSC Cruises"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"MSC Bellissima is a Meraviglia Class MSC Cruises ship measuring 171,598 GT with capacity for 4,488 guests at double occupancy (5,654 maximum) and a crew of 1,536. Delivered 28 February 2019 by Chantiers de l'Atlantique (Saint-Nazaire) as the second ship of the Meraviglia class with direct sister MSC Meraviglia, she was christened on 2 March 2019 in Southampton by Sophia Loren. Her signature space is Galleria Bellissima, a two-deck indoor promenade crowned by an 80-metre LED dome ceiling that cycles through immersive scenes. Dining runs across four main dining rooms — Lighthouse Restaurant, Il Ciliegio, Le Cerisier, and Posidonia Restaurant — plus the Marketplace Buffet and specialty venues Butcher's Cut steakhouse, Kaito Sushi Bar, Kaito Teppanyaki, and Hola! Tacos & Cantina. Jean-Philippe Chocolat & Café and Jean-Philippe Crêpes & Gelato anchor the sweets programme. Entertainment includes the London Theatre production stage and Cirque du Soleil at Sea performances in the purpose-built Carousel Lounge. Upper decks house the Arizona Aquapark, Himalayan Bridge ropes course, Sportplex with bowling and an XD Cinema, and the MSC Aurea Spa. The ship-within-a-ship MSC Yacht Club (Deck 16-19) has its own Top Sail Lounge, fine-dining restaurant, grill, and private sundeck solarium. Bellissima is registered in Valletta, Malta, and operates year-round in East Asia from Yokohama (Tokyo), Shanghai, Keelung, and Naha — the first MSC ship permanently based in Asia (as of 2026). She completed a preparatory refit 27 November – 13 December 2023 at Shanghai Huarun Dadong Dockyard for her Asia deployment."}</script>
   <!-- JSON-LD: FAQPage (ICP-2) -->
   <script type="application/ld+json">
   {
@@ -137,42 +137,42 @@ All work on this project is offered as a gift to God.
     "mainEntity": [
       {
         "@type": "Question",
-        "name": "What dining options are available on MSC Bellissima?",
+        "name": "What dining options are on MSC Bellissima?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "MSC Bellissima offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship and may require reservations or carry an additional charge. Check the dining section above for specific venues available on this ship."
+          "text": "MSC Bellissima has four complimentary main dining rooms — Lighthouse Restaurant, Il Ciliegio, Le Cerisier, and Posidonia Restaurant — plus the Marketplace Buffet on Deck 15. Specialty (extra charge) restaurants include Butcher's Cut steakhouse, Kaito Sushi Bar, Kaito Teppanyaki, and Hola! Tacos & Cantina. Sweet spots include Jean-Philippe Chocolat & Café, Jean-Philippe Crêpes & Gelato, and the Atmosphere Ice Cream Bar. MSC Yacht Club guests have their own fine-dining restaurant, grill, and sundeck bar on the upper decks."
         }
       },
       {
         "@type": "Question",
-        "name": "How do I find the deck plans for MSC Bellissima?",
+        "name": "Which ships are in the same class as MSC Bellissima?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Deck plans are available through the links on this page. You can also find official deck plans on the MSC Cruises website or in the cruise planner app."
+          "text": "MSC Bellissima is part of the Meraviglia class together with MSC Meraviglia (2017). These two ships share the signature Galleria Bellissima/Galleria Meraviglia indoor promenade with the LED dome ceiling and the Carousel Lounge Cirque du Soleil at Sea venue. MSC Grandiosa and MSC Virtuosa are often grouped with them, but those two are a separate Meraviglia-Plus sub-class — slightly larger (181,541 GT) with different internal arrangements. Bellissima's only direct sister in the Meraviglia class is MSC Meraviglia."
         }
       },
       {
         "@type": "Question",
-        "name": "Where does MSC Bellissima sail?",
+        "name": "Where does MSC Bellissima sail in 2026?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Ship deployments vary by season. Check the MSC Cruises website for current itineraries and departure ports for MSC Bellissima."
+          "text": "MSC Bellissima is the first MSC ship permanently based in Asia (as of 2026) and sails year-round in East Asia, rotating between homeports at Yokohama (Tokyo), Shanghai, Keelung (Taipei), and Naha. Typical itineraries are 4- to 7-night round-trips from Tokyo or Shanghai calling at Keelung, Ishigaki, Miyako, and Naha. Check the live tracker above for her current position. She completed a preparatory refit at Shanghai Huarun Dadong Dockyard 27 November – 13 December 2023 for the Asia deployment."
         }
       },
       {
         "@type": "Question",
-        "name": "How can I track MSC Bellissima's current location?",
+        "name": "What makes MSC Bellissima different from other ships?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Use the live ship tracker section on this page to see the ship's current position, speed, and next port in real-time when available."
+          "text": "Her signature is Galleria Bellissima — a two-deck indoor promenade topped by an 80-metre LED dome ceiling that cycles through immersive scenes throughout the day. She is also one of only two MSC ships to carry a purpose-built Cirque du Soleil at Sea venue (the Carousel Lounge), with exclusive shows developed for MSC. Upper decks add the Arizona Aquapark, Himalayan Bridge ropes course, and the Sportplex which includes bowling, an XD Cinema, an F1 racing simulator, and a basketball court. The MSC Yacht Club is a ship-within-a-ship enclave spanning decks 16–19 with private restaurants, lounges, butler service, and its own sundeck."
         }
       },
       {
         "@type": "Question",
-        "name": "Is this information official?",
+        "name": "Who christened MSC Bellissima?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "This page provides planning resources and community insights. Always confirm details with MSC Cruises or your travel advisor before booking."
+          "text": "MSC Bellissima was christened on 2 March 2019 in Southampton by Sophia Loren, MSC Cruises' longtime godmother. A storm forced the ceremony indoors, so Ms. Loren pressed the naming button from the ship's bridge rather than the traditional pierside position. Bellissima's maiden voyage followed on 4 March 2019 with a Mediterranean itinerary from Southampton."
         }
       }
     ]
@@ -196,8 +196,8 @@ All work on this project is offered as a gift to God.
     "@context": "https://schema.org",
     "@type": "Article",
     "headline": "MSC Bellissima — MSC Cruises Ship Guide",
-    "description": "Discover MSC Bellissima: A Meraviglia Class ship from MSC Cruises. 171,598 GT, 4,500 guests, built 2019. Dining, entertainment, deck plans, and planning tips.",
-    "dateModified": "2026-02-21",
+    "description": "MSC Bellissima: Meraviglia Class (171,598 GT), 4,488 double / 5,654 max guests, 1,536 crew. Delivered 2019, Malta flag. Galleria Bellissima 80m LED dome promenade, Cirque du Soleil at Sea in the Carousel Lounge, London Theatre, four main dining rooms plus MSC Yacht Club. Year-round East Asia from Tokyo, Yokohama, Shanghai, and Keelung.",
+    "dateModified": "2026-04-10",
     "author": {
         "@type": "Person",
         "name": "Ken Baker",
@@ -362,39 +362,33 @@ All work on this project is offered as a gift to God.
     <!-- ICP-2: Page Intro -->
     <section class="page-intro" aria-label="MSC Bellissima overview">
       
-      <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Bellissima is a Meraviglia Class cruise ship operated by MSC Cruises. She entered service in 2019, measures 171,598 gross tons, and carries approximately 5,714 guests at double occupancy.</p>
+      <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">MSC Bellissima is the second ship of MSC Cruises' Meraviglia class, delivered on 28 February 2019 by Chantiers de l'Atlantique in Saint-Nazaire and christened by Sophia Loren in Southampton on 2 March 2019. She measures 171,598 gross tons and 315.83 metres in length, carries 4,488 guests at double occupancy (5,654 maximum) with a crew of 1,536, and flies the Maltese flag from Valletta. Her signature space is Galleria Bellissima — a two-deck indoor promenade with an 80-metre LED dome ceiling. She is currently the first MSC ship permanently based in East Asia, operating year-round from Yokohama (Tokyo), Shanghai, Keelung (Taipei), and Naha.</p>
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Class:</strong> Meraviglia Class</li>
-          <li><strong>Year:</strong> 2019</li>
+          <li><strong>Class:</strong> Meraviglia Class (sister ship MSC Meraviglia)</li>
+          <li><strong>Delivered:</strong> 28 February 2019</li>
+          <li><strong>Godmother:</strong> Sophia Loren (2 March 2019, Southampton)</li>
           <li><strong>Tonnage:</strong> 171,598 GT</li>
-          <li><strong>Guests:</strong> 5,714</li>
-          <li><strong>IMO:</strong> 9746119</li>
+          <li><strong>Guests:</strong> 4,488 (double) / 5,654 (max)</li>
+          <li><strong>Crew:</strong> 1,536</li>
+          <li><strong>Length &times; Beam:</strong> 315.83 m &times; 43 m</li>
+          <li><strong>Registry:</strong> Malta (Valletta)</li>
+          <li><strong>IMO:</strong> 9760524</li>
         </ul>
       </div>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> MSC Bellissima (171,598 GT, 5,714 guests, 2019) is a Meraviglia Class ship — featuring a 96-meter LED-domed promenade, Cirque du Soleil at Sea shows, and MSC's first virtual assistant Zoe. This page covers deck plans, live tracking, dining venues, and videos.
+        <strong>Quick Answer:</strong> MSC Bellissima (171,598 GT, 4,488 double / 5,654 max, 1,536 crew, delivered 2019) is a Meraviglia Class ship — featuring the Galleria Bellissima 80-metre LED-domed promenade, Cirque du Soleil at Sea shows in the Carousel Lounge, four main dining rooms, and the MSC Yacht Club ship-within-a-ship enclave. In 2026 she sails year-round East Asia from Tokyo, Shanghai, and Keelung.
       </p>
 
-      <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Families and entertainment lovers who want a mega-ship with Cirque du Soleil shows, diverse dining, and a European international atmosphere at competitive pricing.
+      <p id="who-shes-for" class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
+        <strong>Who She's For:</strong> Families and entertainment lovers drawn to a mega-ship with Cirque du Soleil at Sea, four main dining rooms to rotate through, and the LED-dome Galleria. Excellent for travellers wanting to sail from a Japanese or Chinese homeport — she is the only MSC ship year-round in Asia as of 2026. The MSC Yacht Club enclave makes her compelling for guests who want a premium cocoon inside the larger ship. Not for guests looking for a smaller, quieter vessel, a Mediterranean itinerary (she has moved to Asia), or MSC's World class hardware (2022 and later) which has more outdoor deck space and newer design touches.
       </p>
 
       <p class="content-text">
-        MSC Bellissima is sister to MSC Meraviglia — sharing the signature indoor promenade with LED sky ceiling and Cirque du Soleil at Sea performances. She was the first MSC ship to feature Zoe, the AI-powered cabin assistant. MSC Yacht Club provides a luxury ship-within-a-ship option. If you want the larger Meraviglia Plus version, MSC Grandiosa and Virtuosa offer more space; for the newest MSC design, the World Class ships are the current flagships.
+        MSC Bellissima shares her core layout with MSC Meraviglia — the same indoor promenade architecture under the LED sky ceiling, the same Carousel Lounge for Cirque du Soleil at Sea, and the same London Theatre for production shows. Dining spans four main dining rooms (Lighthouse Restaurant, Il Ciliegio, Le Cerisier, Posidonia Restaurant), the Marketplace Buffet on Deck 15, specialty venues including Butcher's Cut steakhouse, Kaito Sushi Bar, Kaito Teppanyaki, and Hola! Tacos & Cantina, plus the Jean-Philippe Chocolat & Café and Crêpes & Gelato concept. Upper decks add Arizona Aquapark, the Himalayan Bridge ropes course, and the Sportplex (bowling, XD Cinema, F1 simulator). MSC Grandiosa and MSC Virtuosa are often grouped with Bellissima but belong to the separate Meraviglia-Plus sub-class — Bellissima's only direct sister is MSC Meraviglia.
       </p>
-
-      <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
-        <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
-        <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Ship Class:</strong> Meraviglia Class — 171,598 GT, 5,714 guests</li>
-          <li><strong>Signature Features:</strong> LED-domed promenade, Cirque du Soleil at Sea, Zoe AI assistant</li>
-          <li><strong>Itineraries:</strong> Mediterranean, Arabian Gulf, Asia</li>
-          <li><strong>Entered Service:</strong> 2019</li>
-        </ul>
-      </div>
     </section>
 
     <!-- First Look Section -->
@@ -422,62 +416,94 @@ All work on this project is offered as a gift to God.
           </div>
         </section>
 
-        <section class="card" aria-labelledby="diningHeading">
+        <section id="dining-card" class="card" data-ship="MSC Bellissima" aria-labelledby="diningHeading">
       <h2 id="diningHeading">Dining on MSC Bellissima <a href="/restaurants.html" style="font-size: 1rem; font-weight: 400; text-decoration: none; color: var(--accent); opacity: 0.8;" aria-label="Browse all restaurants">→ Browse All</a></h2>
-      <p>Dining venue information coming soon. MSC Cruises ships typically feature a variety of complimentary and specialty dining options.</p>
+      <div class="dining-content" id="dining-content" aria-live="polite">
+          <noscript>
+            <h3>Main Dining Rooms (complimentary)</h3>
+            <ul>
+              <li><strong>Lighthouse Restaurant</strong> (Deck 6)</li>
+              <li><strong>Il Ciliegio</strong> (Deck 6)</li>
+              <li><strong>Le Cerisier</strong> (Deck 6)</li>
+              <li><strong>Posidonia Restaurant</strong> (Deck 5)</li>
+            </ul>
+            <h3>Buffet &amp; Casual</h3>
+            <ul>
+              <li><strong>Marketplace Buffet</strong> (Deck 15)</li>
+              <li><strong>Atmosphere Ice Cream Bar</strong> (Deck 15)</li>
+            </ul>
+            <h3>Specialty Dining (extra charge)</h3>
+            <ul>
+              <li><strong>Butcher's Cut</strong> (Deck 7) — American steakhouse</li>
+              <li><strong>Kaito Sushi Bar</strong> (Deck 7)</li>
+              <li><strong>Kaito Teppanyaki</strong> (Deck 7)</li>
+              <li><strong>Hola! Tacos &amp; Cantina</strong> (Deck 6) — Mexican concept (formerly Hola! Tapas Bar in the original deck plan)</li>
+              <li><strong>Jean-Philippe Chocolat &amp; Café</strong> (Deck 6)</li>
+              <li><strong>Jean-Philippe Crêpes &amp; Gelato</strong> (Deck 6)</li>
+              <li><strong>MSC Yacht Club Restaurant</strong> (Deck 18) — Yacht Club guests only</li>
+            </ul>
+            <h3>Bars &amp; Lounges</h3>
+            <ul>
+              <li><strong>Bellissima Bar &amp; Lounge</strong> (Deck 6)</li>
+              <li><strong>Edge Cocktail Bar</strong> (Deck 6)</li>
+              <li><strong>Champagne Bar</strong> (Deck 7)</li>
+              <li><strong>Masters of the Sea</strong> (Deck 7) — English-style pub</li>
+              <li><strong>TV Studio &amp; Bar</strong> (Deck 7)</li>
+              <li><strong>Infinity Bar</strong> (Deck 5)</li>
+              <li><strong>Sky Lounge</strong> (Deck 18)</li>
+              <li><strong>Sports Bar</strong> (Deck 16)</li>
+              <li><strong>Horizon Bar</strong> (Deck 18)</li>
+              <li><strong>Atmosphere Bar</strong> (Deck 15 North and South)</li>
+              <li><strong>Grand Canyon Bar</strong> (Deck 15)</li>
+              <li><strong>Arizona Bar</strong> (Deck 19 Aquapark)</li>
+              <li><strong>Top Sail Lounge</strong> (Deck 16) — MSC Yacht Club exclusive</li>
+              <li><strong>MSC Yacht Club Grill &amp; Bar</strong> (Deck 19) — Yacht Club exclusive</li>
+            </ul>
+            <h3>Entertainment &amp; Activities</h3>
+            <ul>
+              <li><strong>London Theatre</strong> (Decks 5-6) — main production theatre</li>
+              <li><strong>Carousel Lounge</strong> (Deck 7) — Cirque du Soleil at Sea venue</li>
+              <li><strong>Galleria Bellissima</strong> (Decks 6-7) — two-deck indoor promenade with 80-metre LED dome ceiling</li>
+              <li><strong>Imperial Casino</strong> (Deck 7)</li>
+              <li><strong>Attic Club</strong> (Deck 18) — nightclub</li>
+              <li><strong>Arizona Aquapark</strong> (Deck 19)</li>
+              <li><strong>Himalayan Bridge</strong> (Deck 19) — ropes course</li>
+              <li><strong>Sportplex</strong> (Deck 16) — bowling, basketball, VR Maze, XD Cinema, F1 simulator</li>
+              <li><strong>MSC Aurea Spa</strong> (Deck 7)</li>
+              <li><strong>Emotions Immersive Gallery</strong> (Deck 6)</li>
+            </ul>
+          </noscript>
+        </div>
+      <script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-bellissima","aliases":["MSC Bellissima"]}</script>
     </section>
-<script type="application/json" id="dining-data-source">{"provider":"msc","json":"/assets/data/venues-v2.json","ship_slug":"msc-bellissima","aliases":["MSC Bellissima"]}</script>
 
     <p class="subtitle">MSC Cruises &bull; Meraviglia Class</p>
 
-    <!-- ICP-2 Quick Answer -->
-    <div class="quick-answer" role="region" aria-label="Quick answer">
-      <h3>At a Glance</h3>
-      <p><strong>MSC Bellissima</strong> is a <strong>Meraviglia Class</strong> ship from MSC Cruises.
-      With <strong>171,598 gross tons</strong> and capacity for <strong>4,500 guests</strong>,
-      she entered service in <strong>2019</strong>.</p>
-    </div>
-
-    <!-- Ship Specifications -->
-    <section class="card" data-ship="MSC Bellissima" aria-labelledby="specsHeading">
-      <h2 id="specsHeading">MSC Bellissima Specifications</h2>
-      <div class="ship-specs">
-        <div class="spec-item">
-          <div class="spec-label">Gross Tonnage</div>
-          <div class="spec-value">171,598</div>
-        </div>
-        <div class="spec-item">
-          <div class="spec-label">Guests</div>
-          <div class="spec-value">4,500</div>
-        </div>
-        <div class="spec-item">
-          <div class="spec-label">Year Built</div>
-          <div class="spec-value">2019</div>
-        </div>
-        <div class="spec-item">
-          <div class="spec-label">Class</div>
-          <div class="spec-value">Meraviglia Class</div>
-        </div>
-        <div class="spec-item">
-          <div class="spec-label">Length</div>
-          <div class="spec-value">315m</div>
-        </div>
-        <div class="spec-item">
-          <div class="spec-label">Crew</div>
-          <div class="spec-value">1,536</div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Stub Notice -->
-    
     <!-- Ken's Logbook Section -->
     <section class="card note-kens-logbook" aria-labelledby="logbook">
       <h2 id="logbook">The Logbook: MSC Bellissima</h2>
       <div id="logbook-container" data-ship="msc-bellissima" data-line="msc">
-        <p class="placeholder">Stories and insights from cruisers who have sailed on MSC Bellissima will appear here.</p>
+        <noscript>
+          <article class="story">
+            <h3>What to Expect Aboard MSC Bellissima</h3>
+            <div class="story-body">
+              <p><strong>Q: What's the main draw of MSC Bellissima compared to the rest of the MSC fleet?</strong></p>
+              <p>A: The Galleria Bellissima indoor promenade. It's a two-deck covered boulevard lined with shops, bars, and cafés, crowned by an 80-metre LED dome ceiling that cycles through skies, underwater scenes, and digital art throughout the day. She also carries Cirque du Soleil at Sea, performed in the purpose-built Carousel Lounge — MSC-exclusive shows developed with Cirque specifically for these ships.</p>
+              <p><strong>Q: Is the Asia homeport situation permanent?</strong></p>
+              <p>A: As of 2026 Bellissima is the first (and currently only) MSC ship permanently based in Asia. She operates year-round from Japan, China, and Taiwan — Yokohama/Tokyo, Shanghai, Keelung/Taipei, and Naha — with 4- to 7-night itineraries rotating between these homeports. MSC completed a preparatory refit at Shanghai Huarun Dadong Dockyard (27 November – 13 December 2023) to ready her for the Asia deployment.</p>
+              <p><strong>Q: Who is the MSC Yacht Club for, and is it worth it?</strong></p>
+              <p>A: MSC Yacht Club is the ship-within-a-ship premium enclave on Decks 16–19, with about 95 suites, a private restaurant, Top Sail Lounge, dedicated pool and sundeck, and 24/7 butler service. It typically prices around twice a balcony cabin and appeals to guests who want the social energy of a big-ship experience but also a quiet, private retreat. Yacht Club guests retain access to all the main ship venues too.</p>
+            </div>
+          </article>
+        </noscript>
       </div>
     </section>
+
+    <p class="mt-1">
+      <a href="https://www.msccruises.com/int/our-cruises/ships/msc-bellissima" class="btn-deck-plans" target="_blank" rel="nofollow noopener">
+        View Official Deck Plans →
+      </a>
+    </p>
 
 
     <!-- Videos Section -->
@@ -547,45 +573,54 @@ All work on this project is offered as a gift to God.
     
 
     <!-- Placeholder sections -->
-        <script type="application/json" id="ship-stats-fallback">{"slug":"msc-bellissima","name":"MSC Bellissima","cruise_line":"MSC Cruises","class":"Meraviglia Class","entered_service":2019,"gt":"171,598 GT","guests":"5,714","crew":"1,536"}</script>
+        <script type="application/json" id="ship-stats-fallback">{"slug":"msc-bellissima","name":"MSC Bellissima","cruise_line":"MSC Cruises","class":"Meraviglia Class","entered_service":2019,"imo":"9760524","gt":"171,598 GT","guests":"4,488 (double) / 5,654 (max)","crew":"1,536","length":"1,036 ft (315.83 m)","beam":"141 ft (43 m)","registry":"Malta (Valletta)","builder":"Chantiers de l'Atlantique, Saint-Nazaire, France","godmother":"Sophia Loren"}</script>
 
     <section class="card" aria-labelledby="entertainmentHeading">
-      <h2 id="entertainmentHeading">Entertainment &amp; Activities</h2>
-      <p>Entertainment details coming soon. Explore shows, activities, and onboard experiences.</p>
+      <h2 id="entertainmentHeading">Entertainment &amp; Activities on MSC Bellissima</h2>
+      <p>MSC Bellissima's entertainment centres on the <strong>Carousel Lounge</strong>, a purpose-built venue hosting <strong>Cirque du Soleil at Sea</strong> performances developed exclusively for MSC. The <strong>London Theatre</strong> on Decks 5–6 runs nightly production shows, guest acts, and MSC's multilingual entertainment programme. The signature <strong>Galleria Bellissima</strong> promenade (Decks 6–7) stretches the full width of the ship under an 80-metre LED dome that cycles through skies, underwater scenes, and digital art throughout the day; the adjacent <strong>Plaza Bellissima</strong> hosts live music and street-style performances. The <strong>Imperial Casino</strong> on Deck 7 handles gaming, and the late-night <strong>Attic Club</strong> on Deck 18 runs the dance floor. Outdoor decks add the <strong>Arizona Aquapark</strong>, the <strong>Himalayan Bridge</strong> ropes course, and the <strong>Sportplex</strong> (bowling, an XD Cinema, an F1 simulator, a VR maze, basketball, and a video arcade). Wellness is covered by the <strong>MSC Aurea Spa</strong> on Deck 7 (thermal area, treatment rooms, sauna, and steam rooms) and the <strong>MSC Gym powered by Technogym</strong>. MSC's multilingual youth staff run dedicated kids', tweens', and teens' programmes.</p>
     </section>
 
     <section class="grid-2">
-      
+
     <!-- Ship Statistics -->
-    <section class="card" aria-labelledby="ship-stats-title">
+    <section class="card" aria-labelledby="statsHeading">
       <h3 id="statsHeading">Key Facts About MSC Bellissima</h3>
       <div id="ship-stats" class="stats-grid" data-slug="msc-bellissima">
-        <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">171,598 GT</div></div>
-        <div class="stat-item"><div class="label">Guests</div><div class="value">5,714</div></div>
-        <div class="stat-item"><div class="label">Crew</div><div class="value">1,536</div></div>
-        <div class="stat-item"><div class="label">Entered Service</div><div class="value">2019</div></div>
-        <div class="stat-item"><div class="label">Class</div><div class="value">Meraviglia Class</div></div>
+        <noscript>
+          <div class="stat-item"><div class="label">Class</div><div class="value">Meraviglia Class</div></div>
+          <div class="stat-item"><div class="label">Delivered</div><div class="value">28 February 2019</div></div>
+          <div class="stat-item"><div class="label">Godmother</div><div class="value">Sophia Loren</div></div>
+          <div class="stat-item"><div class="label">Gross Tonnage</div><div class="value">171,598 GT</div></div>
+          <div class="stat-item"><div class="label">Guests</div><div class="value">4,488 (double) / 5,654 (max)</div></div>
+          <div class="stat-item"><div class="label">Crew</div><div class="value">1,536</div></div>
+          <div class="stat-item"><div class="label">Length</div><div class="value">1,036 ft (315.83 m)</div></div>
+          <div class="stat-item"><div class="label">Beam</div><div class="value">141 ft (43 m)</div></div>
+          <div class="stat-item"><div class="label">Registry</div><div class="value">Malta (Valletta)</div></div>
+          <div class="stat-item"><div class="label">IMO</div><div class="value">9760524</div></div>
+        </noscript>
       </div>
     </section>
+
     <section class="card" aria-labelledby="deck-plans">
       <h2 id="deck-plans">MSC Bellissima Deck Plans</h2>
-      <p>View the official deck plans to explore cabin locations, dining venues, pools, and entertainment areas.</p>
-      <p><a href="https://www.msccruises.com/en-us/cruise-ships/msc-bellissima.aspx" class="btn-deck-plans" target="_blank" rel="nofollow noopener">View Official Deck Plans →</a></p>
+      <p>MSC Bellissima occupies 19 decks with 2,217 cabins. The two-deck Galleria Bellissima runs through Decks 6 and 7 under the signature LED dome ceiling, flanked by the Lighthouse Restaurant, Il Ciliegio, Le Cerisier, and the Hola! Tacos &amp; Cantina on Deck 6. Deck 7 adds Butcher's Cut, Kaito Sushi Bar, Kaito Teppanyaki, the Carousel Lounge (Cirque du Soleil), Imperial Casino, and the MSC Aurea Spa. Pool decks, Marketplace Buffet, and outdoor bars are on Deck 15; the Arizona Aquapark and Himalayan Bridge are on Deck 19. MSC Yacht Club occupies Decks 16–19 with its own private restaurant, lounges, and sundeck.</p>
+      <figure>
+        <img src="/assets/ship-map.png" alt="MSC Bellissima simplified deck plan preview" loading="lazy"/>
+        <figcaption class="tiny">Simplified deck layout overview</figcaption>
+      </figure>
+      <p><a href="https://www.msccruises.com/int/our-cruises/ships/msc-bellissima" class="btn-deck-plans" target="_blank" rel="nofollow noopener">View Official MSC Bellissima Deck Plans →</a></p>
     </section>
 
-<section class="card" aria-labelledby="deckPlansHeading">
-        <h2 id="deckPlansHeading">MSC Bellissima Deck Plans</h2>
-        <p>View the official deck plans to explore MSC Bellissima's layout.</p>
-        <figure>
-          <img src="/assets/ship-map.png" alt="MSC Bellissima simplified deck plan preview" loading="lazy"/>
-          <figcaption class="tiny">Simplified deck layout overview</figcaption>
-        </figure>
-        <p><a class="btn" href="https://www.msccruises.com/" target="_blank" rel="noopener">Visit MSC Official Site</a></p>
-      </section>
-      <section class="card" aria-labelledby="liveTrackHeading" data-imo="9746119">
-        <h2 id="liveTrackHeading">Where Is MSC Bellissima?</h2>
-        <p>Track MSC Bellissima's current position and upcoming itinerary.</p>
-        <p><a class="btn" href="https://www.cruisemapper.com/?search=MSC%20Bellissima" target="_blank" rel="noopener">Open Live Tracker</a></p>
+      <section class="card itinerary" aria-labelledby="liveTrackHeading" data-imo="9760524" data-name="MSC-BELLISSIMA">
+        <h2 id="liveTrackHeading">Where Is MSC Bellissima Right Now?</h2>
+        <p>See MSC Bellissima's current position, speed, heading, and next port on the live AIS tracker below.</p>
+        <div id="vf-tracker-container" class="tracker-container">
+          <iframe title="MSC Bellissima live position tracker" src="https://www.vesselfinder.com/aismap?imo=9760524&amp;zoom=4&amp;names=true" width="100%" height="380" frameborder="0" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          <noscript>
+            <p>Live tracking requires JavaScript. You can track MSC Bellissima (IMO 9760524) directly at <a href="https://www.vesselfinder.com/vessels/details/9760524" target="_blank" rel="noopener">VesselFinder</a> or <a href="https://www.cruisemapper.com/ships/MSC-Bellissima-1359" target="_blank" rel="noopener">CruiseMapper</a>.</p>
+          </noscript>
+        </div>
+        <p class="tiny">See <a href="/ports.html">ports</a> for more information about individual ports.</p>
       </section>
     </section>
 
@@ -606,35 +641,42 @@ All work on this project is offered as a gift to God.
     <section class="card faq" id="faq" aria-labelledby="faq-heading">
       <h2 id="faq-heading">Frequently Asked Questions About MSC Bellissima</h2>
 
-      <details  class="section-divider">
-        <summary>What dining options are available on MSC Bellissima?</summary>
-        <p  class="list-indent">MSC Bellissima offers complimentary dining including the main dining room and buffet. Specialty restaurants vary by ship and may require reservations or carry an additional charge. Check the dining section above for specific venues available on this ship.</p>
+      <details class="faq-item section-divider">
+        <summary>What dining options are on MSC Bellissima?</summary>
+        <p class="faq-answer list-indent">MSC Bellissima has four complimentary main dining rooms — <strong>Lighthouse Restaurant</strong>, <strong>Il Ciliegio</strong>, <strong>Le Cerisier</strong>, and <strong>Posidonia Restaurant</strong> — plus the <strong>Marketplace Buffet</strong> on Deck 15. Specialty (extra-charge) venues include <strong>Butcher's Cut</strong> steakhouse, <strong>Kaito Sushi Bar</strong>, <strong>Kaito Teppanyaki</strong>, and <strong>Hola! Tacos &amp; Cantina</strong> (formerly Hola! Tapas Bar in the original deck plan). Sweets and coffee come from <strong>Jean-Philippe Chocolat &amp; Café</strong>, <strong>Jean-Philippe Crêpes &amp; Gelato</strong>, and the <strong>Atmosphere Ice Cream Bar</strong>. MSC Yacht Club guests have their own private Yacht Club Restaurant on Deck 18 plus the Yacht Club Grill &amp; Bar on Deck 19. See the <a href="#dining-card">Dining section</a> above for the full list.</p>
       </details>
 
-      <details  class="section-divider">
-        <summary>How do I find the deck plans for MSC Bellissima?</summary>
-        <p  class="list-indent">Deck plans are available through the links on this page. You can also find official deck plans on the <a href="https://www.msccruises.com" target="_blank" rel="noopener">MSC Cruises</a> website or in the cruise planner app.</p>
+      <details class="faq-item section-divider">
+        <summary>Which ships are in the same class as MSC Bellissima?</summary>
+        <p class="faq-answer list-indent">MSC Bellissima is part of the <strong>Meraviglia class</strong> together with <a href="/ships/msc/msc-meraviglia.html">MSC Meraviglia</a> (delivered 2017) — her only direct sister. These two ships share the Galleria promenade with LED dome ceiling and the Carousel Lounge Cirque du Soleil at Sea venue. <a href="/ships/msc/msc-grandiosa.html">MSC Grandiosa</a> and <a href="/ships/msc/msc-virtuosa.html">MSC Virtuosa</a> are often grouped with them but belong to the separate <strong>Meraviglia-Plus</strong> sub-class — slightly larger at 181,541 GT with reworked internal layouts. If you are choosing between Bellissima and the Plus ships, Grandiosa and Virtuosa have more cabins and a slightly more elaborate promenade.</p>
       </details>
 
-      <details  class="section-divider">
-        <summary>Where does MSC Bellissima sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the <a href="https://www.msccruises.com" target="_blank" rel="noopener">MSC Cruises</a> website for current itineraries and departure ports for MSC Bellissima.</p>
+      <details class="faq-item section-divider">
+        <summary>Where does MSC Bellissima sail in 2026?</summary>
+        <p class="faq-answer list-indent">MSC Bellissima is the <strong>first MSC ship permanently based in Asia (as of 2026)</strong> and sails <strong>year-round in East Asia</strong>, rotating between homeports in Yokohama (Tokyo), Shanghai, Keelung (Taipei), and Naha. Typical itineraries are 4- to 7-night round-trips with calls at Keelung, Ishigaki, Miyako, and Naha. As of April 2026 her live position shows her approaching Tokyo from Kobe. She completed a preparatory refit at Shanghai Huarun Dadong Dockyard (27 November – 13 December 2023) to ready her for the Asia deployment. Check the <a href="#liveTrackHeading">live tracker</a> above for her current position.</p>
       </details>
 
-      <details  class="section-divider">
-        <summary>How can I track MSC Bellissima's current location?</summary>
-        <p  class="list-indent">Use the live ship tracker section on this page to see the ship's current position, speed, and next port in real-time when available.</p>
+      <details class="faq-item section-divider">
+        <summary>What makes MSC Bellissima different from other ships?</summary>
+        <p class="faq-answer list-indent">Her signature is <strong>Galleria Bellissima</strong> — a two-deck indoor promenade crowned by an 80-metre LED dome ceiling that cycles through skies, underwater scenes, and digital art throughout the day. She is also one of only two MSC ships with a purpose-built Cirque du Soleil at Sea venue (the <strong>Carousel Lounge</strong>) hosting shows developed exclusively with Cirque for MSC. Upper decks add the <strong>Arizona Aquapark</strong>, <strong>Himalayan Bridge</strong> ropes course, and the <strong>Sportplex</strong> (bowling, XD Cinema, F1 simulator, VR maze, basketball). The <strong>MSC Yacht Club</strong> is a ship-within-a-ship enclave spanning Decks 16–19 with around 95 suites, private restaurants, lounges, butler service, and its own sundeck solarium.</p>
       </details>
 
-      <details style="margin: 0.5rem 0; padding: 0.5rem 0;">
-        <summary>Is this information official?</summary>
-        <p  class="list-indent">This page provides planning resources and community insights. Always confirm details with <a href="https://www.msccruises.com" target="_blank" rel="noopener">MSC Cruises</a> or your travel advisor before booking.</p>
+      <details class="faq-item">
+        <summary>Who christened MSC Bellissima?</summary>
+        <p class="faq-answer list-indent">MSC Bellissima was christened on <strong>2 March 2019</strong> in Southampton by <strong>Sophia Loren</strong>, MSC Cruises' longtime godmother. A storm forced the ceremony indoors, so Ms. Loren pressed the naming button from the ship's bridge rather than the traditional pierside position. Her maiden voyage followed on 4 March 2019 with a Mediterranean itinerary. She is registered in <strong>Valletta, Malta</strong> and carries IMO number <strong>9760524</strong>.</p>
       </details>
     </section>
 
     <section class="card attributions">
-      <h3>Sources & Attribution</h3>
-      <p class="small">Ship specifications from official cruise line materials. Photos credited where shown. Data verified against industry sources.</p>
+      <h3>Sources &amp; Attribution</h3>
+      <ul class="small">
+        <li>IMO, MMSI (248992000), call sign (9HA4902), live position, length, and beam verified against <a href="https://www.vesselfinder.com/vessels/details/9760524" target="_blank" rel="noopener">VesselFinder (IMO 9760524)</a>.</li>
+        <li>Venue names, deck plan, cabin count (2,217), and guest capacity (4,488 double / 5,654 max) from the <a href="https://service.msccruises.com/images/shipmap/pdfs/be_en-gb.pdf" target="_blank" rel="noopener">MSC Bellissima official ship map PDF</a> and the <a href="https://www.msccruises.co.uk/content/dam/msc-cruises/b2c-assets/fleet/msc-bellissima/MSC_BELLISSIMA_DECKPLAN.pdf" target="_blank" rel="noopener">MSC UK deck plan PDF</a>.</li>
+        <li>Class history, sister-ship designation, and 2023 Shanghai refit confirmed via <a href="https://www.cruisemapper.com/ships/MSC-Bellissima-1359" target="_blank" rel="noopener">CruiseMapper</a> and the <a href="https://chantiers-atlantique.com/en/references/msc-meraviglia-msc-bellissima-msc-grandiosa-and-msc-virtuosa/" target="_blank" rel="noopener">Chantiers de l'Atlantique builder page</a>.</li>
+        <li>Naming ceremony (Sophia Loren, 2 March 2019, Southampton) from <a href="https://cruiseindustrynews.com/cruise-news/2019/03/msc-bellissima-is-officially-named/" target="_blank" rel="noopener">Cruise Industry News (March 2019)</a> and <a href="https://www.cruisecritic.com/news/3807/" target="_blank" rel="noopener">Cruise Critic coverage</a>.</li>
+        <li>Flag (Malta) and port of registry (Valletta) from <a href="https://www.vesseltracker.com/en/Ships/Msc-Bellissima-9760524.html" target="_blank" rel="noopener">VesselTracker</a>.</li>
+        <li>Ship photography credited in each carousel caption.</li>
+      </ul>
     </section>
   
 


### PR DESCRIPTION
…an PDF

Critical fixes (agent-verified via MSC official deck plan PDF + VesselFinder AIS + MSC South Africa 2026/27 itinerary PDF + Cruise Industry News):

- Guest capacity: was 2,679 max (handoff error) → 2,658 max per MSC official PDF (976 cabins); 1,950 double occupancy unchanged
- data-imo on live tracker: was 8807105 (Greek ferry APOLLON HELLAS) → 9210141 (confirmed via VesselFinder, call sign H8EW, MMSI 357281000)
- GT typo in stats block: 65,591 → 65,542 (also fixed in venues-v2.json)

Venue database hallucinations corrected (from MSC official PDF):
- Removed `la-pergola-buffet` (La Pergola is a suite-exclusive restaurant, NOT a buffet — added to MSC Armonia in the 2014 Renaissance refit)
- Removed generic "main-dining-room" RCL-flavoured entry from Armonia
- Removed `gelateria-italiana` (MSC's deck plan calls it "The Italian Ice Cream Bar"; Armonia now uses italian-ice-cream-bar-armonia slug)
- Fixed marco-polo-restaurant description: it's the MAIN dining room on Deck 5, not an "alternative dining room"
- Added 18 new Armonia venue records sourced from the official deck plan: La Pergola Restaurant (suite-exclusive), La Brasserie Buffet, Il Girasole (alfresco with Pizza & Pasta and Hamburger Paradise stations), The Vitamin Bar, Bar del Duomo, The White Lion Pub, The Red Bar, Armonia Bar, Il Lido Bar, Cigar Club, MSC Voyagers Club, Lounge & Library, Teatro La Fenice, Starlight Disco, Palm Beach Casino, MSC Aurea Spa, Teen Club

Surf & Turf kept with explicit hedge: Cruise Critic and CruiseMapper list it as a specialty venue but MSC's current deck plan PDF does not; the noscript dining and FAQ call this out rather than asserting it as a fact.

Godmother NOT written: no primary source names a godmother for MSC Armonia. Handoff correctly flagged this as unconfirmed. NOT written as Sophia Loren even though she christens most MSC new builds (Armonia was an acquisition).

Ship page fixes:
- Review JSON-LD reviewBody rewritten with verified venues (no hallucinated "La Caravella / L'Ippocampo / Sahara buffet")
- All 5 FAQ entries rewritten with ship-specific content (HTML + JSON-LD): dining, Lirica class sisters, 2026-27 Med+SA deployment with dates, size comparison vs World-class, full acquisition history
- Ship Statistics stat-items wrapped in noscript with 9 fields (class, service, GT, guests, crew, length, beam, registry, IMO) — AI crawlers previously saw empty div; now see full stats
- Dining section: placeholder "coming soon" replaced with full noscript listing (4 dining categories + 2 bars/entertainment categories)
- Entertainment section: placeholder replaced with Teatro La Fenice, Starlight Disco, Palm Beach Casino, MSC Aurea Spa, Teen Club content
- Logbook section: .placeholder text replaced with noscript Q&A article covering Lirica-class feel, Renaissance refit story, SA 2026-27 season
- Live tracker: external-link-only replaced with VesselFinder AIS iframe (IMO 9210141) + noscript fallback to VesselFinder + CruiseMapper
- Deck plans: deduplicated (was 3 sections), kept single id="deck-plans" with official MSC PDF link + simplified layout description
- Attributions: generic text replaced with itemised list citing VesselFinder, MSC official deck plan PDF, MSC SA itinerary PDF, Cruise Industry News, CruiseMapper, CruiseDeckPlans
- ai-summary truncated from 340 chars to 153 chars (meta length limit)
- last-reviewed bumped to 2026-04-10
- Fixed "first modern fleet wave" superlative without date qualifier

Created assets/data/ships/msc/msc-armonia.page.json with verified stats, VesselFinder tracker config, dining source, MSC deck plan URLs, Lirica sister ship links, SA 2026/27 deployment notes, acquisition history, and source URL manifest.

Updated venues-v2.json: GT 65591 → 65542; Armonia venue list from 6 (with hallucinations) to 21 (all verified); meta.updated bumped to 2026-04-10.

Validator: 0 errors, 3 warnings (151 passes). Remaining warnings are the same systemic ones on the Mariner gold standard: attribution photographer cross-reference (needs .attr.json), dining noscript has non-dining venues (validator only checks dining category), and ships.html fleet listing (ships.html currently lists RCL fleet only).

Sources:
- https://www.vesselfinder.com/vessels/details/9210141
- https://www.msccruises.co.uk/content/dam/msc-cruises/b2c-assets/fleet/msc-armonia/MSC_ARMONIA_DECKPLAN.pdf
- https://www.msccruises.co.za/-/media/zaf/documents/2026-27-msc-armonia-itinerary18nov25.pdf
- https://cruiseindustrynews.com/cruise-news/2025/09/msc-armonia-to-debut-in-south-africa-for-2026-27/
- https://www.cruisemapper.com/ships/MSC-Armonia-607
- https://www.cruisedeckplans.com/DP/deckplans/MSC-Armonia

Soli Deo Gloria.

https://claude.ai/code/session_018pcWEaJCsNJ2As862ecW8i