### PR TITLE
P2: Celebrity duplicate headers — 29/29 complete

### DIFF
--- a/ships/celebrity-cruises/celebrity-xcel.html
+++ b/ships/celebrity-cruises/celebrity-xcel.html
@@ -241,7 +241,6 @@ All work on this project is offered as a gift to God.
   <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
 
 <header class="site-header hero-header" role="banner">
-<header class="site-header hero-header" role="banner">
 <div class="navbar">
   <div class="brand">
     <img loading="lazy" src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async"/>
@@ -333,11 +332,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>Celebrity Xcel <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#0a7d45;color:white;font-weight:600;font-size:1rem">Active</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 

--- a/ships/celebrity-cruises/celebrity-xpedition.html
+++ b/ships/celebrity-cruises/celebrity-xpedition.html
@@ -370,11 +370,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>Celebrity Xpedition <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#8a2d2d;color:white;font-weight:600;font-size:1rem">Historical</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 

--- a/ships/celebrity-cruises/celebrity-xperience.html
+++ b/ships/celebrity-cruises/celebrity-xperience.html
@@ -352,11 +352,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>Celebrity Xperience <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#8a2d2d;color:white;font-weight:600;font-size:1rem">Historical</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 

--- a/ships/celebrity-cruises/celebrity-xploration.html
+++ b/ships/celebrity-cruises/celebrity-xploration.html
@@ -370,11 +370,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>Celebrity Xploration <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#8a2d2d;color:white;font-weight:600;font-size:1rem">Historical</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 

--- a/ships/celebrity-cruises/horizon.html
+++ b/ships/celebrity-cruises/horizon.html
@@ -370,11 +370,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>Horizon <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#8a2d2d;color:white;font-weight:600;font-size:1rem">Historical</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 

--- a/ships/celebrity-cruises/ss-meridian.html
+++ b/ships/celebrity-cruises/ss-meridian.html
@@ -370,11 +370,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>SS Meridian <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#8a2d2d;color:white;font-weight:600;font-size:1rem">Historical</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 

--- a/ships/celebrity-cruises/unnamed-edge-class.html
+++ b/ships/celebrity-cruises/unnamed-edge-class.html
@@ -351,11 +351,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>Unnamed (Edge-class) <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#8a6b0f;color:white;font-weight:600;font-size:1rem">Coming-Soon</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 

--- a/ships/celebrity-cruises/unnamed-project-nirvana.html
+++ b/ships/celebrity-cruises/unnamed-project-nirvana.html
@@ -351,11 +351,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>Unnamed (Project Nirvana) <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#8a6b0f;color:white;font-weight:600;font-size:1rem">Coming-Soon</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 

--- a/ships/celebrity-cruises/unnamed-river-class-x6.html
+++ b/ships/celebrity-cruises/unnamed-river-class-x6.html
@@ -351,11 +351,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>Unnamed (River-class x6) <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#8a6b0f;color:white;font-weight:600;font-size:1rem">Coming-Soon</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 

--- a/ships/celebrity-cruises/zenith.html
+++ b/ships/celebrity-cruises/zenith.html
@@ -370,11 +370,11 @@ All work on this project is offered as a gift to God.
       </div>
     </div></header></div>
 
-<header>
+<div class="page-title-block">
   <div class="crumbs"><a href="/index.html">Home</a> / <a href="/ships/index.html">Ships</a> / <a href="/ships/celebrity-cruises/index.html">Celebrity Cruises</a></div>
   <h1>Zenith <span style="display:inline-block;padding:.25rem .5rem;border-radius:.5rem;background:#8a2d2d;color:white;font-weight:600;font-size:1rem">Historical</span></h1>
   <div class="small">Cruise Line: Celebrity Cruises</div>
-</header>
+</div>
 <div class="rope"></div>
 <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
 


### PR DESCRIPTION
Fixed remaining 10 Celebrity ships (Xcel, Xpedition, Xperience, Xploration, Horizon, SS Meridian, 3 unnamed placeholders, Zenith).

Xcel: Pattern A — removed duplicate <header class="site-header hero-header">
All 10: changed bare <header> page-title block to <div class="page-title-block">

Verification: no duplicate site-headers, no bare <header> tags across all 29 Celebrity ship pages.

Soli Deo Gloria.