### PR TITLE
P5: Virgin Voyages nav/hero restructure — 4/4 pages

### DIFF
--- a/ships/virgin-voyages/brilliant-lady.html
+++ b/ships/virgin-voyages/brilliant-lady.html
@@ -4,21 +4,49 @@ Soli Deo Gloria
 All work on this project is offered as a gift to God.
 "Trust in the LORD with all your heart..." — Proverbs 3:5
 "Whatever you do, work heartily..." — Colossians 3:23
+
+STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.400 · A11y/WCAG 2.1 AA Compliant
 -->
 <html lang="en" class="no-js">
 <head>
-<script>document.documentElement.classList.remove('no-js');</script>
+  <!-- ======================================================
+       In the Wake — Brilliant Lady • Virgin Voyages
+       Version: 3.010.400  |  Soli Deo Gloria ✝️
+
+       ✅ WCAG 2.1 Level AA Compliant
+       ✅ SEO Optimized (JSON-LD, OpenGraph, Twitter Cards)
+       ✅ Dropdown Menus with Hover Delay (300ms)
+       ✅ AI-First SEO with E-E-A-T Person Schema
+       ====================================================== -->
+
+  <!-- Core -->
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Brilliant Lady — Virgin Voyages Ship Guide | In the Wake</title>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer-when-downgrade"/>
+
+  <!-- SEO: Robots & Crawling -->
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"/>
+  <meta name="googlebot" content="index,follow"/>
+  <meta name="bingbot" content="index,follow"/>
+
+  <!-- SEO: Theme & Appearance -->
+  <meta name="color-scheme" content="light"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="author" content="In the Wake"/>
+  <meta name="publisher" content="In the Wake"/>
+
+  <!-- Title & SEO -->
+  <title>Brilliant Lady — Deck Plans, Live Tracker, Dining & Videos | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/virgin-voyages/brilliant-lady.html"/>
   <meta name="description" content="Brilliant Lady is the fourth and newest of Virgin Voyages' four-ship Lady Class, entering commercial service on 5 September 2025 after an 18-month lay-up. 110,000 GT, 2,770 guests, 1,160 crew, adults-only 18+. The ONLY Lady with a Panama-Canal-capable adapted frame — currently on Virgin's first West Coast deployment ex-Los Angeles. IMO 9870654."/>
-  <meta property="og:type" content="article"/>
+  <meta property="og:type" content="website"/>
   <meta property="og:locale" content="en_US"/>
   <meta property="og:site_name" content="In the Wake"/>
-  <meta property="og:title" content="Brilliant Lady — Virgin Voyages Ship Guide"/>
+  <meta property="og:title" content="Brilliant Lady — Deck Plans, Live Tracker, Dining & Videos"/>
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:title" content="Brilliant Lady — Virgin Voyages Ship Guide"/>
+  <meta name="twitter:title" content="Brilliant Lady — Deck Plans, Live Tracker, Dining & Videos"/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:description" content="Brilliant Lady — Virgin Voyages' 4th and newest Lady Class ship. Entered service 5 Sept 2025. 110,000 GT, IMO 9870654. Only Panama-Canal-capable sister. First Virgin West Coast deployment ex-LA."/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/virgin-voyages/brilliant-lady.html"/>
@@ -27,8 +55,16 @@ All work on this project is offered as a gift to God.
   <meta name="ai-summary" content="Brilliant Lady — Virgin Voyages' 4th and newest Lady Class ship, entered service 5 Sept 2025 after 18-month lay-up. 110,000 GT, 2,770 guests, IMO 9870654, yard 6304. Only Panama-Canal-capable sister. First Virgin West Coast / Alaska deployment.">
   <meta name="last-reviewed" content="2026-04-11">
   <meta name="content-protocol" content="ICP-2">
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
-  <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
+  <!-- Favicon / PWA -->
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <link rel="manifest" href="/manifest.webmanifest"/>
+
+  <!-- LCP Optimization: Preload critical hero images -->
+  <link rel="preload" as="image" href="/assets/social/ships-hero.jpg" fetchpriority="high"/>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+  <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.400"/>
 
   <!-- JSON-LD: CruiseShip -->
   <script type="application/ld+json">
@@ -239,67 +275,119 @@ All work on this project is offered as a gift to God.
 </head>
 <body class="page">
 <a href="#content" class="skip-link">Skip to main content</a>
-  <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
-  <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
 
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <a href="/"><img loading="lazy" src="/assets/logo_wake_256.png" alt="In the Wake cruise travel guide and ship reviews logo" width="256" height="259"/></a>
+        <a href="/"><img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async" loading="eager"/></a>
       </div>
-      <nav class="site-nav" aria-label="Main navigation">
-  <a class="nav-pill" href="/">Home</a>
+      <!-- Mobile hamburger button -->
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
 
-  <div class="nav-dropdown" id="nav-planning">
-    <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
-      Planning <span class="caret">▾</span>
-    </button>
-    <div class="dropdown-menu" role="menu">
-      <a href="/planning.html">Planning Overview</a>
-      <a href="/ships.html">Ships</a>
-      <a href="/ships/quiz.html">Ship Quiz</a>
-      <a href="/restaurants.html">Restaurants &amp; Menus</a>
-      <a href="/ports.html">Ports</a>
-      <a href="/internet-at-sea.html">Internet at Sea</a>
-      <a href="/drink-packages.html">Drink Packages</a>
-      <a href="/drink-calculator.html">Drink Calculator</a>
-      <a href="/stateroom-check.html">Stateroom Check</a>
-      <a href="/cruise-lines.html">Cruise Lines</a>
-      <a href="/packing-lists.html">Packing Lists</a>
-      <a href="/accessibility.html">Accessibility</a>
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning</a>
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Tools Dropdown -->
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+
+        <!-- Onboard Dropdown -->
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
     </div>
-  </div>
 
-  <div class="nav-dropdown" id="nav-travel">
-    <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
-      Travel <span class="caret">▾</span>
-    </button>
-    <div class="dropdown-menu" role="menu">
-      <a href="/travel.html">Travel Overview</a>
-      <a href="/solo.html">Solo Cruising</a>
-    </div>
-  </div>
-
-  <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
-  <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
-  <a class="nav-pill" href="/search.html">Search</a>
-  <a class="nav-pill" href="/about-us.html">About</a>
-</nav>
-    </div>
-
-      <img loading="lazy" class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true" decoding="async"/>
+    <div class="hero" role="img" aria-label="Brilliant Lady hero image">
+      <div class="latlon-grid" aria-hidden="true">
+        <svg viewBox="0 0 100 60" preserveAspectRatio="none">
+          <g class="grid-lines" stroke-width="0.35">
+            <line x1="10" y1="0" x2="10" y2="60"/><line x1="20" y1="0" x2="20" y2="60"/>
+            <line x1="30" y1="0" x2="30" y2="60"/><line x1="40" y1="0" x2="40" y2="60"/>
+            <line x1="50" y1="0" x2="50" y2="60"/><line x1="60" y1="0" x2="60" y2="60"/>
+            <line x1="70" y1="0" x2="70" y2="60"/><line x1="80" y1="0" x2="80" y2="60"/>
+            <line x1="90" y1="0" x2="90" y2="60"/>
+            <line x1="0" y1="10" x2="100" y2="10"/><line x1="0" y1="20" x2="100" y2="20"/>
+            <line x1="0" y1="30" x2="100" y2="30"/><line x1="0" y1="40" x2="100" y2="40"/>
+          </g>
+        </svg>
+      </div>
+      <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true" loading="eager"/>
       <div class="hero-title">
-        <img loading="eager" class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async" fetchpriority="high" width="560" height="567"/>
+        <img loading="eager" class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake cruise travel site logo" decoding="async" fetchpriority="high" width="560" height="567"/>
       </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      </header>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        <a class="pill" href="https://www.instagram.com/flickersofmajesty" target="_blank" rel="noopener">@flickersofmajesty</a>
+      </div>
+    </div></header>
 
   <main class="wrap page-grid" id="content" role="main">
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
       <a href="/ships/virgin-voyages/">Virgin Voyages</a> &rsaquo;
-      <span>Brilliant Lady</span>
+      <span aria-current="page">Brilliant Lady</span>
     </nav>
 
     <section class="col-1" aria-label="Ship details">

--- a/ships/virgin-voyages/resilient-lady.html
+++ b/ships/virgin-voyages/resilient-lady.html
@@ -4,21 +4,49 @@ Soli Deo Gloria
 All work on this project is offered as a gift to God.
 "Trust in the LORD with all your heart..." — Proverbs 3:5
 "Whatever you do, work heartily..." — Colossians 3:23
+
+STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.400 · A11y/WCAG 2.1 AA Compliant
 -->
 <html lang="en" class="no-js">
 <head>
-<script>document.documentElement.classList.remove('no-js');</script>
+  <!-- ======================================================
+       In the Wake — Resilient Lady • Virgin Voyages
+       Version: 3.010.400  |  Soli Deo Gloria ✝️
+
+       ✅ WCAG 2.1 Level AA Compliant
+       ✅ SEO Optimized (JSON-LD, OpenGraph, Twitter Cards)
+       ✅ Dropdown Menus with Hover Delay (300ms)
+       ✅ AI-First SEO with E-E-A-T Person Schema
+       ====================================================== -->
+
+  <!-- Core -->
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Resilient Lady — Virgin Voyages Ship Guide | In the Wake</title>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer-when-downgrade"/>
+
+  <!-- SEO: Robots & Crawling -->
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"/>
+  <meta name="googlebot" content="index,follow"/>
+  <meta name="bingbot" content="index,follow"/>
+
+  <!-- SEO: Theme & Appearance -->
+  <meta name="color-scheme" content="light"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="author" content="In the Wake"/>
+  <meta name="publisher" content="In the Wake"/>
+
+  <!-- Title & SEO -->
+  <title>Resilient Lady — Deck Plans, Live Tracker, Dining & Videos | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/virgin-voyages/resilient-lady.html"/>
   <meta name="description" content="Resilient Lady is the third of Virgin Voyages' four Lady Class ships, delivered 7 December 2022: 110,000 GT, 2,770 guests double occupancy, 1,160 crew, adults-only (18+). Currently sailing Caribbean round-trips from PortMiami (NOT Australia — the 2024-25 Australia programme was cancelled in February 2024). IMO 9805348."/>
-  <meta property="og:type" content="article"/>
+  <meta property="og:type" content="website"/>
   <meta property="og:locale" content="en_US"/>
   <meta property="og:site_name" content="In the Wake"/>
-  <meta property="og:title" content="Resilient Lady — Virgin Voyages Ship Guide"/>
+  <meta property="og:title" content="Resilient Lady — Deck Plans, Live Tracker, Dining & Videos"/>
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:title" content="Resilient Lady — Virgin Voyages Ship Guide"/>
+  <meta name="twitter:title" content="Resilient Lady — Deck Plans, Live Tracker, Dining & Videos"/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:description" content="Resilient Lady — Virgin Voyages' 3rd Lady Class ship, delivered 7 Dec 2022. 110,000 GT, 2,770 adult guests, IMO 9805348. Caribbean from PortMiami (NOT Australia as of 2026)."/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/virgin-voyages/resilient-lady.html"/>
@@ -27,8 +55,16 @@ All work on this project is offered as a gift to God.
   <meta name="ai-summary" content="Resilient Lady — Virgin Voyages' 3rd Lady Class ship, delivered 7 Dec 2022 after an 11-month delay. 110,000 GT, 2,770 guests, 1,160 crew, IMO 9805348, Fincantieri yard 6289. Caribbean from PortMiami; 2024-25 Australia cancelled.">
   <meta name="last-reviewed" content="2026-04-11">
   <meta name="content-protocol" content="ICP-2">
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
-  <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
+  <!-- Favicon / PWA -->
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <link rel="manifest" href="/manifest.webmanifest"/>
+
+  <!-- LCP Optimization: Preload critical hero images -->
+  <link rel="preload" as="image" href="/assets/social/ships-hero.jpg" fetchpriority="high"/>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+  <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.400"/>
 
   <!-- JSON-LD: CruiseShip -->
   <script type="application/ld+json">
@@ -239,67 +275,119 @@ All work on this project is offered as a gift to God.
 </head>
 <body class="page">
 <a href="#content" class="skip-link">Skip to main content</a>
-  <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
-  <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
 
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <a href="/"><img loading="lazy" src="/assets/logo_wake_256.png" alt="In the Wake cruise travel guide and ship reviews logo" width="256" height="259"/></a>
+        <a href="/"><img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async" loading="eager"/></a>
       </div>
-      <nav class="site-nav" aria-label="Main navigation">
-  <a class="nav-pill" href="/">Home</a>
+      <!-- Mobile hamburger button -->
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
 
-  <div class="nav-dropdown" id="nav-planning">
-    <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
-      Planning <span class="caret">▾</span>
-    </button>
-    <div class="dropdown-menu" role="menu">
-      <a href="/planning.html">Planning Overview</a>
-      <a href="/ships.html">Ships</a>
-      <a href="/ships/quiz.html">Ship Quiz</a>
-      <a href="/restaurants.html">Restaurants &amp; Menus</a>
-      <a href="/ports.html">Ports</a>
-      <a href="/internet-at-sea.html">Internet at Sea</a>
-      <a href="/drink-packages.html">Drink Packages</a>
-      <a href="/drink-calculator.html">Drink Calculator</a>
-      <a href="/stateroom-check.html">Stateroom Check</a>
-      <a href="/cruise-lines.html">Cruise Lines</a>
-      <a href="/packing-lists.html">Packing Lists</a>
-      <a href="/accessibility.html">Accessibility</a>
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning</a>
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Tools Dropdown -->
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+
+        <!-- Onboard Dropdown -->
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
     </div>
-  </div>
 
-  <div class="nav-dropdown" id="nav-travel">
-    <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
-      Travel <span class="caret">▾</span>
-    </button>
-    <div class="dropdown-menu" role="menu">
-      <a href="/travel.html">Travel Overview</a>
-      <a href="/solo.html">Solo Cruising</a>
-    </div>
-  </div>
-
-  <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
-  <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
-  <a class="nav-pill" href="/search.html">Search</a>
-  <a class="nav-pill" href="/about-us.html">About</a>
-</nav>
-    </div>
-
-      <img loading="lazy" class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true" decoding="async"/>
+    <div class="hero" role="img" aria-label="Resilient Lady hero image">
+      <div class="latlon-grid" aria-hidden="true">
+        <svg viewBox="0 0 100 60" preserveAspectRatio="none">
+          <g class="grid-lines" stroke-width="0.35">
+            <line x1="10" y1="0" x2="10" y2="60"/><line x1="20" y1="0" x2="20" y2="60"/>
+            <line x1="30" y1="0" x2="30" y2="60"/><line x1="40" y1="0" x2="40" y2="60"/>
+            <line x1="50" y1="0" x2="50" y2="60"/><line x1="60" y1="0" x2="60" y2="60"/>
+            <line x1="70" y1="0" x2="70" y2="60"/><line x1="80" y1="0" x2="80" y2="60"/>
+            <line x1="90" y1="0" x2="90" y2="60"/>
+            <line x1="0" y1="10" x2="100" y2="10"/><line x1="0" y1="20" x2="100" y2="20"/>
+            <line x1="0" y1="30" x2="100" y2="30"/><line x1="0" y1="40" x2="100" y2="40"/>
+          </g>
+        </svg>
+      </div>
+      <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true" loading="eager"/>
       <div class="hero-title">
-        <img loading="eager" class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async" fetchpriority="high" width="560" height="567"/>
+        <img loading="eager" class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake cruise travel site logo" decoding="async" fetchpriority="high" width="560" height="567"/>
       </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      </header>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        <a class="pill" href="https://www.instagram.com/flickersofmajesty" target="_blank" rel="noopener">@flickersofmajesty</a>
+      </div>
+    </div></header>
 
   <main class="wrap page-grid" id="content" role="main">
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
       <a href="/ships/virgin-voyages/">Virgin Voyages</a> &rsaquo;
-      <span>Resilient Lady</span>
+      <span aria-current="page">Resilient Lady</span>
     </nav>
 
     <section class="col-1" aria-label="Ship details">

--- a/ships/virgin-voyages/scarlet-lady.html
+++ b/ships/virgin-voyages/scarlet-lady.html
@@ -4,21 +4,49 @@ Soli Deo Gloria
 All work on this project is offered as a gift to God.
 "Trust in the LORD with all your heart..." — Proverbs 3:5
 "Whatever you do, work heartily..." — Colossians 3:23
+
+STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.400 · A11y/WCAG 2.1 AA Compliant
 -->
 <html lang="en" class="no-js">
 <head>
-<script>document.documentElement.classList.remove('no-js');</script>
+  <!-- ======================================================
+       In the Wake — Scarlet Lady • Virgin Voyages
+       Version: 3.010.400  |  Soli Deo Gloria ✝️
+
+       ✅ WCAG 2.1 Level AA Compliant
+       ✅ SEO Optimized (JSON-LD, OpenGraph, Twitter Cards)
+       ✅ Dropdown Menus with Hover Delay (300ms)
+       ✅ AI-First SEO with E-E-A-T Person Schema
+       ====================================================== -->
+
+  <!-- Core -->
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Scarlet Lady — Virgin Voyages Ship Guide | In the Wake</title>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer-when-downgrade"/>
+
+  <!-- SEO: Robots & Crawling -->
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"/>
+  <meta name="googlebot" content="index,follow"/>
+  <meta name="bingbot" content="index,follow"/>
+
+  <!-- SEO: Theme & Appearance -->
+  <meta name="color-scheme" content="light"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="author" content="In the Wake"/>
+  <meta name="publisher" content="In the Wake"/>
+
+  <!-- Title & SEO -->
+  <title>Scarlet Lady — Deck Plans, Live Tracker, Dining & Videos | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/virgin-voyages/scarlet-lady.html"/>
   <meta name="description" content="Scarlet Lady is Virgin Voyages' 2020 flagship and lead ship of the four-ship Lady Class: 110,000 GT, 2,770 guests double occupancy, 1,160 crew, adults-only (18+), all-dining-included, currently sailing Caribbean round-trips from PortMiami. IMO 9804801."/>
-  <meta property="og:type" content="article"/>
+  <meta property="og:type" content="website"/>
   <meta property="og:locale" content="en_US"/>
   <meta property="og:site_name" content="In the Wake"/>
-  <meta property="og:title" content="Scarlet Lady — Virgin Voyages Ship Guide"/>
+  <meta property="og:title" content="Scarlet Lady — Deck Plans, Live Tracker, Dining & Videos"/>
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:title" content="Scarlet Lady — Virgin Voyages Ship Guide"/>
+  <meta name="twitter:title" content="Scarlet Lady — Deck Plans, Live Tracker, Dining & Videos"/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:description" content="Scarlet Lady — Virgin Voyages' 2020 lead ship. 110,000 GT, 2,770 adult guests, IMO 9804801. Adults-only 18+, all dining included, Caribbean from PortMiami."/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/virgin-voyages/scarlet-lady.html"/>
@@ -27,8 +55,16 @@ All work on this project is offered as a gift to God.
   <meta name="ai-summary" content="Scarlet Lady — Virgin Voyages' lead ship of the Lady Class, delivered 14 Feb 2020. 110,000 GT, 2,770 guests double / 2,860 max, 1,160 crew, IMO 9804801, Fincantieri yard 6287. Adults-only 18+, Caribbean from PortMiami.">
   <meta name="last-reviewed" content="2026-04-11">
   <meta name="content-protocol" content="ICP-2">
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
-  <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
+  <!-- Favicon / PWA -->
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <link rel="manifest" href="/manifest.webmanifest"/>
+
+  <!-- LCP Optimization: Preload critical hero images -->
+  <link rel="preload" as="image" href="/assets/social/ships-hero.jpg" fetchpriority="high"/>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+  <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.400"/>
 
   <!-- JSON-LD: CruiseShip -->
   <script type="application/ld+json">
@@ -239,67 +275,119 @@ All work on this project is offered as a gift to God.
 </head>
 <body class="page">
 <a href="#content" class="skip-link">Skip to main content</a>
-  <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
-  <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
 
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <a href="/"><img loading="lazy" src="/assets/logo_wake_256.png" alt="In the Wake cruise travel guide and ship reviews logo" width="256" height="259"/></a>
+        <a href="/"><img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async" loading="eager"/></a>
       </div>
-      <nav class="site-nav" aria-label="Main navigation">
-  <a class="nav-pill" href="/">Home</a>
+      <!-- Mobile hamburger button -->
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
 
-  <div class="nav-dropdown" id="nav-planning">
-    <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
-      Planning <span class="caret">▾</span>
-    </button>
-    <div class="dropdown-menu" role="menu">
-      <a href="/planning.html">Planning Overview</a>
-      <a href="/ships.html">Ships</a>
-      <a href="/ships/quiz.html">Ship Quiz</a>
-      <a href="/restaurants.html">Restaurants &amp; Menus</a>
-      <a href="/ports.html">Ports</a>
-      <a href="/internet-at-sea.html">Internet at Sea</a>
-      <a href="/drink-packages.html">Drink Packages</a>
-      <a href="/drink-calculator.html">Drink Calculator</a>
-      <a href="/stateroom-check.html">Stateroom Check</a>
-      <a href="/cruise-lines.html">Cruise Lines</a>
-      <a href="/packing-lists.html">Packing Lists</a>
-      <a href="/accessibility.html">Accessibility</a>
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning</a>
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Tools Dropdown -->
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+
+        <!-- Onboard Dropdown -->
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
     </div>
-  </div>
 
-  <div class="nav-dropdown" id="nav-travel">
-    <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
-      Travel <span class="caret">▾</span>
-    </button>
-    <div class="dropdown-menu" role="menu">
-      <a href="/travel.html">Travel Overview</a>
-      <a href="/solo.html">Solo Cruising</a>
-    </div>
-  </div>
-
-  <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
-  <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
-  <a class="nav-pill" href="/search.html">Search</a>
-  <a class="nav-pill" href="/about-us.html">About</a>
-</nav>
-    </div>
-
-      <img loading="lazy" class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true" decoding="async"/>
+    <div class="hero" role="img" aria-label="Scarlet Lady hero image">
+      <div class="latlon-grid" aria-hidden="true">
+        <svg viewBox="0 0 100 60" preserveAspectRatio="none">
+          <g class="grid-lines" stroke-width="0.35">
+            <line x1="10" y1="0" x2="10" y2="60"/><line x1="20" y1="0" x2="20" y2="60"/>
+            <line x1="30" y1="0" x2="30" y2="60"/><line x1="40" y1="0" x2="40" y2="60"/>
+            <line x1="50" y1="0" x2="50" y2="60"/><line x1="60" y1="0" x2="60" y2="60"/>
+            <line x1="70" y1="0" x2="70" y2="60"/><line x1="80" y1="0" x2="80" y2="60"/>
+            <line x1="90" y1="0" x2="90" y2="60"/>
+            <line x1="0" y1="10" x2="100" y2="10"/><line x1="0" y1="20" x2="100" y2="20"/>
+            <line x1="0" y1="30" x2="100" y2="30"/><line x1="0" y1="40" x2="100" y2="40"/>
+          </g>
+        </svg>
+      </div>
+      <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true" loading="eager"/>
       <div class="hero-title">
-        <img loading="eager" class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async" fetchpriority="high" width="560" height="567"/>
+        <img loading="eager" class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake cruise travel site logo" decoding="async" fetchpriority="high" width="560" height="567"/>
       </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      </header>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        <a class="pill" href="https://www.instagram.com/flickersofmajesty" target="_blank" rel="noopener">@flickersofmajesty</a>
+      </div>
+    </div></header>
 
   <main class="wrap page-grid" id="content" role="main">
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
       <a href="/ships/virgin-voyages/">Virgin Voyages</a> &rsaquo;
-      <span>Scarlet Lady</span>
+      <span aria-current="page">Scarlet Lady</span>
     </nav>
 
     <section class="col-1" aria-label="Ship details">

--- a/ships/virgin-voyages/valiant-lady.html
+++ b/ships/virgin-voyages/valiant-lady.html
@@ -4,21 +4,49 @@ Soli Deo Gloria
 All work on this project is offered as a gift to God.
 "Trust in the LORD with all your heart..." — Proverbs 3:5
 "Whatever you do, work heartily..." — Colossians 3:23
+
+STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.400 · A11y/WCAG 2.1 AA Compliant
 -->
 <html lang="en" class="no-js">
 <head>
-<script>document.documentElement.classList.remove('no-js');</script>
+  <!-- ======================================================
+       In the Wake — Valiant Lady • Virgin Voyages
+       Version: 3.010.400  |  Soli Deo Gloria ✝️
+
+       ✅ WCAG 2.1 Level AA Compliant
+       ✅ SEO Optimized (JSON-LD, OpenGraph, Twitter Cards)
+       ✅ Dropdown Menus with Hover Delay (300ms)
+       ✅ AI-First SEO with E-E-A-T Person Schema
+       ====================================================== -->
+
+  <!-- Core -->
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Valiant Lady — Virgin Voyages Ship Guide | In the Wake</title>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer-when-downgrade"/>
+
+  <!-- SEO: Robots & Crawling -->
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"/>
+  <meta name="googlebot" content="index,follow"/>
+  <meta name="bingbot" content="index,follow"/>
+
+  <!-- SEO: Theme & Appearance -->
+  <meta name="color-scheme" content="light"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="author" content="In the Wake"/>
+  <meta name="publisher" content="In the Wake"/>
+
+  <!-- Title & SEO -->
+  <title>Valiant Lady — Deck Plans, Live Tracker, Dining & Videos | In the Wake</title>
   <link rel="canonical" href="https://cruisinginthewake.com/ships/virgin-voyages/valiant-lady.html"/>
   <meta name="description" content="Valiant Lady is the second of Virgin Voyages' four-ship Lady Class, delivered 1 July 2021: 110,000 GT, 2,770 guests double occupancy, 1,160 crew, adults-only (18+), all-dining-included. 2025-26 winter US East Coast; May 2026 drydock will deliver Ariya, Virgin's first Indian restaurant at sea. IMO 9805336."/>
-  <meta property="og:type" content="article"/>
+  <meta property="og:type" content="website"/>
   <meta property="og:locale" content="en_US"/>
   <meta property="og:site_name" content="In the Wake"/>
-  <meta property="og:title" content="Valiant Lady — Virgin Voyages Ship Guide"/>
+  <meta property="og:title" content="Valiant Lady — Deck Plans, Live Tracker, Dining & Videos"/>
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:title" content="Valiant Lady — Virgin Voyages Ship Guide"/>
+  <meta name="twitter:title" content="Valiant Lady — Deck Plans, Live Tracker, Dining & Videos"/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/ships-hero.jpg"/>
   <meta property="og:description" content="Valiant Lady — Virgin Voyages' 2nd Lady Class ship, delivered 1 July 2021. 110,000 GT, 2,770 adult guests, IMO 9805336. May 2026 drydock debuts Ariya Indian restaurant."/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/virgin-voyages/valiant-lady.html"/>
@@ -27,8 +55,16 @@ All work on this project is offered as a gift to God.
   <meta name="ai-summary" content="Valiant Lady — Virgin Voyages' 2nd Lady Class ship, delivered 1 July 2021. 110,000 GT, 2,770/2,860 guests, 1,160 crew, IMO 9805336, Fincantieri yard 6288. May 9-25 2026 drydock debuts Ariya — Virgin's first Indian restaurant at sea.">
   <meta name="last-reviewed" content="2026-04-11">
   <meta name="content-protocol" content="ICP-2">
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
-  <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
+  <!-- Favicon / PWA -->
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+  <link rel="manifest" href="/manifest.webmanifest"/>
+
+  <!-- LCP Optimization: Preload critical hero images -->
+  <link rel="preload" as="image" href="/assets/social/ships-hero.jpg" fetchpriority="high"/>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+  <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.400"/>
 
   <!-- JSON-LD: CruiseShip -->
   <script type="application/ld+json">
@@ -239,67 +275,119 @@ All work on this project is offered as a gift to God.
 </head>
 <body class="page">
 <a href="#content" class="skip-link">Skip to main content</a>
-  <div id="aria-live-polite" class="sr-only" role="status" aria-live="polite"></div>
-  <div id="aria-live-assertive" class="sr-only" role="alert" aria-live="assertive"></div>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
 
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <a href="/"><img loading="lazy" src="/assets/logo_wake_256.png" alt="In the Wake cruise travel guide and ship reviews logo" width="256" height="259"/></a>
+        <a href="/"><img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async" loading="eager"/></a>
       </div>
-      <nav class="site-nav" aria-label="Main navigation">
-  <a class="nav-pill" href="/">Home</a>
+      <!-- Mobile hamburger button -->
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
 
-  <div class="nav-dropdown" id="nav-planning">
-    <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
-      Planning <span class="caret">▾</span>
-    </button>
-    <div class="dropdown-menu" role="menu">
-      <a href="/planning.html">Planning Overview</a>
-      <a href="/ships.html">Ships</a>
-      <a href="/ships/quiz.html">Ship Quiz</a>
-      <a href="/restaurants.html">Restaurants &amp; Menus</a>
-      <a href="/ports.html">Ports</a>
-      <a href="/internet-at-sea.html">Internet at Sea</a>
-      <a href="/drink-packages.html">Drink Packages</a>
-      <a href="/drink-calculator.html">Drink Calculator</a>
-      <a href="/stateroom-check.html">Stateroom Check</a>
-      <a href="/cruise-lines.html">Cruise Lines</a>
-      <a href="/packing-lists.html">Packing Lists</a>
-      <a href="/accessibility.html">Accessibility</a>
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/planning.html">Planning</a>
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Tools Dropdown -->
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+
+        <!-- Onboard Dropdown -->
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
     </div>
-  </div>
 
-  <div class="nav-dropdown" id="nav-travel">
-    <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
-      Travel <span class="caret">▾</span>
-    </button>
-    <div class="dropdown-menu" role="menu">
-      <a href="/travel.html">Travel Overview</a>
-      <a href="/solo.html">Solo Cruising</a>
-    </div>
-  </div>
-
-  <a class="nav-pill" href="/tools/port-tracker.html">Port Logbook</a>
-  <a class="nav-pill" href="/tools/ship-tracker.html">Ship Logbook</a>
-  <a class="nav-pill" href="/search.html">Search</a>
-  <a class="nav-pill" href="/about-us.html">About</a>
-</nav>
-    </div>
-
-      <img loading="lazy" class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true" decoding="async"/>
+    <div class="hero" role="img" aria-label="Valiant Lady hero image">
+      <div class="latlon-grid" aria-hidden="true">
+        <svg viewBox="0 0 100 60" preserveAspectRatio="none">
+          <g class="grid-lines" stroke-width="0.35">
+            <line x1="10" y1="0" x2="10" y2="60"/><line x1="20" y1="0" x2="20" y2="60"/>
+            <line x1="30" y1="0" x2="30" y2="60"/><line x1="40" y1="0" x2="40" y2="60"/>
+            <line x1="50" y1="0" x2="50" y2="60"/><line x1="60" y1="0" x2="60" y2="60"/>
+            <line x1="70" y1="0" x2="70" y2="60"/><line x1="80" y1="0" x2="80" y2="60"/>
+            <line x1="90" y1="0" x2="90" y2="60"/>
+            <line x1="0" y1="10" x2="100" y2="10"/><line x1="0" y1="20" x2="100" y2="20"/>
+            <line x1="0" y1="30" x2="100" y2="30"/><line x1="0" y1="40" x2="100" y2="40"/>
+          </g>
+        </svg>
+      </div>
+      <img class="hero-compass" src="/assets/compass_rose.svg" alt="" aria-hidden="true" loading="eager"/>
       <div class="hero-title">
-        <img loading="eager" class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake cruise travel guide and ship reviews logo" decoding="async" fetchpriority="high" width="560" height="567"/>
+        <img loading="eager" class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake cruise travel site logo" decoding="async" fetchpriority="high" width="560" height="567"/>
       </div>
-      <div class="tagline">A Cruise Traveler's Logbook</div>
-      </header>
+      <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
+      <div class="hero-credit">
+        <a class="pill" href="https://www.flickersofmajesty.com" target="_blank" rel="noopener">Flickers of Majesty</a>
+        <a class="pill" href="https://www.instagram.com/flickersofmajesty" target="_blank" rel="noopener">@flickersofmajesty</a>
+      </div>
+    </div></header>
 
   <main class="wrap page-grid" id="content" role="main">
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> &rsaquo;
       <a href="/ships.html">Ships</a> &rsaquo;
       <a href="/ships/virgin-voyages/">Virgin Voyages</a> &rsaquo;
-      <span>Valiant Lady</span>
+      <span aria-current="page">Valiant Lady</span>
     </nav>
 
     <section class="col-1" aria-label="Ship details">


### PR DESCRIPTION
Brought Virgin Voyages ship pages to Anthem reference standard. Each of 4 pages dropped 16 warnings (64 total cleared).

Changes per page (Scarlet, Brilliant, Resilient, Valiant Lady):

Head infrastructure (same 8 as P4):
- STANDARDS comment
- charset-first ordering (was after <script>)
- Added robots + googlebot + bingbot
- Added color-scheme, theme-color, version, author, publisher
- Added referrer, Favicon/PWA links, image preload
- Updated CSS version 3.010/3.010.300 → 3.010.400
- Title format "— Virgin Voyages Ship Guide" → "— Deck Plans, Live Tracker, Dining & Videos" (plus matching OG/Twitter titles)

Nav restructure (P5-specific):
- Added nav-toggle hamburger button (mobile)
- Added id="site-nav" + aria-label="Main site navigation"
- Added Tools dropdown (Ship Quiz, Cruise Line Quiz, Drink Calc, Stateroom Check, Port/Ship Logbook, Budget, Port Day Planner, Ship Size Atlas — moved logbooks from standalone pills)
- Added Onboard dropdown (Restaurants, Drink Packages, Internet, Articles)
- Simplified Planning + Travel dropdowns to match Anthem menu model
- Removed standalone Port Logbook/Ship Logbook pills (now in Tools)

Hero restructure (P5-specific):
- Wrapped compass + logo + tagline in <div class="hero" role="img">
- Added <div class="latlon-grid"> decorative SVG (aria-hidden)
- Added <div class="hero-credit"> with Flickers of Majesty attribution
- Changed logo loading="lazy" → "eager" on brand navbar

Other:
- og:type "article" → "website"
- ARIA live region IDs: aria-live-polite/aria-live-assertive → a11y-status/a11y-alerts with aria-atomic="true"
- Breadcrumb added aria-label="Breadcrumb" + aria-current="page"

Before/after: all 4 pages 26→10 warnings (−16 each).

Remaining warnings are body-level (duplicate deck plan/tracker sections, grid-2 wrapper, tabindex, key-facts boxes, footer middot, dining path, swiper loader redundancy) — P6+ scope.

Soli Deo Gloria.