### PR TITLE
Lift wheat: session-pulse hook + session-checkpoint v2.0.0

### DIFF
--- a/.claude/hooks/session-pulse-scan.sh
+++ b/.claude/hooks/session-pulse-scan.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# session-pulse-scan.sh — SessionStart hook
+#
+# Scans for an abandoned previous session pulse and prints a recovery
+# summary to stdout. If no stale pulse is found, exits silently.
+#
+# Wired via .claude/settings.json: SessionStart event, no matcher.
+# Non-blocking: any failure exits 0 so a broken hook never wedges a session.
+
+set -u
+
+CHECKPOINT="/home/user/ken/orchestrator/checkpoint.py"
+
+if [ ! -f "$CHECKPOINT" ]; then
+    exit 0
+fi
+
+OUT=$(python3 "$CHECKPOINT" scan 2>/dev/null) || exit 0
+
+# Suppress the "no stale" case; surface anything else.
+case "$OUT" in
+    *'"stale": false'*) exit 0 ;;
+    "") exit 0 ;;
+esac
+
+echo "── Stale session detected ──────────────────────────────────────"
+echo "$OUT"
+echo "────────────────────────────────────────────────────────────────"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-pulse-scan.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/session-checkpoint/SKILL.md
+++ b/.claude/skills/session-checkpoint/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: session-checkpoint
-description: "Enforces atomic commits, checkpoint summaries, rate-limit recovery, and safe resume patterns. Writes session state to cognitive-memory so interrupted sessions can restart cleanly."
-version: 1.0.0
+description: "Enforces atomic commits, checkpoint summaries, rate-limit recovery, and safe resume patterns. Writes session pulses + cognitive memory so interrupted sessions can restart cleanly."
+version: 2.0.0
 ---
 
 # Session Checkpoint
@@ -10,22 +10,46 @@ version: 1.0.0
 
 ## Why This Skill Exists
 
-Claude Code makes multiple API calls per step. Large files + multi-file edits can exhaust per-minute token budgets. When a rate limit fires mid-session, work-in-progress can be lost. This skill prevents that.
+Claude Code makes many API calls per step. Large edits can exhaust per-minute token budgets, and a rate-limit kill in the middle of a multi-file change loses uncommitted work silently. This skill prevents that with two complementary mechanisms:
+
+1. **Cognitive memory checkpoints** — narrative state for the next session.
+2. **Session pulse** — a JSON heartbeat at `<repo>/.claude/state/session-pulse.json` that captures, on every beat, the list of git-uncommitted files. If a session dies before writing a HANDOFF, the next session can scan for stale pulses and see exactly what work was in flight.
+
+The pulse module is `orchestrator/checkpoint.py`. It is pure stdlib, repo-scoped, and has no daemon — the session itself updates the pulse.
 
 ## Session Startup Protocol
 
-### 1. Identify the single target file
-Do not load all files simultaneously. Load only what the task requires.
-
-### 2. Write a session intent to memory
+### 1. Scan for an abandoned previous session
 
 ```bash
-python3 /home/user/ken/orchestrator/memory_ops.py encode cruising insight \
-  "Session intent: [task description]. Target: [files]. Expected: [outcome]." \
+python3 /home/user/ken/orchestrator/checkpoint.py scan
+```
+
+If output is `{"ok": true, "stale": false}` you're clean. If a stale pulse is found you'll get a recovery summary listing the abandoned session's last action, last beat time, and the files that were uncommitted when it died — start work there. The stale pulse is automatically archived to `.claude/state/stale-sessions/`.
+
+### 2. Open a new pulse
+
+```bash
+SID=$(python3 /home/user/ken/orchestrator/checkpoint.py new-id)
+python3 /home/user/ken/orchestrator/checkpoint.py beat \
+  --session "$SID" --action "starting <task>" --context "<short summary>"
+```
+
+Keep `$SID` for the rest of the session. Every later beat must use the same id so `beat_count` increments instead of resetting.
+
+### 3. Identify the single target file
+
+Do not load all files simultaneously. Load only what the task requires.
+
+### 4. Write a session intent to cognitive memory
+
+```bash
+python3 /home/user/ken/orchestrator/memory_ops.py encode ken insight \
+  "Session intent: [task]. Target: [files]. Expected: [outcome]." \
   --tags session,intent,checkpoint
 ```
 
-### 3. Recall prior session state
+### 5. Recall prior session state
 
 ```bash
 python3 /home/user/ken/orchestrator/memory_ops.py recall "session checkpoint" --domain cruising --limit 5
@@ -33,15 +57,25 @@ python3 /home/user/ken/orchestrator/memory_ops.py recall "session checkpoint" --
 
 ## Checkpoint Protocol (During Work)
 
-After every logical unit of work, encode to memory:
+After every logical unit of work do **both**:
+
+**A. Beat the pulse** — refreshes the at-risk-files snapshot.
 
 ```bash
-python3 /home/user/ken/orchestrator/memory_ops.py encode cruising insight \
+python3 /home/user/ken/orchestrator/checkpoint.py beat \
+  --session "$SID" --action "edited foo.py: added retry logic"
+```
+
+**B. Encode to cognitive memory** — narrative for resume.
+
+```bash
+python3 /home/user/ken/orchestrator/memory_ops.py encode ken insight \
   "Checkpoint [N]: Edited [file]. Changed [what]. Still needs [remaining]. Risks: [any]." \
   --tags session,checkpoint
 ```
 
-### When to checkpoint:
+### When to checkpoint
+
 - After completing a function or block edit
 - Before switching to a second file
 - Before any find-and-replace touching multiple locations
@@ -52,20 +86,27 @@ python3 /home/user/ken/orchestrator/memory_ops.py encode cruising insight \
 When you see `Rate limit reached` or HTTP 429:
 
 1. **Stop.** Do not retry immediately.
-2. **Encode recovery state to memory:**
+2. **Beat one final time** with the recovery state in `--action`:
 
-```bash
-python3 /home/user/ken/orchestrator/memory_ops.py encode cruising decision \
-  "RATE LIMIT RECOVERY: Interrupted at [step]. File: [name]. Last clean: [state]. Next step: [action]. Do NOT: [incomplete work]." \
-  --tags session,recovery,rate-limit --protected
-```
+   ```bash
+   python3 /home/user/ken/orchestrator/checkpoint.py beat --session "$SID" \
+     --action "RATE LIMIT: paused at <step> in <file>; resume with <next>"
+   ```
 
-3. **Wait 60 seconds** for per-minute limits to reset.
-4. **On resume**, recall the recovery memory first:
+3. **Encode recovery memory:**
 
-```bash
-python3 /home/user/ken/orchestrator/memory_ops.py recall "rate limit recovery" --domain cruising --limit 3
-```
+   ```bash
+   python3 /home/user/ken/orchestrator/memory_ops.py encode ken decision \
+     "RATE LIMIT RECOVERY: Interrupted at [step]. File: [name]. Last clean: [state]. Next step: [action]. Do NOT: [incomplete work]." \
+     --tags session,recovery,rate-limit --protected
+   ```
+
+4. **Wait 60 seconds** for per-minute limits to reset.
+5. **On resume**, run `checkpoint.py scan` first, then recall the recovery memory:
+
+   ```bash
+   python3 /home/user/ken/orchestrator/memory_ops.py recall "rate limit recovery" --domain cruising --limit 3
+   ```
 
 ## Atomic Commit Rules
 
@@ -84,29 +125,44 @@ python3 /home/user/ken/orchestrator/memory_ops.py recall "rate limit recovery" -
 
 ## End of Session
 
-1. Encode final checkpoint to memory (protected)
-2. List deferred issues in a separate memory
-3. Confirm all touched files are consistent
+1. Write/update `HANDOFF.md` if work is incomplete (per the format in CLAUDE.md).
+2. Encode the final checkpoint to cognitive memory (use `--protected` if it's foundational).
+3. **Mark the pulse complete** so the next session doesn't flag it as abandoned:
 
+   ```bash
+   python3 /home/user/ken/orchestrator/checkpoint.py complete --session "$SID"
+   ```
 
-## InTheWake-Specific Target Files
+4. Confirm all touched files are consistent.
 
-| Task type | Load only |
+## Pulse File Reference
+
+Path: `<repo>/.claude/state/session-pulse.json` (per-repo, atomic single-writer).
+
+```json
+{
+  "session_id": "sess-20260428T015432Z-ac3592",
+  "started_at": "2026-04-28T01:54:32+00:00",
+  "last_beat":  "2026-04-28T01:54:41+00:00",
+  "beat_count": 2,
+  "status":     "active",        // "active" | "complete"
+  "last_action": "edited foo.py",
+  "context":     "refactoring retry logic",
+  "files_in_play": ["foo.py"],   // optional, set explicitly via --files
+  "at_risk":     ["foo.py", "bar.py"]  // git-uncommitted, recomputed each beat
+}
+```
+
+Stale threshold: 30 minutes since `last_beat` with `status != "complete"`.
+Stale archive: `<repo>/.claude/state/stale-sessions/<utc-timestamp>-<session-id>.json`.
+
+## CLI Reference
+
+| Command | Purpose |
 |---|---|
-| Port page content | The specific port HTML only |
-| Ship page content | The specific ship HTML only |
-| Tool/calculator bug | The specific tool JS only |
-| CSS change | styles.css only |
-| Service worker | sw.js only |
-| Schema validation | The specific schema JSON only |
-| Standards update | The specific standards .md only |
-
-**Never load all 388 port pages or 298 ship pages at once.**
-
-## Do Not Break List
-
-- Service worker cache version consistent with manifest
-- sitemap.xml entries match actual files
-- precache-manifest.json current
-- All 9 tools functional after any JS change
-- WCAG 2.1 AA compliance on modified pages
+| `checkpoint.py new-id` | Generate a fresh session id. |
+| `checkpoint.py beat --session ID --action TEXT [--context TEXT] [--files A B]` | Record a heartbeat; refreshes at-risk file list. |
+| `checkpoint.py status [--json]` | Show current pulse + at-risk files. |
+| `checkpoint.py scan [--stale-minutes N] [--json]` | If pulse is stale-and-not-complete, archive it and print recovery summary. |
+| `checkpoint.py recover [--json]` | Print recovery summary for the latest pulse. |
+| `checkpoint.py complete [--session ID]` | Mark current pulse complete (graceful end). |


### PR DESCRIPTION
From ken's recent work — second wave of cross-repo lift.

New SessionStart hook (advisory, exits 0 silently if clean):
- session-pulse-scan.sh — scans for an abandoned previous session pulse via /home/user/ken/orchestrator/checkpoint.py and prints a recovery summary if a stale pulse is found.

session-checkpoint SKILL bumped to v2.0.0:
- Adds the session-pulse mechanism (JSON heartbeat at .claude/state/session-pulse.json) alongside the existing cognitive- memory checkpoint protocol. The pulse captures the live list of uncommitted files on each beat so a session that dies before writing HANDOFF.md can still be reconstructed.
- Domain references customized for this repo: --domain cruising

Skipped: keeper/ (ken-only session-continuity CLI), orchestrator/ checkpoint.py (lives in ken; other repos call it cross-repo via path), triad orchestrator mode (ken-only), per-repo orchestrate SKILL updates (intentionally mode-tuned per repo, not replaceable from hub).

https://claude.ai/code/session_01Nao6yBrN63CVjAv6ErHNME