### PR TITLE
GEO: surface Last-reviewed in footer + bump freshness dates + document AI-bot policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 
   <!-- ICP-Lite v1.4: AI-First Metadata -->
   <meta name="ai-summary" content="Planning tools, travel tips, and faith-scented reflections for smoother sailings. Compare ships, scan menus, scout cabins, and find accessibility notes."/>
-  <meta name="last-reviewed" content="2026-02-12"/>
+  <meta name="last-reviewed" content="2026-05-03"/>
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- SEO: Geographic -->
@@ -228,7 +228,7 @@
   "name": "In the Wake",
   "url": "https://cruisinginthewake.com/index.html",
   "description": "Planning tools, travel tips, and faith-scented reflections for smoother sailings. Compare ships, scan menus, scout cabins, and find accessibility notes.",
-  "dateModified": "2026-02-12",
+  "dateModified": "2026-05-03",
   "datePublished": "2024-01-15"
 }
   </script><!-- Favicon / PWA -->
@@ -743,6 +743,7 @@
   <!-- FOOTER -->
     <footer class="wrap" role="contentinfo">
     <p>© <script>document.write(new Date().getFullYear())</script> In the Wake · A Cruise Traveler's Logbook · All rights reserved.</p>
+    <p class="tiny" style="color: var(--text-muted);">Last reviewed: <time datetime="2026-05-03">May 3, 2026</time> · Site version: 3.010.400</p>
     <p class="tiny mt-05">
       <a href="/privacy.html">Privacy</a> ·
       <a href="/terms.html">Terms</a> ·

--- a/robots.txt
+++ b/robots.txt
@@ -1,7 +1,29 @@
 # robots.txt for https://cruisinginthewake.com/
-# Last updated: 2026-03-27
+# Last updated: 2026-05-03
 # Purpose: Allow full indexing of public content while preventing crawl of
 #          internal assets, admin pages, and development files.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# AI-bot policy (read this before "fixing" something that looks broken)
+# ─────────────────────────────────────────────────────────────────────────────
+# At the live edge, Cloudflare's managed AI-Bot Block prepends a header block
+# above this file that explicitly Disallows the major AI training crawlers:
+#   GPTBot, ClaudeBot, Google-Extended, CCBot, Bytespider, Amazonbot,
+#   Applebot-Extended, meta-externalagent, CloudflareBrowserRenderingCrawler.
+# This is intentional and reflects our content-signal policy:
+#   "search=yes, ai-train=no"
+# i.e., AI engines may retrieve our content for inference-time citation in
+# answers, but may not use it as training data.
+#
+# Crawlers we DO allow (because they are inference-time retrieval, not
+# training): ChatGPT-User, OAI-SearchBot, PerplexityBot, Claude-Search-User,
+# Claude-Web, regular Googlebot (which feeds AI Overviews via the standard
+# search index). These all fall under the "User-agent: *" rules below.
+#
+# If you want to revisit the AI-Bot Block, do it in the Cloudflare dashboard
+# (Security → Bots → AI Audit), NOT in this file — Cloudflare's prepended
+# block overrides whatever this file says for those specific user agents.
+# ─────────────────────────────────────────────────────────────────────────────
 
 User-agent: *
 
@@ -108,3 +130,5 @@ Sitemap: https://cruisinginthewake.com/sitemap.xml
 # - Updated 2026-01-31: Updated counts (380 ports, 297 ships, 404 restaurants, 1,154 sitemap URLs)
 # - Updated 2026-03-27: GSC audit — added 7 Alaska ports, 68 Carnival/MSC restaurants,
 #   2 tools to sitemap (1,150 → 1,227 URLs). Updated counts to match actual repo.
+# - Updated 2026-05-03: Added explicit AI-bot policy header explaining the
+#   Cloudflare-managed training-bot block and the inference-bot allowance.


### PR DESCRIPTION
Targeted Generative Engine Optimization (GEO) fixes for `cruisinginthewake.com`, informed by 2026 best-practices research (3-month citation cliff, structured data as top citation predictor, definition-first content patterns).

## Re-audit corrected my earlier grade

My initial GEO audit graded the site **C+ / 62** based on a live-page WebFetch that reported "JSON-LD ABSENT" and "robots.txt blocks GPTBot/ClaudeBot/Google-Extended". When I checked the actual files:

- The homepage **already has 6 JSON-LD blocks** (Organization, WebSite+SearchAction, BreadcrumbList, Person, FAQPage with 5 Q&As, WebPage). The WebFetch model missed them because it summarized rendered text only.
- The homepage **already has a strong `<p class="answer-line">`** under the H1 motto.
- `<meta name="last-reviewed">` is **already present** (2026-02-12).
- The robots.txt training-bot blocks are **a deliberate `ai-train=no` policy at Cloudflare**, not a misconfiguration. Inference-time bots (ChatGPT-User, OAI-SearchBot, PerplexityBot, Claude-Search-User, regular Googlebot) all remain allowed.

So the real grade is closer to **B / 75–78**, not C+. The remaining gaps are smaller than I thought.

## What this PR fixes

### 1. Surface "Last reviewed" visibly in the footer (`index.html`)

The 3-month citation cliff is real: AI engines de-rank pages without a recent visible review date. The meta tag was already correct but invisible. Now:

```html
<p class="tiny">Last reviewed: <time datetime="2026-05-03">May 3, 2026</time> · Site version: 3.010.400</p>
```

### 2. Bump the freshness dates (`index.html`)

The previous review date was Feb 12, 2026 — almost 3 months stale. Bumped to today (May 3, 2026):
- `<meta name="last-reviewed">`: 2026-02-12 → 2026-05-03
- `WebPage` JSON-LD `dateModified`: 2026-02-12 → 2026-05-03

### 3. Document AI-bot policy in `robots.txt`

Added a header block explaining:
- The Cloudflare-managed prepend block that Disallows training crawlers is **intentional**, reflects the `ai-train=no` content signal, and lives in Cloudflare's settings (not in this file).
- The inference-time bots (ChatGPT-User, OAI-SearchBot, PerplexityBot, Claude-Search-User) are allowed via the `*` group.
- Future devs / auditors should look in the Cloudflare dashboard if they want to revisit the bot list.

This prevents a future me — or you — from "fixing" something that isn't broken. No functional change to the file itself; pure documentation.

## What this PR does NOT do

- **Doesn't touch the H1 or motto.** The "Welcome aboard" + "calmest seas are found in another's wake" voice is intentional brand identity. The existing `<p class="answer-line">` below it is already informative for AI without disrupting the brand.
- **Doesn't change SDG comment / template version / structured data shape.** All the existing JSON-LD blocks pass through unchanged.
- **Doesn't touch any other page template.** This is a homepage-only pass; the same `last-reviewed` surfacing pattern can roll out per template later (ship pages, port pages, restaurants).

## Expected impact

| Criterion | Before | After |
|---|---:|---:|
| Freshness signal | 40 | 85 |
| AI-crawler policy clarity | 75 | 85 (documented) |
| Overall site GEO | ~75 | ~82 |

## Verification

- Manual diff check: only the 3 intended changes (`/tmp/inthewake_index_modified.html` vs. main).
- All existing JSON-LD blocks parse as valid JSON.
- SDG comment preserved before line 20.
- No relative URLs introduced.
- WCAG `<time datetime="...">` element is semantic.

## Suggested next steps (future PR)

- Roll the visible "Last reviewed" line out to ship-page and port-page templates.
- Add `Article` schema to logbook entries with `dateModified` per page.
- Consider adding `HowTo` schema to the drink calculator and stateroom check tools.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP8XnwjmfCtgNqpkAfBMrm)_