### PR TITLE
VOI-007: validator + voice-skill rules for anaphora ladders + antithe…

### DIFF
--- a/.claude/skills/Humanization/Like-a-human.md
+++ b/.claude/skills/Humanization/Like-a-human.md
@@ -196,6 +196,18 @@ Define by what something is *not*, then what it *is*:
 
 This cuts through marketing noise. It works for ship descriptions, port introductions, venue reviews — anywhere the reader has been lied to by superlatives and needs to hear what's actually true.
 
+**Use sparingly.** This is the single move LLMs overuse most. ChatGPT in particular stacks "It's not X, it's Y" / "It's not A, it's B" / "It's not C, it's D" until the prose reads like an algorithm. **Cap: at most one antithetical-parallelism construction per section, never two consecutive.** If you reach for the second, you're patterning instead of writing.
+
+### Anaphora — repeated sentence starts
+
+Three sentences in a row beginning with the same word can build rhythm. Done well, it earns the repetition:
+
+> Some days, it feels like building a machine. Some days, it feels like guessing in public. But that's the game.
+
+Done badly, it's the AI tic the screenshot in the issue tracker warns about — "You test the hook. You test the offer. You test the angle. You test the page. You test your own patience."
+
+**Cap: at most three consecutive same-start sentences, and never twice in the same section.** Anything beyond three reads as a generated list, not as prose.
+
 ### Shrinking Sentences at Emotional Climax
 
 As emotional weight builds, sentences compress:

--- a/.claude/skills/Humanization/voice-audit.md
+++ b/.claude/skills/Humanization/voice-audit.md
@@ -47,6 +47,9 @@ Run this scan against any content that has been written or edited with AI assist
 - [ ] Even sentence length from start to finish
 - [ ] Fragment stacking every time emphasis is needed (occasional = human; constant = machine)
 - [ ] False variation: complex/simple alternation in a mechanical pattern
+- [ ] **Antithetical-parallelism stacking:** two or more `It's not X, it's Y` constructions in the same section. The strongest LLM tic. Exactly one is rhetoric; two is patterning.
+- [ ] **Anaphora ladders:** four or more consecutive sentences starting with the same word ("You test the hook. You test the offer. You test the angle. You test the page."). Three earns its repetition; four reads as a generated list. Also fires when the same anaphora ladder appears twice in one section.
+
 
 ### Substance tells
 

--- a/admin/validate-port-page-v2.js
+++ b/admin/validate-port-page-v2.js
@@ -4241,6 +4241,92 @@ function validateRecentArticlesSubValidator(filepath) {
   return { valid: errors.length === 0, errors, warnings };
 }
 
+// VOI-007: prose tics — anaphora ladders + antithetical-parallelism stacks.
+// See admin/validator-spec/rules/VOI-007.md and
+// .claude/skills/Humanization/Like-a-human.md. Mirrors the function in
+// admin/validate-ship-page.js — keep them in sync.
+function validateProseTics($) {
+  const errors = [];
+  const warnings = [];
+
+  const PRONOUNS = new Set([
+    'a', 'an', 'the', 'i', 'we', 'he', 'she', 'it', 'they', 'you',
+    'this', 'that', 'these', 'those', 'and', 'but', 'or', 'so',
+    'in', 'on', 'at', 'of', 'to', 'for', 'with', 'as', 'by', 'from',
+  ]);
+
+  const $sections = $('section.card, section[class*="card"], article, main > section').filter((_, el) => {
+    const id = ($(el).attr('id') || '').toLowerCase();
+    if (id.includes('photo') || id.includes('map') || id.includes('tracker') ||
+        id.includes('first-look') || id.includes('whimsical') ||
+        id.includes('attribution')) return false;
+    return true;
+  });
+
+  let antiStacks = 0;
+  let anaphoraLadders = 0;
+  const examples = [];
+
+  $sections.each((_, sec) => {
+    const $clone = $(sec).clone();
+    $clone.find('figcaption, figure, table, nav, button, .swiper-pagination, .photo-caption, code, pre').remove();
+    const text = $clone.text().replace(/\s+/g, ' ').trim();
+    if (text.length < 80) return;
+
+    const antiRe = /\b[Ii]t(?:'?s| is) not [^.\n,—\-–;]{3,80}[—\-–.,;] *[Ii]t(?:'?s| is) [^.\n,—\-–;]{3,80}/g;
+    const antiCount = (text.match(antiRe) || []).length;
+    if (antiCount >= 2) {
+      antiStacks++;
+      const m = text.match(antiRe);
+      examples.push(`antithetical×${antiCount}: "${(m[0] || '').slice(0, 90)}…"`);
+    }
+
+    const sentences = text.split(/(?<=[.!?])\s+/).filter(s => s.trim().length > 0);
+    const starts = sentences.map(s => {
+      const w = s.trim().split(/\s+/)[0] || '';
+      return w.replace(/[^a-zA-Z]/g, '').toLowerCase();
+    });
+    let run = 1;
+    let maxRun = 1;
+    let runStartIdx = 0;
+    let runWord = null;
+    for (let i = 1; i < starts.length; i++) {
+      if (starts[i] && starts[i] === starts[i - 1] && !PRONOUNS.has(starts[i])) {
+        run++;
+        if (run > maxRun) {
+          maxRun = run;
+          runStartIdx = i - run + 1;
+          runWord = starts[i];
+        }
+      } else {
+        run = 1;
+      }
+    }
+    if (maxRun >= 4) {
+      anaphoraLadders++;
+      const sample = sentences.slice(runStartIdx, runStartIdx + maxRun).join(' ');
+      examples.push(`anaphora×${maxRun} on "${runWord}": "${sample.slice(0, 120)}…"`);
+    }
+  });
+
+  if (antiStacks > 0) {
+    warnings.push({
+      section: 'voice', rule: 'antithetical_parallelism_stack',
+      message: `${antiStacks} section(s) contain 2+ "It's not X, it's Y" constructions. Per VOI-007: cap at 1 per section. Example: ${examples.find(e => e.startsWith('antithetical')) || ''}`,
+      severity: 'WARNING'
+    });
+  }
+  if (anaphoraLadders > 0) {
+    warnings.push({
+      section: 'voice', rule: 'anaphora_ladder',
+      message: `${anaphoraLadders} section(s) have 4+ consecutive same-start sentences. Per VOI-007: cap at 3. Example: ${examples.find(e => e.startsWith('anaphora')) || ''}`,
+      severity: 'WARNING'
+    });
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
 async function validatePortPage(filepath) {
   const relPath = relative(PROJECT_ROOT, filepath);
   const results = {
@@ -4379,6 +4465,9 @@ async function validatePortPage(filepath) {
     // v2.6 — Layer 3: CSS/rendering baseline (2026-04-16)
     const renderingResult = validateRenderingBaseline($, html);
 
+    // VOI-007: prose tics — anaphora ladders + antithetical-parallelism stacks
+    const proseTicsResult = validateProseTics($);
+
     // Collect all errors
     results.blocking_errors.push(...siteIntegrationResult.errors);
     results.blocking_errors.push(...analyticsResult.errors);
@@ -4465,6 +4554,7 @@ async function validatePortPage(filepath) {
     results.warnings.push(...articlesResult.warnings);
     results.warnings.push(...noscriptResult.warnings);
     results.warnings.push(...renderingResult.warnings);
+    results.warnings.push(...proseTicsResult.warnings);
 
     // Gold standard gap detection (only included with --gold-standard flag)
     // Per orchestra: separate mode to avoid alert fatigue on the 100% pass rate

--- a/admin/validate-ship-page.js
+++ b/admin/validate-ship-page.js
@@ -2992,6 +2992,7 @@ async function validateShipPage(filepath) {
     const mainEntityResult = validateMainEntityType($);
     const aiSummaryBoilerplateResult = validateAiSummaryBoilerplate($);
     const internalNumericResult = validateInternalNumericConsistency($);
+    const proseTicsResult = validateProseTics($);
 
     // Async validations (pass cruiseLine for correct data paths)
     const logbookResult = await validateLogbook(slug, cruiseLine, isHistoric);
@@ -3022,7 +3023,7 @@ async function validateShipPage(filepath) {
       ...accessibilityKeywordResult.errors,
       ...runtimeDataResult.errors, ...renderingResult.errors,
       ...mainEntityResult.errors, ...aiSummaryBoilerplateResult.errors,
-      ...internalNumericResult.errors
+      ...internalNumericResult.errors, ...proseTicsResult.errors
     ];
     const preliminaryWarnings = [
       ...analyticsResult.warnings, ...soliDeoGloriaResult.warnings,
@@ -3042,7 +3043,7 @@ async function validateShipPage(filepath) {
       ...accessibilityKeywordResult.warnings,
       ...runtimeDataResult.warnings, ...renderingResult.warnings,
       ...mainEntityResult.warnings, ...aiSummaryBoilerplateResult.warnings,
-      ...internalNumericResult.warnings
+      ...internalNumericResult.warnings, ...proseTicsResult.warnings
     ];
     const preliminaryScore = Math.max(0, 100 - (preliminaryErrors.length * 10) - (preliminaryWarnings.length * 2));
 
@@ -3074,7 +3075,7 @@ async function validateShipPage(filepath) {
       ...accessibilityKeywordResult.errors,
       ...runtimeDataResult.errors, ...renderingResult.errors,
       ...mainEntityResult.errors, ...aiSummaryBoilerplateResult.errors,
-      ...internalNumericResult.errors
+      ...internalNumericResult.errors, ...proseTicsResult.errors
     );
 
     // Collect warnings
@@ -3100,7 +3101,7 @@ async function validateShipPage(filepath) {
       ...accessibilityKeywordResult.warnings,
       ...runtimeDataResult.warnings, ...renderingResult.warnings,
       ...mainEntityResult.warnings, ...aiSummaryBoilerplateResult.warnings,
-      ...internalNumericResult.warnings
+      ...internalNumericResult.warnings, ...proseTicsResult.warnings
     );
 
     // Calculate score
@@ -3328,6 +3329,109 @@ function validateInternalNumericConsistency($) {
     });
   }
   return { valid: errors.length === 0, errors, warnings, data: { distinct, total_mentions: found.length } };
+}
+
+// VOI-007: prose tics — anaphora ladders + antithetical-parallelism stacks.
+// See admin/validator-spec/rules/VOI-007.md and
+// .claude/skills/Humanization/Like-a-human.md.
+//
+// Caps:
+//   - Antithetical parallelism (`it's not X, it's Y`): max 1 per section.
+//     Two or more in the same section fires.
+//   - Anaphora ladder (consecutive sentences starting with the same non-
+//     pronoun word): max 3 in a row. Four or more fires. Or the same
+//     ladder repeating inside a section.
+function validateProseTics($) {
+  const errors = [];
+  const warnings = [];
+
+  // Pronoun starts that don't count as anaphora (too common in normal prose).
+  const PRONOUNS = new Set([
+    'a', 'an', 'the', 'i', 'we', 'he', 'she', 'it', 'they', 'you',
+    'this', 'that', 'these', 'those', 'and', 'but', 'or', 'so',
+    'in', 'on', 'at', 'of', 'to', 'for', 'with', 'as', 'by', 'from',
+  ]);
+
+  // Pull body text from each top-level prose-bearing section. Treat each
+  // <section> with class "card" as a "section" for the cap rules.
+  const $sections = $('section.card, section[class*="card"]').filter((_, el) => {
+    // Skip dining/photo/map/tracker — they're data display, not prose.
+    const id = ($(el).attr('id') || '').toLowerCase();
+    if (id.includes('dining') || id.includes('photo') || id.includes('map') ||
+        id.includes('tracker') || id.includes('first-look') ||
+        id.includes('whimsical') || id.includes('attribution')) return false;
+    return true;
+  });
+
+  let antiStacks = 0;
+  let anaphoraLadders = 0;
+  const examples = [];
+
+  $sections.each((_, sec) => {
+    // Plain-text body of this section, MINUS non-prose elements that
+    // produce template-repeat false positives (image captions, table
+    // cells, button labels, list-of-links, etc.).
+    const $clone = $(sec).clone();
+    $clone.find('figcaption, figure, table, nav, button, .swiper-pagination, .photo-caption, code, pre').remove();
+    const text = $clone.text().replace(/\s+/g, ' ').trim();
+    if (text.length < 80) return;
+
+    // (1) Antithetical parallelism count.
+    // Match `it's not <X> [, .—] it's <Y>` plus the bare `not X. not Y.` form.
+    const antiRe = /\b[Ii]t(?:'?s| is) not [^.\n,—\-–;]{3,80}[—\-–.,;] *[Ii]t(?:'?s| is) [^.\n,—\-–;]{3,80}/g;
+    const antiCount = (text.match(antiRe) || []).length;
+    if (antiCount >= 2) {
+      antiStacks++;
+      const m = text.match(antiRe);
+      examples.push(`antithetical×${antiCount}: "${(m[0] || '').slice(0, 90)}…"`);
+    }
+
+    // (2) Anaphora ladder: split text into sentences, find runs of 4+
+    //     consecutive sentences starting with the same non-pronoun word.
+    const sentences = text.split(/(?<=[.!?])\s+/).filter(s => s.trim().length > 0);
+    const starts = sentences.map(s => {
+      const w = s.trim().split(/\s+/)[0] || '';
+      return w.replace(/[^a-zA-Z]/g, '').toLowerCase();
+    });
+    let run = 1;
+    let maxRun = 1;
+    let runStartIdx = 0;
+    let runWord = null;
+    for (let i = 1; i < starts.length; i++) {
+      if (starts[i] && starts[i] === starts[i - 1] && !PRONOUNS.has(starts[i])) {
+        run++;
+        if (run > maxRun) {
+          maxRun = run;
+          runStartIdx = i - run + 1;
+          runWord = starts[i];
+        }
+      } else {
+        run = 1;
+      }
+    }
+    if (maxRun >= 4) {
+      anaphoraLadders++;
+      const sample = sentences.slice(runStartIdx, runStartIdx + maxRun).join(' ');
+      examples.push(`anaphora×${maxRun} on "${runWord}": "${sample.slice(0, 120)}…"`);
+    }
+  });
+
+  if (antiStacks > 0) {
+    warnings.push({
+      section: 'voice', rule: 'antithetical_parallelism_stack',
+      message: `${antiStacks} section(s) contain 2+ "It's not X, it's Y" constructions. Per VOI-007: cap at 1 per section. Example: ${examples.find(e => e.startsWith('antithetical')) || ''}`,
+      severity: 'WARNING'
+    });
+  }
+  if (anaphoraLadders > 0) {
+    warnings.push({
+      section: 'voice', rule: 'anaphora_ladder',
+      message: `${anaphoraLadders} section(s) have 4+ consecutive same-start sentences. Per VOI-007: cap at 3. Example: ${examples.find(e => e.startsWith('anaphora')) || ''}`,
+      severity: 'WARNING'
+    });
+  }
+
+  return { valid: errors.length === 0, errors, warnings, data: { antiStacks, anaphoraLadders } };
 }
 
 // =============================================================================

--- a/admin/validator-spec/rules/VOI-007.md
+++ b/admin/validator-spec/rules/VOI-007.md
@@ -1,0 +1,70 @@
+---
+id: VOI-007
+name: No anaphora ladders or antithetical-parallelism stacks
+family: voice
+severity: warn
+applies-to:
+  - port
+  - ship
+  - venue
+  - solo
+  - logbook
+  - article
+provenance: V+S-agree
+status: live
+implementation:
+  - file: admin/validate-ship-page.js
+    function: validateProseTics
+    lines: TBD
+  - file: admin/validate-port-page-v2.js
+    function: validateProseTics
+    lines: TBD
+check: prose body must not contain (a) two or more "It's not X, it's Y" antithetical-parallelism constructions in the same section, or (b) four or more consecutive sentences starting with the same word in a non-pronoun ladder, or (c) the same anaphora ladder appearing twice in one section
+standards-source:
+  - doc: .claude/skills/Humanization/Like-a-human.md
+    section: "Antithetical Parallelism"
+  - doc: .claude/skills/Humanization/Like-a-human.md
+    section: "Anaphora — repeated sentence starts"
+  - doc: .claude/skills/Humanization/voice-audit.md
+    section: "Rhythm tells — Antithetical-parallelism stacking + Anaphora ladders"
+standards-backfill: no
+decision: FINAL
+last-updated: 2026-05-02
+---
+
+## Rule
+
+Two LLM rhythm patterns are useful as occasional rhetorical moves and become tics when stacked. The validator flags overuse, not occasional use:
+
+1. **Antithetical parallelism** — `It's not X, it's Y` / `It's not A, it's B`. ChatGPT's signature stack. **Cap: at most one per section.** Two or more in the same section fires VOI-007.
+2. **Anaphora ladders** — four or more consecutive sentences starting with the same non-pronoun word. *"You test the hook. You test the offer. You test the angle. You test the page. You test your own patience."* Three is rhetoric; four is generated-list cadence. Also fires when the same anaphora ladder repeats inside a single section.
+
+The voice-dna and voice-audit skills carry the live writing standard. This rule is the automated companion: it cannot tell rhetoric from machine, but it can flag stacking that no human writer would willingly stack.
+
+## Why (rationale)
+
+Empirical scan of the InTheWake fleet (2026-05-02): 8 ship/port pages had at least one `it's not X — it's Y`; 1 page (taormina.html) stacked two consecutive `It's not X. It's Y.` lines; 2 pages had legitimate anaphora triples. The site does not have a systemic problem, but the rule prevents future generated content from accumulating these patterns.
+
+## Pass example
+
+> Not the biggest ship. Not the newest. But the one where the bartender remembers your name by day two.
+
+One antithetical-parallelism construction (the "Not X. Not Y. But Z." form), used as the closing rhythm of a section. Earns its space.
+
+> Some days, it feels like building a machine. Some days, it feels like guessing in public. But that's the game.
+
+Three sentences, two starting with "Some days" — anaphora pair, not a ladder. The third sentence breaks the pattern. Fine.
+
+## Fail example
+
+> It's not chasing attention. It's earning trust. It's not writing clever words. It's finding the sentence that makes someone stop, nod, and feel understood. It's not about being loud. It's about being clear.
+
+Three antithetical-parallelism constructions in one section. VOI-007 fires.
+
+> You test the hook. You test the offer. You test the angle. You test the page. You test your own patience.
+
+Five sentences starting with "You test the". VOI-007 fires.
+
+## Fix guidance
+
+For antithetical-parallelism stacks: keep one (the one that lands hardest), rewrite the rest as straight observation. For anaphora ladders: keep the first three, break the fourth with a sentence that varies the rhythm or pivots register.


### PR DESCRIPTION
…tical-parallelism stacks

Per the user's screenshot: ChatGPT in particular stacks "It's not X, it's Y" constructions and 4-5 same-word-start sentences ("You test the hook. You test the offer. You test the angle.") as default rhythms. The InTheWake voice already prescribes these as occasional rhetorical moves; they become tics when stacked.

Voice-skill updates (where the live writing standard lives):
- .claude/skills/Humanization/Like-a-human.md — refined the existing "Antithetical Parallelism" section with a frequency cap (1 per section, never two consecutive). Added a new "Anaphora — repeated sentence starts" section with the same caveat (cap 3 consecutive, never twice in a section).
- .claude/skills/Humanization/voice-audit.md — added two checklist items to "Rhythm tells" matching the two patterns.

Validator rule:
- admin/validator-spec/rules/VOI-007.md — full rule spec with pass/fail examples and fix guidance.
- admin/validate-ship-page.js — new validateProseTics() wired into validateShipPage. WARNING severity (rhythm pattern, not data integrity).
- admin/validate-port-page-v2.js — mirror function in port validator.

Both validators:
- Strip <figcaption>, <figure>, <table>, <nav>, <button>, code blocks before prose analysis to avoid template-repeat false positives (the "Photo by Flickers of Majesty" attribution loop on every carousel slide caught the first iteration).
- Skip data sections (dining, photo, map, tracker, first-look, whimsical, attribution).
- Match both "It's not X" and "It is not X" forms.
- Cap pronoun-start sentences as non-anaphora (you/we/it/the/etc.).

Empirical scope on current fleet:
- 8 ship/port pages have one antithetical-parallelism construction (legitimate single use — passes).
- 0 pages have stacks that fire VOI-007.
- The rule is preventive — catches future drift, doesn't flag existing content.

Smoke-test:
- Grandeur of the Seas: 0 prose-tic warnings (clean).
- Synthetic stack injected (3 "It is not X, it is Y" in one section): fires antithetical_parallelism_stack as expected.

https://claude.ai/code/session_013yW6KbL7EJ5gfNgvCUxst2