### PR TITLE
ports: revert fabricated hazard prose from PR 2 (careful-not-clever)

### DIFF
--- a/admin/backfill-weather-seasonal-guide.cjs
+++ b/admin/backfill-weather-seasonal-guide.cjs
@@ -67,20 +67,41 @@ function pickActivityMonths(port, label) {
   return 'N/A';
 }
 
+/**
+ * Render the hazard-warning block ONLY when the source JSON has truthful data.
+ *
+ * Two truthful sources, in priority order:
+ *   1. hurricane_zone === true → real hurricane warning with hurricane_season,
+ *      peak_risk_months, and (when present) hazards.note
+ *   2. hazards.note exists → render the curated note verbatim
+ *
+ * If neither: return empty string. The validator will then fail H001/H002
+ * on those pages (hazard-warning required) — that is the honest cost of not
+ * having curated hazard data, and it surfaces the gap so it can be filled
+ * by humans rather than papered over with template filler.
+ *
+ * NOTE: a prior version of this generator emitted a fabricated "Off-Season
+ * Weather" block when neither truthful source existed. That violated the
+ * careful-not-clever doctrine ("Never fabricate to satisfy a structural
+ * check") and shipped to 35 ports before being reverted.
+ */
 function renderHazard(port) {
   const h = port.hazards || {};
   if (h.hurricane_zone) {
-    const season = h.hurricane_season || 'Jun 1 – Nov 30';
+    const season = h.hurricane_season || '';
     const peak = Array.isArray(h.peak_risk_months) ? h.peak_risk_months.join(', ') : '';
-    const note = h.note || 'Travel insurance with weather-event coverage is recommended.';
+    const note = h.note || '';
+    const lines = [
+      `                        <strong>Hurricane Zone</strong>`,
+      season ? `                        <p>Season: ${escapeHTML(season)}</p>` : '',
+      peak ? `                        <p>Peak risk: ${escapeHTML(peak)}</p>` : '',
+      note ? `                        <p class="hazard-note">${escapeHTML(note)}</p>` : '',
+    ].filter(Boolean).join('\n');
     return `
                     <div class="hazard-warning">
                       <span class="hazard-icon">🌀</span>
                       <div class="hazard-content">
-                        <strong>Hurricane Zone</strong>
-                        <p>Season: ${escapeHTML(season)}</p>
-                        ${peak ? `<p>Peak risk: ${escapeHTML(peak)}</p>` : ''}
-                        <p class="hazard-note">${escapeHTML(note)}</p>
+${lines}
                       </div>
                     </div>`;
   }
@@ -94,29 +115,22 @@ function renderHazard(port) {
                       </div>
                     </div>`;
   }
-  // Fallback: derive from avoid_months
-  const avoid = joinMonths(port.avoid_months || []);
-  return `
-                    <div class="hazard-warning">
-                      <span class="hazard-icon">⚠️</span>
-                      <div class="hazard-content">
-                        <strong>Off-Season Weather</strong>
-                        <p>Months to weigh carefully: ${escapeHTML(avoid)}</p>
-                        <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                      </div>
-                    </div>`;
+  // Neither hurricane_zone nor a curated hazards.note. Emit nothing so the
+  // validator can flag the gap honestly, rather than silencing it with filler.
+  return '';
 }
 
 function renderSeasonalGuide(port) {
   const g = port.at_a_glance || {};
   const cs = port.cruise_seasons || { high: [], transitional: [], low: [] };
+  // Emit only what the JSON registry has. Do NOT pad to satisfy validator
+  // minimums — fabricating filler is the careful-not-clever violation
+  // ("Never fabricate to satisfy a structural check"). If a port has fewer
+  // than 3 catches or packing items the validator will fail CATCH_003 /
+  // PACK_003, which honestly surfaces the gap for human curation.
   const catches = (port.catches_off_guard || []).slice(0, 7);
   const packing = (port.packing_nudges || []).slice(0, 7);
   const avoid = joinMonths(port.avoid_months || []);
-
-  // Pad catches/packing to a minimum of 3 if the registry under-supplied
-  while (catches.length < 3) catches.push('Verify current conditions and ship return-to-pier deadlines on the day of arrival.');
-  while (packing.length < 3) packing.push('Check the weather forecast 48 hours before sail-in and adjust layers accordingly.');
 
   const activitiesHTML = ACTIVITY_LABELS.map(label => {
     const months = pickActivityMonths(port, label);
@@ -177,13 +191,17 @@ ${packingHTML}
                   </div>
                 </details>
 
-                <details class="seasonal-section" open>
+${(() => {
+  const hazardHTML = renderHazard(port);
+  if (!hazardHTML) return ''; // No truthful hazard data; omit the section entirely
+  return `                <details class="seasonal-section" open>
                   <summary class="seasonal-section-title">Weather Hazards</summary>
-                  <div class="seasonal-hazards">${renderHazard(port)}
+                  <div class="seasonal-hazards">${hazardHTML}
                   </div>
                 </details>
 
-                <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
+`;
+})()}                <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
               </div>
             </noscript>`;
 }
@@ -230,7 +248,7 @@ function renameSidebarGlance(html) {
  * If no <noscript> exists inside the widget, insert one immediately after the
  * widget's opening tag.
  */
-function backfill(html, portSlug) {
+function backfill(html, portSlug, opts = {}) {
   const port = seasonalGuides[portSlug];
   if (!port) return { changed: false, reason: `port "${portSlug}" not in seasonal-guides.json` };
 
@@ -241,11 +259,13 @@ function backfill(html, portSlug) {
   const widgetStart = widgetMatch.index;
   const afterTag = widgetStart + widgetMatch[0].length;
 
-  // Look for an existing seasonal-guide already in the widget — if so, only the
-  // sidebar rename runs; the widget content is left alone.
+  // Look for an existing seasonal-guide already in the widget. By default
+  // we skip these (PR 2 idempotency); with --force we replace the existing
+  // <noscript> block too — needed for re-rendering after generator fixes
+  // (e.g., reverting fabricated hazard prose).
   const widgetSlice = html.substring(widgetStart, widgetStart + 10000);
   const widgetAlreadyHasGuide = /class="seasonal-guide/.test(widgetSlice);
-  if (widgetAlreadyHasGuide) {
+  if (widgetAlreadyHasGuide && !opts.force) {
     const { html: renamedHtml, renamed } = renameSidebarGlance(html);
     if (renamed > 0) return { changed: true, html: renamedHtml, reason: `sidebar At a Glance renamed (${renamed})` };
     return { changed: false, reason: 'widget already has class="seasonal-guide" (skip)' };
@@ -285,6 +305,7 @@ function backfill(html, portSlug) {
 function main() {
   const args = process.argv.slice(2);
   const apply = args.includes('--apply');
+  const force = args.includes('--force');
   const explicitFiles = args.filter(a => a.endsWith('.html'));
 
   let portFiles;
@@ -308,7 +329,7 @@ function main() {
     if ((bodyType || metaType || 'port') !== 'port') { nonPort++; continue; }
 
     const slug = path.basename(filePath, '.html');
-    const result = backfill(html, slug);
+    const result = backfill(html, slug, { force });
     const rel = path.relative(path.join(__dirname, '..'), filePath);
 
     if (!result.changed) {

--- a/ports/alexandria.html
+++ b/ports/alexandria.html
@@ -282,20 +282,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Jul, Aug</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/antarctic-peninsula.html
+++ b/ports/antarctic-peninsula.html
@@ -280,20 +280,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Apr, May, Jun, Jul, Aug, Sep, Oct</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/antarctica.html
+++ b/ports/antarctica.html
@@ -278,20 +278,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Apr, May, Jun, Jul, Aug, Sep, Oct</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/bangkok.html
+++ b/ports/bangkok.html
@@ -278,20 +278,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Aug, Sep</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/bar-harbor.html
+++ b/ports/bar-harbor.html
@@ -280,20 +280,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Dec, Jan, Feb, Mar</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/bay-of-islands.html
+++ b/ports/bay-of-islands.html
@@ -517,20 +517,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/brisbane.html
+++ b/ports/brisbane.html
@@ -537,20 +537,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/brunei.html
+++ b/ports/brunei.html
@@ -552,20 +552,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/buenos-aires.html
+++ b/ports/buenos-aires.html
@@ -538,20 +538,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/buzios.html
+++ b/ports/buzios.html
@@ -313,20 +313,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/callao.html
+++ b/ports/callao.html
@@ -541,20 +541,6 @@ Soli Deo Gloria
                                 </div>
                               </details>
               
-                              <details class="seasonal-section" open>
-                                <summary class="seasonal-section-title">Weather Hazards</summary>
-                                <div class="seasonal-hazards">
-                                  <div class="hazard-warning">
-                                    <span class="hazard-icon">⚠️</span>
-                                    <div class="hazard-content">
-                                      <strong>Off-Season Weather</strong>
-                                      <p>Months to weigh carefully: N/A</p>
-                                      <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                    </div>
-                                  </div>
-                                </div>
-                              </details>
-              
                               <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                             </div>
                           </noscript>

--- a/ports/cape-cod.html
+++ b/ports/cape-cod.html
@@ -280,20 +280,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Jan, Feb, Mar</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/casablanca.html
+++ b/ports/casablanca.html
@@ -226,20 +226,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/charlottetown.html
+++ b/ports/charlottetown.html
@@ -230,20 +230,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Dec, Jan, Feb, Mar</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/cherbourg.html
+++ b/ports/cherbourg.html
@@ -230,20 +230,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/chilean-fjords.html
+++ b/ports/chilean-fjords.html
@@ -294,20 +294,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Jun, Jul, Aug</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/cork.html
+++ b/ports/cork.html
@@ -539,20 +539,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/dakar.html
+++ b/ports/dakar.html
@@ -571,20 +571,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Aug, Sep</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/denali.html
+++ b/ports/denali.html
@@ -448,20 +448,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                         </div>
                       </details>
       
-                      <details class="seasonal-section" open>
-                        <summary class="seasonal-section-title">Weather Hazards</summary>
-                        <div class="seasonal-hazards">
-                          <div class="hazard-warning">
-                            <span class="hazard-icon">⚠️</span>
-                            <div class="hazard-content">
-                              <strong>Off-Season Weather</strong>
-                              <p>Months to weigh carefully: Nov, Dec, Jan, Feb, Mar</p>
-                              <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                            </div>
-                          </div>
-                        </div>
-                      </details>
-      
                       <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                     </div>
                   </noscript>

--- a/ports/drake-passage.html
+++ b/ports/drake-passage.html
@@ -311,20 +311,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                         </div>
                       </details>
       
-                      <details class="seasonal-section" open>
-                        <summary class="seasonal-section-title">Weather Hazards</summary>
-                        <div class="seasonal-hazards">
-                          <div class="hazard-warning">
-                            <span class="hazard-icon">⚠️</span>
-                            <div class="hazard-content">
-                              <strong>Off-Season Weather</strong>
-                              <p>Months to weigh carefully: Apr, May, Jun, Jul, Aug, Sep, Oct</p>
-                              <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                            </div>
-                          </div>
-                        </div>
-                      </details>
-      
                       <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                     </div>
                   </noscript>

--- a/ports/dubai.html
+++ b/ports/dubai.html
@@ -560,20 +560,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Jun, Jul, Aug</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/easter-island.html
+++ b/ports/easter-island.html
@@ -568,20 +568,6 @@ Soli Deo Gloria
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/fairbanks.html
+++ b/ports/fairbanks.html
@@ -446,20 +446,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                         </div>
                       </details>
       
-                      <details class="seasonal-section" open>
-                        <summary class="seasonal-section-title">Weather Hazards</summary>
-                        <div class="seasonal-hazards">
-                          <div class="hazard-warning">
-                            <span class="hazard-icon">⚠️</span>
-                            <div class="hazard-content">
-                              <strong>Off-Season Weather</strong>
-                              <p>Months to weigh carefully: Nov, Dec, Jan</p>
-                              <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                            </div>
-                          </div>
-                        </div>
-                      </details>
-      
                       <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                     </div>
                   </noscript>

--- a/ports/glacier-alley.html
+++ b/ports/glacier-alley.html
@@ -279,20 +279,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                               </div>
                             </details>
             
-                            <details class="seasonal-section" open>
-                              <summary class="seasonal-section-title">Weather Hazards</summary>
-                              <div class="seasonal-hazards">
-                                <div class="hazard-warning">
-                                  <span class="hazard-icon">⚠️</span>
-                                  <div class="hazard-content">
-                                    <strong>Off-Season Weather</strong>
-                                    <p>Months to weigh carefully: Jun, Jul, Aug</p>
-                                    <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                  </div>
-                                </div>
-                              </div>
-                            </details>
-            
                             <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                           </div>
                         </noscript>

--- a/ports/glasgow.html
+++ b/ports/glasgow.html
@@ -636,20 +636,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                               </div>
                             </details>
             
-                            <details class="seasonal-section" open>
-                              <summary class="seasonal-section-title">Weather Hazards</summary>
-                              <div class="seasonal-hazards">
-                                <div class="hazard-warning">
-                                  <span class="hazard-icon">⚠️</span>
-                                  <div class="hazard-content">
-                                    <strong>Off-Season Weather</strong>
-                                    <p>Months to weigh carefully: N/A</p>
-                                    <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                  </div>
-                                </div>
-                              </div>
-                            </details>
-            
                             <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                           </div>
                         </noscript>

--- a/ports/isafjordur.html
+++ b/ports/isafjordur.html
@@ -315,20 +315,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Nov, Dec, Jan, Feb</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/jakarta.html
+++ b/ports/jakarta.html
@@ -309,20 +309,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Jan, Feb</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/montreal.html
+++ b/ports/montreal.html
@@ -310,20 +310,6 @@ Soli Deo Gloria
                                 </div>
                               </details>
               
-                              <details class="seasonal-section" open>
-                                <summary class="seasonal-section-title">Weather Hazards</summary>
-                                <div class="seasonal-hazards">
-                                  <div class="hazard-warning">
-                                    <span class="hazard-icon">⚠️</span>
-                                    <div class="hazard-content">
-                                      <strong>Off-Season Weather</strong>
-                                      <p>Months to weigh carefully: Jan, Feb</p>
-                                      <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                    </div>
-                                  </div>
-                                </div>
-                              </details>
-              
                               <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                             </div>
                           </noscript>

--- a/ports/port-arthur.html
+++ b/ports/port-arthur.html
@@ -327,20 +327,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/puerto-montt.html
+++ b/ports/puerto-montt.html
@@ -432,20 +432,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/punta-del-este.html
+++ b/ports/punta-del-este.html
@@ -322,20 +322,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/rotorua.html
+++ b/ports/rotorua.html
@@ -381,20 +381,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/salvador.html
+++ b/ports/salvador.html
@@ -291,20 +291,6 @@ Soli Deo Gloria
                               </div>
                             </details>
             
-                            <details class="seasonal-section" open>
-                              <summary class="seasonal-section-title">Weather Hazards</summary>
-                              <div class="seasonal-hazards">
-                                <div class="hazard-warning">
-                                  <span class="hazard-icon">⚠️</span>
-                                  <div class="hazard-content">
-                                    <strong>Off-Season Weather</strong>
-                                    <p>Months to weigh carefully: May, Jun</p>
-                                    <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                  </div>
-                                </div>
-                              </div>
-                            </details>
-            
                             <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                           </div>
                         </noscript>

--- a/ports/south-shetland-islands.html
+++ b/ports/south-shetland-islands.html
@@ -364,20 +364,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: Apr, May, Jun, Jul, Aug, Sep, Oct</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>

--- a/ports/torshavn.html
+++ b/ports/torshavn.html
@@ -284,20 +284,6 @@ ITW-Lite v3.010 | ICP-Lite v1.4
                             </div>
                           </details>
           
-                          <details class="seasonal-section" open>
-                            <summary class="seasonal-section-title">Weather Hazards</summary>
-                            <div class="seasonal-hazards">
-                              <div class="hazard-warning">
-                                <span class="hazard-icon">⚠️</span>
-                                <div class="hazard-content">
-                                  <strong>Off-Season Weather</strong>
-                                  <p>Months to weigh carefully: N/A</p>
-                                  <p class="hazard-note">Conditions outside the cruise window can include disruptive weather; verify forecasts close to your sail date.</p>
-                                </div>
-                              </div>
-                            </div>
-                          </details>
-          
                           <p class="weather-noscript-note"><em>Enable JavaScript for live weather conditions and 48-hour forecast.</em></p>
                         </div>
                       </noscript>


### PR DESCRIPTION
PR 2 (commit a69f1471) shipped fabricated content to 35 ports under the guise of a structural backfill. When seasonal-guides.json had no curated hazard data for a port (hurricane_zone:false AND no hazards.note), the generator emitted an invented "Off-Season Weather" hazard-warning block:

    "Off-Season Weather"
    "Months to weigh carefully: <avoid_months>"
    "Conditions outside the cruise window can include disruptive weather;
     verify forecasts close to your sail date."

This is the same anti-pattern the 2026-03-27 careful-not-clever audit explicitly named under "What Was Clever (And Shouldn't Have Been)":

    "AI content treated as verified — Port details generated by AI were
     committed without independent verification."

And it violates the rule from .claude/skills/careful-not-clever/CAREFUL.md:

    "Never fabricate to satisfy a structural check"

Changes:

1. admin/backfill-weather-seasonal-guide.cjs: drop the "Off-Season Weather" fallback in renderHazard. Emit hazard-warning ONLY when one of two truthful sources exists: - hurricane_zone === true (with real hurricane_season / peak_risk_months / note from the JSON) - hazards.note (curated text, rendered verbatim) When neither: omit the entire Weather Hazards <details> section so the validator surfaces the gap (H001/H002) honestly instead of silencing it with filler.

2. Drop the dead catches/packing padding code that would have inserted generic "Verify current conditions..." / "Check the weather forecast 48 hours..." sentences if any port had <3 items. (Inspection of seasonal-guides.json confirmed every port has >=3 items, so the padding never fired — but the code itself was a doctrine violation.)

3. Add --force flag to allow re-rendering ports that already have a seasonal-guide. Used once now to re-render the 35 affected ports.

Verified:
  - grep "Off-Season Weather" ports/*.html  -> 0 matches (was 35)
  - grep "verify forecasts close to your sail date" -> 0 matches (was 35)
  - grep "Months to weigh carefully" -> 0 matches (was 35)
  - End-to-end test: dubai (no truthful hazard) emits no hazard section; cozumel (hurricane_zone:true) emits Hurricane Zone block; venice (curated note) emits Weather and Local Hazards block.

Honest validator delta (weather sub-validator, all 387 ports):
  - H001 (Weather Hazards title): 49 -> 84 errors  (+35, expected)
  - H002 (hazard-warning class):  49 -> 84 errors  (+35, expected)
  - Pages with 2-5 errors: 214 -> 185 (-29, moved to "6+ errors" bucket)
  - PASS/WARN total: unchanged (2 PASS / 21 WARN — neither budget was close enough for these 35 to swing across the threshold)

The score going DOWN on those 35 pages is the point. They were silently passing on invented content; they now correctly fail and surface the real gap (no curated hazard data) for human curation.

https://claude.ai/code/session_01DNacLQcPzMRVQPKT4oik48