### PR TITLE
voice: tune voice-dna, like-a-human, voice-audit, emotional-hook-test…

### DIFF
--- a/.claude/skills/emotional-hook-test/SKILL.md
+++ b/.claude/skills/emotional-hook-test/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: emotional-hook-test
+description: "Pre-publication quality gate that evaluates reader emotional experience. Complements voice-audit (mechanical tells) and like-a-human (during-writing standard) with feeling-level assessment. Applied during content review before publishing any page."
+version: 2.0.0
+---
+
+# The 30-Second Emotional Hook Test
+
+*Does this page make a cruiser feel calmer, more confident, and more prepared — in 30 seconds?*
+
+## Where This Sits Among the Voice Skills
+
+- **like-a-human** shapes the *writing* — voice markers, rhythms, vocabulary, precision.
+- **voice-dna** measures the *corpus* — data-driven baseline for the other skills.
+- **voice-audit** reviews the *output* — scanning for machine tells and authenticity risk.
+- **emotional-hook-test** (this skill) evaluates the *feeling* — what the reader experiences in 30 seconds.
+
+When a page passes voice-audit and the technical validators but fails the emotional hook test, the technical precision is irrelevant. **The reader doesn't feel schema compliance. They feel trust, calm, and preparation — or they don't.**
+
+## The Curse of Knowledge Problem
+
+The builders of InTheWake live inside the machinery: version trees, superset logic, cache busting, JSON-LD, disclosure tiers, canonical invocations. The reader does not. The reader feels:
+
+- "This feels trustworthy." — or it doesn't.
+- "This feels like someone who actually sailed." — or it doesn't.
+- "This feels calm." — or it doesn't.
+
+This test bridges that gap. It is the feeling-equivalent of what the technical validators do for compliance.
+
+## The Five Questions (30 Seconds)
+
+Apply these in sequence. Each question maps to a time window the reader actually experiences as they scan.
+
+### 1. CLARITY (0–5 seconds)
+
+**Can I tell what this page is *for* — not what it contains — in 5 seconds?**
+
+What to check:
+- Title communicates purpose, not just subject
+- Lead paragraph answers "why am I here?" not "what is this about?"
+- Visual hierarchy draws the eye to the most important thing first
+
+Pass: Purpose is immediately obvious. The reader knows why this page exists.
+Fail: Reader has to scroll or parse to understand intent. Title is SEO-first instead of reader-first.
+
+*Example — title that passes:* "Juneau, Alaska" with "Region: Alaska | Season: May–Sep | Tender: No"
+*Example — title that fails:* "Allure of the Seas — Deck Plans, Live Tracker, Dining & Videos" (this is a feature list, not a purpose statement)
+
+### 2. CALM (5–10 seconds)
+
+**After scanning for 10 seconds, do I feel calmer or more anxious?**
+
+What to check:
+- Visual density: does the page breathe?
+- Information hierarchy: is the most comforting/useful thing first?
+- Competing calls-to-action: are there too many things demanding attention?
+- Content before chrome: does the reader see content or navigation/infrastructure?
+
+Pass: The page breathes. White space. Clear sections. One clear next step.
+Fail: Overwhelmed. Multiple competing elements. Dense text walls. Promotional interrupts before orientation.
+
+*Example — calm:* "From the Pier" distance bars on port pages. One visual, immediate practical value.
+*Example — anxious:* A stats grid with tonnage, crew count, registry, and beam width before any human context.
+
+### 3. SEEN (10–15 seconds)
+
+**Does this page feel like someone thought about *me* specifically?**
+
+What to check:
+- First-person voice or specific detail that signals lived experience
+- Reader-addressing language ("If you're nervous about..." "You owe no one your story...")
+- Acknowledgment of the reader's actual situation — not generic cruise info
+- For vulnerable audiences (disability, grief, solo): does it communicate "someone thought about me" instantly?
+
+Pass: "This was written by someone who's been where I'm going."
+Fail: "This could be any cruise wiki. This is scraped content with a logo."
+
+*Pastoral guardrail:* "Assume the reader is exhausted by being disbelieved or dismissed elsewhere. This is not another place that does that."
+
+### 4. CONFIDENCE (15–20 seconds)
+
+**Do I feel "I can do this" — prepared, not just informed?**
+
+What to check:
+- Actionable guidance, not just data dumps
+- Decision support: does the page help me *choose*, or just list options?
+- Honest limitations acknowledged (builds trust)
+- Specific prices, times, distances — not vague qualifiers
+
+Pass: "I know what to do when I get there."
+Fail: "I have more information but not more clarity."
+
+*Example — confidence:* "You will see whales." (Juneau logbook) — direct, specific, earned assurance.
+*Example — no confidence:* A list of 15 excursions with prices but no guidance on which to choose.
+
+### 5. GUIDED (20–30 seconds)
+
+**Would a non-technical 62-year-old first-time cruiser feel guided, not overwhelmed?**
+
+What to check:
+- Page navigation: can someone find what they need without understanding the site architecture?
+- Progressive disclosure: collapsible sections, anchor links, table of contents for long pages
+- Page length management: comprehensive is good, overwhelming is not
+- The grandmother test: could you hand your phone to someone's grandmother and she'd find what she needs?
+
+Pass: "I could follow this page with no instructions."
+Fail: "This is comprehensive but intimidating. I don't know where to start."
+
+## Per-Page Feeling Targets
+
+Each page type has a specific emotional target. If the page doesn't hit its target, the technical compliance doesn't matter.
+
+| Page Type | Feeling Target | The Reader's Inner Voice |
+|-----------|---------------|-------------------------|
+| **Home** | Trust + orientation | "I'm in the right place. This is trustworthy. I can find what I need." |
+| **Ship** | Personality in 60 seconds | "I understand what it's like to be on this ship." |
+| **Port** | Preparation + anxiety reduction | "I feel prepared stepping off this ship. Less anxious about this port." |
+| **Restaurant** | Clarity + value judgment | "I can see what I'll eat and whether it's worth paying for." |
+| **Disability/Accessibility** | Dignity + being seen | "Someone thought about me." |
+| **Solo/Grief** | Not alone | "I'm not alone in this." |
+| **Tools** | Manageable complexity | "This makes something confusing feel manageable." |
+| **Article/Logbook** | Authenticity + learning | "I learned something real from someone who was there." |
+
+## Scoring
+
+For each of the 5 questions:
+
+- **PASS** — The question is answered positively. The feeling lands.
+- **PARTIAL** — Some elements work but something blocks the full feeling. Note what blocks it.
+- **FAIL** — The feeling target is not met. The page needs revision before this test is re-run.
+
+**Overall page assessment:**
+
+- 5/5 PASS → Ship it.
+- 4/5 PASS, 1 PARTIAL → Ship it with a note on what to improve.
+- 3/5 or fewer → Hold. Revise before publishing.
+
+## How to Run the Test
+
+1. Open the page in a browser (or read the HTML body content).
+2. Start a 30-second timer.
+3. Scan naturally — don't read every word. Mimic how a real visitor would land.
+4. Answer each question honestly. "Partial" is always available.
+5. Record the results using the format below.
+
+### Audit Report Format
+
+```
+## Emotional Hook Test — [Page Name]
+**Page:** [filename]
+**Type:** [Home / Ship / Port / Restaurant / etc.]
+**Feeling Target:** [from table above]
+**Date:** [YYYY-MM-DD]
+
+| # | Question | Result | Notes |
+|---|----------|--------|-------|
+| 1 | CLARITY (5s) | PASS/PARTIAL/FAIL | ... |
+| 2 | CALM (10s) | PASS/PARTIAL/FAIL | ... |
+| 3 | SEEN (15s) | PASS/PARTIAL/FAIL | ... |
+| 4 | CONFIDENCE (20s) | PASS/PARTIAL/FAIL | ... |
+| 5 | GUIDED (30s) | PASS/PARTIAL/FAIL | ... |
+
+**Overall:** [X/5 PASS] — [Ship it / Ship with notes / Hold for revision]
+**Key finding:** [One sentence summary]
+```
+
+## The Antidote
+
+Every time a module is revised, ask only this:
+
+1. What does this make the cruiser *feel*?
+2. Does this reduce friction?
+3. Does this reduce uncertainty?
+4. Does this make them feel calmer?
+5. Would a non-technical 62-year-old cruiser feel guided, not overwhelmed?
+
+If yes — keep building.
+If no — simplify.
+
+## The Product
+
+InTheWake is not a database, a cruise wiki, or a modular PDF system. It is:
+
+**The feeling of boarding informed.**
+**The feeling of stepping ashore prepared.**
+**The feeling of sailing with a trusted companion.**
+
+The PDFs are the cron job. The architecture is the mechanism. The feeling is the product.
+
+---
+
+*Soli Deo Gloria* — Excellence as worship means the reader feels cared for, not just technically served.

--- a/.claude/skills/like-a-human/SKILL.md
+++ b/.claude/skills/like-a-human/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: like-a-human
+description: "Voice & Presence — fires during cruise content writing. Guards the sound of the prose so it reads as written by someone who has actually sailed the route, not by a brochure or a model. Shapes voice markers, rhythm, vocabulary, and pastoral honesty. For post-draft diagnostics, see voice-audit."
+version: 3.0.0
+---
+
+# like-a-human — Cruise Voice & Presence Standard
+
+## Core Principle
+
+The reader can tell a sailor from a brochure inside one paragraph. They can also tell a model from a sailor inside one paragraph. This skill shapes prose so the answer is always *sailor* — someone who walked off the pier, paid the price, watched the queue form, ate the food, and reports back.
+
+The standard is not detection-software-pass. The standard is a 62-year-old first-time cruiser saying *"this person has been where I'm going."*
+
+## Four Trust Signals (in priority order)
+
+1. **Lived experience** — attested, dated, specific.
+2. **Honest limitation** — "I haven't done X." "I can't speak to Y."
+3. **Calm steadiness** — the reader feels less anxious by the second paragraph.
+4. **Practical preparation** — the reader knows what to do, not just what exists.
+
+If prose lands all four, voice is intact regardless of polish.
+
+## The Window Pane Principle
+
+Prose disappears when unnoticed. Avoid:
+
+- Over-polish (too clean, too resolved, no seams)
+- Decorative cleverness (the writer wants to be admired)
+- Symmetric paragraph structures
+- Smooth transitions that mask weak moves
+
+Human writing has seams — places the prose changes direction, where a tension stays unresolved, where the writer admits something they didn't expect to admit. Protect those seams. Don't sand them.
+
+## Hard-Banned Vocabulary
+
+**Cruise-marketing tells (zero tolerance):**
+
+`world-class, stunning, luxurious, elevate, elevating, unforgettable, pristine, breathtaking, majestic, idyllic, paradise, exclusive, indulge, indulgent, opulent, lavish, sumptuous, hidden gem, must-do, must-see, bucket-list, jaw-dropping, dream destination`
+
+**Generic AI tells:**
+
+`delve, tapestry, leverage, framework, holistic, unpack, resonate, garner, showcase, underscore, encompass, nestled, enduring, boasts, facilitate, exemplify, robust, seamless, seamlessly, vibrant, nuanced, comprehensive, in essence, dive into, dive in, navigate (as metaphor), unlock, transform`
+
+**Filler transitions:**
+
+`Moreover, Furthermore, Additionally, In essence, In conclusion, Ultimately, At its core, Whether you're, Look no further than`
+
+**Promotional drift:**
+
+`offers, features, provides (as a verb of marketing), boasts, showcases, presents` — use plain copulas (`is, has, includes`) instead.
+
+## Replace Vague with Specific
+
+- "beautiful beach" → name the beach, give the sand color, give the walk distance from the pier
+- "great food" → name the dish, give the price, say what was actually on the plate
+- "easy to navigate" → say which deck, which side, which elevator bank
+- "family-friendly" → say what specifically: kids' club hours, age splits, water-park rules
+- "a short walk" → give meters or minutes
+- "reasonable prices" → give a number, in dollars, with a date
+
+## Machine Tells to Eliminate
+
+**Announcement-Before-Move.** Sentences that narrate the next move instead of executing it: "In this guide, I'll walk you through..." "Let's explore what makes..." Cut the announcement; do the move.
+
+**Participial Editorializing.** Trailing `-ing` clauses that interpret instead of report: "...offering visitors an unforgettable experience" or "...providing a glimpse into local culture." End the sentence at the fact.
+
+**Synonym Cycling.** Rotating `port → destination → locale → stop` to avoid repetition. Pick the right word and reuse it.
+
+**False Ranges.** "From budget to luxury," "From relaxing to adventurous" — require actual endpoints, not abstract scales.
+
+**Synthetic Earnestness.** "Here's the truth:" or "Let me be honest:" followed by content that is not a confession. If it is not a real confession, cut the marker.
+
+**Antithetical-Parallelism Stacking.** Multiple "It's not just X, it's Y" or "Not just X. Not just Y. But Z." constructions. One per page max in the cruise voice. (The sermon voice tolerates more; the cruise voice does not.)
+
+**Stat-Grid Opening.** Tonnage / passenger count / crew count before any human context. Open with what the reader will *experience*, not what the ship *contains*.
+
+**Generic Beauty Language.** "Crystal-clear waters," "sun-kissed sand," "vibrant local culture" — cut every one. Replace with what was actually there.
+
+## Native Moves (Protect These)
+
+- **First-person attestation with a date.** "I sailed Allure in March 2024." "We tendered in Cabo last fall." Date the experience.
+- **Honest limitation.** "I haven't been on the kids' deck." "I can't speak to suite class." Naming what you don't know is a trust move.
+- **From-the-pier specifics.** What you see when you actually walk off. Not what the brochure claims is nearby.
+- **Real prices in real currency on a real date.** "$32 in March 2024" beats "reasonably priced."
+- **Named real people.** Crew first names, fellow passengers, family travelers. Not personas.
+- **Negative observations stated plainly.** "The buffet at lunch was mediocre." Not "some travelers may find it underwhelming."
+- **Direct reader address for vulnerable moments.** "If you're nervous about this, here's what to know." "You owe no one your story."
+- **Quiet confidence at the climax.** "You will see whales." Short. Earned. No hedge.
+- **Logbook signoffs.** Dated, named, brief.
+
+## Three Moves Worth Borrowing (Use Sparingly)
+
+1. **Voiced objection.** State the reader's likely interruption in their voice, then answer it.
+2. **Cascade of three short questions.** Three parallel questions before answers arrive. Once per page max.
+3. **Named-uncertainty illustration.** "I'm not sure if it was the second or third night, but..." Naming uncertainty while telling the story anyway.
+
+## Rhythm and Cadence
+
+The cruise voice builds through **short declarative reporting + a longer reflective sentence at the turn**:
+
+> "The tender was rough. Twenty minutes, swells. We landed wet but laughing, and the dock crew already had towels stacked at the rail."
+
+**Protect:**
+
+- Shrinking sentences at moments of confidence ("You will see whales.")
+- Em-dash for breath, not decoration
+- Anaphora at parallel beats ("Five decks. Five bars. Five different crowds.")
+- Paragraph-length variation — a one-sentence paragraph after a dense one is a feature, not a problem
+- One surprise word per page (not more)
+
+**Avoid:**
+
+- Uniform sentence lengths
+- Predictable paragraph rhythm (e.g., always 3-sentence paragraphs)
+- Mechanical compression-release at every section
+
+## Pastoral Guardrails (For Vulnerable Audiences)
+
+For accessibility, solo, and grief content the standard is heightened:
+
+- Assume the reader is exhausted by being disbelieved or dismissed elsewhere. This is not another place that does that.
+- Do not perform empathy. Report the practical, in clear language, with dignity intact.
+- Do not treat the reader as a category. Treat them as a person who happens to be traveling with a specific situation.
+- "Dignity-first" beats "inspirational." Always.
+- The first paragraph must communicate *someone thought about me*. Within 15 seconds of arrival.
+
+## What Fails the Standard
+
+- Uniform paragraph lengths
+- Predictable section rhythm
+- Symmetric structure across decks/ports/restaurants
+- Smooth transitions masking weak moves
+- Comfort arriving in the same paragraph as a real warning
+- Generic "beautiful" or "vibrant" doing work that a specific should be doing
+- Sustained absence of a real number, a real name, or a real date
+- Performance of voice rather than the voice itself
+- Promotional drift (the prose starts selling)
+
+## The Safety Root Cause
+
+All machine tells share one source: **writing for safety instead of report**. The diagnostic question is: *Am I including this because the page needs it, or because I'm not sure the next sentence will land?*
+
+When in doubt, trust the specific. Cut the crutch. The reader feels the difference.
+
+---
+
+*The PDFs are the cron job. The architecture is the mechanism. The voice is what the reader actually feels.*

--- a/.claude/skills/voice-audit/SKILL.md
+++ b/.claude/skills/voice-audit/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: voice-audit
+description: "Post-draft diagnostic for InTheWake content. Scans for cruise-marketing tells and AI fingerprints, assesses authenticity risk, and checks voice continuity against the measured corpus profile. Fires before committing content edits or before publishing a new page. For during-writing standards, see like-a-human. For corpus measurement, see voice-dna."
+version: 2.0.0
+---
+
+# Voice Audit — Post-Draft Diagnostic
+
+## Purpose
+
+`like-a-human` shapes the writing process. `voice-dna` measures the corpus. `voice-audit` evaluates a *finished* page — catches what slipped through, rates the authenticity risk, and recommends surgical restoration edits, not rewrites.
+
+The rule: when a page is on-voice except for a handful of tells, restore the page. Never rewrite a page wholesale to fix a voice problem — wholesale rewrites introduce new machine patterns the corpus has not seen.
+
+## When to Fire
+
+- Before every content commit (port, ship, venue, article, logbook)
+- Before publishing a new page
+- Before merging a PR that touches reader-facing prose
+- On `/voice-audit <path>`
+- After any large AI-assisted draft (treat AI assists as suspect by default)
+
+## The Six-Axis Scan
+
+### 1. Machine Tell Scan
+
+Count instances of:
+
+- **Banned cruise-marketing vocabulary** (`world-class, stunning, luxurious, elevate, unforgettable, pristine, breathtaking, majestic, idyllic, paradise, exclusive, indulge, opulent, lavish, sumptuous, hidden gem, must-do, must-see, bucket-list, jaw-dropping, dream destination`)
+- **Generic AI tells** (`delve, tapestry, leverage, framework, holistic, unpack, resonate, garner, showcase, underscore, encompass, nestled, boasts, facilitate, robust, seamless, vibrant, nuanced, dive into, navigate (metaphor), unlock, transform`)
+- **Filler transitions** (`Moreover, Furthermore, Additionally, In essence, In conclusion, Ultimately, At its core, Whether you're, Look no further than`)
+- **Promotional verbs** (`offers, features, provides, boasts, showcases, presents` doing marketing work)
+- **Antithetical-parallelism stacking** (multiple "not just X, it's Y" — the strongest LLM tell in this voice)
+- **Participial editorializing** (trailing `-ing` clauses that interpret rather than report)
+- **Synonym cycling** (rotating `port / destination / locale / stop` in one section)
+- **Announcement-before-move** ("In this guide, I'll walk you through...")
+- **Synthetic earnestness** ("Here's the truth:" with no real confession)
+- **False ranges** ("From budget to luxury" without endpoints)
+- **Stat-grid openings** (tonnage/crew/passenger count before any human context)
+- **Generic beauty language** ("crystal-clear waters," "sun-kissed sand," "vibrant culture")
+
+Report: **count + locations**. Do not paraphrase — quote the exact phrase and line.
+
+### 2. Voice Continuity Check
+
+Verify presence of **required voice markers**:
+
+- [ ] First-person attestation with a date (at least one per page; logbook entries require multiple)
+- [ ] Honest limitation acknowledged (at least one per long-form page)
+- [ ] From-the-pier specificity (port pages: required; ship pages: required for venues with physical location)
+- [ ] Real number, real currency, real date (at least three numbers, varied: dollars, distances, minutes, deck numbers)
+- [ ] Named real person OR named specific (one per page)
+- [ ] Plain copulas dominant over promotional verbs
+- [ ] Direct reader address for vulnerable-audience pages
+
+Report markers **present / missing**. If three or more are missing, page is at minimum Medium risk regardless of machine-tell count.
+
+### 3. Cadence Check
+
+Verify:
+
+- [ ] Sentence length variance — not uniform
+- [ ] Paragraph length variance — not uniform
+- [ ] At least one short sentence at a confidence-building moment (the "You will see whales." beat)
+- [ ] Em-dash used for breath, not decoration
+- [ ] No mechanical compression-release at every section
+
+Flag: any uniform stretch (5+ paragraphs of similar length, 5+ sentences of similar length, repeated section rhythm).
+
+### 4. Specificity Check
+
+The page must tether to *this* place / ship / restaurant, not be interchangeable with another:
+
+- [ ] Deck numbers, side (port/starboard), elevator bank, or named venue
+- [ ] Sensory detail not transferable to another location
+- [ ] At least one detail that can be fact-checked
+- [ ] Limitation tied to a specific situation, not a generic disclaimer
+
+Fail trigger: if all the specifics could be swapped for another port/ship without breaking sense, the page is generic. High risk.
+
+### 5. Promotional Drift Check
+
+The cruise voice does not sell. Verify:
+
+- [ ] No "offers," "features," "provides" doing marketing work
+- [ ] No "perfect for" or "ideal for" segmenting readers
+- [ ] No "a must" or "a must-do"
+- [ ] No closing call-to-action language ("Book now," "Don't miss out")
+- [ ] Honest weaknesses acknowledged where present
+
+If the page reads like a brochure could publish it unchanged, the voice has drifted. Flag.
+
+### 6. Pastoral Honesty Check (vulnerable-audience pages only)
+
+For accessibility, solo, and grief content:
+
+- [ ] First paragraph signals "someone thought about me"
+- [ ] No performance of empathy
+- [ ] Reader treated as a person, not a category
+- [ ] Dignity-first language; no inspirational framing
+- [ ] Practical guidance present, not just sentiment
+
+A pastoral-page failure on this axis is automatically High risk regardless of other axes.
+
+## Authenticity Risk Rating
+
+Assemble the six-axis output into a risk rating:
+
+**Low risk** — ship it.
+- Machine tells: 0–2
+- All required voice markers present
+- Cadence varied; specificity present; no promotional drift
+- Pastoral check passes (if applicable)
+
+**Medium risk** — restore before commit.
+- Machine tells: 3–5
+- 1–2 required voice markers missing
+- One cadence flag OR one specificity flag
+- Light promotional drift
+
+**High risk** — hold for revision.
+- Machine tells: 6+
+- 3+ required voice markers missing
+- Specificity check fails (page is generic)
+- Promotional drift dominant
+- Pastoral honesty failure on a vulnerable-audience page
+- Antithetical-parallelism stacking with 3+ instances
+
+## Restoration, Not Rewriting
+
+When the rating is Medium, recommend **3–5 surgical edits**, each one:
+
+- Quotes the exact phrase to remove
+- Provides a 1–3 word replacement OR a deletion
+- Names the axis the edit fixes
+
+Do not propose new paragraphs. Do not add content. Do not "polish." The author wrote the page; the audit's job is to remove the mechanical overlay, not to introduce a new voice.
+
+When the rating is High, the recommendation is to **rewrite the page from the original facts**, not to patch it. A High-risk draft has too many tells to restore without ending up with a Frankenstein voice.
+
+## Audit Report Format
+
+```
+## Voice Audit — [page-name]
+**Path:** [file path]
+**Page type:** [port / ship / venue / article / logbook / accessibility / tool]
+**Date:** [YYYY-MM-DD]
+
+### Machine Tells
+- Banned cruise vocab: [N] — [list with line numbers]
+- Generic AI tells: [N] — [list]
+- Filler transitions: [N] — [list]
+- Promotional verbs: [N] — [list]
+- Antithetical stacking: [N] instances
+- Participial editorializing: [N]
+- Synonym cycling: [N]
+- Announcement-before-move: [N]
+- Synthetic earnestness: [N]
+- False ranges: [N]
+- Stat-grid opening: [yes/no]
+- Generic beauty language: [N]
+
+### Voice Markers
+- First-person attestation: [present/missing]
+- Honest limitation: [present/missing]
+- From-the-pier specificity: [present/missing/N/A]
+- Real numbers: [count]
+- Named real person/specific: [present/missing]
+- Plain copulas dominant: [yes/no]
+- Direct reader address (vulnerable): [present/missing/N/A]
+
+### Cadence
+- Sentence variance: [varied/uniform]
+- Paragraph variance: [varied/uniform]
+- Confidence-moment short sentence: [present/missing]
+- Em-dash usage: [breath/decorative]
+
+### Specificity
+- Tied to this place: [yes/no]
+- Fact-checkable details: [count]
+- Verdict: [specific/generic]
+
+### Promotional Drift
+- [pass/fail with specifics]
+
+### Pastoral Honesty (if applicable)
+- [pass/fail with specifics]
+
+### Risk Rating: [Low / Medium / High]
+
+### Recommended Edits
+1. [exact quote] → [replacement/deletion] — [axis]
+2. ...
+```
+
+## Integration With Other Skills
+
+- Run **after** `port-content-builder`, `port-page-generator`, `venue-page-writer`, or any AI-assisted edit.
+- Run **before** `publication-proofreader`.
+- Pair with `emotional-hook-test` for the feeling-level pass; voice-audit catches mechanical tells, emotional-hook-test catches whether the prose actually lands.
+- Feed Medium and High audits back to `voice-dna` periodically — if a particular tell keeps slipping through, the corpus may need re-baselining.
+
+---
+
+*The audit's job is to remove the mechanical overlay. The author's voice is already there.*

--- a/.claude/skills/voice-dna/SKILL.md
+++ b/.claude/skills/voice-dna/SKILL.md
@@ -1,36 +1,157 @@
 ---
 name: voice-dna
-description: "Discovers voice patterns from the cruise content corpus. Analyzes port guides, ship profiles, and articles to extract the actual rhythms, vocabulary, and experiential fingerprints."
-version: 1.0.0
+description: "Discovers voice patterns from the InTheWake content corpus. Measures rhythm, vocabulary, and experiential fingerprints across port guides, ship profiles, logbook entries, and restaurant pages — data-driven voice profiling that feeds like-a-human and voice-audit."
+version: 2.0.0
 ---
 
-# Voice DNA — Voice Discovery from Cruise Content
+# Voice DNA — Voice Discovery from the Cruise Corpus
 
-> Measure the voice. Don't guess it.
+> Don't guess the voice. Measure it.
 
 ## Purpose
 
-InTheWake has Humanization (like-a-human + voice-audit) to enforce and check the voice. Voice DNA **discovers** it by analyzing the best existing content. This makes the voice guardrails data-driven.
+`like-a-human` enforces the voice. `voice-audit` checks the voice. `voice-dna` **discovers** the voice by measuring the actual InTheWake corpus. Run it to extract real patterns so the other voice skills are calibrated against this site's prose, not against a generic "travel writing" abstraction.
+
+The cruise voice is not the sermon voice. It is the voice of a steady observer who has actually sailed the route, walked off the pier, paid the price, and reports back without marketing varnish. Measurement protects that voice from drift.
 
 ## When to Fire
 
 - On `/voice-dna` command
-- When calibrating voice for a new content type
-- When voice feels like it's drifted
+- When establishing voice for a new content type (e.g., a new ship line, a new port region, accessibility content)
+- When a reviewer reports voice has drifted toward generic travel-blog
+- After every 50 new published pages, to refresh the baseline
 
-## Analysis
+## Sample Selection
 
-Sample 10-15 of the best pages (port guides with strong engagement, articles readers share, tool descriptions that feel right). Extract:
+Select 12–18 pages that represent the voice at its best. Mix:
 
-- **Sentence rhythm:** length, variance, fragments at emotional moments
-- **Experiential precision:** sensory detail frequency, specificity level
-- **Honesty markers:** limitations mentioned, "here's what's not great" frequency
-- **Gear-shift markers:** "Here's what they don't tell you:" frequency
-- **Grief content:** how hard things are held, when comfort arrives
-- **Vocabulary:** cruise-specific terms, avoided AI words, signature phrases
+- **3–4 gold-standard port pages** (e.g., `dubai.html`, `juneau.html`) — the voice anchor.
+- **2–3 ship profiles** with strong logbook entries (Royal, Carnival, NCL, Virgin, MSC — mix lines so vocabulary doesn't skew to one fleet).
+- **2–3 restaurant/venue pages** that handle real food and real prices.
+- **2 accessibility or solo/grief pages** (vulnerable-audience voice; pastoral guardrails active).
+- **2 article/logbook entries** with first-person attestation.
+- **1–2 tool/calculator descriptions** (they have a different voice; measure the difference deliberately).
 
-Output a Voice DNA Profile that calibrates the Humanization skills with measured data.
+Avoid: thin port stubs, scraped ship-spec tables, anything flagged by `voice-audit` as High risk.
+
+## Pattern Extraction
+
+For each sample, measure:
+
+### Sentence Rhythm
+- Average sentence length (words)
+- Sentence length variance — high variance = human; low variance = AI
+- Shortest sentence in a confidence-building moment ("You will see whales.")
+- Longest sentence in narrative or sensory passages
+- Fragment frequency per page
+
+### Paragraph Structure
+- Average paragraph length
+- One-sentence paragraph frequency
+- Length variance across a page (uniform = AI; varied = human)
+- Position of first paragraph break (early = scannable; late = essay-style)
+
+### Vocabulary Fingerprint
+- Most frequent concrete nouns (deck names, port features, ship names, price terms)
+- Cruise terminology preferences ("tender" vs. "shuttle boat"; "specialty dining" vs. "upscale restaurant")
+- First-person attestation density ("I sailed," "we tendered," "my wife and I") per page
+- Limitation acknowledgements per page ("I haven't done X," "I can't speak to Y")
+- Words used that AI would not choose unprompted
+- Cruise-marketing vocabulary that should be **absent** ("world-class," "stunning," "luxurious," "elevate," "unforgettable," "pristine")
+
+### Experiential Texture
+- Sensory detail frequency (smell, sound, temperature, footing, queue length, wait time)
+- Specific-number density (deck numbers, dollar figures, distances, minutes)
+- Named-real-people frequency (crew members, fellow passengers, family members) per page
+- Negative/critical content frequency (honest weaknesses) per page
+- "From the pier" specificity (what you actually see when you step off)
+
+### Cadence Patterns
+- Compression-release frequency (stacked short → one longer reflective sentence)
+- Anaphora instances (repeated sentence starts) per page
+- Pause-and-pivot moves (em-dash, semicolon used for breath, not decoration)
+- Direct reader address frequency ("if you're nervous," "you owe no one your story")
+- Questions asked per page (cruise voice asks fewer than sermon voice; measure)
+
+### Structural DNA
+- Average page length (words)
+- Number of major sections per page
+- Opening pattern (orientation? attestation? warning?)
+- Closing pattern (logbook signoff? practical checklist? pastoral note?)
+- Image-to-prose ratio
+- Schema/data-block density (should be low in body prose, contained in headers/sidebars)
+
+## Profile Output
+
+Produce a **Voice DNA Profile**:
+
+```
+## Voice DNA Profile — InTheWake — [date]
+**Corpus:** [N] pages analyzed
+**Baseline pages:** [list]
+
+### Rhythm
+- Avg sentence: [N] words (σ=[N])
+- Shortest at confidence moment: [N] words
+- Fragment frequency: [N] per page
+- Paragraph variance: [high/medium/low]
+
+### Vocabulary
+- Top concrete nouns: [list with frequency]
+- First-person attestation: [N] instances per page avg
+- Limitation acknowledgements: [N] per page avg
+- Banned vocabulary appearances: [should be 0]
+- Signature phrases: [list of 5–10 phrases unique to this corpus]
+
+### Experiential
+- Sensory details: [N] per page
+- Specific numbers (decks/$/min): [N] per page
+- Named real people: [N] per page
+- "From the pier" specificity: [N] per page
+
+### Cadence
+- Compression-release: [N] per page avg
+- Anaphora: [N] per page avg
+- Em-dash for breath: [N] per page avg
+- Direct reader address: [N] per page avg
+
+### Structure
+- Avg length: [N] words
+- Sections: [N] avg
+- Opening pattern: [orientation / attestation / warning / scene]
+- Closing pattern: [logbook signoff / checklist / pastoral note]
+```
+
+## Different Voice Profiles Within the Site
+
+The same site has several voices; measure them separately so they don't bleed into each other:
+
+- **Logbook voice** — first-person attested, dated, specific. The anchor.
+- **Port-guide voice** — second-person guidance + first-person attestation; calmer than the logbook.
+- **Ship-profile voice** — less first-person; more steady-observer; specs in tables, personality in prose.
+- **Restaurant/venue voice** — sensory-forward; honest about value; price-anchored.
+- **Accessibility / solo / grief voice** — pastoral guardrails. Slower cadence. Direct address. "Someone thought about me."
+- **Tool / calculator voice** — terse, instructional, no marketing.
+
+A `voice-dna` run can extract any one of these from the right sample subset.
+
+## Feeding Other Skills
+
+The Voice DNA Profile feeds:
+
+- **like-a-human** — update measured patterns, replace guesses with numbers.
+- **voice-audit** — calibrate Low/Medium/High thresholds against this corpus.
+- **port-page-generator** and **venue-page-writer** — these generators sample the profile to stay on-voice.
+- **emotional-hook-test** — confirms the measured voice still produces the target feeling.
+
+## Encode to Memory
+
+```bash
+python3 /home/user/ken/orchestrator/memory_ops.py encode inthewake pattern \
+  "Voice DNA: avg sentence 16 words, σ=9. Sensory details 4.2/page. First-person attestation 1.8/page. Banned vocab: world-class, stunning, luxurious, elevate, unforgettable, pristine." \
+  --tags voice-dna,voice-profile,baseline --protected
+```
 
 ---
 
-*Soli Deo Gloria*
+*The reader can tell a sailor from a brochure inside a paragraph. Measure what makes the difference.*


### PR DESCRIPTION
… for cruise content

- Promote Humanization/ files into proper top-level skill folders so they auto-activate. Old folder left intact (per request) but new SKILL.md files at .claude/skills/{like-a-human,voice-audit,emotional-hook-test}/ are now the canonical sources.
- Deepen voice-dna from a 1.4KB stub to a Romans-depth corpus-measurement skill, with cruise-specific categories (sensory density, from-the-pier specificity, logbook attestation frequency).
- Rewrite machine-tell list against cruise-marketing vocabulary ("world-class," "stunning vistas," "elevate your experience," "luxurious") and protect cruise-native voice markers (deck numbers, real prices, attested limitations, "I sailed this in [month/year]").
- Add cruise-tuned authenticity risk rubric to voice-audit.
- Move emotional-hook-test into its own activatable skill folder, unfencing the YAML frontmatter so the harness can load it.