### PR TITLE
fix: address site audit findings on home, privacy, and Carnival fleet…

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@
   <header class="hero-header" role="banner">
     <div class="navbar">
       <div class="brand">
-        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" title="In the Wake wordmark" decoding="async"/>
         <span class="tiny version-badge" aria-label="Site version V1.Beta">V1.Beta</span>
       </div>
       <!-- Mobile hamburger button -->
@@ -367,9 +367,9 @@
 
     <!-- Hero -->
     <div class="hero">
-      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" title="Compass rose" aria-hidden="true" decoding="async"/>
       <div class="hero-title">
-        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" width="560" height="567" alt="In the Wake" decoding="async" fetchpriority="high"/>
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" width="560" height="567" alt="In the Wake" title="In the Wake" decoding="async" fetchpriority="high"/>
       </div>
       <div class="tagline" aria-hidden="true">A Cruise Traveler's Logbook</div>
       <div class="hero-credit">
@@ -628,10 +628,10 @@
           <strong>Send us a picture and be featured on our website and Instagram!</strong>
         </p>
         <div class="actions" style="margin-top: 1rem; display: flex; gap: 0.75rem; flex-wrap: wrap;">
-          <a class="pill" href="mailto:ken@cruisinginthewake.com?subject=I%20Found%20a%20Duck!&body=Hi!%20I%20found%20a%20duck%20on%20my%20cruise.%20Here's%20my%20photo%20(please%20attach).%0A%0AShip:%20%0ADate:%20%0ALocation%20where%20I%20found%20it:%20%0A%0A"
+          <!--email_off--><a class="pill" href="mailto:ken@cruisinginthewake.com?subject=I%20Found%20a%20Duck!&body=Hi!%20I%20found%20a%20duck%20on%20my%20cruise.%20Here's%20my%20photo%20(please%20attach).%0A%0AShip:%20%0ADate:%20%0ALocation%20where%20I%20found%20it:%20%0A%0A"
              style="background: #ffd700; color: #333; border-color: #d4a017; font-weight: 600; font-size: 1.05rem; padding: 0.75rem 1.5rem;">
             Send Your Duck Photo!
-          </a>
+          </a><!--/email_off-->
           <a class="pill" href="https://instagram.com/flickersofmajesty" target="_blank" rel="noopener"
              style="background: #fff; color: #d4a017; border: 2px solid #ffd700; font-weight: 600; font-size: 1.05rem; padding: 0.75rem 1.5rem;">
             See Featured Ducks on Instagram
@@ -706,7 +706,7 @@
         <a href="/authors/ken-baker.html" aria-label="View Ken Baker's profile">
           <picture>
             <source srcset="/authors/img/ken1.webp?v=3.010.400" type="image/webp"/>
-            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo" decoding="async" loading="lazy"/>
+            <img class="author-avatar" src="/authors/img/ken1_96.webp" srcset="/authors/img/ken1_96.webp 1x, /authors/img/ken1_192.webp 2x" width="96" height="96" alt="Author photo of Ken Baker" title="Ken Baker" decoding="async" loading="lazy"/>
           </picture>
         </a>
         <h4><a href="/authors/ken-baker.html">Ken Baker</a></h4>

--- a/privacy.html
+++ b/privacy.html
@@ -248,8 +248,9 @@
 
   <!-- MAIN CONTENT -->
   <main class="wrap page-grid" id="main-content" role="main" tabindex="-1">
-    <section style="grid-column: 1;" aria-label="Privacy Policy content">
+    <section style="grid-column: 1;" aria-labelledby="privacy-title">
       <article class="card">
+        <h1 id="privacy-title">Privacy Policy</h1>
         <p><strong>Effective Date:</strong> January 15, 2025</p>
         <p><strong>Last Updated:</strong> January 3, 2026</p>
 

--- a/ships/carnival/index.html
+++ b/ships/carnival/index.html
@@ -20,7 +20,9 @@ All work on this project is offered as a gift to God.
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="ai-summary" content="Complete guide to Carnival Cruise Line's 27-ship fleet organized by class: Excel (XL), Vista, Dream, Conquest, Spirit, Sunshine, Splendor, Venice, Grand, and Fantasy classes with signature venues and ship comparisons.">
   <meta name="last-reviewed" content="2026-01-14">
-  <meta name="content-protocol" content="ICP-Lite v1.4"><title>Carnival Cruise Line Fleet Guide — All Ships by Class | In The Wake</title>  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=2.234"/>
+  <meta name="content-protocol" content="ICP-Lite v1.4">
+  <meta name="description" content="Carnival Cruise Line fleet guide: all 27 ships organized by class — Excel, Vista, Dream, Conquest, Spirit, Sunshine, Splendor, Venice, Grand, and Fantasy — with deck plans, dining, and signature venues.">
+  <title>Carnival Cruise Line Fleet Guide — All Ships by Class | In The Wake</title>  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=2.234"/>
 <style id="carnival-page-overrides">
     .brand-title{display:none!important}
 


### PR DESCRIPTION
… pages

- Wrap duck-photo mailto: in <!--email_off--> so Cloudflare stops rewriting the href into /cdn-cgi/l/email-protection (was 404 in scan)
- Add title attributes to 4 flagged images on the homepage (logos, compass rose, author avatar) so the audit's "no image title" check passes; alt text preserved
- Add missing <h1>Privacy Policy</h1> to privacy.html (audit reported H1 missing) and switch the wrapping section to aria-labelledby
- Add missing meta description to ships/carnival/index.html