### PR TITLE
feat(sourcing): automated image-sourcing harness + workflow refresh

### DIFF
--- a/admin/IMAGE_SOURCING_WORKFLOW.md
+++ b/admin/IMAGE_SOURCING_WORKFLOW.md
@@ -4,11 +4,83 @@
 port / ship / venue pages when the existing files are placeholders or lack
 proper attribution.
 
-**Status:** Proven end-to-end on 2026-04-10/11 (college-fjord repair).
+**Status:** Re-verified 2026-05-10 against the live sandbox; all documented
+sources still reachable, all blocked sources still blocked. Now driven by an
+automation harness (see §"Harness — admin/sourcing.py" below).
 **Audience:** Any future session picking up image work.
 
 > **Prerequisite — read first:** `admin/CAREFUL.md` §"Image Verification Protocol".
 > Every image must be visually verified with the Read tool before it lands in the repo.
+
+---
+
+## Harness — `admin/sourcing.py`
+
+Every mechanical step in this workflow is wrapped by `admin/sourcing.py`. The
+harness is the recommended way to drive sourcing in 2026 and beyond — direct
+curl/Pillow incantations are still valid but are no longer documented in detail
+in §"The six-step workflow" because they drift; the harness is canonical.
+
+```
+python3 admin/sourcing.py doctor                      # preflight
+python3 admin/sourcing.py inventory <slug>            # files vs HTML refs vs gaps
+python3 admin/sourcing.py audit-attr <slug>           # Flickr-889 / placeholder detector
+python3 admin/sourcing.py verify-flickr <photo-url>   # fetch + extract CC license
+python3 admin/sourcing.py verify-loc <item-id>        # JSON API + rights + file URLs
+python3 admin/sourcing.py fetch <url> <local-path>    # --http1.1 --fail + integrity check
+python3 admin/sourcing.py convert <jpg> <webp>        # Pillow -> WebP, q=85, max 1600px
+python3 admin/sourcing.py write-attr <webp> <kv...>   # canonical attr.json shape
+python3 admin/sourcing.py rewrite-html <slug>         # repoint <img> to files on disk
+python3 admin/sourcing.py validate <slug>             # image-section blockers only
+python3 admin/sourcing.py plan <slug>                 # next-actions list
+```
+
+What the harness does NOT do (intentional integrity boundary):
+
+- It does not invent search hits. `WebSearch` and `WebFetch` are tools the
+  calling agent owns; the harness only takes URLs the agent has produced.
+- It does not skip visual verification. `fetch` puts bytes on disk; the agent
+  must `Read()` the image and confirm the scene before calling `convert`.
+  Bypassing that step reintroduces the college-fjord / Flickr-889 failure class.
+- It refuses to write attribution JSON whose `license` field is `Flickr (verify
+  license)`, contains `verify license`, or is any NC/ND/NC-ND/NC-SA variant.
+  This is the same guard as ATTR-003 and was added because 889 such files
+  shipped to production in spring 2026.
+
+### Canonical attribution JSON shape (written by `write-attr`)
+
+```json
+{
+  "sourceUrl": "https://www.loc.gov/item/2024686372/",
+  "license": "No known restrictions",
+  "licenseUrl": "https://www.loc.gov/rr/print/res/107_curt.html",
+  "photographer": "Edward S. Curtis (1868-1952), photographer",
+  "title": "Canoe, Ketchican",
+  "description": "1899 Curtis photograph of a Tlingit canoe near Ketchikan.",
+  "alt": "Wooden canoe with single occupant on calm water at edge of forest",
+  "verifiedBy": "sourcing.py session 2026-05-10",
+  "verifiedDate": "2026-05-10"
+}
+```
+
+`sourceUrl`, `license`, `licenseUrl`, `photographer`, `title`, `description`,
+and `alt` are required. `verifiedBy` and `verifiedDate` auto-fill if omitted.
+The harness rejects writes that are missing required fields (override with
+`--allow-partial` only when the gap is documented in caller's notes).
+
+### Sandbox-egress note (re-verified 2026-05-10)
+
+| Host | Reachable? | Notes |
+|---|:---:|---|
+| `www.loc.gov` (HTML, JSON API) | ✓ | Use `?fo=json` for item lookups |
+| `tile.loc.gov` | ✓ for files | Root path returns 403; specific files return 200. **Force `--http1.1`** — HTTP/2 stream truncation is a known issue on this CDN |
+| `www.flickr.com` (photo pages) | ✓ | Use `verify-flickr` to extract license |
+| `live.staticflickr.com` | ✓ | Static image CDN |
+| `images.unsplash.com`, `images.pexels.com` | ✓ | Permissive licenses by default |
+| `www.nps.gov` | ✓ | National Park Service |
+| `commons.wikimedia.org`, `upload.wikimedia.org` | ✗ 403 | Sandbox blocks Wikimedia entirely |
+| `archive.org` | ✗ 403 | Internet Archive blocked |
+| `cdn.pixabay.com` | ✗ 503 | Pixabay CDN blocked |
 
 ---
 
@@ -29,7 +101,9 @@ the third is caught only by opening the file.
 
 ## Sandbox networking — what works and what doesn't
 
-Tested 2026-04-10:
+Re-verified 2026-05-10 (results shown in §"Harness" above). Original 2026-04-10
+table preserved below for change-tracking; if these diverge from `python3
+admin/sourcing.py doctor`, trust `doctor` and update the table.
 
 | Host | Reachable? | Purpose |
 |------|:---:|---|
@@ -67,11 +141,24 @@ primary working sources.
 ⚠ **Any Flickr URL returned by an LLM must be verified** — see the AI shootout
 section at the bottom of this file. LLMs hallucinate Flickr IDs with high confidence.
 
-## The six-step workflow
+## The six-step workflow (now driven by the harness)
+
+The steps below remain conceptually the same. The commands shown are now the
+harness wrappers; the inline curl / Pillow recipes are kept further down for
+when you need to customise behaviour.
 
 ### 1. Identify the specific subject need
 
-For each port / ship, list what images you need by subject — e.g.:
+Run the inventory + plan commands first; they tell you what's already on disk,
+what HTML refs are broken, and what subjects are still needed:
+
+```
+python3 admin/sourcing.py inventory <slug>
+python3 admin/sourcing.py audit-attr <slug>     # flags Flickr-889 placeholders
+python3 admin/sourcing.py plan <slug>           # ordered next actions
+```
+
+Then list what images you need by subject — e.g.:
 - college-fjord-hero: wide view of College Fjord itself
 - gallery 1: Harvard Glacier face
 - gallery 2: Yale Glacier
@@ -112,6 +199,23 @@ curl -s -A "InTheWakePortPageRepair/1.0 (admin@cruisinginthewake.com)" \
 
 ### 3. Verify existence + license
 
+The harness wraps the verification so you don't have to read schema.org or LoC
+JSON by hand:
+
+```
+python3 admin/sourcing.py verify-flickr 'https://www.flickr.com/photos/USER/ID/'
+python3 admin/sourcing.py verify-loc <ITEM_ID>     # e.g. 2024686372
+```
+
+Both return JSON with a `verdict` of `OK`, `REVIEW`, or `FAIL`. Verdicts:
+`OK` means the license is one of CC BY/BY-SA 1-4, CC0, or "no known
+restrictions / public domain"; `REVIEW` means the source is reachable but the
+license string needs human eyes; `FAIL` means non-200, no CC link, or known-bad
+license.
+
+The raw recipes below are kept for the cases where the harness verdict is
+`REVIEW` and you need to inspect details by hand.
+
 For Flickr:
 ```
 WebFetch(
@@ -147,9 +251,23 @@ Avoid the `u.tif` master (50MB+) and the `_150px.jpg` thumbnail.
 
 ### 5. Download + visually verify
 
+Use the harness — it forces `--http1.1`, fails on non-200, and runs a Pillow
+load to catch the silent truncation that `tile.loc.gov` is known to ship over
+HTTP/2:
+
+```
+python3 admin/sourcing.py fetch <DIRECT_URL> /tmp/cf-src/FILENAME.jpg
+```
+
+The output reports `verdict: OK` only after Pillow successfully loads the file.
+If you see `TRUNCATED — re-fetch`, the bytes are short — re-run.
+
+Direct curl recipe (kept for reference):
+
 ```bash
-curl -s -o /tmp/cf-src/FILENAME.jpg \
+curl -sSL --http1.1 --fail \
   -A "InTheWakePortPageRepair/1.0 (admin@cruisinginthewake.com)" \
+  -o /tmp/cf-src/FILENAME.jpg \
   -w "HTTP=%{http_code} SIZE=%{size_download}\n" \
   "DIRECT_URL"
 ```
@@ -168,6 +286,38 @@ calibration strips and mount borders. Crop those out — see step 6.
 
 ### 6. Convert + save + update metadata
 
+Convert with the harness (sane defaults: WebP quality 85, max width 1600px,
+optional `--crop l,t,r,b` fractions for archival-scan borders):
+
+```
+python3 admin/sourcing.py convert /tmp/cf-src/source.jpg \
+    /home/user/InTheWake/ports/img/PORT/PORT-hero.webp
+# or with crop
+python3 admin/sourcing.py convert /tmp/cf-src/source.jpg \
+    /home/user/InTheWake/ports/img/PORT/PORT-hero.webp \
+    --crop 0.08,0.22,0.87,0.95
+```
+
+Write the attribution JSON in one shot:
+
+```
+python3 admin/sourcing.py write-attr \
+    /home/user/InTheWake/ports/img/PORT/PORT-hero.webp \
+    'sourceUrl=https://www.loc.gov/item/2024686372/' \
+    'license=No known restrictions' \
+    'licenseUrl=https://www.loc.gov/rr/print/res/107_curt.html' \
+    'photographer=Edward S. Curtis (1868-1952), photographer' \
+    'title=Canoe, Ketchican' \
+    'description=1899 Curtis photograph of a Tlingit canoe near Ketchikan.' \
+    'alt=Wooden canoe with single occupant on calm water at edge of forest'
+```
+
+The harness writes to `<image>.attr.json` (canonical `<stem>.webp.attr.json`)
+and refuses any write whose `license` is the Flickr-889 placeholder shape or
+an NC/ND variant.
+
+Direct Pillow recipe (kept for reference):
+
 ```python
 from PIL import Image
 img = Image.open('/tmp/cf-src/source.jpg')
@@ -180,7 +330,8 @@ if img.width > 1600:
 img.save('/home/user/InTheWake/ports/img/PORT/PORT-hero.webp', 'WEBP', quality=85, method=6)
 ```
 
-Then write the attribution JSON at `ports/img/PORT/PORT-hero-attr.json`:
+Direct attribution-JSON recipe (kept for reference) at
+`ports/img/PORT/PORT-hero.webp.attr.json`:
 ```json
 {
   "source": "Library of Congress, Prints & Photographs Division",

--- a/admin/audit-reports/2026-05-10-baseline/IMAGE_SOURCING_PLAN_2026-05-10.md
+++ b/admin/audit-reports/2026-05-10-baseline/IMAGE_SOURCING_PLAN_2026-05-10.md
@@ -226,6 +226,44 @@ The deficiency the validator does flag is **broken references** — pages whose 
 
 ---
 
+## 6b. Fleet-wide attribution audit (added 2026-05-10 after harness build)
+
+`python3 admin/sourcing.py audit-attr` run across all 387 ports surfaced a much
+larger problem than the validator's image-section blockers alone. Detail per
+port in `admin/audit-reports/2026-05-10-baseline/fleet-attr-audit.json`.
+
+| Finding | Ports | Files |
+|---|---:|---:|
+| Attribution JSON with the **Flickr-889 placeholder shape** (`license: "Flickr (verify license)"`, `source_type: "Flickr public feed"`) | **302** | **891** |
+| Ports failing the validator's ATTR-003 source-URL-diversity check | 180 | — |
+
+**Implication.** The validator's ATTR-003 check was written to catch the Flickr-889
+escape (892 files in spring 2026), but it only fires when 4+ images share 1–2
+source URLs. The cleverer pattern that's in production today uses **distinct
+source URLs per image but the same placeholder license string** — so 122 ports
+have 8 placeholder files apiece with 8 different source URLs and pass ATTR-003
+even though their licenses are explicitly marked unverified.
+
+This means **a separate validator rule is needed** for "license string contains
+'verify license'" (or alternatively for `source_type == 'Flickr public feed'`).
+The harness's `audit-attr` enforces it; the canonical validator does not yet.
+
+**Sourcing implication for this plan.** Phase 1 (reference repair) does not
+fix any of these 891 placeholder files — they are a separate, larger problem.
+The honest path is a **Phase 1.5** that re-verifies each placeholder license
+file by license, and either:
+
+- (a) Confirms the cited Flickr URL is actually CC and rewrites the attr.json
+  to the canonical schema, OR
+- (b) Confirms the cited Flickr URL is All-Rights-Reserved, deletes both the
+  webp and the attr.json, and treats the slot as a sourcing gap.
+
+At ~30 sec per file via `verify-flickr` + Read inspection, 891 files is
+roughly 7–10 hours of careful work. **This belongs in the plan and was not
+visible in the original §6 baseline because it required the harness to detect.**
+
+---
+
 ## 7. Per-tier execution order I propose
 
 Smallest, highest-leverage work first. **None of this is started yet — I am asking for sign-off on the order before touching a port.**
@@ -243,6 +281,13 @@ This phase touches no image bytes for the cheap cases — it only fixes HTML poi
 - **13+ broken refs (2 ports):** hong-kong (18), singapore (16). These are the heaviest sourcing work in the entire fleet — and they're high-traffic ports, so they're worth doing well.
 
 Estimated effort: 2–4 days of careful work, gallery-by-gallery, including the special cases (punta-del-este naming mismatch, fortaleza external-Wikimedia rewrite, royal-beach-club-cozumel cross-port pointer correction).
+
+### Phase 1.5 — Placeholder-license audit (302 ports, 891 attr.json files)
+For each port flagged by `audit-attr`, run `verify-flickr` against the cited
+source URL, then either rewrite the attr.json with the canonical schema (real
+license confirmed) or delete the file pair (license actually ARR or NC). This
+is the work the validator cannot currently catch on its own. Estimated effort:
+**7–10 hours sustained**, gated on Flickr availability.
 
 ### Phase 2 — Tier D acute sourcing (callao, catania)
 Full six-step workflow per port. Each port needs ~10 new sourced images to reach the floor. **Estimated effort: 4–6 hours per port** if Flickr + LoC searches go cleanly; longer if rare ports yield few CC hits.

--- a/admin/audit-reports/2026-05-10-baseline/fleet-attr-audit.json
+++ b/admin/audit-reports/2026-05-10-baseline/fleet-attr-audit.json
@@ -1,0 +1,1814 @@
+{
+  "abu-dhabi": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "acapulco": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "adelaide": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "agadir": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "airlie-beach": {
+    "attr_003_fail": false,
+    "distinct_sources": 14,
+    "placeholders": 8,
+    "total_attr": 15
+  },
+  "aitutaki": {
+    "attr_003_fail": false,
+    "distinct_sources": 14,
+    "placeholders": 8,
+    "total_attr": 15
+  },
+  "akaroa": {
+    "attr_003_fail": false,
+    "distinct_sources": 14,
+    "placeholders": 8,
+    "total_attr": 15
+  },
+  "akureyri": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "amber-cove": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "anchorage": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "antigua": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 2,
+    "total_attr": 9
+  },
+  "aruba": {
+    "attr_003_fail": false,
+    "distinct_sources": 11,
+    "placeholders": 4,
+    "total_attr": 11
+  },
+  "athens": {
+    "attr_003_fail": false,
+    "distinct_sources": 10,
+    "placeholders": 3,
+    "total_attr": 10
+  },
+  "barbados": {
+    "attr_003_fail": false,
+    "distinct_sources": 14,
+    "placeholders": 8,
+    "total_attr": 14
+  },
+  "barcelona": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 3,
+    "total_attr": 9
+  },
+  "bay-of-islands": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "beijing": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "belfast": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "belize": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "bergen": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "bermuda": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "bilbao": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 7
+  },
+  "bimini": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "bodrum": {
+    "attr_003_fail": false,
+    "distinct_sources": 13,
+    "placeholders": 7,
+    "total_attr": 14
+  },
+  "bonaire": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "bora-bora": {
+    "attr_003_fail": false,
+    "distinct_sources": 5,
+    "placeholders": 5,
+    "total_attr": 5
+  },
+  "bordeaux": {
+    "attr_003_fail": false,
+    "distinct_sources": 4,
+    "placeholders": 3,
+    "total_attr": 9
+  },
+  "boston": {
+    "attr_003_fail": false,
+    "distinct_sources": 4,
+    "placeholders": 3,
+    "total_attr": 9
+  },
+  "brisbane": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "busan": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "cadiz": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "cagliari": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "cairns": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "callao": {
+    "attr_003_fail": false,
+    "distinct_sources": 1,
+    "placeholders": 1,
+    "total_attr": 1
+  },
+  "cannes": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "cape-liberty": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "cape-town": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 2,
+    "total_attr": 8
+  },
+  "capri": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "cartagena": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "cartagena-spain": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "casablanca": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "catania": {
+    "attr_003_fail": false,
+    "distinct_sources": 1,
+    "placeholders": 1,
+    "total_attr": 1
+  },
+  "cephalonia": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "charleston": {
+    "attr_003_fail": false,
+    "distinct_sources": 5,
+    "placeholders": 4,
+    "total_attr": 8
+  },
+  "charlottetown": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "cherbourg": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "cochin": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 10
+  },
+  "cococay": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "college-fjord": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 7
+  },
+  "colombo": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 10
+  },
+  "copenhagen": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "corfu": {
+    "attr_003_fail": false,
+    "distinct_sources": 4,
+    "placeholders": 3,
+    "total_attr": 9
+  },
+  "corinto": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "cork": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "costa-maya": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "cozumel": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "curacao": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 22
+  },
+  "da-nang": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 10
+  },
+  "doha": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "dominica": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "doubtful-sound": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "dover": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "dravuni": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "dublin": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "dunedin": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "edinburgh": {
+    "attr_003_fail": false,
+    "distinct_sources": 4,
+    "placeholders": 4,
+    "total_attr": 4
+  },
+  "endicott-arm": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 10
+  },
+  "ensenada": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "falkland-islands": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "falmouth-jamaica": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "flam": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 4
+  },
+  "fortaleza": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "freeport": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 7,
+    "total_attr": 8
+  },
+  "fremantle": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "ft-lauderdale": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "fukuoka": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "funchal": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "galveston": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 12
+  },
+  "gatun-lake": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "gdansk": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "geiranger": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 4
+  },
+  "genoa": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 14
+  },
+  "gibraltar": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "gijon": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "glacier-bay": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "goa": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 10
+  },
+  "gothenburg": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "gran-canaria": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "grand-cayman": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "grand-turk": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "greenock": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 4
+  },
+  "grenada": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 14
+  },
+  "guadeloupe": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "guam": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "guayaquil": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "ha-long-bay": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "hakodate": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "halifax": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 9
+  },
+  "hamburg": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 4
+  },
+  "harvest-caye": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "helsinki": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "heraklion": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "hilo": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "hiroshima": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "ho-chi-minh": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 4
+  },
+  "ho-chi-minh-city": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "hobart": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "holyhead": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 7
+  },
+  "homer": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "honfleur": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "hong-kong": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "honningsvag": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "honolulu": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 12
+  },
+  "huatulco": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "hubbard-glacier": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 5
+  },
+  "hvar": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 7,
+    "total_attr": 8
+  },
+  "ibiza": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "invergordon": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "istanbul": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "jacksonville": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "jamaica": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "jeju": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "kagoshima": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "key-west": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "kiel": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "kirkwall": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "klaipeda": {
+    "attr_003_fail": false,
+    "distinct_sources": 7,
+    "placeholders": 7,
+    "total_attr": 7
+  },
+  "kobe": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "kodiak": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 7
+  },
+  "koh-samui": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "komodo": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "kona": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "koper": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "kotor": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "kusadasi": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "kyoto": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "la-coruna": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "la-spezia": {
+    "attr_003_fail": false,
+    "distinct_sources": 7,
+    "placeholders": 7,
+    "total_attr": 7
+  },
+  "labadee": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 6
+  },
+  "langkawi": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 1,
+    "total_attr": 12
+  },
+  "le-havre": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "lerwick": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "lifou": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "limassol": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "liverpool": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "livorno": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "lombok": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "los-angeles": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 12
+  },
+  "lyttelton": {
+    "attr_003_fail": false,
+    "distinct_sources": 6,
+    "placeholders": 5,
+    "total_attr": 6
+  },
+  "malaga": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "maldives": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "manaus": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "manila": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 4
+  },
+  "manta": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "maputo": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "marseille": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "martinique": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "maui": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 13
+  },
+  "mauritius": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "melbourne": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "messina": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "miami": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 12
+  },
+  "milford-sound": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 7,
+    "total_attr": 8
+  },
+  "mobile": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "monte-carlo": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "montego-bay": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "montevideo": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "montreal": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "moorea": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "mumbai": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "muscat": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "mykonos": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 1,
+    "total_attr": 8
+  },
+  "mystery-island": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "nagasaki": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "napier": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "nassau": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 10
+  },
+  "nawiliwili": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "new-orleans": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 12
+  },
+  "newcastle": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "newport": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "nha-trang": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "norfolk": {
+    "attr_003_fail": false,
+    "distinct_sources": 12,
+    "placeholders": 7,
+    "total_attr": 14
+  },
+  "norwegian-fjords": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "nosy-be": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "noumea": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "ocho-rios": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 10
+  },
+  "okinawa": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "olden": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "osaka": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "oslo": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "palau": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "palma": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "panama-canal": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "papeete": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "patmos": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "penang": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "philipsburg": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "phuket": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "picton": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "pitcairn": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "ponta-delgada": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 7,
+    "total_attr": 8
+  },
+  "port-canaveral": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "port-elizabeth": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "port-everglades": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "port-miami": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "portimao": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "portland": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "portland-maine": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "porto": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "portofino": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "puerto-caldera": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "puerto-limon": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "puerto-madryn": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "punta-arenas": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "punta-del-este": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 6,
+    "total_attr": 8
+  },
+  "puntarenas": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "quebec-city": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "ravenna": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "recife": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 10
+  },
+  "reykjavik": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "rhodes": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "riga": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "rio-de-janeiro": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "roatan": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "rostock": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "royal-beach-club-antigua": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "royal-beach-club-cozumel": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "royal-beach-club-nassau": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 15
+  },
+  "safaga": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "saguenay": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "saint-john": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "saipan": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "salalah": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "salvador": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 15
+  },
+  "samana": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "san-diego": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 4
+  },
+  "san-francisco": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 12
+  },
+  "san-juan": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 13
+  },
+  "santos": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 1,
+    "total_attr": 12
+  },
+  "scotland": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "seattle": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 12
+  },
+  "seychelles": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "shanghai": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "sharm-el-sheikh": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "sihanoukville": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "singapore": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "sitka": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 7
+  },
+  "skagway": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 7
+  },
+  "sorrento": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "south-georgia": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "south-pacific": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "southampton": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "split": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "st-barts": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "st-croix": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "st-helena": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "st-john-usvi": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "st-kitts": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "st-lucia": {
+    "attr_003_fail": false,
+    "distinct_sources": 14,
+    "placeholders": 8,
+    "total_attr": 14
+  },
+  "st-maarten": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "st-petersburg": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "st-thomas": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "stavanger": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "stockholm": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "suva": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 9
+  },
+  "sydney": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "sydney-ns": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "taipei": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 7,
+    "total_attr": 10
+  },
+  "tallinn": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 7
+  },
+  "tangier": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "taormina": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "tauranga": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 7,
+    "total_attr": 8
+  },
+  "tender-ports": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "tenerife": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "tianjin": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "tokyo": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "tonga": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "tortola": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "tracy-arm": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 7
+  },
+  "trieste": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "tristan-da-cunha": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "tunis": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "ushuaia": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 11
+  },
+  "valencia": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "valletta": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "valparaiso": {
+    "attr_003_fail": false,
+    "distinct_sources": 9,
+    "placeholders": 8,
+    "total_attr": 10
+  },
+  "vancouver": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "vanuatu": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "victoria-bc": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "vigo": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "villefranche": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "virgin-gorda": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 5
+  },
+  "walvis-bay": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "warnemunde": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "waterford": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "wellington": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 13
+  },
+  "whittier": {
+    "attr_003_fail": true,
+    "distinct_sources": 2,
+    "placeholders": 0,
+    "total_attr": 7
+  },
+  "zadar": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "zakynthos": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 8,
+    "total_attr": 8
+  },
+  "zanzibar": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 12
+  },
+  "zeebrugge": {
+    "attr_003_fail": true,
+    "distinct_sources": 1,
+    "placeholders": 0,
+    "total_attr": 8
+  },
+  "zihuatanejo": {
+    "attr_003_fail": false,
+    "distinct_sources": 8,
+    "placeholders": 1,
+    "total_attr": 8
+  }
+}

--- a/admin/sourcing.py
+++ b/admin/sourcing.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""
+Image-sourcing harness for In the Wake port pages.
+
+Wraps the mechanical steps of the six-step workflow documented in
+admin/IMAGE_SOURCING_WORKFLOW.md so a session can drive sourcing
+end-to-end without retyping curl flags, attribution JSON shapes, or
+file-rename logic.
+
+What the harness does NOT do (intentional integrity boundary):
+- It does not invent search hits. WebSearch / WebFetch are tools
+  the calling agent owns; the harness only takes URLs the agent has
+  already produced.
+- It does not skip visual verification. The 'fetch' subcommand puts
+  the bytes on disk; the agent must Read() the file and confirm the
+  scene before calling 'convert'. Bypassing that step reintroduces
+  the college-fjord/Flickr-889 failure class.
+
+Subcommands:
+  doctor                          preflight: network, Pillow, validator
+  inventory <slug>                files on disk, HTML refs, gaps
+  audit-attr <slug>               flag Flickr-889 / placeholder attr shapes
+  verify-flickr <url>             fetch photo page, extract CC license
+  verify-loc <item-id>            JSON API: rights + downloadable file URLs
+  fetch <url> <local-path>        --http1.1 --fail download with integrity check
+  convert <src> <dst-webp>        Pillow -> WebP (quality 85, max 1600px)
+  write-attr <webp-path> <kv...>  canonical attr.json with required fields
+  rewrite-html <slug>             update <img> srcs to match files on disk
+  validate <slug>                 run validate-port-page-v2.js, parse images
+  plan <slug>                     end-to-end work plan for one port
+
+Soli Deo Gloria.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import urllib.parse
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ROOT = Path("/home/user/InTheWake")
+PORTS_HTML = ROOT / "ports"
+PORTS_IMG = ROOT / "ports" / "img"
+ATTR_CSV = ROOT / "attributions" / "attributions.csv"
+VALIDATOR = ROOT / "admin" / "validate-port-page-v2.js"
+ALLOWLIST = ROOT / "admin" / "cross-port-image-allowlist.json"
+HASH_CACHE = ROOT / "admin" / ".port-image-hashes.json"
+
+USER_AGENT = "InTheWakePortPageRepair/1.0 (admin@cruisinginthewake.com)"
+HTTP_TIMEOUT = 30
+
+ACCEPTABLE_LICENSES = {
+    "cc by 1.0", "cc by 2.0", "cc by 2.5", "cc by 3.0", "cc by 4.0",
+    "cc by-sa 1.0", "cc by-sa 2.0", "cc by-sa 2.5", "cc by-sa 3.0", "cc by-sa 4.0",
+    "cc0", "cc0 1.0",
+    "public domain", "public domain mark", "no known restrictions",
+    "u.s. government work",
+}
+
+UNACCEPTABLE_LICENSE_HINTS = (
+    "all rights reserved",
+    "by-nc", "by-nd", "by-nc-nd", "by-nc-sa",
+    "noncommercial", "no derivatives",
+)
+
+
+# ---------- helpers ----------
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=HTTP_TIMEOUT * 2, **kwargs)
+
+
+def _curl(url: str, *, head_only: bool = False, output: Path | None = None,
+          extra: list[str] | None = None) -> tuple[int, bytes, str]:
+    cmd = [
+        "curl", "-sSL", "--http1.1", "--max-time", str(HTTP_TIMEOUT),
+        "-A", USER_AGENT,
+    ]
+    if head_only:
+        cmd.append("-I")
+    if output is not None:
+        cmd += ["--fail", "-o", str(output), "-w", "%{http_code}\\n"]
+    else:
+        cmd += ["-w", "\\n%{http_code}\\n"]
+    if extra:
+        cmd += extra
+    cmd.append(url)
+    proc = subprocess.run(cmd, capture_output=True, timeout=HTTP_TIMEOUT * 2)
+    body = proc.stdout
+    if output is not None:
+        # When -o is used, stdout is just the http_code from -w.
+        try:
+            code = int(body.decode("utf-8", "replace").strip().splitlines()[-1])
+        except Exception:
+            code = -1
+        return code, b"", proc.stderr.decode("utf-8", "replace")
+    # When body comes back, the last line is the http_code from -w.
+    text = body.decode("utf-8", "replace")
+    parts = text.rsplit("\n", 2)
+    if len(parts) >= 2 and parts[-2].strip().isdigit():
+        code = int(parts[-2].strip())
+        body_str = parts[0]
+    else:
+        code = -1
+        body_str = text
+    return code, body_str.encode("utf-8"), proc.stderr.decode("utf-8", "replace")
+
+
+def _slug_paths(slug: str) -> tuple[Path, Path]:
+    return PORTS_HTML / f"{slug}.html", PORTS_IMG / slug
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _today() -> str:
+    return _dt.date.today().isoformat()
+
+
+def _attr_path_for(image_path: Path) -> Path:
+    """ATTR-001 accepts <name>-attr.json or <name>.webp.attr.json.
+    Canonical going forward: <stem>.webp.attr.json.
+    """
+    if image_path.suffix.lower() == ".webp":
+        return image_path.with_suffix(".webp.attr.json")
+    return image_path.with_name(image_path.name + ".attr.json")
+
+
+def _is_placeholder_attr(attr: dict[str, Any]) -> str | None:
+    """Detect the Flickr-889 / college-fjord-class shapes that ATTR-003 catches."""
+    license_str = str(attr.get("license", "")).strip().lower()
+    source_type = str(attr.get("source_type", "")).strip().lower()
+    if license_str == "flickr (verify license)":
+        return "license=='Flickr (verify license)' (Flickr-889 placeholder shape)"
+    if "verify license" in license_str:
+        return f"license still says 'verify': {license_str}"
+    if source_type == "flickr public feed":
+        return "source_type=='Flickr public feed' (placeholder shape)"
+    if not attr.get("license") and not attr.get("license_url"):
+        return "no license/license_url"
+    if not (attr.get("source") or attr.get("sourceUrl") or attr.get("source_url") or attr.get("url")):
+        return "no source URL of any kind"
+    return None
+
+
+# ---------- subcommands ----------
+
+def cmd_doctor(args) -> int:
+    print("=== preflight check ===")
+    ok = True
+
+    # Pillow
+    try:
+        from PIL import Image, features, __version__ as _v
+        print(f"  Pillow: {_v} (webp={features.check('webp')})")
+    except Exception as e:
+        print(f"  Pillow: MISSING ({e}) — run: pip3 install --quiet Pillow")
+        ok = False
+
+    # Validator
+    if VALIDATOR.exists():
+        print(f"  validator: {VALIDATOR.relative_to(ROOT)}")
+    else:
+        print(f"  validator: MISSING at {VALIDATOR}")
+        ok = False
+
+    # Network egress (matches IMAGE_SOURCING_WORKFLOW.md sandbox table)
+    expected_reachable = [
+        "https://www.loc.gov/",
+        "https://www.flickr.com/photos/",
+        "https://images.unsplash.com/",
+        "https://images.pexels.com/",
+        "https://www.nps.gov/",
+    ]
+    expected_blocked = [
+        "https://commons.wikimedia.org/",
+        "https://upload.wikimedia.org/",
+    ]
+    print("  network:")
+    for url in expected_reachable:
+        code, _, _ = _curl(url, head_only=True)
+        sym = "OK" if 200 <= code < 400 else "FAIL"
+        if sym == "FAIL":
+            ok = False
+        print(f"    {sym:4s} {url}  {code}")
+    for url in expected_blocked:
+        code, _, _ = _curl(url, head_only=True)
+        if code in (200, 301, 302):
+            print(f"    NEW  {url}  {code}  (was blocked; doc may be stale)")
+        else:
+            print(f"    BLK  {url}  {code}  (expected blocked)")
+
+    # tile.loc.gov has known HTTP/2 truncation; we force --http1.1 site-wide
+    print("  loc-cdn-http1.1: enforced")
+
+    # Attribution CSV reachable
+    if ATTR_CSV.exists():
+        rows = sum(1 for _ in ATTR_CSV.open())
+        print(f"  {ATTR_CSV.relative_to(ROOT)}: {rows} rows")
+    else:
+        print(f"  {ATTR_CSV.relative_to(ROOT)}: MISSING")
+        ok = False
+
+    # Cross-port allowlist
+    if ALLOWLIST.exists():
+        try:
+            data = json.loads(_read_text(ALLOWLIST))
+            print(f"  allowlist: {len(data.get('reviewed', []))} approved cross-port duplicates")
+        except Exception as e:
+            print(f"  allowlist: PARSE ERROR ({e})")
+            ok = False
+    else:
+        print(f"  allowlist: MISSING")
+        ok = False
+
+    print(f"\n  result: {'OK' if ok else 'BLOCKERS — fix before sourcing'}")
+    return 0 if ok else 1
+
+
+def cmd_inventory(args) -> int:
+    slug = args.slug
+    html_path, img_dir = _slug_paths(slug)
+    if not html_path.exists():
+        print(f"ERROR: no HTML page at {html_path}", file=sys.stderr)
+        return 1
+    html = _read_text(html_path)
+
+    # Image files on disk
+    files = sorted([p for p in img_dir.glob("*") if p.suffix.lower() in (".webp", ".jpg", ".jpeg", ".png")]) if img_dir.exists() else []
+    attrs = sorted([p for p in img_dir.glob("*-attr.json")]) + sorted([p for p in img_dir.glob("*.webp.attr.json")]) if img_dir.exists() else []
+    attr_set = {p.name.replace(".webp.attr.json", ".webp").replace("-attr.json", ".webp"): p for p in attrs}
+
+    # HTML <img> refs scoped to this port
+    refs = re.findall(r'<img\b[^>]*\bsrc=["\']([^"\']+)["\']', html, re.IGNORECASE)
+    own = []
+    chrome = []
+    other = []
+    for r in refs:
+        clean = r.split("?", 1)[0].split("#", 1)[0]
+        if clean.startswith(f"/ports/img/{slug}/") or clean.startswith(f"ports/img/{slug}/"):
+            own.append(clean)
+        elif clean.startswith("/ports/img/"):
+            other.append(clean)
+        else:
+            chrome.append(clean)
+
+    own_resolved, own_broken = [], []
+    for r in own:
+        local = ROOT / r.lstrip("/")
+        (own_resolved if local.exists() else own_broken).append(r)
+
+    out = {
+        "slug": slug,
+        "html": str(html_path.relative_to(ROOT)),
+        "img_dir": str(img_dir.relative_to(ROOT)) if img_dir.exists() else None,
+        "files_on_disk": [p.name for p in files],
+        "attr_files_on_disk": [p.name for p in attrs],
+        "files_without_attr": [p.name for p in files if p.name not in attr_set and p.stem != f"{slug}-hero"],
+        "html_img_refs": {
+            "own_resolved": own_resolved,
+            "own_broken": own_broken,
+            "cross_port": other,
+            "chrome": chrome,
+        },
+        "counts": {
+            "files_on_disk": len(files),
+            "attr_files": len(attrs),
+            "img_tags_total": len(refs),
+            "own_resolved": len(own_resolved),
+            "own_broken": len(own_broken),
+        },
+    }
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+def cmd_audit_attr(args) -> int:
+    slug = args.slug
+    img_dir = PORTS_IMG / slug
+    if not img_dir.exists():
+        print(f"ERROR: no image dir at {img_dir}", file=sys.stderr)
+        return 1
+
+    findings = []
+    for attr_path in sorted(img_dir.glob("*attr.json")):
+        try:
+            attr = json.loads(_read_text(attr_path))
+        except Exception as e:
+            findings.append({"file": attr_path.name, "issue": f"unparseable JSON: {e}"})
+            continue
+        problem = _is_placeholder_attr(attr)
+        if problem:
+            findings.append({"file": attr_path.name, "issue": problem,
+                             "license": attr.get("license"),
+                             "source": attr.get("source") or attr.get("sourceUrl") or attr.get("url")})
+
+    # ATTR-003 source-URL diversity check (in-gallery)
+    sources = []
+    for attr_path in sorted(img_dir.glob("*attr.json")):
+        try:
+            attr = json.loads(_read_text(attr_path))
+            sources.append(str(attr.get("source") or attr.get("sourceUrl") or attr.get("source_url") or attr.get("url") or ""))
+        except Exception:
+            pass
+    distinct = len({s for s in sources if s})
+    diversity = {"total_attr": len(sources), "distinct_sources": distinct,
+                 "fail_attr_003": (len(sources) >= 4 and distinct <= 2)}
+
+    print(json.dumps({"slug": slug, "placeholder_findings": findings,
+                       "diversity_check": diversity}, indent=2))
+    return 0 if not findings and not diversity["fail_attr_003"] else 2
+
+
+def cmd_verify_flickr(args) -> int:
+    url = args.url
+    code, body, _ = _curl(url)
+    if code != 200:
+        print(json.dumps({"url": url, "http": code, "verdict": "FAIL", "reason": "non-200"}))
+        return 2
+    text = body.decode("utf-8", "replace")
+    cc_links = re.findall(r"https?://creativecommons\.org/(?:licenses|publicdomain)/[\w\.\-/]+", text)
+    if cc_links:
+        license_url = cc_links[0]
+        m = re.search(r"creativecommons\.org/licenses/([\w\-]+)/([\d\.]+)/?", license_url)
+        if m:
+            license_label = f"CC {m.group(1).upper()} {m.group(2)}"
+        elif "publicdomain" in license_url:
+            license_label = "Public Domain (CC0)"
+        else:
+            license_label = "Creative Commons (verify)"
+        # author from schema.org / og:image:owner / "by USER" text
+        author = None
+        for pat in (r'"author"\s*:\s*\{[^}]*"name"\s*:\s*"([^"]+)"',
+                    r'photos/([\w\-_]+)/'):
+            m = re.search(pat, text)
+            if m:
+                author = m.group(1)
+                break
+        verdict = "OK" if license_label.lower() in ACCEPTABLE_LICENSES or "public domain" in license_label.lower() else "REVIEW"
+        print(json.dumps({"url": url, "http": code, "license": license_label,
+                          "license_url": license_url, "author": author, "verdict": verdict}, indent=2))
+        return 0 if verdict == "OK" else 2
+    # No CC link → ARR
+    print(json.dumps({"url": url, "http": code, "verdict": "FAIL",
+                       "reason": "no creativecommons.org link found (likely All Rights Reserved)"}))
+    return 2
+
+
+def cmd_verify_loc(args) -> int:
+    item_id = args.item_id.strip().strip("/")
+    json_url = f"https://www.loc.gov/item/{item_id}/?fo=json"
+    code, body, _ = _curl(json_url)
+    if code != 200:
+        print(json.dumps({"item_id": item_id, "http": code, "verdict": "FAIL"}))
+        return 2
+    try:
+        data = json.loads(body)
+    except Exception as e:
+        print(json.dumps({"item_id": item_id, "verdict": "FAIL", "reason": f"json parse: {e}"}))
+        return 2
+    item = data.get("item", {})
+    rights = item.get("rights_information") or item.get("rights_advisory") or ""
+    title = item.get("title", "")
+    creators = item.get("contributor_names") or item.get("creator", "")
+    files = []
+    for r in data.get("resources", [])[:1]:
+        for fg in r.get("files", []):
+            for f in fg:
+                if "jpeg" in str(f.get("mimetype", "")):
+                    files.append({"url": f.get("url"), "size": f.get("size"),
+                                  "info": f.get("info", "")})
+    rights_lower = rights.lower() if isinstance(rights, str) else ""
+    pd_signals = ("public domain", "no known restrictions", "no copyright")
+    verdict = "OK" if any(s in rights_lower for s in pd_signals) else "REVIEW"
+    print(json.dumps({"item_id": item_id, "title": title, "rights": rights,
+                       "creators": creators, "files": files, "verdict": verdict,
+                       "human_url": f"https://www.loc.gov/item/{item_id}/"}, indent=2))
+    return 0 if verdict == "OK" else 2
+
+
+def cmd_fetch(args) -> int:
+    url = args.url
+    out = Path(args.local_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    code, _, stderr = _curl(url, output=out)
+    if code != 200 or not out.exists():
+        print(json.dumps({"url": url, "http": code, "verdict": "FAIL", "stderr": stderr}))
+        return 2
+    size = out.stat().st_size
+    # Sanity: tile.loc.gov sometimes truncates JPEGs. Try a Pillow load.
+    try:
+        from PIL import Image
+        img = Image.open(out)
+        img.load()
+        ok = True
+        info = {"size": size, "image_size": img.size, "mode": img.mode}
+    except Exception as e:
+        ok = False
+        info = {"size": size, "load_error": str(e)}
+    print(json.dumps({"url": url, "local": str(out), "http": code,
+                       "verdict": "OK" if ok else "TRUNCATED — re-fetch",
+                       **info}, indent=2))
+    return 0 if ok else 3
+
+
+def cmd_convert(args) -> int:
+    src = Path(args.src)
+    dst = Path(args.dst)
+    if not src.exists():
+        print(f"ERROR: source missing: {src}", file=sys.stderr)
+        return 1
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    from PIL import Image
+    img = Image.open(src)
+    img.load()
+    if args.crop:
+        l, t, r, b = (float(x) for x in args.crop.split(","))
+        w, h = img.size
+        img = img.crop((int(w * l), int(h * t), int(w * r), int(h * b)))
+    if img.width > args.max_width:
+        ratio = args.max_width / img.width
+        img = img.resize((args.max_width, int(img.height * ratio)), Image.LANCZOS)
+    img.save(dst, "WEBP", quality=args.quality, method=6)
+    print(json.dumps({"src": str(src), "dst": str(dst),
+                       "size": dst.stat().st_size,
+                       "image_size": img.size}, indent=2))
+    return 0
+
+
+def cmd_write_attr(args) -> int:
+    image_path = Path(args.image)
+    if not image_path.exists():
+        print(f"ERROR: image missing: {image_path}", file=sys.stderr)
+        return 1
+    fields: dict[str, Any] = {}
+    for kv in args.fields or []:
+        if "=" not in kv:
+            print(f"ERROR: field must be key=value: {kv}", file=sys.stderr)
+            return 1
+        k, v = kv.split("=", 1)
+        fields[k.strip()] = v.strip()
+
+    # verifiedBy/verifiedDate auto-fill BEFORE the missing check so they don't
+    # appear in the error message.
+    fields.setdefault("verifiedDate", _today())
+    fields.setdefault("verifiedBy", f"sourcing.py session {_today()}")
+
+    required = {"sourceUrl", "license", "licenseUrl", "photographer", "title",
+                "description", "alt"}
+    missing = required - set(fields.keys())
+    if missing and not args.allow_partial:
+        print(f"ERROR: required fields missing: {sorted(missing)}\n"
+              f"Pass --allow-partial only when you can document the gap.",
+              file=sys.stderr)
+        return 1
+
+    # Defensive license check
+    license_str = str(fields.get("license", "")).lower()
+    if any(h in license_str for h in UNACCEPTABLE_LICENSE_HINTS):
+        print(f"ERROR: license '{fields['license']}' is not acceptable for this site.", file=sys.stderr)
+        return 1
+    if "verify license" in license_str:
+        print(f"ERROR: license '{fields['license']}' is the Flickr-889 placeholder shape.", file=sys.stderr)
+        return 1
+
+    out = _attr_path_for(image_path)
+    out.write_text(json.dumps(fields, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"image": str(image_path), "attr": str(out), "fields": list(fields.keys())}, indent=2))
+    return 0
+
+
+def cmd_rewrite_html(args) -> int:
+    """Repoint <img src> on a port HTML to the actual files on disk.
+    Conservative: only rewrites refs whose stem matches an existing on-disk file.
+    Reports unmatched refs without modifying them.
+    """
+    slug = args.slug
+    html_path, img_dir = _slug_paths(slug)
+    if not html_path.exists():
+        print(f"ERROR: no HTML at {html_path}", file=sys.stderr)
+        return 1
+    html = _read_text(html_path)
+    files_on_disk = {p.name for p in img_dir.glob("*") if p.suffix.lower() in (".webp", ".jpg", ".png")} if img_dir.exists() else set()
+
+    # Build a stem-keyed lookup so 'pde-hero.webp' -> 'punta-del-este-hero.webp' if a clear match exists
+    by_stem = {p.split(".")[0]: p for p in files_on_disk}
+    by_token = {}
+    for p in files_on_disk:
+        for token in p.replace(".webp", "").split("-"):
+            by_token.setdefault(token, set()).add(p)
+
+    fixes: list[dict[str, str]] = []
+    unmatched: list[str] = []
+
+    def _replace(match: re.Match) -> str:
+        full = match.group(0)
+        src = match.group(1)
+        clean = src.split("?", 1)[0].split("#", 1)[0]
+        if not clean.startswith(f"/ports/img/{slug}/"):
+            return full
+        local = ROOT / clean.lstrip("/")
+        if local.exists():
+            return full
+        wanted = local.name
+        # Already-good-stem fallback: drop dir prefix variants
+        if wanted in files_on_disk:
+            return full
+        # Try common renames: pde- -> <slug>-, .jpg -> .webp
+        candidates = []
+        if wanted.endswith(".jpg") or wanted.endswith(".jpeg"):
+            stem = wanted.rsplit(".", 1)[0]
+            cand = stem + ".webp"
+            if cand in files_on_disk:
+                candidates.append(cand)
+        # Token overlap heuristic
+        wanted_tokens = set(wanted.replace(".webp", "").split("-"))
+        wanted_tokens.discard(slug)
+        if wanted_tokens:
+            for cand in files_on_disk:
+                cand_tokens = set(cand.replace(".webp", "").split("-"))
+                cand_tokens.discard(slug)
+                if wanted_tokens & cand_tokens:
+                    candidates.append(cand)
+        if len(set(candidates)) == 1:
+            chosen = candidates[0]
+            fixes.append({"old": clean, "new": f"/ports/img/{slug}/{chosen}"})
+            return full.replace(src, f"/ports/img/{slug}/{chosen}")
+        unmatched.append(clean)
+        return full
+
+    new_html = re.sub(r'<img\b[^>]*\bsrc=["\']([^"\']+)["\']', _replace, html, flags=re.IGNORECASE)
+    if args.dry_run:
+        print(json.dumps({"slug": slug, "fixes": fixes, "unmatched": sorted(set(unmatched)),
+                          "would_write": new_html != html}, indent=2))
+        return 0
+    if new_html != html:
+        html_path.write_text(new_html, encoding="utf-8")
+    print(json.dumps({"slug": slug, "fixes": fixes, "unmatched": sorted(set(unmatched)),
+                       "wrote": new_html != html}, indent=2))
+    return 0
+
+
+def cmd_validate(args) -> int:
+    slug = args.slug
+    html_path, _ = _slug_paths(slug)
+    if not html_path.exists():
+        print(f"ERROR: no HTML at {html_path}", file=sys.stderr)
+        return 1
+    proc = subprocess.run(
+        ["node", str(VALIDATOR), f"ports/{slug}.html", "--json-output", "--quiet"],
+        cwd=str(ROOT), capture_output=True, text=True, timeout=120,
+    )
+    try:
+        data = json.loads(proc.stdout)
+    except Exception:
+        print("ERROR: validator did not return JSON", file=sys.stderr)
+        print(proc.stdout[-2000:])
+        return 2
+    if not isinstance(data, dict):
+        print("ERROR: validator JSON not an object", file=sys.stderr)
+        return 2
+    image_blockers = [b for b in data.get("blocking_errors", [])
+                      if b.get("section") == "images"
+                         or "image" in str(b.get("rule", "")).lower()
+                         or b.get("rule") == "missing_image_file"]
+    image_warnings = [w for w in data.get("warnings", [])
+                      if w.get("section") == "images"]
+    summary = {
+        "slug": slug,
+        "valid": data.get("valid"),
+        "score": data.get("score"),
+        "image_blockers": image_blockers,
+        "image_warnings_count": len(image_warnings),
+        "all_blockers_count": len(data.get("blocking_errors", [])),
+    }
+    print(json.dumps(summary, indent=2))
+    return 0 if not image_blockers else 2
+
+
+def cmd_plan(args) -> int:
+    """End-to-end work plan for one port slug, derived from current state."""
+    slug = args.slug
+    html_path, img_dir = _slug_paths(slug)
+    if not html_path.exists():
+        print(f"ERROR: no HTML at {html_path}", file=sys.stderr)
+        return 1
+    inv_args = argparse.Namespace(slug=slug)
+    saved_stdout = sys.stdout
+    try:
+        sys.stdout = open(os.devnull, "w")
+        # Reuse inventory logic by capturing
+        files_on_disk = sorted([p.name for p in img_dir.glob("*") if p.suffix.lower() in (".webp", ".jpg", ".png")]) if img_dir.exists() else []
+        html = _read_text(html_path)
+        refs = re.findall(r'<img\b[^>]*\bsrc=["\']([^"\']+)["\']', html, re.IGNORECASE)
+        own = [r.split("?", 1)[0].split("#", 1)[0] for r in refs
+               if r.split("?", 1)[0].startswith(f"/ports/img/{slug}/")]
+        own_resolved = [r for r in own if (ROOT / r.lstrip("/")).exists()]
+        own_broken = [r for r in own if not (ROOT / r.lstrip("/")).exists()]
+    finally:
+        sys.stdout.close()
+        sys.stdout = saved_stdout
+
+    actions = []
+    if own_broken:
+        actions.append({
+            "step": "rewrite-html",
+            "rationale": f"{len(own_broken)} broken own-port refs; try heuristic rename first",
+            "command": f"python3 admin/sourcing.py rewrite-html {slug} --dry-run",
+        })
+    files_without_attr = []
+    if img_dir.exists():
+        attrs = {p.name for p in img_dir.glob("*attr.json")}
+        for f in files_on_disk:
+            if f"{f}.attr.json" not in attrs and f"{f.rsplit('.', 1)[0]}-attr.json" not in attrs and not f.endswith("-hero.webp"):
+                files_without_attr.append(f)
+    if files_without_attr:
+        actions.append({
+            "step": "audit-attr",
+            "rationale": f"{len(files_without_attr)} files lack attr.json",
+            "command": f"python3 admin/sourcing.py audit-attr {slug}",
+        })
+    actions.append({
+        "step": "validate",
+        "rationale": "confirm image blockers cleared",
+        "command": f"python3 admin/sourcing.py validate {slug}",
+    })
+
+    print(json.dumps({"slug": slug, "files_on_disk": len(files_on_disk),
+                       "own_resolved": len(own_resolved),
+                       "own_broken": len(own_broken),
+                       "files_without_attr": files_without_attr,
+                       "next_actions": actions}, indent=2))
+    return 0
+
+
+# ---------- argparse plumbing ----------
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Image-sourcing harness for In the Wake port pages")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("doctor", help="preflight: network, Pillow, validator")
+
+    s = sub.add_parser("inventory", help="files on disk, HTML refs, gaps")
+    s.add_argument("slug")
+
+    s = sub.add_parser("audit-attr", help="flag Flickr-889 / placeholder attr shapes")
+    s.add_argument("slug")
+
+    s = sub.add_parser("verify-flickr", help="fetch photo page, extract CC license")
+    s.add_argument("url")
+
+    s = sub.add_parser("verify-loc", help="JSON API: rights + downloadable file URLs")
+    s.add_argument("item_id", help="LoC item id, e.g. 2024686372")
+
+    s = sub.add_parser("fetch", help="--http1.1 --fail download with integrity check")
+    s.add_argument("url")
+    s.add_argument("local_path")
+
+    s = sub.add_parser("convert", help="Pillow -> WebP (quality 85, max 1600px)")
+    s.add_argument("src")
+    s.add_argument("dst")
+    s.add_argument("--max-width", type=int, default=1600)
+    s.add_argument("--quality", type=int, default=85)
+    s.add_argument("--crop", help="crop fractions 'l,t,r,b' (e.g. 0.05,0.10,0.95,0.92)")
+
+    s = sub.add_parser("write-attr", help="canonical attribution JSON")
+    s.add_argument("image", help="path to webp file (sibling .webp.attr.json is written)")
+    s.add_argument("fields", nargs="*", help="key=value pairs (sourceUrl=, license=, ...)")
+    s.add_argument("--allow-partial", action="store_true",
+                   help="allow missing required fields (document the gap in caller's notes)")
+
+    s = sub.add_parser("rewrite-html", help="update <img> srcs to match files on disk")
+    s.add_argument("slug")
+    s.add_argument("--dry-run", action="store_true")
+
+    s = sub.add_parser("validate", help="run validate-port-page-v2.js, parse images")
+    s.add_argument("slug")
+
+    s = sub.add_parser("plan", help="end-to-end work plan for one port")
+    s.add_argument("slug")
+
+    args = p.parse_args()
+    handler = {
+        "doctor": cmd_doctor,
+        "inventory": cmd_inventory,
+        "audit-attr": cmd_audit_attr,
+        "verify-flickr": cmd_verify_flickr,
+        "verify-loc": cmd_verify_loc,
+        "fetch": cmd_fetch,
+        "convert": cmd_convert,
+        "write-attr": cmd_write_attr,
+        "rewrite-html": cmd_rewrite_html,
+        "validate": cmd_validate,
+        "plan": cmd_plan,
+    }[args.cmd]
+    return handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Re-verified IMAGE_SOURCING_WORKFLOW.md against the live 2026-05-10 sandbox: documented sources still reachable, Wikimedia/archive.org/ Pixabay still blocked. Workflow doc was 30 days stale on two points that mattered:

- tile.loc.gov silently truncates JPEGs over HTTP/2; the doc never mentioned it. The harness forces --http1.1 site-wide and runs a Pillow load on every fetch so truncation surfaces immediately.
- Production attr.json shape diverged from the doc's aspirational schema. Most files in production are the Flickr-889 placeholder shape (license: "Flickr (verify license)") — explicitly the kind of file ATTR-003 was added to catch.

Added admin/sourcing.py (~700 LOC) with subcommands for the entire six-step workflow:

  doctor        preflight: network reachability, Pillow, validator
  inventory     files vs HTML refs vs gaps for one port
  audit-attr    detect Flickr-889 / placeholder shapes
  verify-flickr fetch photo page, parse CC license URL
  verify-loc    JSON API lookup with rights + downloadable URLs
  fetch         --http1.1 --fail download with Pillow integrity check
  convert       Pillow -> WebP, quality 85, max 1600px, optional crop
  write-attr    canonical schema; refuses placeholder-license writes
  rewrite-html  conservative <img src> repair (single-token match)
  validate      run validate-port-page-v2.js, return image blockers
  plan          ordered next-actions for one port

The harness deliberately keeps two things in human/agent hands: URL discovery (WebSearch produces the URLs) and visual verification (Read renders the image; the agent confirms the scene). Bypassing either step reintroduces the college-fjord/Flickr-889 failure class.

Fleet-wide audit (fleet-attr-audit.json) found 891 placeholder attr.json files across 302 ports — slightly worse than the spring 2026 baseline. Validator's ATTR-003 only catches 180 of them because it gates on source-URL diversity; the cleverer pattern uses distinct URLs per file with the same placeholder license string, slipping past. A new validator rule for "license string contains 'verify license'" is recommended in the updated plan (Phase 1.5).

Soli Deo Gloria.

https://claude.ai/code/session_01JrhJPW2bAQosPML667RQ75