### PR TITLE
sanitizer v1.2.0 audit: pin Actions to SHAs + fix SEC-005 worked example

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Link Checker (Lychee)
-        uses: lycheeverse/lychee-action@v2.1.0
+        uses: lycheeverse/lychee-action@f81112d0d2814ded911bd23e3beaa9dda9093915  # v2.1.0
         with:
           # Use config file for exclusions (lychee.toml)
           args: >-
@@ -35,7 +35,7 @@ jobs:
           lycheeVersion: v0.18.0  # Pin to stable version
 
       - name: Upload Link Check Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         if: always()
         with:
           name: lychee-report
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Check for Unknown placeholders
         run: |
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Check theological requirements
         run: |
@@ -159,10 +159,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '22'
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/admin/validator-spec/rules/SEC-005.md
+++ b/admin/validator-spec/rules/SEC-005.md
@@ -45,10 +45,12 @@ if (!apiKey) throw new Error('SOME_API_KEY not set');
 ## Fail example
 ```js
 const password = "hunter2";  // BLOCKING
-const apiSecret = "AKIAIOSFODNN7EXAMPLE";  // BLOCKING
-const googleMapsKey = "AIzaSyBExampleKey1234567890Abcdefghijklmno";  // BLOCKING
+const apiSecret = "[AWS-ACCESS-KEY-PLACEHOLDER]";  // BLOCKING — real pattern: ^AKIA[0-9A-Z]{16}$
+const googleMapsKey = "[GOOGLE-API-KEY-PLACEHOLDER]";  // BLOCKING — real pattern: ^AIza[0-9A-Za-z_-]{35}$
 ```
 Validator emits: `No hardcoded API keys or secrets`.
+
+> Note: the example uses non-regex-matching placeholders by design — a worked example that matches its own pattern would re-trigger any downstream credential scanner (including this project's `opensource-sanitizer` v1.2.0). The pattern definitions above (`^AKIA[0-9A-Z]{16}$`, `^AIza[0-9A-Za-z_-]{35}$`) are the source of truth for what this rule blocks.
 
 ## Fix guidance
 - Rotate the exposed secret immediately — assume compromised.


### PR DESCRIPTION
Three changes from the v1.2.0 household audit:

1. admin/validator-spec/rules/SEC-005.md — replaced the AWS dummy key (AKIAIOSFODNN7EXAMPLE, AWS-published canonical example) and the fake Google Maps key with non-regex-matching placeholders. The previous examples re-triggered the rule's own Stage 1 regex on every sanitizer run. Per Grok's red-team backdoor pattern #5: worked examples must not double as the pattern they exemplify. Pattern definitions remain the source of truth.

2. .github/workflows/quality.yml — pinned actions/checkout, actions/upload-artifact, actions/setup-node, and the community action lycheeverse/lychee-action@v2.1.0 to commit SHAs. The community action is the higher-risk pin.

3. .github/workflows/static.yml — pinned actions/checkout, configure-pages, upload-pages-artifact, deploy-pages to commit SHAs.

Full report: /tmp/HOUSEHOLD-SANITIZATION-REPORT-v1.2.0.md

https://claude.ai/code/session_01GDpbJ9bE8HTFTqy7X855my