### PR TITLE
fix: add missing ship path redirects (celebrity, holland-america, ncl)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -77,6 +77,14 @@
 
   # royal-caribbean → rcl (Ship Size Atlas uses wrong path; real pages live at /ships/rcl/)
   RewriteRule ^ships/royal-caribbean/(.*)$ /ships/rcl/$1 [R=301,L]
+  # celebrity -> celebrity-cruises (path mismatch - real pages live at /ships/celebrity-cruises/)
+  RewriteRule ^ships/celebrity/(.*)$ /ships/celebrity-cruises/$1 [R=301,L]
+
+  # holland-america -> holland-america-line (path mismatch - real pages live at /ships/holland-america-line/)
+  RewriteRule ^ships/holland-america/(.*)$ /ships/holland-america-line/$1 [R=301,L]
+
+  # ncl -> norwegian (path mismatch - real pages live at /ships/norwegian/)
+  RewriteRule ^ships/ncl/(.*)$ /ships/norwegian/$1 [R=301,L]
 
   # Fix double-cruise-line naming (ships/carnival/carnival-carnival-*.html)
   RewriteRule ^ships/carnival/carnival-carnival-(.*)$ /ships/carnival/carnival-$1 [R=301,L]


### PR DESCRIPTION
## What

Adds three missing 301 redirects to `.htaccess` for ship URL path mismatches identified during the 2026-05-13 site audit.

## Redirects Added

| Old path | Correct path | Why |
|----------|-------------|-----|
| `/ships/celebrity/*` | `/ships/celebrity-cruises/*` | Wrong slug — real pages at `celebrity-cruises` |
| `/ships/holland-america/*` | `/ships/holland-america-line/*` | Wrong slug — real pages at `holland-america-line` |
| `/ships/ncl/*` | `/ships/norwegian/*` | Wrong slug — real pages at `norwegian` (fixes Norwegian Encore 404) |

## Already in .htaccess (not duplicated)
- `royal-caribbean` → `rcl` ✅
- `carnival-cruise-line` → `carnival` ✅

## Tested
- Norwegian Encore confirmed live at `/ships/norwegian/norwegian-encore.html`
- Celebrity pages confirmed at `/ships/celebrity-cruises/`
- HAL pages confirmed at `/ships/holland-america-line/`

Soli Deo Gloria