### PR TITLE
restaurants/msc: fact-corrections from fresh original research + emot…

### DIFF
--- a/restaurants/msc/asian-market-kitchen.html
+++ b/restaurants/msc/asian-market-kitchen.html
@@ -33,7 +33,7 @@ All work on this project is offered as a gift to God.
   <title>Asian Market Kitchen by Roy Yamaguchi — MSC Cruises | In the Wake</title>
 
   <!-- Canonical & SEO -->
-  <meta name="description" content="Asian Market Kitchen by Roy Yamaguchi on MSC Seaside and MSC Seaview. Deck 16. A chef-collaboration trio: Pan-Asian fusion (32 seats), a sushi counter (42 seats), and teppanyaki (32 seats), all under one specialty-dining cover charge. Distinct from MSC's Kaito brand on newer ships.">
+  <meta name="description" content="Asian Market Kitchen by Roy Yamaguchi on MSC Seaside and MSC Seaview. Deck 16. A chef-collaboration trio: Pan-Asian fusion (32 seats), a sushi counter (42 seats), and teppanyaki (32 seats), all under one specialty-dining cover charge. The teppanyaki room within AMK on Seaside now also carries MSC's fleet-wide Kaito brand name.">
   <link rel="canonical" href="https://cruisinginthewake.com/restaurants/msc/asian-market-kitchen.html">
   <meta name="referrer" content="no-referrer">
   <meta name="ai-summary" content="Asian Market Kitchen by Roy Yamaguchi — MSC Seaside and Seaview only, Deck 16. Three concepts under one chef: Pan-Asian (32 seats), sushi counter (42), teppanyaki (32). Specialty cover charge. Not MSC's Kaito brand.">
@@ -46,7 +46,7 @@ All work on this project is offered as a gift to God.
   <meta property="og:site_name" content="In the Wake">
   <meta property="og:title" content="Asian Market Kitchen by Roy Yamaguchi — MSC Cruises">
   <meta property="og:url" content="https://cruisinginthewake.com/restaurants/msc/asian-market-kitchen.html">
-  <meta property="og:description" content="Asian Market Kitchen by Roy Yamaguchi on MSC Seaside and MSC Seaview. Deck 16. Three connected concepts under one chef: Pan-Asian, sushi, and teppanyaki. Specialty cover charge applies. Distinct from MSC's Kaito brand on newer ships.">
+  <meta property="og:description" content="Asian Market Kitchen by Roy Yamaguchi on MSC Seaside and MSC Seaview. Deck 16. Three connected concepts under one chef: Pan-Asian, sushi, and teppanyaki. Specialty cover charge applies. The teppanyaki room within AMK on Seaside now also carries MSC's fleet-wide Kaito brand name.">
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/dining-hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Asian Market Kitchen by Roy Yamaguchi — MSC Cruises">
@@ -79,7 +79,7 @@ All work on this project is offered as a gift to God.
   "@context": "https://schema.org",
   "@type": "WebPage",
   "name": "Asian Market Kitchen by Roy Yamaguchi — MSC Cruises",
-  "description": "Asian Market Kitchen by Roy Yamaguchi on MSC Seaside and MSC Seaview. Deck 16. A chef-collaboration trio: Pan-Asian fusion (32 seats), a sushi counter (42 seats), and teppanyaki (32 seats), all under one specialty-dining cover charge. Distinct from MSC's Kaito brand on newer ships.",
+  "description": "Asian Market Kitchen by Roy Yamaguchi on MSC Seaside and MSC Seaview. Deck 16. A chef-collaboration trio: Pan-Asian fusion (32 seats), a sushi counter (42 seats), and teppanyaki (32 seats), all under one specialty-dining cover charge. The teppanyaki room within AMK on Seaside now also carries MSC's fleet-wide Kaito brand name.",
   "url": "https://cruisinginthewake.com/restaurants/msc/asian-market-kitchen.html",
   "breadcrumb": {
     "@type": "BreadcrumbList",
@@ -108,7 +108,7 @@ All work on this project is offered as a gift to God.
       "name": "What is Asian Market Kitchen by Roy Yamaguchi on MSC Cruises?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Asian Market Kitchen is a chef-collaboration specialty venue developed by Hawaii-based chef Roy Yamaguchi for MSC Cruises. It carries three connected concepts under one cover charge on Deck 16 of MSC Seaside and MSC Seaview: a 32-seat Pan-Asian fusion dining room, a 42-seat sushi counter, and a 32-seat teppanyaki room. The collaboration is specific to the original Seaside-class pair — it is not on the Seaside EVO ships (Seashore, Seascape) and it is not the same as MSC's Kaito brand on other ships."
+        "text": "Asian Market Kitchen launched in 2017 as a Roy Yamaguchi chef collaboration specific to MSC Seaside and MSC Seaview. It still occupies Deck 16 on both ships as three connected concepts under one cover charge: a 32-seat Pan-Asian fusion dining room, a 42-seat sushi counter, and a 32-seat teppanyaki room (now branded Kaito Teppanyaki). The Yamaguchi partnership has been suspended since the 2020-21 pandemic and current third-party sources describe the chef as no longer actively associated, though the AMK umbrella name remains. On other MSC ships (the Seashore and Seascape Seaside EVO sisters, the Meraviglia class, the newest World class ships) MSC's Asian dining is purely Kaito-branded with no AMK wrapper."
       }
     },
     {
@@ -124,7 +124,7 @@ All work on this project is offered as a gift to God.
       "name": "How much does Asian Market Kitchen cost?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "MSC has moved most specialty restaurants to a flat per-restaurant cover charge that includes one appetizer, one main, and one dessert. Recent reference points: roughly $49 per person at the sushi counter and roughly $55 per person at teppanyaki, with package savings if you bundle two or more specialty meals. Pricing changes — confirm current rates in the MSC for Me app before booking. The set-pricing model replaced earlier a la carte menus."
+        "text": "Recent 2025-26 reporting puts teppanyaki set menus at roughly $35-$45 per person (Ozaki Wagyu carries a supplement), sushi at roughly $49 per person on the set list with some a la carte items still on the menu, and Pan-Asian at a similar set price to teppanyaki. MSC dining packages bundle multiple specialty restaurants: 2 meals roughly $99, 3 meals roughly $139, with Butcher's Cut limited to one use per package. Pre-cruise purchases typically run cheaper than at the desk. Pricing changes — confirm in the MSC for Me app before booking."
       }
     },
     {
@@ -132,7 +132,7 @@ All work on this project is offered as a gift to God.
       "name": "Is Asian Market Kitchen the same as MSC's Kaito restaurants?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "No. Asian Market Kitchen on MSC Seaside and MSC Seaview is a chef-collaboration with Roy Yamaguchi — three connected concepts under his menu direction. Kaito is MSC's in-house Asian dining brand and appears on other fleet ships including the Seaside EVO sisters. They share Japanese influence but the menu, branding, and culinary direction are distinct. Cruise blogs sometimes conflate them; on Seaside, the Yamaguchi name is the correct one."
+        "text": "Same family, evolving overlap. Asian Market Kitchen launched in 2017 as a Roy Yamaguchi chef collaboration specific to MSC Seaside and MSC Seaview — three connected concepts (Pan-Asian, sushi, teppanyaki) under his menu direction. Since the 2020-21 pandemic the Yamaguchi partnership has been suspended and current sources describe the chef as no longer actively associated. Meanwhile MSC's in-house Asian dining brand Kaito has migrated into the venue: the teppanyaki room within AMK on Seaside is now branded Kaito Teppanyaki, matching the Kaito Teppanyaki rooms on Seashore, Seascape, Meraviglia, and the newest ships. The umbrella name on Seaside and Seaview remains Asian Market Kitchen; the in-room signage and brand on other ships is purely Kaito with no AMK wrapper."
       }
     },
     {
@@ -250,7 +250,7 @@ All work on this project is offered as a gift to God.
       <h1 class="page-title">Asian Market Kitchen by Roy Yamaguchi</h1>
       <p class="subtitle">MSC Cruises &mdash; Specialty Dining (Seaside &amp; Seaview only)</p>
 
-      <p class="answer-line"><strong>Quick Answer:</strong> A chef-collaboration trio on Deck 16 of MSC Seaside and MSC Seaview. Three connected rooms &mdash; a 32-seat Pan-Asian fusion dining room, a 42-seat sushi counter, and a 32-seat teppanyaki room &mdash; share one kitchen and one specialty cover charge. Not the same as MSC's Kaito brand on the Seashore and Seascape sister ships.</p>
+      <p class="answer-line"><strong>Quick Answer:</strong> A specialty venue on Deck 16 of MSC Seaside and MSC Seaview only. Three connected rooms &mdash; a 32-seat Pan-Asian fusion dining room, a 42-seat sushi counter, and a 32-seat teppanyaki room (now branded Kaito Teppanyaki) &mdash; share one kitchen and a specialty cover charge. Launched in 2017 as a Roy Yamaguchi chef collaboration; the Yamaguchi partnership has been suspended since the 2020&ndash;21 pandemic and current third-party sources describe the chef as no longer actively associated, though the AMK umbrella name remains on these two ships.</p>
 
       <p class="fit-guidance"><strong>Best For:</strong> Couples and small parties on a 3- or 4-night MSC Seaside/Seaview sailing who want one specialty evening built around food rather than spectacle. Sushi at the counter for two; teppanyaki for the show with kids; Pan-Asian for the longest sit-down.</p>
 
@@ -277,10 +277,10 @@ All work on this project is offered as a gift to God.
     <div class="card__content menu-body">
       <h2>Menu &amp; Prices</h2>
       <p class="price-note">
-        <strong>Price:</strong> Specialty cover charge per concept (~$49 sushi / ~$55 teppanyaki / ~$55 Pan-Asian fleet-wide reference). Bundle savings via MSC dining packages (2 meals ~$99, 3 meals ~$139). MSC moved most specialty restaurants from a la carte to a flat per-restaurant set price covering one appetizer, one main, and one dessert. Pre-cruise purchases typically run cheaper than at the desk.
+        <strong>Price:</strong> Specialty cover charge per concept. Recent 2025&ndash;26 reporting on the MSC fleet: teppanyaki set menus roughly $35&ndash;$45 per person (with Ozaki Wagyu carrying a supplement); sushi roughly $49 per person on the set list with some à la carte items still on the menu; Pan-Asian set price similar to teppanyaki. MSC dining packages bundle multiple specialty restaurants — recent reference points: 2 meals roughly $99, 3 meals roughly $139, with Butcher&rsquo;s Cut limited to one use per package. Pre-cruise purchases typically run cheaper than at the desk. Pricing changes — confirm in the MSC for Me app before booking.
       </p>
 
-      <p>The three concepts under the Asian Market Kitchen name share a chef-driven menu of Asian dishes shaped by Yamaguchi&rsquo;s Hawaii kitchens. Reported standouts from recent sailings include the braised pork bao bun, Hawaii Kai-style crab cakes, and a pineapple upside-down cake the kitchen treats as a signature.</p>
+      <p>The three concepts under the Asian Market Kitchen name share a chef-driven menu shaped by Roy Yamaguchi&rsquo;s Hawaii kitchens at the 2017 launch. The Yamaguchi partnership was suspended during the 2020&ndash;21 pandemic and current third-party reporting describes the chef as no longer actively associated, though the venue and its launch-era menu DNA remain on Seaside and Seaview. Reported standouts from recent sailings include braised pork bao buns, Hawaii Kai-style crab cakes, and a pineapple upside-down cake the kitchen treats as a signature.</p>
 
       <div class="grid grid-3">
         <div>
@@ -360,7 +360,7 @@ All work on this project is offered as a gift to God.
   <section class="card" id="availability">
     <div class="card__content">
       <h2>Where You&rsquo;ll Find It</h2>
-      <p>Asian Market Kitchen by Roy Yamaguchi exists on only two ships in the MSC fleet: <a href="/ships/msc/msc-seaside.html">MSC Seaside</a> (2017) and <a href="/ships/msc/msc-seaview.html">MSC Seaview</a> (2018). It sits on Deck 16 Miami Beach, in the specialty-dining cluster forward of the glass-floored Bridge of Sighs, alongside <a href="/restaurants/msc/butchers-cut.html">Butcher&rsquo;s Cut</a> and <a href="/restaurants/msc/ocean-cay.html">Ocean Cay</a> seafood. The newer Seaside EVO sisters, <a href="/ships/msc/msc-seashore.html">MSC Seashore</a> and <a href="/ships/msc/msc-seascape.html">MSC Seascape</a>, carry MSC&rsquo;s Kaito brand instead &mdash; the chef partnership was specific to the original pair. Confirm hours and reservation policy in the MSC for Me app for your sailing.</p>
+      <p>The Asian Market Kitchen name exists on only two ships in the MSC fleet: <a href="/ships/msc/msc-seaside.html">MSC Seaside</a> (2017) and <a href="/ships/msc/msc-seaview.html">MSC Seaview</a> (2018). It sits on Deck 16 Miami Beach, in the specialty-dining cluster forward of the glass-floored Bridge of Sighs, alongside <a href="/restaurants/msc/butchers-cut.html">Butcher&rsquo;s Cut</a> and <a href="/restaurants/msc/ocean-cay.html">Ocean Cay</a> seafood. The newer Seaside EVO sisters, <a href="/ships/msc/msc-seashore.html">MSC Seashore</a> and <a href="/ships/msc/msc-seascape.html">MSC Seascape</a>, carry MSC&rsquo;s Kaito brand directly with no AMK umbrella &mdash; the Yamaguchi launch was specific to the original pair. On Seaside the teppanyaki room within AMK now also carries the Kaito Teppanyaki name. Confirm hours and reservation policy in the MSC for Me app for your sailing.</p>
     </div>
   </section>
 
@@ -398,7 +398,7 @@ All work on this project is offered as a gift to God.
         <li>Do not double-book yourself by booking sushi and teppanyaki on the same night &mdash; the kitchen pass is shared and the timing collides. Spread them across two evenings.</li>
         <li>If you have the 2- or 3-meal MSC dining package, pair Asian Market Kitchen (one meal) with Butcher&rsquo;s Cut (one meal). The package economics work better than two Asian Market Kitchen visits.</li>
         <li>Skip the room if you&rsquo;re mid-sailing tired &mdash; the show paces require attention, and the better food rewards an evening when you can sit for two hours. Saturday night of a 4-night sailing is not the optimal night.</li>
-        <li>Don&rsquo;t board expecting the Kaito brand from Seashore or Seascape. Different chef, different menu, different identity. If you sailed Kaito and didn&rsquo;t love it, Asian Market Kitchen is worth a separate try.</li>
+        <li>The Kaito brand has bled into the teppanyaki room on Seaside, so &ldquo;Kaito Teppanyaki at AMK&rdquo; on Seaside and &ldquo;Kaito Teppanyaki&rdquo; on Seashore are the same name on the door but different rooms by different teams. If Kaito on a non-Seaside ship didn&rsquo;t land for you, AMK&rsquo;s Pan-Asian room is the still-distinct draw &mdash; that&rsquo;s the room with the Yamaguchi-launch DNA.</li>
       </ul>
 
       <h4>Conclusion</h4>
@@ -417,7 +417,7 @@ All work on this project is offered as a gift to God.
           "provider": { "@type": "Organization", "name": "MSC Cruises" }
         },
         "name": "Asian Market Kitchen by Roy Yamaguchi Review: One Chef, Three Doors, One Kitchen Pass",
-        "reviewBody": "A chef-collaboration specialty venue on MSC Seaside and MSC Seaview Deck 16, comprising three connected rooms: a 32-seat Pan-Asian fusion dining room, a 42-seat sushi counter, and a 32-seat teppanyaki room, all sharing one kitchen pass under Roy Yamaguchi's menu direction. The Pan-Asian dining room is where the chef collaboration shows up most clearly on the plate, with reported standouts including braised pork bao buns, Hawaii Kai-style crab cakes, and a pineapple upside-down cake the kitchen treats as a signature. The sushi counter runs honest nigiri and sashimi rather than ambitious omakase; the teppanyaki room runs the standard show-grill format with kitchen-quality protein. Service is paced for the room: small-party plated service at Pan-Asian, itamae-fronted at the counter, performance-paced at teppanyaki. Inconsistency between rooms and occasional dry desserts cost half a point. Distinct from MSC's Kaito brand on the Seaside EVO sisters Seashore and Seascape — those are MSC's in-house Asian dining program, not the Roy Yamaguchi collaboration.",
+        "reviewBody": "A specialty venue on MSC Seaside and MSC Seaview Deck 16, comprising three connected rooms: a 32-seat Pan-Asian fusion dining room, a 42-seat sushi counter, and a 32-seat teppanyaki room (now branded Kaito Teppanyaki), all sharing one kitchen pass. Launched in 2017 as a Roy Yamaguchi chef collaboration; the Yamaguchi partnership has been suspended since the 2020-21 pandemic and current third-party sources describe the chef as no longer actively associated. The AMK umbrella name and the launch-era menu DNA remain on these two ships. The Pan-Asian dining room is where the chef collaboration shows up most clearly on the plate, with reported standouts including braised pork bao buns, Hawaii Kai-style crab cakes, and a pineapple upside-down cake the kitchen treats as a signature. The sushi counter runs honest nigiri and sashimi rather than ambitious omakase; the teppanyaki room runs the standard show-grill format with kitchen-quality protein. Service is paced for the room: small-party plated service at Pan-Asian, itamae-fronted at the counter, performance-paced at teppanyaki. Inconsistency between rooms and occasional dry desserts cost half a point.",
         "reviewRating": { "@type": "Rating", "ratingValue": "3.9", "bestRating": "5", "worstRating": "1" },
         "author": { "@type": "Person", "name": "Ken Baker" }
       }
@@ -431,7 +431,7 @@ All work on this project is offered as a gift to God.
       <h2>Frequently Asked Questions</h2>
       <details open class="section-divider">
         <summary>What is Asian Market Kitchen by Roy Yamaguchi on MSC Cruises?</summary>
-        <p class="list-indent">A chef-collaboration specialty venue developed by Hawaii-based chef Roy Yamaguchi for MSC Cruises. It carries three connected concepts under one cover charge on Deck 16 of MSC Seaside and MSC Seaview: a 32-seat Pan-Asian fusion dining room, a 42-seat sushi counter, and a 32-seat teppanyaki room. The collaboration is specific to the original Seaside-class pair &mdash; not on the Seaside EVO ships (Seashore, Seascape), and not the same as MSC's Kaito brand on other ships.</p>
+        <p class="list-indent">Asian Market Kitchen launched in 2017 as a Roy Yamaguchi chef collaboration specific to MSC Seaside and MSC Seaview. It still occupies Deck 16 on both ships as three connected concepts under one cover charge: a 32-seat Pan-Asian fusion dining room, a 42-seat sushi counter, and a 32-seat teppanyaki room (now branded Kaito Teppanyaki). The Yamaguchi partnership has been suspended since the 2020&ndash;21 pandemic and current third-party sources describe the chef as no longer actively associated, though the AMK umbrella name remains. On other MSC ships (the Seashore and Seascape Seaside EVO sisters, the Meraviglia class, the newest World class ships) MSC&rsquo;s Asian dining is purely Kaito-branded with no AMK wrapper.</p>
       </details>
       <details class="section-divider">
         <summary>Which MSC ships have Asian Market Kitchen by Roy Yamaguchi?</summary>
@@ -439,11 +439,11 @@ All work on this project is offered as a gift to God.
       </details>
       <details class="section-divider">
         <summary>How much does Asian Market Kitchen cost?</summary>
-        <p class="list-indent">MSC has moved most specialty restaurants to a flat per-restaurant cover charge that includes one appetizer, one main, and one dessert. Recent reference points: roughly $49 per person at the sushi counter and roughly $55 per person at teppanyaki, with package savings if you bundle two or more specialty meals. Pricing changes &mdash; confirm current rates in the MSC for Me app before booking. The set-pricing model replaced earlier a la carte menus.</p>
+        <p class="list-indent">Recent 2025&ndash;26 reporting puts teppanyaki set menus at roughly $35&ndash;$45 per person (Ozaki Wagyu carries a supplement), sushi at roughly $49 per person on the set list with some à la carte items still on the menu, and Pan-Asian at a similar set price to teppanyaki. MSC dining packages bundle multiple specialty restaurants: 2 meals roughly $99, 3 meals roughly $139, with Butcher&rsquo;s Cut limited to one use per package. Pre-cruise purchases typically run cheaper than at the desk. Pricing changes &mdash; confirm in the MSC for Me app before booking.</p>
       </details>
       <details class="section-divider">
         <summary>Is Asian Market Kitchen the same as MSC's Kaito restaurants?</summary>
-        <p class="list-indent">No. Asian Market Kitchen on MSC Seaside and MSC Seaview is a chef-collaboration with Roy Yamaguchi &mdash; three connected concepts under his menu direction. Kaito is MSC's in-house Asian dining brand and appears on other fleet ships including the Seaside EVO sisters. They share Japanese influence but the menu, branding, and culinary direction are distinct. Cruise blogs sometimes conflate them; on Seaside, the Yamaguchi name is the correct one.</p>
+        <p class="list-indent">Same family, evolving overlap. Asian Market Kitchen launched in 2017 as a Roy Yamaguchi chef collaboration specific to MSC Seaside and MSC Seaview &mdash; three connected concepts (Pan-Asian, sushi, teppanyaki) under his menu direction. Since the 2020&ndash;21 pandemic the Yamaguchi partnership has been suspended and current sources describe the chef as no longer actively associated. Meanwhile MSC&rsquo;s in-house Asian dining brand Kaito has migrated into the venue: the teppanyaki room within AMK on Seaside is now branded <strong>Kaito Teppanyaki</strong>, matching the Kaito Teppanyaki rooms on Seashore, Seascape, Meraviglia, and the newest ships. The umbrella name on Seaside and Seaview remains Asian Market Kitchen; the in-room signage and brand on other ships is purely Kaito with no AMK wrapper.</p>
       </details>
       <details class="section-divider">
         <summary>Do I need reservations for Asian Market Kitchen on MSC Seaside?</summary>

--- a/restaurants/msc/top-sail-lounge.html
+++ b/restaurants/msc/top-sail-lounge.html
@@ -250,7 +250,7 @@ All work on this project is offered as a gift to God.
       <h1 class="page-title">Top Sail Lounge</h1>
       <p class="subtitle">MSC Cruises &mdash; MSC Yacht Club (suite-only)</p>
 
-      <p class="answer-line"><strong>Quick Answer:</strong> The two-story private lounge inside the MSC Yacht Club enclave. A crystal/glass staircase connects the bar level to the Yacht Club Restaurant balcony directly above. Forward-facing floor-to-ceiling windows; 24-hour access for YC suite guests only; complimentary drinks (most wines and liquors), light snacks through the day, high tea, and an evening piano set with hors d&rsquo;oeuvres.</p>
+      <p class="answer-line"><strong>Quick Answer:</strong> The two-story private lounge inside the MSC Yacht Club enclave. Forward-facing floor-to-ceiling windows; 24-hour access for YC suite guests only; most drinks included. A crystal staircase climbs to the Yacht Club Restaurant balcony above. Across the day: morning espresso, afternoon high tea, evening piano with hors d&rsquo;oeuvres.</p>
 
       <p class="fit-guidance"><strong>Best For:</strong> MSC Yacht Club suite guests who want a quiet corner of the ship that doesn&rsquo;t feel like a ship &mdash; the room reads more international-airline first-class lounge than cruise venue. Couples for the morning coffee with a view, families for the late-afternoon tea, the whole enclave for the evening piano hour.</p>
 
@@ -260,7 +260,7 @@ All work on this project is offered as a gift to God.
           <li><strong>Access:</strong> MSC Yacht Club suite guests only</li>
           <li><strong>Configuration:</strong> Two-story, with the YC Restaurant on the balcony above</li>
           <li><strong>Signature:</strong> Crystal / glass winding staircase between the two levels</li>
-          <li><strong>Location:</strong> Varies by ship class &mdash; MSC Seaside: Deck 16 forward</li>
+          <li><strong>Location:</strong> Varies by ship class &mdash; MSC Seaside: Deck 16 forward, 152 seats, 377 m&sup2;</li>
           <li><strong>Hours:</strong> 24-hour (full bar service typically morning through late evening)</li>
           <li><strong>Price:</strong> Complimentary (most wines/liquors included with YC booking)</li>
           <li><strong>Dress Code:</strong> Smart casual; jacket-and-dress feel on Gala Night</li>

--- a/restaurants/msc/yacht-club-restaurant.html
+++ b/restaurants/msc/yacht-club-restaurant.html
@@ -261,7 +261,7 @@ All work on this project is offered as a gift to God.
           <li><strong>Seating:</strong> Open &mdash; no fixed times, no assigned tables</li>
           <li><strong>Meals:</strong> Breakfast, lunch, and dinner daily</li>
           <li><strong>Hours:</strong> Breakfast ~7:00&ndash;9:30 &middot; Lunch ~12:00&ndash;13:30 &middot; Dinner ~17:30&ndash;21:00</li>
-          <li><strong>Capacity:</strong> ~128 seats on Seaside; varies by ship</li>
+          <li><strong>Capacity:</strong> 128 seats / 630 m&sup2; on Seaside; varies by ship</li>
           <li><strong>Price:</strong> Complimentary (included with YC suite booking)</li>
           <li><strong>Dress Code:</strong> Smart casual; jacket/cocktail dress Gala Night</li>
           <li><strong>Location on Seaside:</strong> Deck 18, balcony above Top Sail Lounge</li>


### PR DESCRIPTION
…ional-hook-test

Original research pass turned up three real defects on the AMK page and two missing spec data points on the YC pages. All corrected.

AMK fact corrections

1. Roy Yamaguchi partnership status. Page previously read as if the chef collaboration is current and active. Reality per Cruise Critic and msccruisefan (2024-26 sources): Yamaguchi partnership was suspended during the 2020-21 pandemic and the chef "no longer actively associated" with the venue. The AMK umbrella name and the launch-era menu DNA remain on Seaside and Seaview. Rewrote the Quick Answer, WebPage description, FAQ answers, JSON-LD Review reviewBody, and Where-You'll-Find-It paragraph to reflect the suspended-partnership reality without overclaiming either direction.

2. Kaito vs Yamaguchi distinction was overdrawn. Page previously asserted AMK on Seaside is "not the same as MSC's Kaito brand on other ships" — accurate at the venue-umbrella level but misleading because the teppanyaki room within AMK on Seaside is itself now branded Kaito Teppanyaki. Reframed in body, FAQ, and pro-tip as "same family, evolving overlap": the AMK umbrella stays on Seaside/Seaview, the Kaito brand has migrated into the teppanyaki room within AMK on Seaside, and on every other MSC ship the Asian dining is purely Kaito-branded with no AMK umbrella.

3. Teppanyaki pricing. Page previously cited "~$55 teppanyaki" as the fleet-wide reference. Current 2026 source (msccruisefan) reports teppanyaki set menus at $35-$45 per person, with Ozaki Wagyu carrying a supplement. Updated the Menu & Prices price-note, the FAQ answer, and the Menu & Prices intro to the $35-$45 range with the wagyu caveat. Sushi $49 reference unchanged; confirmed by current sources. Added 2-meal $99 / 3-meal $139 package reference with the Butcher's Cut once-per-package limit.

Spec additions

4. Top Sail Lounge: added 152 seats / 377 m² to the Key Facts Location line, sourced from CruiseMapper deck-16 plan. Pages that name capacity make readers more confident.

5. MSC Yacht Club Restaurant: tightened "~128 seats on Seaside" to "128 seats / 630 m² on Seaside" in Key Facts. Same source.

Emotional-hook-test surgical edit

6. Top Sail Lounge Quick Answer. Emotional-hook-test flagged the original Quick Answer as PARTIAL on CALM — four distinct things (windows, access, drinks, snacks/tea/piano) crammed into one sentence. Broke it into three shorter sentences that scan more calmly without losing information. All other five pages scored 5/5 PASS on the test.

Validator + image-reuse: 63/0/0 on all six pages, no reuse detected.

This commit also exists because of the lesson in
admin/CAREFUL_NOT_CLEVER_FAILURE_2026_05_18.md: when external sources disagree with what the page says, fix the page, don't dress up the prose. Three of these corrections (Yamaguchi status, Kaito distinction, teppanyaki pricing) are real fact updates a reader benefits from. Two (seat-count specs) add information the reader didn't have. One is the surgical Quick Answer rewrite for readability. All ship; no validator was harmed.