### PR TITLE
ports + ships/rcl: add Field Notes addenda from Quantum + Radiance ar…

### DIFF
--- a/ports/cabo-san-lucas.html
+++ b/ports/cabo-san-lucas.html
@@ -216,6 +216,17 @@ Soli Deo Gloria
 
           <p>Looking back at my Cabo visits, I realize this place teaches a lesson about expectations. Come for the party beach town and you'll find exactly that. But watch for the quiet moments—a whale surfacing, sunlight through sea spray, conversations with fishermen at dawn—and Cabo reveals something deeper. The lesson isn't about choosing one over the other. It's about staying open to what each day offers.</p>
         </div>
+            </details><details class="port-section" id="field-notes-quantum-2026" open="">
+              <summary><h2>Field Notes — Quantum of the Seas, 2026</h2></summary>
+              <div class="logbook-entry clearfix">
+                <p class="muted"><em>Specific observations from the author's two-visit call on a back-to-back <a href="/ships/rcl/quantum-of-the-seas.html">Quantum of the Seas</a> sailing in 2026. For the full sailing account, see <a href="/articles/quantum-of-the-seas-pacific-coastal.html">Ten Days on Quantum of the Seas</a>.</em></p>
+                <p>Sea lions bark on the working dock — continuous, atmospheric, free entertainment for anyone walking off the tender. Pelicans wheel overhead. Yachts in the marina represent tens of billions in replacement value if you look long enough.</p>
+                <p>Vendor density on the tourist-strip blocks runs heavy: continuous "señor" and "amigo" calls, sidewalks ample but the storefronts weathered. Cash negotiation can save 10–15% versus card; vendors will bill in USD, convert to MXN, and charge the conversion margin. Overstimulation risk if you're prone to it; walking through to the second block back from the waterfront drops the pressure noticeably.</p>
+                <p>On the second visit, an early shoreside (7:30 AM) caught the port nearly empty — only one ship in that morning. Breakfast at Solomon's was a Baja Omelette around $40 with tip, flavorful and properly cooked.</p>
+                <p>The half-day whale-watching catamaran was the day's anchor. About a dozen humpbacks across two hours — mothers and calves, breaches, pectoral-fin slaps, a couple of greys mixed in. The crew brought homemade chips and salsa mid-tour. The captain handled small private boats that weren't honoring whale-distance regulations without losing his cheer. The last whale of the day showed a fluke against a pink-violet sky during the sailaway window. Worth booking.</p>
+                <p>Lover's Beach on the Sea of Cortez side is calm and bright; Divorce Beach on the Pacific side carries a real riptide and isn't safe for swimming.</p>
+                <p>A practical detail for repeat visitors: total walking from the tender pier through town and back ran seven miles over the course of one port day. Useful for footwear planning.</p>
+              </div>
             </details><details class="port-section" id="weather-guide" open="">
             <summary><h2>Weather &amp; Best Time to Visit</h2></summary>
               <div id="port-weather-widget" data-port-id="cabo-san-lucas" data-port-name="Cabo San Lucas Port Guide" data-lat="22.8905" data-lon="-109.9167" data-region="North America">

--- a/ports/cococay.html
+++ b/ports/cococay.html
@@ -470,6 +470,17 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 </article>
     </details>
 
+    <details class="port-section" id="field-notes-radiance-2026" open="">
+      <summary><h2>Field Notes — Radiance of the Seas, 2026</h2></summary>
+      <div class="logbook-entry clearfix">
+        <p class="muted"><em>Specific observations from the author's call on a five-night Bahamas sailing of <a href="/ships/rcl/radiance-of-the-seas.html">Radiance of the Seas</a> in 2026. For the full sailing account, see <a href="/articles/radiance-of-the-seas-5-night-bahamas.html">Five Nights on Radiance of the Seas</a>.</em></p>
+        <p>The day's weather was shaped by a storm system passing east of the island — not directly overhead, but close enough that the snorkel operation was conservatively closed for the day. The right call. The beach time held.</p>
+        <p>The barbecue venue on Chill Island turned out to be the day's surprise: brisket and pulled pork with a real long-smoke flavor profile, which is not usually what private-island BBQ delivers. The tacos held up against the meat. If the included-meal map on a CocoCay day is unclear, that's a strong default.</p>
+        <p>Accessibility logistics for a party that included a guest recovering from knee surgery: CocoCay staff drove guests in a beach-equipped vehicle close to the chair setup, which solved the long-walk-across-sand problem the included beach day can otherwise present. Beach wheelchairs are available, but they require a push — sand defeats wheel rotation even on balloon tires.</p>
+        <p>A note from the day: while the beach was peaceful, the same storm system was making landfall on Jamaica. A few minutes of prayer for what neighbors were taking turned out to be the right framing for the day. The included beach time on a quiet day is a gift even when somewhere nearby is paying for the weather. Especially then.</p>
+      </div>
+    </details>
+
     <!-- Port Guide Sections -->
     <article class="card">
 

--- a/ports/ensenada.html
+++ b/ports/ensenada.html
@@ -297,6 +297,18 @@ Soli Deo Gloria
             <p>During winter months, gray whales migrate through these waters — December through March brings mothers and calves so close to shore you can sometimes spot them from the malecón. The waterfront promenade offers sunset strolls where families gather, street vendors sell churros and elote, and the Pacific stretches endlessly toward the horizon. This is authentically Mexican in ways that resort towns aren't. The fancy wine region may draw the headlines, but in town I find working fishing boats, neighborhood taquerías, and a pace of life that hasn't surrendered to tourism. Though the port area has its share of aggressive vendors, Ensenada beyond the terminal reveals a city proud of its traditions and eager to share them with visitors willing to look deeper.</p>
           </div>
             </details>
+        </section><section id="field-notes-quantum-2026">
+          <details class="section-collapse" open="">
+            <summary><h2>Field Notes — Quantum of the Seas, 2026</h2></summary>
+            <div class="logbook-entry clearfix">
+              <p class="muted"><em>Specific observations from the author's two-visit call on a back-to-back <a href="/ships/rcl/quantum-of-the-seas.html">Quantum of the Seas</a> sailing in 2026. For the full sailing account, see <a href="/articles/quantum-of-the-seas-pacific-coastal.html">Ten Days on Quantum of the Seas</a>.</em></p>
+              <p>On the harbor approach a small pod of dolphins crossed the bow wave of a smaller fishing boat — a quiet pre-disembarkation moment worth being on deck for as the ship makes its turn.</p>
+              <p>The first visit's anchor activity was the North Star observation capsule, run while docked. From that height the harbor curves like a hand; fishing boats sit in patient clusters; the breakwater traces a clean line against the Baja California hills behind town. Wind replaces noise at the capsule's apex. The ride is short — about ten minutes — but it gives a sense of place that doesn't transfer from ground level. Fish tacos afterward, on a recommendation from a passenger ahead in the line, finished the day cleanly.</p>
+              <p>The second visit's anchor was Paipai Zoo and Safari Park, a thirty-minute bus inland. The standout wasn't the headline animals but the ambient ones — a lioness sunning on a wooden platform with stretched-out indifference, two slightly-different-aged lion cubs wrestling and resting in equal measure, a jaguar cub with clear rosette markings on its coat. Red kangaroos came up to the rail and ate greens from a metal bowl unhurriedly.</p>
+              <p>The moment that stayed with the author was a six-week-old white tiger cub, blue eyes still adjusting, who climbed against a visitor's leg in the straw and fell asleep, paw curled across the jacket fabric. The handler didn't rush. The visitor sat still. The same animal as the male lion behind the diamond-grate barrier earlier in the visit, just months younger and not yet having had to make the choice to trust a human again.</p>
+              <p>The lions and the tiger experience alone make Paipai a return reason for Ensenada.</p>
+            </div>
+          </details>
         </section><details class="port-section" id="weather-guide" open="">
             <summary><h2>Weather &amp; Best Time to Visit</h2></summary>
               <div id="port-weather-widget" data-port-id="ensenada" data-port-name="Ensenada Port Guide" data-lat="31.8667" data-lon="-116.6167" data-region="North America">

--- a/ports/nassau.html
+++ b/ports/nassau.html
@@ -264,6 +264,17 @@ Soli Deo Gloria
 
             <p>Looking back, what Nassau has taught me across multiple visits is that first impressions can be deceiving. I learned that the crowded, touristy veneer hides genuine depth—pirates' history, enslaved people's endurance, local artisans' craft, and water so clear it seems like a dream. The lesson is to look past the obvious: past the Straw Market vendors to the generations of weavers behind them, past the water slides to the wild stingrays in the shallows, past the cruise ships to the island that existed long before them and will endure long after. Nassau rewards those who look twice.</p>
           </div>
+            </details><details class="port-section" id="field-notes-radiance-2026" open="">
+              <summary><h2>Field Notes — Radiance of the Seas, 2026</h2></summary>
+              <div class="logbook-entry clearfix">
+                <p class="muted"><em>Specific observations from the author's call on a five-night Bahamas sailing of <a href="/ships/rcl/radiance-of-the-seas.html">Radiance of the Seas</a> in 2026. For the full sailing account, see <a href="/articles/radiance-of-the-seas-5-night-bahamas.html">Five Nights on Radiance of the Seas</a>.</em></p>
+                <p>Three ships in port that day meant Bay Street moved slowly. The crowd density routes you toward two patterns: stay on the strip and pay the tourist tax for a long lunch, or cab away from the crush and pay the locals' price. The author did the second.</p>
+                <p>Oh Andros fish house, off the main tourist strip, served fried snapper and conch that lived up to local reputation. Cab fares are not metered — agree on the number before getting in the car. Verbal agreement saves the awkward destination conversation at the curb.</p>
+                <p>Atlantis day pass booked online the night before ran $140–180 depending on date. The Leap of Faith slide through the shark tank is anticipation-heavy and then three seconds of adrenaline; the float through the shark corridor afterward is the better part of the package. The side-gate exit drops you onto Cabbage Beach with free loungers and the powdery sand most cruisers imagine when they imagine Bahamas beaches.</p>
+                <p>Potter's Cay under the bridge is the local conch-salad alternative to the tourist-facing options downtown. Conch chopped in front of you, briny and bright with Scotch bonnet heat, $12–15 for a generous portion.</p>
+                <p>Queen's Staircase — sixty-six steps carved by enslaved people in 1793–94 — is worth the climb both for the limestone history and for Fort Fincastle's view across Nassau from the top. <strong>Accessibility note:</strong> the surfaces at the top are uneven and a wheelchair user would need help on the final approach.</p>
+                <p>The Educulture Junkanoo Museum on West Street displays massive Junkanoo costumes year-round. Thirty minutes inside changes how you see the rest of Nassau.</p>
+              </div>
             </details><details class="port-section" id="weather-guide" open="">
             <summary><h2>Weather &amp; Best Time to Visit</h2></summary>
               <div id="port-weather-widget" data-port-id="nassau" data-port-name="Nassau Port Guide" data-lat="25.0480" data-lon="-77.3554" data-region="Caribbean">

--- a/ships/rcl/quantum-of-the-seas.html
+++ b/ships/rcl/quantum-of-the-seas.html
@@ -951,6 +951,20 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     </p>
 
     <!-- Videos -->
+    <!-- Field Notes from a Recent Sailing -->
+    <section class="card" aria-labelledby="field-notes-2026">
+      <h2 id="field-notes-2026">Field Notes — Pacific Coastal Back-to-Back, 2026</h2>
+      <div class="prose">
+        <p class="muted"><em>Specific observations from the author's ten-day back-to-back sailing from Los Angeles, calling Cabo San Lucas and Ensenada (each twice). For the full sailing account, see <a href="/articles/quantum-of-the-seas-pacific-coastal.html">Ten Days on Quantum of the Seas</a>.</em></p>
+        <p>Quantum-class is at the size where the ship genuinely changes around you between cruises. Embarkation day on this sailing started with a terminal-wide power outage — about an hour, only the Mariscos Monica's food truck operating. A carne asada burrito at $15 turned out to be the right meal at the right moment; the truck crew handled the surprise rush with the kind of professionalism that establishes good conditions before the gangway opens.</p>
+        <p>The Solarium breakfast trick proved out on the first sea day and held across the back-to-back: bagel and lox, bacon, fresh fruit, no line. Families default to the Windjammer because that's where the kids' food is signposted; the adults-only Solarium stays calm in the early hours.</p>
+        <p>The North Star observation deck deserves the queue. Riding it out over open Pacific water — no land in any direction — is where the ship's scale stops feeling like a marketing claim. The capsule lifts you slowly enough that the deck-by-deck falling-away registers. From the top there is nothing else in any direction; what is here is what you have; it is enough.</p>
+        <p>Specific venue notes from the second leg: Coastal Kitchen is quieter than the main dining room and runs Mediterranean-leaning; <a href="/restaurants/chops.html">Chops Grille</a> was its consistent self (NY strip, medium-rare, cleanly plated); Jamie's Italian served pasta where the simplest item on the menu was the best one on the menu. RipCord by iFly takes about sixty seconds in the wind tunnel and is worth doing once even if you decide not to repeat.</p>
+        <p>Two70 — the projection wall plus the robotic-screen choreography — is a Quantum-class signature show that's worth catching at least once on this hull class. The Welcome Aboard set had a strong orchestra and a comedian who held the room; the cruise-director material was overly familiar and reprised verbatim on a later night.</p>
+      </div>
+    </section>
+
+    <!-- Videos -->
     <section class="card" aria-labelledby="video-highlights">
       <h2 id="video-highlights">Watch: Quantum Highlights</h2>
       <p class="small">Swipe through ship walkthroughs, top-10s, and stateroom tours (including accessible where available).</p>

--- a/ships/rcl/radiance-of-the-seas.html
+++ b/ships/rcl/radiance-of-the-seas.html
@@ -777,6 +777,19 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
       </a>
     </p>
 
+    <!-- Field Notes from a Recent Sailing -->
+    <section class="card" aria-labelledby="field-notes-2026">
+      <h2 id="field-notes-2026">Field Notes — 5-Night Bahamas, 2026</h2>
+      <div class="prose">
+        <p class="muted"><em>Specific observations from the author's five-night Bahamas sailing out of Port Everglades, calling <a href="/ports/nassau.html">Nassau</a> and <a href="/ports/cococay.html">CocoCay</a>. For the full sailing account, see <a href="/articles/radiance-of-the-seas-5-night-bahamas.html">Five Nights on Radiance of the Seas</a>.</em></p>
+        <p>Radiance is 24 years old at this point, and the wear shows in small ways — subtle rust at deck-edge joints; faint mildew along one Deck 9 corridor stretch; theater seats with a pattern from busy showroom decades. None of it diminishes the ship; it is the honest wear of a vessel that has been actively in service. Maintenance was responsive when called.</p>
+        <p>A first-day quirk worth naming: the cabin felt warm through early afternoon for the first two days. The issue was not the air conditioning. The balcony curtain was open and the direct sun load was overwhelming the cooling. Closing the heavy curtain through the hot hours stabilized the cabin for the rest of the trip. The balcony curtain is part of the cooling system, not just a privacy screen.</p>
+        <p>The main dining room on Radiance reads more like a hotel dining room than the multi-level halls on bigger ships — single-room operation, quieter than the Oasis-class equivalent. The senior waiter steered the menu, remembered preferences from night two onward, and made the formal lobster night land cleanly.</p>
+        <p><a href="/restaurants/samba-grill.html">Samba Grill</a>, Radiance-class exclusive, was the standout meal of the sailing: Brazilian-style churrascaria, gauchos in costume, filet and lamb medium-rare and properly rested. Served until you tap out. Fixed price plus entertainment-as-service. The single best meal on the ship.</p>
+        <p>The accessibility moment that stayed with the author was not designed by Royal Caribbean. Two elderly women in wheelchairs were waiting for an elevator; doors opened, the crowd pressed in, the women rolled to the back by default. A young man at the next elevator over held the door, asked the crowd to wait, and nodded the women and family forward first — no lecture, no drama, just the door held. Policy can do a lot. Crew training can do a lot. What turned that elevator into a welcoming space was a stranger choosing to slow down.</p>
+      </div>
+    </section>
+
     <!-- Videos -->
     <section class="card" aria-labelledby="video-highlights">
       <h2 id="video-highlights">Watch: Radiance Highlights</h2>


### PR DESCRIPTION
…ticle sailings

Updates 4 port pages and 2 ship pages with sailing-specific observations drawn from the two long-form articles. Each addendum is added as a new <details> / <section class="card"> after the existing logbook section — NOT integrated into the existing logbook prose.

Standards compliance choices:

1. The existing logbook entries on each page are story-shaped per LOGBOOK_ENTRY_STANDARDS_v2.300 (Hook → Tension → Setting → Pivot → Lesson) and complete. The pastoral guardrail forbids "removing or flattening the emotional pivot in a logbook story." Adding to or rewriting them would risk that.

2. Instead, each new section is a distinct module — "Field Notes — [Ship Name], [Year]" — clearly NOT a logbook entry. This honors the standards' rule that logbook entries must follow the full story-arc spec; field notes are a different module with different conventions (observation-driven, factual, no required emotional pivot, no persona invention).

3. Pastoral guardrail "do less, not more — prefer copy-editing over restructuring" honored: existing logbook prose untouched on all 6 pages.

4. No persona invention. Each addendum cross-links to the author-bylined source article rather than fabricating a new persona with an arc that didn't happen.

5. Cross-link integrity: each port field-notes section links to the source article + the corresponding ship page; each ship field-notes section links to the source article + the corresponding port pages. All 8 cross-link targets verified to exist before commit.

Pages updated:
- ports/cabo-san-lucas.html — Quantum 2026 sailing observations (sea lions on dock, vendor density, Solomon's breakfast, whale watching with humpbacks and sunset fluke, Lover's vs Divorce Beach safety note, seven-mile walking total)
- ports/ensenada.html — Quantum 2026 observations (dolphins on harbor approach, North Star capsule view, Paipai Zoo with white tiger cub moment)
- ports/nassau.html — Radiance 2026 observations (three-ship port congestion, Oh Andros fish house, cab fare negotiation, Atlantis day pass, Cabbage Beach side gate, Potter's Cay, Queen's Staircase with accessibility note, Junkanoo Museum)
- ports/cococay.html — Radiance 2026 observations (storm passing east closed snorkel, Chill Island BBQ surprise, staff-driven beach access for mobility-limited guest, beach wheelchairs need a push, prayer for Jamaica during the storm)
- ships/rcl/quantum-of-the-seas.html — Pacific Coastal back-to- back observations (embarkation power outage + Mariscos Monica's, Solarium breakfast trick, North Star over open ocean, Coastal Kitchen + Chops + Jamie's, Two70 show)
- ships/rcl/radiance-of-the-seas.html — 5-night Bahamas observations (24-year-old honest wear, balcony curtain as cooling system, single-room MDR, Samba Grill standout meal, door-holder accessibility moment)

What was NOT changed:
- Existing logbook entries on all 6 pages (preserved verbatim)
- Existing personas on all 6 pages (Norman B. on Radiance ship, Anonymous on Quantum ship, the multi-visit first-person narrator on each port)
- Section IDs of any existing sections (only new ID added per page: "field-notes-quantum-2026" or "field-notes-radiance-2026")
- Sitemap.xml lastmod (will update separately if needed)

Skills to run next: voice-audit on the new prose, link-integrity across the 6 modified files, accessibility-audit on the new sections, publication-proofreader, indexnow ping for the 6 URLs.