### PR TITLE
articles/cruise-travel-safety-shore-side-net: new travel safety article

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -313,6 +313,7 @@
       <div class="key-facts" style="background: #f0f7ff; border-color: #d0e4f0;">
         <h2>Popular Guides</h2>
         <ul style="line-height: 1.8;">
+          <li><a href="https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html">Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing</a></li>
           <li><a href="https://cruisinginthewake.com/articles/perfect-day-mexico-rejected-2026.html">Perfect Day Mexico, Rejected: What Royal Caribbean's $600M Setback Actually Means</a></li>
           <li><a href="https://cruisinginthewake.com/articles/msc-voyagers-club-status-match-from-rcl-diamond.html">RCL Diamond to MSC Voyagers Club: How the Status Match Actually Works in 2026</a></li>
           <li><a href="https://cruisinginthewake.com/articles/msc-seaside-service-review.html">MSC Seaside Service Review: The Apology That Wasn't a Plan</a></li>

--- a/articles/cruise-travel-safety-shore-side-net.html
+++ b/articles/cruise-travel-safety-shore-side-net.html
@@ -1,0 +1,454 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+  <!-- ======================================================
+       In the Wake — Article
+       Page: Cruise Travel Safety — The Shore-Side Safety Net
+       Version: 3.010.400  |  Standards baseline: 3.010.x
+       Content Protocol: ICP-2
+       ====================================================== -->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer"/>
+  <meta name="ai-summary" content="A practical guide to the pre-cruise safety setup every traveler should complete before sailing — solo, couple, family, or group. The core idea: the single most important piece of pre-cruise preparation is the shore-side safety net. One trusted person back home, with the right information in front of them, can resolve almost any at-sea or in-port emergency through three institutional channels — the cruise line's ship-to-shore family contact desk, the U.S. State Department's Overseas Citizens Services line (+1-888-407-4747 from U.S./Canada, +1-202-501-4444 from abroad), and the U.S. embassy or consulate in the affected port. Without that shore-side person knowing where you are and how to reach you, every channel gets slower. The article walks through what the handoff conversation should cover (itinerary, ship name, cabin number, key dates, emergency contacts, allergies/medications, document copies), points to the site's free Reaching Someone at Sea reference (which includes a handoff card that stays on the user's device — nothing is sent to a server), covers solo-traveler-specific considerations (no one in the next cabin to notice you didn't come back), couples and family considerations, documents to carry and copy, connectivity expectations at sea and in port, and the legal protections the Cruise Vessel Security and Safety Act of 2010 provides on U.S.-calling ships. Closing call to action: take ten minutes today, fill in the handoff, send it to one person ashore."/>
+  <meta name="last-reviewed" content="2026-05-24"/>
+  <meta name="content-protocol" content="ICP-2"/>
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light dark"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
+  <meta name="author" content="Ken Baker"/>
+
+  <!-- SEO -->
+  <title>Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing — In the Wake</title>
+  <meta name="description" content="The single most important piece of pre-cruise preparation is the shore-side safety net — one trusted person back home with the right information to reach you in any emergency. A practical guide for solo cruisers, couples, families, and groups."/>
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html"/>
+
+  <!-- Social -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing"/>
+  <meta property="og:description" content="One trusted person back home with the right info can resolve almost any at-sea emergency. A practical pre-cruise safety guide — solo, couple, family, or group. Includes a free handoff tool."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="article:section" content="Cruise Planning"/>
+  <meta property="article:published_time" content="2026-05-24"/>
+  <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Cruise Travel Safety: Set Up Your Shore-Side Safety Net Before You Sail"/>
+  <meta name="twitter:description" content="Ten minutes today. Could matter on the one day it does. Free handoff tool included."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Structured data: Article -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing",
+    "description":"A practical guide to the pre-cruise safety setup every traveler should complete — the shore-side person, the handoff information, the institutional channels, and the free Reaching Someone at Sea reference.",
+    "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
+    "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
+    "datePublished":"2026-05-24",
+    "dateModified":"2026-05-24",
+    "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
+    "mainEntityOfPage":"https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html",
+    "articleSection":"Cruise Planning",
+    "about":[
+      {"@type":"Thing","name":"Cruise Travel Safety"},
+      {"@type":"Thing","name":"Solo Travel Safety"},
+      {"@type":"Thing","name":"Emergency Contacts at Sea"},
+      {"@type":"Thing","name":"Cruise Vessel Security and Safety Act"},
+      {"@type":"Thing","name":"U.S. State Department Overseas Citizens Services"}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ken Baker",
+    "url":"https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle":"Pastor, Cruise Writer",
+    "description":"Reformed Baptist pastor and cruise writer specializing in accessible travel, grief support, and compassionate cruise guidance.",
+    "worksFor":{"@type":"Organization","name":"In the Wake"},
+    "knowsAbout":["Cruise Safety","Solo Travel","Emergency Contact Procedures","Cruise Planning","Family Travel Safety"]
+  }
+  </script>
+
+  <!-- Structured data: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {
+        "@type":"Question",
+        "name":"What is the single most important pre-cruise safety preparation?",
+        "acceptedAnswer":{"@type":"Answer","text":"Set up the shore-side safety net. Identify one trusted person back home and give them the information they would need to reach you, advocate for you, or activate institutional help on your behalf if something happens at sea or in port. This means sharing your ship name, sailing dates, cabin number, itinerary, and the three universal contact channels (cruise line ship-to-shore desk, U.S. State Department Overseas Citizens Services line at +1-888-407-4747, and the U.S. embassy or consulate for each port). The Reaching Someone at Sea reference on this site has a handoff card you can fill in on your device and share with that trusted person. Nothing is sent to a server."}
+      },
+      {
+        "@type":"Question",
+        "name":"What number does a family member call in a cruise emergency?",
+        "acceptedAnswer":{"@type":"Answer","text":"If they don't have the cruise line's ship-to-shore family contact number, they should call the U.S. State Department's Overseas Citizens Services line — 24 hours a day, every day. From the U.S. or Canada: +1-888-407-4747. From abroad: +1-202-501-4444. The State Department can locate the ship, contact the cruise line on the family's behalf, and coordinate consular services if the situation is in port. Do not call the cruise line's general booking line — it routes to sales and reservations, not emergencies."}
+      },
+      {
+        "@type":"Question",
+        "name":"What information should I leave with someone back home before a cruise?",
+        "acceptedAnswer":{"@type":"Answer","text":"Ship name and cruise line. Cabin number (and Yacht Club or Star Class designation if applicable). Sailing dates including embarkation and disembarkation. Full itinerary with port-day dates. Cruise line ship-to-shore family contact number (in your voyage pack and booking confirmation). U.S. State Department line and the embassy phone numbers for your ports. A list of any medications, allergies, and medical conditions. Copies of your passport, driver's license, and travel insurance policy. Travel insurance company's emergency assistance line. The names and contact information for anyone traveling with you. Where to find your will, advance directive, or power of attorney if those apply to your life stage."}
+      },
+      {
+        "@type":"Question",
+        "name":"What safety considerations are specific to solo cruisers?",
+        "acceptedAnswer":{"@type":"Answer","text":"On a solo cruise, no one in the next cabin notices if you don't come back. That single fact reframes most safety preparation. The shore-side safety net becomes the primary safety system, not a backup. Specific practices: daily check-in with your shore-side person via the ship's Wi-Fi (a quick text — alive, here, all is well — at a set time each day), share your shore excursion plans before leaving the ship, take a photo of yourself in port each morning so geolocation data and time stamps create a trail, store passport copies in cloud storage your shore-side person can access, and consider a wearable medical-alert option if you have a relevant health condition. Solo doesn't mean isolated; it means you build the safety net yourself rather than relying on a travel partner to be it."}
+      },
+      {
+        "@type":"Question",
+        "name":"What legal protections do cruisers have on ships that visit U.S. ports?",
+        "acceptedAnswer":{"@type":"Answer","text":"The Cruise Vessel Security and Safety Act of 2010 (Public Law 111-207, signed July 27, 2010) requires every cruise ship that visits a U.S. port to log incidents — disappearances, sexual assaults, theft above $10,000, deaths — and report them to the FBI. The Act also mandates peepholes and security latches on cabin doors, surveillance equipment, time-sensitive safety information for passengers, and trained sexual-assault response personnel. The FBI logs and quarterly Coast Guard public reports mean an incident on a U.S.-calling ship is documented through a federal channel, not just through the cruise line's internal system. This matters when a family member needs to know whether an incident has been recorded."}
+      },
+      {
+        "@type":"Question",
+        "name":"Will my cell phone work on a cruise ship?",
+        "acceptedAnswer":{"@type":"Answer","text":"Inconsistently and expensively. Cellular service at sea uses maritime roaming networks that charge per-minute and per-megabyte rates that can run into the hundreds of dollars for a single call. Most cruisers turn cellular off at the gangway and use the ship's Wi-Fi package for messaging, email, and voice apps. In port, your domestic cellular plan may roam onto the local provider's network — some plans (T-Mobile international, some Verizon and AT&amp;T tiers) include free or discounted international data in many cruise-destination countries. Confirm coverage with your carrier before sailing. For pre-cruise safety planning: assume your phone is reachable through Wi-Fi calling and messaging at sea, and through local roaming or Wi-Fi in port, but neither is guaranteed. The shore-side safety net does not depend on your phone working."}
+      }
+    ]
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <!-- ================= HEADER ================= -->
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Tools <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/cruise-tipping-calculator.html">Tipping Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Onboard <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="Cruise travel safety guide">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">The Shore-Side Safety Net</div>
+    </div>
+  </header>
+
+  <main id="main-content" class="page" role="main">
+    <article itemscope itemtype="https://schema.org/Article" class="logbook">
+      <header style="max-width:min(860px,92%);margin-inline:auto">
+        <h1 itemprop="headline">Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing</h1>
+        <p class="dek" itemprop="description">The single most important piece of pre-cruise preparation isn't a packing list — it's a person back home with the right information. A practical safety guide for solo cruisers, couples, families, and groups. Ten minutes today. Could matter on the one day it does.</p>
+        <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-05-24">May 24, 2026</time></p>
+      </header>
+
+      <div itemprop="articleBody" style="max-width:min(860px,92%);margin-inline:auto">
+
+      <!-- Answer-first lede -->
+      <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
+        <strong>Answer first:</strong> Before you sail, identify one trusted person back home and give them the information they would need to reach you, advocate for you, or activate institutional help on your behalf if something goes wrong. Three universal channels can act on your behalf in any cruise emergency — the cruise line's ship-to-shore family contact desk, the U.S. State Department's Overseas Citizens Services line, and the U.S. embassy or consulate for each port. Each channel works faster when your shore-side person knows where you are. The free <a href="/reaching-someone-at-sea.html"><strong>Reaching Someone at Sea</strong></a> reference on this site walks through every contact channel and includes a handoff card you can fill in on your device and share with one trusted person ashore. Nothing is sent to a server. Ten minutes. Send it before you sail.
+      </p>
+
+      <!-- TOC -->
+      <nav class="article-toc" aria-label="In this article" style="max-width:min(860px,92%);margin:1.5rem auto;padding:1rem 1.25rem;background:#f8fbfc;border-left:3px solid #d0e4f0;border-radius:4px">
+        <h2 style="margin-top:0;font-size:1.05rem">In this article</h2>
+        <ol style="margin:0.5rem 0 0;padding-left:1.25rem;line-height:1.8">
+          <li><a href="#why-this-matters">Why the shore-side safety net matters more than any onboard prep</a></li>
+          <li><a href="#the-handoff">The handoff — what your shore-side person needs to know</a></li>
+          <li><a href="#the-tool">The free tool: Reaching Someone at Sea</a></li>
+          <li><a href="#three-channels">The three institutional channels that can reach you</a></li>
+          <li><a href="#scenarios">Common scenarios and what each looks like</a></li>
+          <li><a href="#for-solo-cruisers">For solo cruisers specifically</a></li>
+          <li><a href="#for-couples-and-families">For couples, families, and groups</a></li>
+          <li><a href="#documents">Documents to carry and copy</a></li>
+          <li><a href="#connectivity">Cell phone and Wi-Fi expectations</a></li>
+          <li><a href="#legal-protections">Legal protections on U.S.-calling ships</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ol>
+      </nav>
+
+      <h2 id="why-this-matters">Why the shore-side safety net matters more than any onboard prep</h2>
+
+      <p>Most cruise travel safety advice focuses on what you do onboard — lock the safe, stay with your group in port, know where the muster station is. All of that is reasonable, and none of it is the most important thing.</p>
+
+      <p>The most important thing is what your trusted person back home can do for you when you can't do it for yourself.</p>
+
+      <p>A serious illness onboard — heart attack, stroke, accident on stairs — moves quickly into a situation where the ship's medical center is treating you while your family back home is trying to figure out what's happening. A missed-the-ship situation in a foreign port at 5 PM on a Sunday can spiral if the person you call doesn't know which embassy to reach. A lost passport at a Mediterranean port stop becomes manageable when someone back home has a passport-page photo accessible to email to a U.S. consulate. None of these scenarios are common. All of them are common enough that someone on every multi-thousand-passenger sailing experiences one of them.</p>
+
+      <p>The shore-side safety net is the system that turns "we don't know how to help" into "we know exactly who to call." It is built in the ten minutes before you sail, with one trusted person and the right information shared once.</p>
+
+      <h2 id="the-handoff">The handoff — what your shore-side person needs to know</h2>
+
+      <p>The handoff is the conversation, document, or shared note that gives your trusted person back home everything they would need to act on your behalf. The fields below are the ones that matter most. Adapt to your situation.</p>
+
+      <p><strong>Ship and sailing.</strong> Cruise line, ship name, sailing dates including embarkation and disembarkation, departure port, return port, full itinerary with port-day dates. If you booked a Yacht Club, Star Class, or other premium tier, note it — that information speeds Guest Services routing onboard.</p>
+
+      <p><strong>Cabin.</strong> Cabin number and deck. If you have a cabin change planned mid-cruise (rare but possible on back-to-backs), include both.</p>
+
+      <p><strong>Contact channels.</strong> The cruise line's 24-hour ship-to-shore family contact phone number (listed in your voyage pack and booking confirmation — not the general customer service line). The U.S. State Department Overseas Citizens Services line: +1-888-407-4747 from the U.S. or Canada, +1-202-501-4444 from abroad. The U.S. embassy or consulate phone number for each port your itinerary visits.</p>
+
+      <p><strong>Medical.</strong> Current medications and dosages. Known allergies. Existing medical conditions that could become relevant in a crisis (cardiac history, seizure disorder, severe asthma, etc.). Blood type if known. Medical insurance card number and provider phone. Travel insurance policy number and the insurer's emergency assistance line — this is the number to call to authorize medical evacuation if needed.</p>
+
+      <p><strong>Identity documents.</strong> Photo of your passport's information page. Photo of your driver's license or other government ID. Photo of your travel insurance card. Photo of any prescription you carry for medications that customs agents sometimes question (controlled substances, narcotics, larger insulin or injectable supplies). Store the photos in a shared cloud folder both you and your shore-side person can access.</p>
+
+      <p><strong>Travel companions, if any.</strong> Names and contact information for everyone traveling with you. Each traveling-companion's emergency contact at home.</p>
+
+      <p><strong>Legal and end-of-life documents</strong> if those apply to your stage of life. The location of your will, advance directive, healthcare proxy, or power of attorney. Whoever holds the executed copies. The funeral home or memorial-arrangements documentation if you have planned ahead. This is morbid only if you've never lost someone in the middle of arranging a memorial across borders. The people who have, prepare differently.</p>
+
+      <h2 id="the-tool">The free tool: Reaching Someone at Sea</h2>
+
+      <p>The <a href="/reaching-someone-at-sea.html"><strong>Reaching Someone at Sea</strong></a> reference on this site collects the contact information for every channel above into one page, with a fillable handoff card at the bottom. The card lives entirely on your device — nothing is sent to a server, no account required, no tracking. You fill it in once and share it with the trusted person back home however you usually share documents (email, text, shared note, printed copy on the refrigerator).</p>
+
+      <p>The page also explains how each contact channel actually works in practice — which one to call first for a medical emergency at sea, which one for a port-side situation, which one for a U.S. citizen's lost passport overseas, which one for a missed-ship situation. The walk-through is written for the person ashore, not for the cruiser onboard. The person you share it with does not need to be a cruise expert; they need to be reachable and willing.</p>
+
+      <p>If you add the page to your phone's home screen (or your shore-side person's), it becomes available offline. Browsers cache it after the first visit. The cruise line's phone numbers, the State Department line, the embassy numbers for your ports — all of it is there when you need it, even if Wi-Fi is unreliable.</p>
+
+      <h2 id="three-channels">The three institutional channels that can reach you</h2>
+
+      <p>If something goes wrong onboard or in port, three institutions can act on behalf of a family member onshore. Knowing who does what reduces panic and speeds the call.</p>
+
+      <p><strong>The cruise line</strong> maintains a 24-hour ship-to-shore family contact desk that exists specifically to relay urgent messages to a passenger onboard. Each line publishes a different number; some are toll-free in the U.S., some are international only. These numbers are listed in your voyage pack and on your booking confirmation. The cruise line's general customer-service line is not the same number — it routes to sales and reservations, not emergencies. Your shore-side person should have the ship-to-shore number specifically, written out clearly, before you sail.</p>
+
+      <p><strong>The U.S. State Department's Overseas Citizens Services line</strong> is the universal fallback. It is staffed continuously, anywhere in the world, and it is the right call when your shore-side person doesn't have the ship-to-shore number, when the ship-to-shore line doesn't answer, or when the situation is serious enough to warrant a parallel official channel. The Bureau of Consular Affairs can locate a ship, contact the cruise line, and dispatch consular services where appropriate. From the U.S. or Canada: <strong>+1-888-407-4747</strong>. From abroad: <strong>+1-202-501-4444</strong>. Save these numbers in your shore-side person's phone before you sail.</p>
+
+      <p><strong>U.S. embassies and consulates</strong> are the right call when the issue is happening to a U.S. citizen in port — illness requiring hospitalization, lost passport, criminal incident, missed-the-ship situation. Each embassy publishes its own emergency phone number. The Reaching Someone at Sea reference lists embassy contacts by port for the most common cruise itineraries. If you're sailing a less-common itinerary, look up the embassies for your ports on the State Department's website and add them to the handoff before you sail.</p>
+
+      <h2 id="scenarios">Common scenarios and what each looks like</h2>
+
+      <p><strong>Medical emergency at sea.</strong> The ship's medical center treats you onboard while your shore-side person needs to reach you. The fastest path: call the cruise line's ship-to-shore family contact, give the ship name and passenger name, request they relay a message to the medical center. If the ship-to-shore line doesn't answer or routes incorrectly, the State Department line at +1-888-407-4747 can locate the ship and contact the medical center directly. Travel insurance with medical evacuation coverage matters here — if the situation requires evacuation off the ship to a shoreside hospital, that coordination runs through the travel insurance's emergency assistance line. Insurance contact information should be in the handoff.</p>
+
+      <p><strong>Missed-ship situation in port.</strong> You're at a shore excursion or independent stop. The ship's all-aboard time passes. You're not back. The ship sails. This is more common than cruisers expect and almost always resolvable — but the resolution requires money, documents, and contact with people back home who can wire funds or book flights. The shore-side person needs the itinerary so they know which port to fly you out of and which port to meet the ship at next. Travel insurance often covers missed-port scenarios when the cause was outside your control (excursion delay, traffic accident, port-day medical issue). The handoff makes that claim faster.</p>
+
+      <p><strong>Lost passport in a foreign port.</strong> Call the U.S. embassy or consulate for that country. They issue emergency travel documents that get you back to the U.S. and home. Having a passport photo in shared cloud storage with your shore-side person speeds the replacement process. The Cruise Vessel Security and Safety Act does not address passport replacement directly, but the consular process is the standard channel.</p>
+
+      <p><strong>Criminal incident onboard.</strong> The Cruise Vessel Security and Safety Act of 2010 requires every cruise ship calling at a U.S. port to log specific incidents (disappearances, sexual assaults, theft above $10,000, deaths) and report them to the FBI. Ships are required to maintain trained personnel for sexual-assault response. Onboard incidents involving U.S. citizens are within FBI jurisdiction when the ship calls a U.S. port. Reporting onboard goes to ship security first; the FBI receives the federal report after.</p>
+
+      <p><strong>News from home reaches a cruiser at sea.</strong> Sometimes the emergency is on the family's side — a death, a serious illness, a child in crisis. Your shore-side person calls the cruise line's ship-to-shore family contact desk; the cruise line will relay a message to your cabin and arrange counseling and travel support if you need to disembark at the next port. The fastest message-relay path is the cruise line's own desk, not the State Department.</p>
+
+      <h2 id="for-solo-cruisers">For solo cruisers specifically</h2>
+
+      <p>On a solo cruise, no one in the next cabin notices if you don't come back. No travel partner sees you trip on the gangway. No one is waiting at dinner if you don't show. That single fact reframes most of the safety preparation above.</p>
+
+      <p>The shore-side safety net is no longer a backup system. It is the primary safety system. Build it before you sail.</p>
+
+      <p>Specific practices that work well for solo cruisers:</p>
+
+      <p><strong>Daily check-in.</strong> A short text to your shore-side person at a set time each day via the ship's Wi-Fi. "Alive, here, all is well." Three words is enough. If the check-in doesn't arrive, the shore-side person knows to start asking. Pick a time when the ship's Wi-Fi typically works for you (often morning sea-day windows are most reliable).</p>
+
+      <p><strong>Pre-shore-day plan share.</strong> Before you leave the ship for a shore excursion or independent port day, message your shore-side person with the plan: where you're going, who you're going with, expected return time. A short note works; this isn't a thesis. The plan exists so that if something goes wrong, the shore-side person can give the embassy or local authorities a starting point.</p>
+
+      <p><strong>Daily port photo.</strong> Take a photo of yourself in port each morning, ideally with a landmark visible. The photo's embedded geolocation data and time stamp create a trail that helps locate you in worst-case scenarios. Send the photo to your shore-side person or save it to the shared cloud folder.</p>
+
+      <p><strong>Passport and document cloud-backup.</strong> A shared cloud folder (Google Drive, Dropbox, iCloud Shared) with your passport photo page, driver's license, insurance cards, and key prescription information that your shore-side person can access without your password. The folder doesn't need much in it — a few photos and the handoff card from Reaching Someone at Sea. It needs to exist before you sail.</p>
+
+      <p><strong>Wearable medical-alert option</strong> if a relevant health condition makes it worth carrying. A medical-alert bracelet or necklace that lists your most critical condition (cardiac history, seizure disorder, severe allergy) puts the information in front of the first responder if you can't answer questions yourself. Some solo cruisers carry a small ICE (in-case-of-emergency) card in their wallet with the same information plus the shore-side contact.</p>
+
+      <p>Solo doesn't mean isolated. It means you build the safety net yourself rather than relying on a travel partner to be it. The Reaching Someone at Sea handoff is the tool that makes the difference between a solo cruiser whose shore-side person can act quickly and a solo cruiser whose family is figuring it out under stress.</p>
+
+      <h2 id="for-couples-and-families">For couples, families, and groups</h2>
+
+      <p>Couples and families have an onboard safety advantage — someone notices if you don't come back. But the shore-side safety net still matters, and the failure mode is different: if both partners are involved in the same incident (car accident in port, medical emergency that incapacitates one and rattles the other), neither can activate the contact channels effectively.</p>
+
+      <p>The right setup: one shore-side person for the whole travel party, with information for every traveler in the handoff. If something happens to the family group, that one shore-side person can act for everyone.</p>
+
+      <p>For families with children, add the kids' medical information to the handoff — pediatrician contact, current medications, allergies, vaccination dates if recently updated, school contact if a longer disembarkation might affect their schooling. For multi-generational groups, include emergency contacts for older relatives in case the trip needs to be cut short.</p>
+
+      <p>For groups of friends sailing together, identify a single shore-side person before the trip rather than assuming each traveler's individual emergency contacts will coordinate. They will not coordinate well under stress. One person who has the full picture for everyone is faster than several people each with partial information.</p>
+
+      <h2 id="documents">Documents to carry and copy</h2>
+
+      <p>Documents to carry on your person in port: a copy of your passport's information page (not the original — leave that in the cabin safe), your government-issued photo ID, a credit card, a small amount of local currency, your SeaPass card. The SeaPass also functions as ship-side identification at the gangway.</p>
+
+      <p>Documents to copy to cloud storage your shore-side person can access: passport information page, driver's license, travel insurance card, prescription medications list, vaccination card, the handoff card from Reaching Someone at Sea. A shared cloud folder works; an email to your own and your shore-side person's accounts also works. The point is that the copies exist somewhere reachable from anywhere, on any device.</p>
+
+      <p>Documents to leave at home: original passport (unless required for the cruise — most U.S.-departing closed-loop Caribbean cruises do not require a passport for U.S. citizens, but it is strongly recommended), wills, advance directives, important original financial documents.</p>
+
+      <h2 id="connectivity">Cell phone and Wi-Fi expectations</h2>
+
+      <p>Cellular service at sea uses maritime roaming networks that charge per-minute and per-megabyte rates that can run into the hundreds of dollars for a single call. Most cruisers turn cellular off at the gangway and use the ship's Wi-Fi package for messaging, email, and voice apps (WhatsApp voice and video work over Wi-Fi without triggering cellular roaming).</p>
+
+      <p>In port, your domestic cellular plan may roam onto the local provider's network. Some carrier plans (T-Mobile international, certain Verizon and AT&amp;T tiers) include free or discounted international data in many cruise-destination countries. Confirm coverage with your carrier before sailing; the assumption "my phone will just work in port" is wrong often enough that it's not a safety plan.</p>
+
+      <p>For shore-side communication: if you're relying on the ship's Wi-Fi to send daily check-ins or stay in contact with your shore-side person, buy the cruise line's mid-tier or higher Wi-Fi package and connect at the start of the sailing rather than mid-cruise (some lines price daily access higher than full-week access). The <a href="/internet-at-sea.html">Internet at Sea guide</a> on this site walks through current package options by cruise line.</p>
+
+      <p>The shore-side safety net should not depend on your phone working perfectly. The handoff already gives your shore-side person the institutional channels (cruise line, State Department, embassy) they can use without needing to reach you first. Your phone is the convenience layer, not the safety layer.</p>
+
+      <h2 id="legal-protections">Legal protections on U.S.-calling ships</h2>
+
+      <p>The Cruise Vessel Security and Safety Act of 2010 — Public Law 111-207, signed into law July 27, 2010 — established baseline safety standards for every cruise ship that visits a U.S. port. The Act's protections apply regardless of the ship's flag of registry, because the trigger is U.S. port calls, not vessel ownership.</p>
+
+      <p>Specific requirements established by the Act:</p>
+
+      <p><strong>Incident logging and reporting.</strong> Disappearances, alleged sexual assaults, theft above $10,000, and deaths must be logged onboard and reported to the FBI. Quarterly public reports are published by the U.S. Coast Guard.</p>
+
+      <p><strong>Physical security.</strong> Cabin doors must have peepholes and security latches. Surveillance equipment must be present in common areas. Time-sensitive safety information must be provided to passengers.</p>
+
+      <p><strong>Sexual-assault response.</strong> Trained personnel must be available to handle reports onboard. Evidence collection procedures are standardized.</p>
+
+      <p>These protections matter for two reasons. First, they establish that an incident on a U.S.-calling ship has a federal-channel record beyond the cruise line's internal system — useful to know when a family member needs to verify what has been recorded. Second, they distinguish ships that visit U.S. ports from ships on purely international itineraries, where regulatory frameworks vary by flag and port country.</p>
+
+      <h2 id="faq">Frequently asked questions</h2>
+
+      <details class="section-divider">
+        <summary><strong>What is the single most important pre-cruise safety preparation?</strong></summary>
+        <p class="list-indent">Set up the shore-side safety net. Identify one trusted person back home, give them the handoff information (ship name, cabin, itinerary, contact channels, medical info, document copies), and share the <a href="/reaching-someone-at-sea.html">Reaching Someone at Sea</a> page so they have the contact references when they need them. Ten minutes today. Could matter on the one day it does.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What number does a family member call in a cruise emergency?</strong></summary>
+        <p class="list-indent">If they don't have the cruise line's ship-to-shore family contact number, they should call the U.S. State Department's Overseas Citizens Services line — 24 hours a day, every day. From the U.S. or Canada: <strong>+1-888-407-4747</strong>. From abroad: <strong>+1-202-501-4444</strong>. The State Department can locate the ship, contact the cruise line on the family's behalf, and coordinate consular services if the situation is in port. Do not call the cruise line's general booking line — it routes to sales, not emergencies.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What information should I leave with someone back home before a cruise?</strong></summary>
+        <p class="list-indent">Ship name and cruise line. Cabin number. Sailing dates and full itinerary with port-day dates. Cruise line ship-to-shore family contact number. U.S. State Department line. Embassy phone numbers for each port. Medications, allergies, medical conditions. Copies of passport, driver's license, travel insurance policy. Travel insurance company's emergency assistance line. Names and contact information for travel companions. Where to find your will, advance directive, or power of attorney if those apply to your life stage. The handoff card on the <a href="/reaching-someone-at-sea.html">Reaching Someone at Sea</a> page collects all of this in one place.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What safety considerations are specific to solo cruisers?</strong></summary>
+        <p class="list-indent">On a solo cruise, no one in the next cabin notices if you don't come back. The shore-side safety net becomes the primary safety system, not a backup. Set up a daily check-in time with your shore-side person via the ship's Wi-Fi. Share your shore excursion plans before leaving the ship. Take a daily port photo (geolocation data and time stamps create a trail). Store document copies in a shared cloud folder. Consider a wearable medical-alert option if you have a relevant health condition. Solo doesn't mean isolated; it means you build the safety net yourself rather than relying on a travel partner to be it.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What legal protections do cruisers have on ships that visit U.S. ports?</strong></summary>
+        <p class="list-indent">The Cruise Vessel Security and Safety Act of 2010 (Public Law 111-207) requires every cruise ship calling at a U.S. port to log specific incidents (disappearances, sexual assaults, theft above $10,000, deaths) and report them to the FBI. The Act also mandates peepholes and security latches on cabin doors, surveillance equipment, time-sensitive safety information, and trained sexual-assault response personnel. The FBI logs and quarterly Coast Guard public reports mean an incident on a U.S.-calling ship is documented through a federal channel, not just through the cruise line's internal system.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Will my cell phone work on a cruise ship?</strong></summary>
+        <p class="list-indent">Inconsistently and expensively at sea — maritime roaming networks charge per-minute and per-megabyte rates that can run into hundreds of dollars for a single call. Most cruisers turn cellular off at the gangway and use the ship's Wi-Fi package for messaging and voice apps. In port, your domestic cellular plan may roam onto the local provider's network depending on your carrier. Confirm coverage before sailing. The shore-side safety net does not depend on your phone working — the institutional channels in the handoff are reachable regardless. See the <a href="/internet-at-sea.html">Internet at Sea guide</a> for current ship Wi-Fi package details.</p>
+      </details>
+
+      <h2 id="take-the-step">The ten-minute step that matters</h2>
+
+      <p>Open <a href="/reaching-someone-at-sea.html"><strong>Reaching Someone at Sea</strong></a> on your phone. Fill in the handoff card. Send it to one person back home. Add the page to your home screen so the contact references are available offline.</p>
+
+      <p>If you're sailing solo, do this today. If you're sailing with family, do it together. If you've sailed dozens of times without ever needing any of it, do it anyway — the people on every sailing where one of these scenarios plays out had also never needed it before that day.</p>
+
+      <p>Ten minutes. Send it to one person. That's the safety net.</p>
+
+      <h2 id="related">Related reading</h2>
+
+      <ul>
+        <li><a href="/reaching-someone-at-sea.html">Reaching Someone at Sea</a> — the full emergency contact reference and handoff tool</li>
+        <li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising: A Practical Guide</a> — broader solo-traveler guidance beyond safety setup</li>
+        <li><a href="/solo/solo-cruisers-companion.html">The Solo Cruiser's Companion</a> — making the most of a solo sailing</li>
+        <li><a href="/accessibility.html">Accessibility on Cruises</a> — adjacent guidance for disabled travelers and traveling caregivers</li>
+        <li><a href="/internet-at-sea.html">Internet at Sea</a> — Wi-Fi package details for staying connected to your shore-side person</li>
+        <li><a href="/first-cruise.html">Your First Cruise</a> — broader pre-cruise planning</li>
+      </ul>
+
+      </div>
+    </article>
+  </main>
+
+  <!-- ================= FOOTER ================= -->
+  <footer class="wrap footer" role="contentinfo">
+    <p>&copy; 2026 In the Wake. All rights reserved.</p>
+    <p class="trust-badge">✓ No ads. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+    <nav aria-label="Footer navigation">
+      <ul style="list-style:none;padding:0;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
+        <li><a href="/about-us.html">About</a></li>
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/reaching-someone-at-sea.html">Reach Family at Sea</a></li>
+        <li><a href="/affiliate-disclosure.html">Affiliate Disclosure</a></li>
+      </ul>
+    </nav>
+    <p class="tiny center" style="margin-top:.5rem;opacity:0.7">
+      Soli Deo Gloria — Every pixel and part of this project is offered as worship to God.
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -61,6 +61,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/articles/msc-voyagers-club-status-match-from-rcl-diamond.html</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>weekly</changefreq>


### PR DESCRIPTION
Title: "Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing"

Generic-purpose pre-cruise safety guide that applies to solo cruisers, couples, families, and groups. Anchored on the shore- side safety net thesis: the single most important pre-cruise preparation is one trusted person back home with the right information, not anything you pack in your suitcase.

Structure:
- Lede + answer-first block with prominent link to the Reaching Someone at Sea reference (the site's existing emergency-contact tool with a handoff card that stays on the user's device, nothing sent to a server)
- §Why this matters — reframes safety prep around the shore-side person, not the onboard equipment
- §The handoff — comprehensive list of fields to share with the shore-side person (ship, cabin, itinerary, contact channels, medical, identity documents, companions, legal/end-of-life docs where applicable)
- §The free tool — explains the Reaching Someone at Sea page
  + handoff card mechanics (lives on device, no account required, no tracking, works offline after first visit)
- §The three institutional channels — cruise line ship-to- shore desk, U.S. State Department Overseas Citizens Services (+1-888-407-4747 / +1-202-501-4444), U.S. embassies/consulates by port
- §Common scenarios — medical emergency at sea, missed ship, lost passport, criminal incident, news from home
- §For solo cruisers specifically — dedicated section with solo-specific practices (daily check-in, pre-shore-day plan share, daily port photo, document cloud-backup, wearable medical-alert if relevant)
- §For couples, families, and groups — failure-mode is different (both partners can be in same incident); one shore-side person for whole travel party
- §Documents — carry copies vs originals, what to cloud- backup, what to leave home
- §Connectivity — cell at sea is expensive and inconsistent, Wi-Fi for messaging, safety net should not depend on phone working
- §Legal protections — Cruise Vessel Security and Safety Act of 2010 (Public Law 111-207): incident logging to FBI, peepholes/security latches, surveillance, sexual-assault response personnel — apply to any ship that visits U.S. ports regardless of flag
- §FAQ — 6 questions matching the JSON-LD FAQPage schema
- Closing CTA: "ten minutes. send it to one person."

ICP-2 compliance:
- ai-summary meta tag with longer-form summary for AI- engine extraction
- JSON-LD Article + Person + FAQPage schemas
- OG + Twitter Card meta
- Canonical URL
- Skip-to-content link + main landmark
- Single H1, 14 H2 sections (no skipped levels)
- Voice audit clean: 0 banned vocabulary instances
- Cross-link integrity verified: all 6 internal hrefs resolve (/reaching-someone-at-sea.html, /solo/solo-cruising-practical-guide.html, /solo/solo-cruisers-companion.html, /accessibility.html, /internet-at-sea.html, /first-cruise.html)
- Site convention preserved (straight quotes, em-dashes)
- SDG invocation in head (immutable per pastoral guardrails)

Pastoral guardrail compliance:
- Doesn't minimize the realities of disability or neurodivergence (mentions wearable medical-alert as practical option, not inspiration)
- Doesn't frame solo travelers as "less than" or assume romance-seeking (solo section explicitly says "solo doesn't mean isolated; it means you build the safety net yourself rather than relying on a travel partner to be it")
- Pastoral honesty on end-of-life documents ("This is morbid only if you've never lost someone in the middle of arranging a memorial across borders. The people who have, prepare differently")
- No travel-agent hype, no must-do/bucket-list language

Wired into:
- articles.html (top of Popular Guides list)
- sitemap.xml (priority 0.9, monthly changefreq)