### PR TITLE
skills/voice-audit + like-a-human: AI-Tell Detection Framework v3 + f…

### DIFF
--- a/.claude/skills/like-a-human/SKILL.md
+++ b/.claude/skills/like-a-human/SKILL.md
@@ -305,7 +305,44 @@ When in doubt, trust the specific. Cut the crutch. The reader feels the differen
 
 ---
 
+## AI-Tell Discipline (v3 — During-Writing Rules)
+
+Added 2026-05-25. Three rules to internalize during composition. The full post-draft detection framework these rules emerged from lives in `voice-audit/SKILL.md` under "AI-Tell Detection Framework (v3)" — this skill carries the discipline; voice-audit carries the scan.
+
+### Rule 1 — Every abstraction earns a concrete referent within two sentences
+
+If the prose says "the mission," the next sentence (or the one after) names the mission. If the prose says "the rooms where decisions get made," the next sentence names a room. If the prose says "the work," surrounding text identifies what work — by named program, named meeting, named outcome.
+
+Test during composition: when an abstract phrase is drafted, ask whether the reader could trace it to a specific referent without re-reading the whole document. If not, the abstraction is filler and either gets a referent or gets cut.
+
+### Rule 2 — Triplet closures and parallel structures must do work, not just sound like work
+
+Parallel constructions and triplet closures are powerful — and they are everywhere in skilled human writing (Paul, Spurgeon, Robinson, Berry). They are also what AI overproduces because they sound resonant without requiring substance.
+
+Test during composition: if the third item in a triplet is deleted, does the meaning collapse or does the sentence only lose its musical close? If only the music is lost, the closure was decorative — cut it or replace the third item with one that carries distinct content.
+
+### Rule 3 — Cluster, not single
+
+No individual feature determines verdict. A single chiasmus is human rhetoric. A single triplet is human cadence. A single stock phrase is laziness, not AI. The signal is density — multiple features stacking in a short span without counter-signals (named specifics, authorial hedging, friction, unexpected word choice) to balance them.
+
+The discipline during composition: notice when several features are clustering. Then deliberately add a counter-signal — a specific dollar amount, a named meeting, an admitted contradiction, an awkward unexpected phrase, a hedge that names the limit of the claim. Counter-signals are what keep skilled writing on the human side of the framework.
+
+### Read alongside
+
+- `voice-audit/SKILL.md` — the post-draft detection framework these rules support
+- `voice-audit/falsification-test.md` — polished human writing the framework must not flag as AI; the reference for what "skilled human prose with structural features" looks like in practice
+
+### Important constraints to internalize
+
+- Performative is not artificial. Humans are often performative — especially in testimony, preaching, advocacy.
+- Rhetorical devices (chiasmus, anaphora, parallelism, triplet closure, contrast reframing) are human first, AI second. Their presence is never a verdict.
+- Specificity strongly favors human authorship. Vagueness alone does not prove AI.
+- All conclusions about authorship are probabilistic.
+
+---
+
 ## Version History
 
+- **v3.2.0 (2026-05-25)** — Added AI-Tell Discipline section (v3 during-writing rules). Three rules: every abstraction earns a concrete referent within two sentences; triplet closures and parallel structures must do work not just sound like work; cluster not single. Companion to the post-draft detection framework added to voice-audit in the same session.
 - **v3.1.0 (2026-05-10)** — Lifted ten sub-disciplines from Romans's `like-a-human` (in cruise voice): copula avoidance with replacement table, decorative adverb kill list, rule of three, low-probability details, dead metaphor, one-point dilution, syntactic template repetition, punctuation fingerprint, the controlled flaw, the building pattern with concrete examples, cadence escalation (two kinds of acceleration + pause-and-pivot). Reorganized Plain Language Discipline as the spine of the document.
 - **v3.0.0** — Initial cruise-voice version: hard-banned vocabulary, native moves, three borrowed moves, pastoral guardrails.

--- a/.claude/skills/voice-audit/SKILL.md
+++ b/.claude/skills/voice-audit/SKILL.md
@@ -283,7 +283,67 @@ When the rating is High, the recommendation is to **rewrite the page from the or
 
 ---
 
+## AI-Tell Detection Framework (v3)
+
+Added 2026-05-25. This section codifies a layered framework for identifying probable AI authorship in completed prose. The framework was refined through adversarial iteration; the prior versions overclaimed on isolated features (chiasmus, performative tone, "humans don't usually open this way"). The v3 version corrects those errors and operationalizes the core insight: **AI authorship is detected by clustering and density, not by individual features.**
+
+### The operational rule: cluster, don't single
+
+No single feature is a verdict. A passage flagged only for one item in any layer below is at most a yellow flag, not a finding. The framework requires clustering across layers — at least one strong signal and one or more supporting signals, with counter-signals weighed against them — before any AI-likelihood claim is made.
+
+### Layer 1 — Strong signals (high confidence when clustered)
+
+- **Semantic placeholders where concrete referents could go.** AI gravitates to "the mission," "the work," "the hard questions," "the rooms where decisions get made," "the journey," "the challenge." Test each instance: can the abstraction be traced to a concrete referent in surrounding context? If yes, the placeholder is shorthand and acceptable. If no, the placeholder is filler.
+- **Broad authority claims with no specifics.** "I've been in the rooms where decisions get made" without naming a single room is the canonical case. Acceptable form: the claim with the anchor ("the budget review on the third Tuesday, the program redesign that landed on my desk in October"). Unacceptable form: the claim without the anchor.
+- **Triplet closures carrying rhythm but not content.** Test: if the third item in the triplet is deleted, does meaning collapse or does the sentence just lose its musical close? If only the music is lost, the closure was decoration.
+- **Clean, linear persuasion arc** with no digression, no authorial uncertainty, no moment where the writer admits something doesn't fit cleanly. Human prose has friction; optimized AI output rarely does.
+
+### Layer 2 — Supporting signals (need Layer 1 to confirm)
+
+- Stock consultant phrases ("seamlessly," "robust," "leverage," "best-in-class," "world-class")
+- Clichés ("every shape and size," "more with less")
+- Sustained staccato fragment-clustering without rhythm variation
+- Parallel structures and chiasmus when they read manufactured-clean (chiasmus is ancient rhetoric — its presence is human-first; the signal is overuse and unbroken cleanness, not appearance)
+- "Too smooth" delivery — no awkwardness, no recovered phrases, no second thoughts
+
+### Layer 3 — Counter-signals (favor human authorship)
+
+- Named entities, places, dates, dollar amounts, document numbers, statute citations, ship/port/venue names
+- Mild awkwardness, sentence-shape variation, unexpected word choices
+- Localized claims with bounded scope ("on this sailing in May 2026," "on a four-night Caribbean itinerary," "in the November budget cycle")
+- Authorial hedging that names the limit of what's claimable ("n=1," "what I observed; what generalizes is a separate question")
+- Specific verifiable quotes with attribution
+- Friction, contradiction, or admitted uncertainty within the prose
+
+### Hard constraints (non-negotiable; these override the cluster test)
+
+Earlier framework versions produced false positives by violating these. They are absolute:
+
+- **Performative is not artificial.** Humans are routinely performative — especially in testimony, advocacy, preaching, public speaking. A passage that reads "performed" is not on that basis AI-generated.
+- **Rhetorical devices are human first.** Chiasmus, anaphora, parallelism, triplet closures, contrast reframing — all are ancient rhetoric, all predate AI by centuries. Their presence is never evidence of AI authorship. Their clean, mechanized overuse without substance is the actual signal.
+- **Specificity strongly favors human authorship; lack of specificity does not prove AI.** Many human writers are vague. Vagueness alone is not a verdict.
+- **All conclusions are probabilistic.** The framework produces "likely AI," "likely human," or "unclear" — never a definitive label.
+- **Context matters.** Testimony, preaching, advocacy, sermon, eulogy, and political address operate at elevated register by genre convention. Apply the framework with awareness of which register the passage is in.
+
+### Cluster scoring (operational)
+
+To produce a verdict, count by layer:
+
+- 0 Layer 1 signals → likely human regardless of Layer 2
+- 1 Layer 1 + 0 Layer 2 → unclear (yellow flag, no verdict)
+- 1 Layer 1 + 2+ Layer 2 → likely AI, modulo counter-signals
+- 2+ Layer 1 → likely AI, modulo counter-signals
+
+Counter-signals modulate the verdict downward by one notch each (likely AI → unclear; unclear → likely human). Three or more counter-signals override any combination of Layer 1 + Layer 2 signals; this is what protects skilled human writing from false positives.
+
+### Falsification test
+
+Before any change to this framework, run the modified framework against the passages in `falsification-test.md` in this directory. Those passages are highly polished human writing with multiple features the framework lists as AI signals. They should pass the cluster test (counter-signals outweigh) and produce "likely human" verdicts. If a framework update causes any of those passages to be flagged as AI, the update is too aggressive and must be revised.
+
+---
+
 ## Version History
 
+- **v2.2.0 (2026-05-25)** — Added AI-Tell Detection Framework section (v3 of the underlying framework). Refines prior overclaims on chiasmus, performative tone, and statistical claims about human writing patterns. Operationalizes the cluster-density rule and adds a falsification-test file (Spurgeon passages) the framework must not flag as AI before any further refinement is accepted.
 - **v2.1.0 (2026-05-10)** — Lifted four diagnostics from Romans's `voice-audit` (in cruise voice): grep pattern for announcement-before-move, grep pattern for assumed-familiarity, image-density scan with per-paragraph thresholds, must-be-absent list with explicit drift indicators. Updated risk-rating thresholds and audit-report format to reflect the new checks.
 - **v2.0.0** — Six-axis scan with cruise-marketing vocabulary list and pastoral-honesty axis.

--- a/.claude/skills/voice-audit/falsification-test.md
+++ b/.claude/skills/voice-audit/falsification-test.md
@@ -1,0 +1,107 @@
+# Voice-Audit Falsification Test
+
+This file holds polished human-written passages that the AI-tell detection framework in `SKILL.md` MUST classify as "likely human." Each passage has multiple features the framework lists as AI signals (parallel structure, triplet closure, manufactured-quotable lines, elevated register), yet should pass the cluster test because of counter-signals (specific scriptural anchors, theological humility, personal voice, named events, period-specific vocabulary).
+
+## Why this file exists
+
+The framework's earlier versions overclaimed on isolated features. Skilled human writers — preachers, poets, essayists — routinely use the structural patterns AI also produces. Without a falsification anchor, the framework risks drifting back toward "any clean prose = AI."
+
+Before any change to the AI-tell detection framework, re-run the modified framework against the passages below. If a framework update produces a "likely AI" verdict on any of them, the update is too aggressive and must be revised.
+
+## Test passage 1 — Charles Spurgeon, *All of Grace* (1886)
+
+> "He is a Savior, and a great one. He is able to save to the uttermost them that come unto God by him. He has saved me. He can save you. He will save all who trust him.
+>
+> He who made the world undertakes to deal with you, if you will but accept his Son. He gave his Son to die, that men might live; and that fact remains forever. Despite all your unworthiness, you are bidden simply to believe in him, and live."
+
+### What the naive framework would flag
+
+- Triplet closure: "He has saved me. He can save you. He will save all..."
+- Parallel construction sustained across multiple sentences
+- Repeated subject construction ("He is... He is able... He has... He can... He will...")
+- Elevated, polished register
+- Rhetorical clean delivery with no friction
+
+### What the cluster test catches (counter-signals)
+
+- Specific scriptural anchor: "able to save to the uttermost them that come unto God by him" — direct paraphrase of Hebrews 7:25, a named referent any Reformed Baptist reader would recognize without explanation
+- Named theological subject: Christ as the named Savior, not an abstraction
+- Direct address to the reader: "He can save you," "you are bidden" — personal, second-person, specific
+- Specific theological proposition: substitutionary atonement ("He gave his Son to die, that men might live") — a doctrinal claim with content, not a sentiment
+- Period-specific vocabulary: "bidden," "unworthiness," "uttermost" — pre-1928 register that pre-dates AI training corpora's modal contemporary voice
+
+### Verdict the framework MUST produce
+
+**Likely human.** The counter-signals dominate. The triplet and parallel construction are skilled-preacher rhetoric, not AI output.
+
+## Test passage 2 — Charles Spurgeon, *Morning and Evening* (devotional, undated, 19th century)
+
+> "Faith is the foot of the soul by which it can march along the road of the commandments. Love can make the feet move more swiftly; but it is faith that carries the soul. Faith is the oil enabling the wheels of holy devotion and earnest piety to move well; and without faith the wheels are taken from the chariot, and we drag heavily."
+
+### What the naive framework would flag
+
+- Multiple parallel metaphors stacked (faith as foot, oil, mechanism)
+- Triplet implied (foot / love / wheels)
+- Elevated register
+- Polished, speech-ready cadence
+- Manufactured-quotable lines
+
+### What the cluster test catches (counter-signals)
+
+- Specific concrete imagery: "the road of the commandments," "the wheels of holy devotion," "the chariot" — each image is a named, traceable referent inside a specific theological tradition
+- Personal voice with collective subject: "we drag heavily" — admits the speaker's own struggle, not an abstract universal claim
+- Theological precision: distinguishes faith from love as functions ("Love can make the feet move more swiftly; but it is faith that carries the soul") — a doctrinal distinction that requires substance, not a rhetorical flourish
+- Mechanical-imagery specificity: "the wheels are taken from the chariot" — a concrete physical picture, not an abstraction
+- Period-specific vocabulary and syntax: "march along the road of the commandments" is 19th-century English that does not appear in contemporary AI training corpora's modal voice
+
+### Verdict the framework MUST produce
+
+**Likely human.** The metaphorical density is preacher's rhetoric. The cluster of counter-signals (theological precision, admitted struggle, period vocabulary, specific imagery) outweighs the structural features.
+
+## Test passage 3 — Charles Spurgeon, *The Treasury of David*, on Psalm 23 (commentary, 1869–1885)
+
+> "The position of this Psalm is worthy of notice. It follows the twenty-second, which is peculiarly the Psalm of the cross. There are no green pastures, no still waters on the other side of the twenty-second Psalm. It is only after we have read, 'My God, my God, why hast thou forsaken me?' that we come to 'The Lord is my Shepherd.' We must by experience know the value of blood-shedding, and see the sword awakened against the Shepherd, before we shall be able to truly know the Sweetness of the Shepherd's care."
+
+### What the naive framework would flag
+
+- Parallel construction across sentences
+- Manufactured-quotable framing ("It is only after we have read X that we come to Y")
+- Elevated register
+- Rhetorical authority claim ("worthy of notice")
+
+### What the cluster test catches (counter-signals)
+
+- Specific cited referents: "the twenty-second" Psalm, "the twenty-third" Psalm — named, traceable, verifiable
+- Direct scriptural quotation: "My God, my God, why hast thou forsaken me?" (Psalm 22:1) and "The Lord is my Shepherd" (Psalm 23:1) — quoted, attributable
+- Theological sequence-claim with substance: argues for an experiential order (cross before comfort, suffering before peace) that is a specific doctrinal position, not a rhetorical flourish
+- Period vocabulary: "blood-shedding," "the Sweetness of the Shepherd's care" — 19th-century capitalization conventions, syntactic registers AI does not reliably reproduce
+
+### Verdict the framework MUST produce
+
+**Likely human.** The Psalm-sequence argument is doctrinal scholarship, not generated prose.
+
+## How to use this file
+
+When the AI-tell detection framework in `SKILL.md` is modified:
+
+1. Re-run the modified framework against each passage above
+2. For each passage, produce a verdict using the framework's cluster-scoring rule
+3. If any passage produces "likely AI" or worse, the framework update is too aggressive
+4. Either revise the update or add a more explicit counter-signal protection
+
+## Adding new test passages
+
+When a new piece of polished human writing is found to be misclassified by the framework (or feared likely to be misclassified), add it to this file as a new test passage with:
+
+- Full quote (or representative excerpt) with attribution
+- "What the naive framework would flag" — the structural features that look AI-like
+- "What the cluster test catches" — the counter-signals that should produce "likely human"
+- "Verdict the framework MUST produce" — the required output
+
+Good candidates for additional test passages: Marilynne Robinson's *Gilead*, Wendell Berry's essays, John Donne's sermons, Frederick Douglass's *Narrative*, James Baldwin's *The Fire Next Time*, any sustained Spurgeon sermon excerpt, any sustained passage from a working pastor's contemporary sermon notes.
+
+Falsification tests are how the framework stays honest. Without them, every refinement drifts back toward over-classification.
+
+---
+
+*Soli Deo Gloria*


### PR DESCRIPTION
…alsification test

Adds operational AI-tell detection framework to both skills as a new section (no restructuring of existing content). Framework was refined through adversarial iteration; the v3 version corrects prior overclaims on chiasmus, performative tone, and statistical claims about human writing patterns.

The core insight v3 codifies: AI authorship is detected by clustering and density, not by individual features. No single feature is a verdict.

Changes:

1. voice-audit/SKILL.md (v2.1.0 → v2.2.0): appended new section "AI-Tell Detection Framework (v3)" before the version history. Section covers:
   - The operational rule (cluster, don't single)
   - Layer 1 strong signals (semantic placeholders, broad authority claims, triplet closures carrying rhythm without content, clean linear persuasion arcs)
   - Layer 2 supporting signals (stock phrases, clichés, sustained staccato, manufactured-clean parallel structures, "too smooth" delivery)
   - Layer 3 counter-signals (named entities, awkwardness, localized claims, authorial hedging, friction)
   - Hard constraints (performative is not artificial; rhetorical devices are human first; specificity favors human; all conclusions are probabilistic; context matters)
   - Cluster scoring rules
   - Falsification test reference

2. like-a-human/SKILL.md (v3.1.0 → v3.2.0): appended new section "AI-Tell Discipline (v3 — During-Writing Rules)" before the version history. Three rules:
   - Rule 1: every abstraction earns a concrete referent within two sentences
   - Rule 2: triplet closures and parallel structures must do work, not just sound like work
   - Rule 3: cluster, not single Plus the same hard constraints from voice-audit so they fire during composition, not just post-draft.

3. voice-audit/falsification-test.md (new file): three Spurgeon passages with multiple structural features the framework would naively flag as AI, but counter-signals (specific scriptural anchors, theological precision, period vocabulary, named events, personal voice) that should produce "likely human" verdicts. Each passage includes:
   - The full quote with attribution
   - What the naive framework would flag
   - What the cluster test catches (counter-signals)
   - The verdict the framework MUST produce Instructions for adding new test passages included.

Why Spurgeon and not Lincoln: Spurgeon fits the site's pastoral register naturally and avoids historical-trauma language that some content-filtering systems flag. The structural features (chiasmus, parallel construction, triplet closures, elevated register) are present in equal measure.

The falsification test is the discipline mechanism: before any future change to the AI-tell detection framework, the modified framework must be re-run against these passages. If any passage gets flagged as AI, the update is too aggressive and must be revised.

This is what keeps the framework from drifting back toward "any clean prose = AI" — the failure mode the v3 refinement exists to prevent.