### PR TITLE
voice skills: name identity-archetype and template-reinforcement expl…

### DIFF
--- a/.claude/skills/voice-audit/SKILL.md
+++ b/.claude/skills/voice-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: voice-audit
 description: "Post-draft diagnostic for InTheWake content. Scans for cruise-marketing tells and AI fingerprints, assesses authenticity risk, and checks voice continuity against the measured corpus profile. Fires before committing content edits or before publishing a new page. For during-writing standards, see like-a-human. For corpus measurement, see voice-dna."
-version: 2.1.0
+version: 2.3.0
 ---
 
 # Voice Audit — Post-Draft Diagnostic
@@ -297,6 +297,7 @@ No single feature is a verdict. A passage flagged only for one item in any layer
 - **Broad authority claims with no specifics.** "I've been in the rooms where decisions get made" without naming a single room is the canonical case. Acceptable form: the claim with the anchor ("the budget review on the third Tuesday, the program redesign that landed on my desk in October"). Unacceptable form: the claim without the anchor.
 - **Triplet closures carrying rhythm but not content.** Test: if the third item in the triplet is deleted, does meaning collapse or does the sentence just lose its musical close? If only the music is lost, the closure was decoration.
 - **Clean, linear persuasion arc** with no digression, no authorial uncertainty, no moment where the writer admits something doesn't fit cleanly. Human prose has friction; optimized AI output rarely does.
+- **Predictable identity archetype.** AI gravitates to a recognizable narrative arc: the writer saw what others missed, was first to notice the change, bridges what insiders cannot bridge. In cruise writing this surfaces as "before everyone discovered this port," "I knew the line had changed years ago," "most travelers don't realize that...," "I've been doing this long enough to see what's coming." Test each instance: is the claim anchored to a dated sailing, a named change, a specific observation? Generic posture without anchor is the tell. The signal is the archetype itself — a known piece of skilled human writing that names a real change at a real time on a real ship is not flagged.
 
 ### Layer 2 — Supporting signals (need Layer 1 to confirm)
 
@@ -305,6 +306,7 @@ No single feature is a verdict. A passage flagged only for one item in any layer
 - Sustained staccato fragment-clustering without rhythm variation
 - Parallel structures and chiasmus when they read manufactured-clean (chiasmus is ancient rhetoric — its presence is human-first; the signal is overuse and unbroken cleanness, not appearance)
 - "Too smooth" delivery — no awkwardness, no recovered phrases, no second thoughts
+- **Template reinforcement.** Any rhetorical template (other than antithetical parallelism, already flagged in §1) reused two or more times in slightly varied form across the page — e.g., the "It is not about X — it is about Y" frame appearing in three different sections, or the "What looks like X is actually Y" frame recurring with different fillers. The signal is the template repeating without being earned by the argument. A skilled human writer who deploys the same frame deliberately at three pressure points — each pressure point named, each frame doing distinct work — is not flagged.
 
 ### Layer 3 — Counter-signals (favor human authorship)
 
@@ -344,6 +346,7 @@ Before any change to this framework, run the modified framework against the pass
 
 ## Version History
 
+- **v2.3.0 (2026-05-25)** — Named two patterns previously covered only by general framework rules: **predictable identity archetype** added to Layer 1 (catches "I saw what others missed" arc with anchor-required test) and **template reinforcement** added to Layer 2 (catches rhetorical frames other than antithetical parallelism that recur with variation but no argument). Both additions carry explicit skilled-human-writing protection in their wording so the falsification-test passages still pass.
 - **v2.2.0 (2026-05-25)** — Added AI-Tell Detection Framework section (v3 of the underlying framework). Refines prior overclaims on chiasmus, performative tone, and statistical claims about human writing patterns. Operationalizes the cluster-density rule and adds a falsification-test file (Spurgeon passages) the framework must not flag as AI before any further refinement is accepted.
 - **v2.1.0 (2026-05-10)** — Lifted four diagnostics from Romans's `voice-audit` (in cruise voice): grep pattern for announcement-before-move, grep pattern for assumed-familiarity, image-density scan with per-paragraph thresholds, must-be-absent list with explicit drift indicators. Updated risk-rating thresholds and audit-report format to reflect the new checks.
 - **v2.0.0** — Six-axis scan with cruise-marketing vocabulary list and pastoral-honesty axis.

--- a/.claude/skills/voice-dna/SKILL.md
+++ b/.claude/skills/voice-dna/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: voice-dna
 description: "Discovers voice patterns from the InTheWake content corpus. Measures rhythm, vocabulary, and experiential fingerprints across port guides, ship profiles, logbook entries, and restaurant pages — data-driven voice profiling that feeds like-a-human and voice-audit."
-version: 2.0.0
+version: 2.1.0
 ---
 
 # Voice DNA — Voice Discovery from the Cruise Corpus
@@ -80,6 +80,21 @@ For each sample, measure:
 - Closing pattern (logbook signoff? practical checklist? pastoral note?)
 - Image-to-prose ratio
 - Schema/data-block density (should be low in body prose, contained in headers/sidebars)
+
+### Abstract Authority Density
+- Frequency of abstract authority nouns per page (`the experience, the adventure, the journey, the memory, the moment, the destination`) — measured by grep
+- For each instance found in the sample, classify: **anchored** (specific referent within the surrounding two sentences — named ship, dated sailing, deck number, real port stop) or **floating** (no concrete anchor)
+- Baseline expectation: floating instances per page should be near zero; anchored instances are corpus vocabulary, not tells. A page with three or more floating instances should be removed from the sample (or the page itself has drifted and needs revision)
+
+### Template Frequency
+- Count antithetical-parallelism instances per page (`"not X — Y"`, `"it's not about X, it's about Y"`) — measured by grep
+- Compute the average + standard deviation across the sample; use this to set the cap in `voice-audit` (the cap should be roughly mean + 1σ rounded down — currently 1 per page; verify against measured corpus)
+- Also count broader template repetition: any rhetorical frame (`"what looks like X is actually Y"`, `"the real story is..."`) that appears 2+ times on a single sample page. Flag sample pages with 3+ template repetitions for re-baselining — they may have drifted
+
+### Identity-Archetype Absence
+- Grep the sample for identity-archetype patterns: `"I saw .* coming|I knew .* before|most travelers don't realize|before everyone discovered|I've been doing this long enough"`
+- The corpus baseline should produce zero hits for unanchored uses. Hits with anchors (named change, dated observation, specific ship) are corpus voice and acceptable; unanchored hits flag the sample page as drifted
+- Use this measurement to confirm the falsification protection in `voice-audit` — the corpus itself should never produce a Layer 1 archetype flag
 
 ## Profile Output
 


### PR DESCRIPTION
…icitly

v3 framework in voice-audit already covered these implicitly through "broad authority claims" (Layer 1) and "parallel structures when manufactured-clean" (Layer 2). Naming them explicitly catches cases the implicit rules miss: the cruise-writing identity arc ("I knew the line had changed before everyone else") and rhetorical templates other than antithetical parallelism that recur across the page without being earned by the argument. Both adds carry skilled-human-writing protection in their wording so the falsification-test Spurgeon passages still produce "likely human."

In voice-dna, add three measurement categories so the baseline corpus is checked for these patterns: abstract-authority density (anchored vs floating), template frequency (calibrates the voice-audit cap), and identity-archetype absence (corpus should produce zero unanchored hits).