### PR TITLE
Recover three articles 404 on live site after main force-push

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -313,6 +313,9 @@
       <div class="key-facts" style="background: #f0f7ff; border-color: #d0e4f0;">
         <h2>Popular Guides</h2>
         <ul style="line-height: 1.8;">
+          <li><a href="https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html">Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing</a></li>
+          <li><a href="https://cruisinginthewake.com/articles/perfect-day-mexico-rejected-2026.html">Perfect Day Mexico, Rejected: What Royal Caribbean's $600M Setback Actually Means</a></li>
+          <li><a href="https://cruisinginthewake.com/articles/msc-voyagers-club-status-match-from-rcl-diamond.html">RCL Diamond to MSC Voyagers Club: How the Status Match Actually Works in 2026</a></li>
           <li><a href="https://cruisinginthewake.com/articles/msc-seaside-service-review.html">MSC Seaside Service Review: The Apology That Wasn't a Plan</a></li>
           <li><a href="https://cruisinginthewake.com/articles/royal-caribbean-vs-msc.html">Royal Caribbean vs MSC: Side by Side from the Deck</a></li>
           <li><a href="https://cruisinginthewake.com/articles/cruise-ship-size-explained.html">Cruise Ship Size, Explained: When Bigger Feels Smaller</a></li>

--- a/articles/cruise-travel-safety-shore-side-net.html
+++ b/articles/cruise-travel-safety-shore-side-net.html
@@ -1,0 +1,460 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+  <!-- ======================================================
+       In the Wake — Article
+       Page: Cruise Travel Safety — The Shore-Side Safety Net
+       Version: 3.010.400  |  Standards baseline: 3.010.x
+       Content Protocol: ICP-2
+       ====================================================== -->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer"/>
+  <meta name="ai-summary" content="A practical guide to the pre-cruise safety setup every traveler should complete before sailing — solo, couple, family, or group. The core idea: the single most important piece of pre-cruise preparation is the shore-side safety net. One trusted person back home, with the right information in front of them, can resolve almost any at-sea or in-port emergency through three institutional channels — the cruise line's ship-to-shore family contact desk, the U.S. State Department's Overseas Citizens Services line (+1-888-407-4747 from U.S./Canada, +1-202-501-4444 from abroad), and the U.S. embassy or consulate in the affected port. Without that shore-side person knowing where you are and how to reach you, every channel gets slower. The article walks through what the handoff conversation should cover (itinerary, ship name, cabin number, key dates, emergency contacts, allergies/medications, document copies), points to the site's free Reaching Someone at Sea reference (which includes a handoff card that stays on the user's device — nothing is sent to a server), covers solo-traveler-specific considerations (no one in the next cabin to notice you didn't come back), couples and family considerations, documents to carry and copy, connectivity expectations at sea and in port, and the legal protections the Cruise Vessel Security and Safety Act of 2010 provides on U.S.-calling ships. Closing call to action: take ten minutes today, fill in the handoff, send it to one person ashore."/>
+  <meta name="last-reviewed" content="2026-05-24"/>
+  <meta name="content-protocol" content="ICP-2"/>
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light dark"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
+  <meta name="author" content="Ken Baker"/>
+
+  <!-- SEO -->
+  <title>Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing — In the Wake</title>
+  <meta name="description" content="The single most important piece of pre-cruise preparation is the shore-side safety net — one trusted person back home with the right information to reach you in any emergency. A practical guide for solo cruisers, couples, families, and groups."/>
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html"/>
+
+  <!-- Social -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing"/>
+  <meta property="og:description" content="One trusted person back home with the right info can resolve almost any at-sea emergency. A practical pre-cruise safety guide — solo, couple, family, or group. Includes a free handoff tool."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="article:section" content="Cruise Planning"/>
+  <meta property="article:published_time" content="2026-05-24"/>
+  <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Cruise Travel Safety: Set Up Your Shore-Side Safety Net Before You Sail"/>
+  <meta name="twitter:description" content="Ten minutes today. Could matter on the one day it does. Free handoff tool included."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Structured data: Article -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing",
+    "description":"A practical guide to the pre-cruise safety setup every traveler should complete — the shore-side person, the handoff information, the institutional channels, and the free Reaching Someone at Sea reference.",
+    "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
+    "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
+    "datePublished":"2026-05-24",
+    "dateModified":"2026-05-24",
+    "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
+    "mainEntityOfPage":"https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html",
+    "articleSection":"Cruise Planning",
+    "about":[
+      {"@type":"Thing","name":"Cruise Travel Safety"},
+      {"@type":"Thing","name":"Solo Travel Safety"},
+      {"@type":"Thing","name":"Emergency Contacts at Sea"},
+      {"@type":"Thing","name":"Cruise Vessel Security and Safety Act"},
+      {"@type":"Thing","name":"U.S. State Department Overseas Citizens Services"}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ken Baker",
+    "url":"https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle":"Pastor, Cruise Writer",
+    "description":"Reformed Baptist pastor and cruise writer specializing in accessible travel, grief support, and compassionate cruise guidance.",
+    "worksFor":{"@type":"Organization","name":"In the Wake"},
+    "knowsAbout":["Cruise Safety","Solo Travel","Emergency Contact Procedures","Cruise Planning","Family Travel Safety"]
+  }
+  </script>
+
+  <!-- Structured data: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {
+        "@type":"Question",
+        "name":"What is the single most important pre-cruise safety preparation?",
+        "acceptedAnswer":{"@type":"Answer","text":"Set up the shore-side safety net. Identify one trusted person back home and give them the information they would need to reach you, advocate for you, or activate institutional help on your behalf if something happens at sea or in port. This means sharing your ship name, sailing dates, cabin number, itinerary, and the three universal contact channels (cruise line ship-to-shore desk, U.S. State Department Overseas Citizens Services line at +1-888-407-4747, and the U.S. embassy or consulate for each port). The Reaching Someone at Sea reference on this site has a handoff card you can fill in on your device and share with that trusted person. Nothing is sent to a server."}
+      },
+      {
+        "@type":"Question",
+        "name":"What number does a family member call in a cruise emergency?",
+        "acceptedAnswer":{"@type":"Answer","text":"If they don't have the cruise line's ship-to-shore family contact number, they should call the U.S. State Department's Overseas Citizens Services line — 24 hours a day, every day. From the U.S. or Canada: +1-888-407-4747. From abroad: +1-202-501-4444. The State Department can locate the ship, contact the cruise line on the family's behalf, and coordinate consular services if the situation is in port. Do not call the cruise line's general booking line — it routes to sales and reservations, not emergencies."}
+      },
+      {
+        "@type":"Question",
+        "name":"What information should I leave with someone back home before a cruise?",
+        "acceptedAnswer":{"@type":"Answer","text":"Ship name and cruise line. Cabin number (and Yacht Club or Star Class designation if applicable). Sailing dates including embarkation and disembarkation. Full itinerary with port-day dates. Cruise line ship-to-shore family contact number (in your voyage pack and booking confirmation). U.S. State Department line and the embassy phone numbers for your ports. A list of any medications, allergies, and medical conditions. Copies of your passport, driver's license, and travel insurance policy. Travel insurance company's emergency assistance line. The names and contact information for anyone traveling with you. Where to find your will, advance directive, or power of attorney if those apply to your life stage."}
+      },
+      {
+        "@type":"Question",
+        "name":"What safety considerations are specific to solo cruisers?",
+        "acceptedAnswer":{"@type":"Answer","text":"On a solo cruise, no one in the next cabin notices if you don't come back. That single fact reframes most safety preparation. The shore-side safety net becomes the primary safety system, not a backup. Specific practices: daily check-in with your shore-side person via the ship's Wi-Fi (a quick text — alive, here, all is well — at a set time each day), share your shore excursion plans before leaving the ship, take a photo of yourself in port each morning so geolocation data and time stamps create a trail, store passport copies in cloud storage your shore-side person can access, and consider a wearable medical-alert option if you have a relevant health condition. Solo doesn't mean isolated; it means you build the safety net yourself rather than relying on a travel partner to be it."}
+      },
+      {
+        "@type":"Question",
+        "name":"What legal protections do cruisers have on ships that visit U.S. ports?",
+        "acceptedAnswer":{"@type":"Answer","text":"The Cruise Vessel Security and Safety Act of 2010 (Public Law 111-207, signed July 27, 2010) requires every cruise ship that visits a U.S. port to log incidents — disappearances, sexual assaults, theft above $10,000, deaths — and report them to the FBI. The Act also mandates peepholes and security latches on cabin doors, surveillance equipment, time-sensitive safety information for passengers, and trained sexual-assault response personnel. The FBI logs and quarterly Coast Guard public reports mean an incident on a U.S.-calling ship is documented through a federal channel, not just through the cruise line's internal system. This matters when a family member needs to know whether an incident has been recorded."}
+      },
+      {
+        "@type":"Question",
+        "name":"Will my cell phone work on a cruise ship?",
+        "acceptedAnswer":{"@type":"Answer","text":"Inconsistently and expensively. Cellular service at sea uses maritime roaming networks that charge per-minute and per-megabyte rates that can run into the hundreds of dollars for a single call. Most cruisers turn cellular off at the gangway and use the ship's Wi-Fi package for messaging, email, and voice apps. In port, your domestic cellular plan may roam onto the local provider's network — some plans (T-Mobile international, some Verizon and AT&amp;T tiers) include free or discounted international data in many cruise-destination countries. Confirm coverage with your carrier before sailing. For pre-cruise safety planning: assume your phone is reachable through Wi-Fi calling and messaging at sea, and through local roaming or Wi-Fi in port, but neither is guaranteed. The shore-side safety net does not depend on your phone working."}
+      }
+    ]
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <!-- ================= HEADER ================= -->
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Tools <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/cruise-tipping-calculator.html">Tipping Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Onboard <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="Cruise travel safety guide">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">The Shore-Side Safety Net</div>
+    </div>
+  </header>
+
+  <main id="main-content" class="page" role="main">
+    <article itemscope itemtype="https://schema.org/Article" class="logbook">
+      <header style="max-width:min(860px,92%);margin-inline:auto">
+        <h1 itemprop="headline">Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing</h1>
+        <p class="dek" itemprop="description">The single most important piece of pre-cruise preparation isn't a packing list — it's a person back home with the right information. A practical safety guide for solo cruisers, couples, families, and groups. Ten minutes today. Could matter on the one day it does.</p>
+        <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-05-24">May 24, 2026</time></p>
+      </header>
+
+      <div itemprop="articleBody" style="max-width:min(860px,92%);margin-inline:auto">
+
+      <!-- Answer-first lede -->
+      <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
+        <strong>Answer first:</strong> Before you sail, identify one trusted person back home and give them the information they would need to reach you, advocate for you, or activate institutional help on your behalf if something goes wrong. Three universal channels can act on your behalf in any cruise emergency — the cruise line's ship-to-shore family contact desk, the U.S. State Department's Overseas Citizens Services line, and the U.S. embassy or consulate for each port. Each channel works faster when your shore-side person knows where you are. The free <a href="/reaching-someone-at-sea.html"><strong>Reaching Someone at Sea</strong></a> reference on this site walks through every contact channel and includes a handoff card you can fill in on your device and share with one trusted person ashore. Nothing is sent to a server. Ten minutes. Send it before you sail.
+      </p>
+
+      <!-- TOC -->
+      <nav class="article-toc" aria-label="In this article" style="max-width:min(860px,92%);margin:1.5rem auto;padding:1rem 1.25rem;background:#f8fbfc;border-left:3px solid #d0e4f0;border-radius:4px">
+        <h2 style="margin-top:0;font-size:1.05rem">In this article</h2>
+        <ol style="margin:0.5rem 0 0;padding-left:1.25rem;line-height:1.8">
+          <li><a href="#why-this-matters">Why the shore-side safety net matters more than any onboard prep</a></li>
+          <li><a href="#the-handoff">The handoff — what your shore-side person needs to know</a></li>
+          <li><a href="#the-tool">The free tool: Reaching Someone at Sea</a></li>
+          <li><a href="#three-channels">The three institutional channels that can reach you</a></li>
+          <li><a href="#scenarios">Common scenarios and what each looks like</a></li>
+          <li><a href="#for-solo-cruisers">For solo cruisers specifically</a></li>
+          <li><a href="#for-couples-and-families">For couples, families, and groups</a></li>
+          <li><a href="#documents">Documents to carry and copy</a></li>
+          <li><a href="#connectivity">Cell phone and Wi-Fi expectations</a></li>
+          <li><a href="#legal-protections">Legal protections on U.S.-calling ships</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ol>
+      </nav>
+
+      <h2 id="why-this-matters">Why the shore-side safety net matters more than any onboard prep</h2>
+
+      <p>Most cruise travel safety advice focuses on what you do onboard — lock the safe, stay with your group in port, know where the muster station is. All of that is reasonable, and none of it is the most important thing.</p>
+
+      <p>The most important thing is what your trusted person back home can do for you when you can't do it for yourself.</p>
+
+      <p>A serious illness onboard — heart attack, stroke, accident on stairs — moves quickly into a situation where the ship's medical center is treating you while your family back home is trying to figure out what's happening. A missed-the-ship situation in a foreign port at 5 PM on a Sunday can spiral if the person you call doesn't know which embassy to reach. A lost passport at a Mediterranean port stop becomes manageable when someone back home has a passport-page photo accessible to email to a U.S. consulate. None of these scenarios are common. All of them are common enough that someone on every multi-thousand-passenger sailing experiences one of them.</p>
+
+      <p>The shore-side safety net is the system that turns "we don't know how to help" into "we know exactly who to call." It is built in the ten minutes before you sail, with one trusted person and the right information shared once.</p>
+
+      <h2 id="the-handoff">The handoff — what your shore-side person needs to know</h2>
+
+      <p>The handoff is the conversation, document, or shared note that gives your trusted person back home everything they would need to act on your behalf. The fields below are the ones that matter most. Adapt to your situation.</p>
+
+      <p><strong>Ship and sailing.</strong> Cruise line, ship name, sailing dates including embarkation and disembarkation, departure port, return port, full itinerary with port-day dates. If you booked a Yacht Club, Star Class, or other premium tier, note it — that information speeds Guest Services routing onboard.</p>
+
+      <p><strong>Cabin.</strong> Cabin number and deck. If you have a cabin change planned mid-cruise (rare but possible on back-to-backs), include both.</p>
+
+      <p><strong>Contact channels.</strong> The cruise line's 24-hour ship-to-shore family contact phone number (listed in your voyage pack and booking confirmation — not the general customer service line). The U.S. State Department Overseas Citizens Services line: +1-888-407-4747 from the U.S. or Canada, +1-202-501-4444 from abroad. The U.S. embassy or consulate phone number for each port your itinerary visits.</p>
+
+      <p><strong>Medical.</strong> Current medications and dosages. Known allergies. Existing medical conditions that could become relevant in a crisis (cardiac history, seizure disorder, severe asthma, etc.). Blood type if known. Medical insurance card number and provider phone. Travel insurance policy number and the insurer's emergency assistance line — this is the number to call to authorize medical evacuation if needed.</p>
+
+      <p><strong>Identity documents.</strong> Photo of your passport's information page. Photo of your driver's license or other government ID. Photo of your travel insurance card. Photo of any prescription you carry for medications that customs agents sometimes question (controlled substances, narcotics, larger insulin or injectable supplies). Store the photos in a shared cloud folder both you and your shore-side person can access.</p>
+
+      <p><strong>Travel companions, if any.</strong> Names and contact information for everyone traveling with you. Each traveling-companion's emergency contact at home.</p>
+
+      <p><strong>Legal and end-of-life documents</strong> if those apply to your stage of life. The location of your will, advance directive, healthcare proxy, or power of attorney. Whoever holds the executed copies. The funeral home or memorial-arrangements documentation if you have planned ahead. This is morbid only if you've never lost someone in the middle of arranging a memorial across borders. The people who have, prepare differently.</p>
+
+      <h2 id="the-tool">The free tool: Reaching Someone at Sea</h2>
+
+      <p>The <a href="/reaching-someone-at-sea.html"><strong>Reaching Someone at Sea</strong></a> reference on this site collects the contact information for every channel above into one page, with a fillable handoff card at the bottom. The card lives entirely on your device — nothing is sent to a server, no account required, no tracking. You fill it in once and share it with the trusted person back home however you usually share documents (email, text, shared note, printed copy on the refrigerator).</p>
+
+      <p>The page also explains how each contact channel actually works in practice — which one to call first for a medical emergency at sea, which one for a port-side situation, which one for a U.S. citizen's lost passport overseas, which one for a missed-ship situation. The walk-through is written for the person ashore, not for the cruiser onboard. The person you share it with does not need to be a cruise expert; they need to be reachable and willing.</p>
+
+      <p>If you add the page to your phone's home screen (or your shore-side person's), it becomes available offline. Browsers cache it after the first visit. The cruise line's phone numbers, the State Department line, the embassy numbers for your ports — all of it is there when you need it, even if Wi-Fi is unreliable.</p>
+
+      <p>For shore-side people who'd rather have a paper copy on the refrigerator or in the glove box, the same handoff card exists as a <a href="/admin/voyage-packs/emergency-handoff-card-agnostic.pdf"><strong>printable PDF version</strong></a> — sailing-agnostic, fill in the blanks for your specific cruise, pre-filled with major cruise-line emergency numbers and the U.S. State Department line. Print one copy for the trusted person ashore, keep a phone photo for yourself, and the offline backup is in place. If you want the same card fully calibrated for a specific itinerary — with embassy phone numbers already pre-filled for your exact ports and the right cruise-line emergency desk for your specific line — that lives inside the paid <a href="/voyage-packs.html">Voyage Packs</a>; the free agnostic version above covers the universal pieces for everyone else.</p>
+
+      <h2 id="three-channels">The three institutional channels that can reach you</h2>
+
+      <p>If something goes wrong onboard or in port, three institutions can act on behalf of a family member onshore. Knowing who does what reduces panic and speeds the call.</p>
+
+      <p><strong>The cruise line</strong> maintains a 24-hour ship-to-shore family contact desk that exists specifically to relay urgent messages to a passenger onboard. Each line publishes a different number; some are toll-free in the U.S., some are international only. These numbers are listed in your voyage pack and on your booking confirmation. The cruise line's general customer-service line is not the same number — it routes to sales and reservations, not emergencies. Your shore-side person should have the ship-to-shore number specifically, written out clearly, before you sail.</p>
+
+      <p><strong>The U.S. State Department's Overseas Citizens Services line</strong> is the universal fallback. It is staffed continuously, anywhere in the world, and it is the right call when your shore-side person doesn't have the ship-to-shore number, when the ship-to-shore line doesn't answer, or when the situation is serious enough to warrant a parallel official channel. The Bureau of Consular Affairs can locate a ship, contact the cruise line, and dispatch consular services where appropriate. From the U.S. or Canada: <strong>+1-888-407-4747</strong>. From abroad: <strong>+1-202-501-4444</strong>. Save these numbers in your shore-side person's phone before you sail.</p>
+
+      <p><strong>U.S. embassies and consulates</strong> are the right call when the issue is happening to a U.S. citizen in port — illness requiring hospitalization, lost passport, criminal incident, missed-the-ship situation. Each embassy publishes its own emergency phone number. The Reaching Someone at Sea reference lists embassy contacts by port for the most common cruise itineraries. If you're sailing a less-common itinerary, look up the embassies for your ports on the State Department's website and add them to the handoff before you sail.</p>
+
+      <h2 id="scenarios">Common scenarios and what each looks like</h2>
+
+      <p><strong>Medical emergency at sea.</strong> The ship's medical center treats you onboard while your shore-side person needs to reach you. The fastest path: call the cruise line's ship-to-shore family contact, give the ship name and passenger name, request they relay a message to the medical center. If the ship-to-shore line doesn't answer or routes incorrectly, the State Department line at +1-888-407-4747 can locate the ship and contact the medical center directly. Travel insurance with medical evacuation coverage matters here — if the situation requires evacuation off the ship to a shoreside hospital, that coordination runs through the travel insurance's emergency assistance line. Insurance contact information should be in the handoff.</p>
+
+      <p><strong>Missed-ship situation in port.</strong> You're at a shore excursion or independent stop. The ship's all-aboard time passes. You're not back. The ship sails. This is more common than cruisers expect and almost always resolvable — but the resolution requires money, documents, and contact with people back home who can wire funds or book flights. The shore-side person needs the itinerary so they know which port to fly you out of and which port to meet the ship at next. Travel insurance often covers missed-port scenarios when the cause was outside your control (excursion delay, traffic accident, port-day medical issue). The handoff makes that claim faster.</p>
+
+      <p><strong>Lost passport in a foreign port.</strong> Call the U.S. embassy or consulate for that country. They issue emergency travel documents that get you back to the U.S. and home. Having a passport photo in shared cloud storage with your shore-side person speeds the replacement process. The Cruise Vessel Security and Safety Act does not address passport replacement directly, but the consular process is the standard channel.</p>
+
+      <p><strong>Criminal incident onboard.</strong> The Cruise Vessel Security and Safety Act of 2010 requires every cruise ship calling at a U.S. port to log specific incidents (disappearances, sexual assaults, theft above $10,000, deaths) and report them to the FBI. Ships are required to maintain trained personnel for sexual-assault response. Onboard incidents involving U.S. citizens are within FBI jurisdiction when the ship calls a U.S. port. Reporting onboard goes to ship security first; the FBI receives the federal report after.</p>
+
+      <p><strong>News from home reaches a cruiser at sea.</strong> Sometimes the emergency is on the family's side — a death, a serious illness, a child in crisis. Your shore-side person calls the cruise line's ship-to-shore family contact desk; the cruise line will relay a message to your cabin and arrange counseling and travel support if you need to disembark at the next port. The fastest message-relay path is the cruise line's own desk, not the State Department.</p>
+
+      <h2 id="for-solo-cruisers">For solo cruisers specifically</h2>
+
+      <p>On a solo cruise, no one in the next cabin notices if you don't come back. No travel partner sees you trip on the gangway. No one is waiting at dinner if you don't show. That single fact reframes most of the safety preparation above.</p>
+
+      <p>The shore-side safety net is no longer a backup system. It is the primary safety system. Build it before you sail.</p>
+
+      <p>Specific practices that work well for solo cruisers:</p>
+
+      <p><strong>Daily check-in.</strong> A short text to your shore-side person at a set time each day via the ship's Wi-Fi. "Alive, here, all is well." Three words is enough. If the check-in doesn't arrive, the shore-side person knows to start asking. Pick a time when the ship's Wi-Fi typically works for you (often morning sea-day windows are most reliable).</p>
+
+      <p><strong>Pre-shore-day plan share.</strong> Before you leave the ship for a shore excursion or independent port day, message your shore-side person with the plan: where you're going, who you're going with, expected return time. A short note works; this isn't a thesis. The plan exists so that if something goes wrong, the shore-side person can give the embassy or local authorities a starting point.</p>
+
+      <p><strong>Daily port photo.</strong> Take a photo of yourself in port each morning, ideally with a landmark visible. The photo's embedded geolocation data and time stamp create a trail that helps locate you in worst-case scenarios. Send the photo to your shore-side person or save it to the shared cloud folder.</p>
+
+      <p><strong>Passport and document cloud-backup.</strong> A shared cloud folder (Google Drive, Dropbox, iCloud Shared) with your passport photo page, driver's license, insurance cards, and key prescription information that your shore-side person can access without your password. The folder doesn't need much in it — a few photos and the handoff card from Reaching Someone at Sea. It needs to exist before you sail.</p>
+
+      <p><strong>Wearable medical-alert option</strong> if a relevant health condition makes it worth carrying. A medical-alert bracelet or necklace that lists your most critical condition (cardiac history, seizure disorder, severe allergy) puts the information in front of the first responder if you can't answer questions yourself. Some solo cruisers carry a small ICE (in-case-of-emergency) card in their wallet with the same information plus the shore-side contact.</p>
+
+      <p>Solo doesn't mean isolated. It means you build the safety net yourself rather than relying on a travel partner to be it. The Reaching Someone at Sea handoff is the tool that makes the difference between a solo cruiser whose shore-side person can act quickly and a solo cruiser whose family is figuring it out under stress.</p>
+
+      <h2 id="for-couples-and-families">For couples, families, and groups</h2>
+
+      <p>Couples and families have an onboard safety advantage — someone notices if you don't come back. But the shore-side safety net still matters, and the failure mode is different: if both partners are involved in the same incident (car accident in port, medical emergency that incapacitates one and rattles the other), neither can activate the contact channels effectively.</p>
+
+      <p>The right setup: one shore-side person for the whole travel party, with information for every traveler in the handoff. If something happens to the family group, that one shore-side person can act for everyone.</p>
+
+      <p>For families with children, add the kids' medical information to the handoff — pediatrician contact, current medications, allergies, vaccination dates if recently updated, school contact if a longer disembarkation might affect their schooling. For multi-generational groups, include emergency contacts for older relatives in case the trip needs to be cut short.</p>
+
+      <p>For groups of friends sailing together, identify a single shore-side person before the trip rather than assuming each traveler's individual emergency contacts will coordinate. They will not coordinate well under stress. One person who has the full picture for everyone is faster than several people each with partial information.</p>
+
+      <h2 id="documents">Documents to carry and copy</h2>
+
+      <p>Documents to carry on your person in port: a copy of your passport's information page (not the original — leave that in the cabin safe), your government-issued photo ID, a credit card, a small amount of local currency, your SeaPass card. The SeaPass also functions as ship-side identification at the gangway.</p>
+
+      <p>Documents to copy to cloud storage your shore-side person can access: passport information page, driver's license, travel insurance card, prescription medications list, vaccination card, the handoff card from Reaching Someone at Sea. A shared cloud folder works; an email to your own and your shore-side person's accounts also works. The point is that the copies exist somewhere reachable from anywhere, on any device.</p>
+
+      <p>Documents to leave at home: original passport (unless required for the cruise — most U.S.-departing closed-loop Caribbean cruises do not require a passport for U.S. citizens, but it is strongly recommended), wills, advance directives, important original financial documents.</p>
+
+      <h2 id="connectivity">Cell phone and Wi-Fi expectations</h2>
+
+      <p>Cellular service at sea uses maritime roaming networks that charge per-minute and per-megabyte rates that can run into the hundreds of dollars for a single call. Most cruisers turn cellular off at the gangway and use the ship's Wi-Fi package for messaging, email, and voice apps (WhatsApp voice and video work over Wi-Fi without triggering cellular roaming).</p>
+
+      <p>In port, your domestic cellular plan may roam onto the local provider's network. Some carrier plans (T-Mobile international, certain Verizon and AT&amp;T tiers) include free or discounted international data in many cruise-destination countries. Confirm coverage with your carrier before sailing; the assumption "my phone will just work in port" is wrong often enough that it's not a safety plan.</p>
+
+      <p>For shore-side communication: if you're relying on the ship's Wi-Fi to send daily check-ins or stay in contact with your shore-side person, buy the cruise line's mid-tier or higher Wi-Fi package and connect at the start of the sailing rather than mid-cruise (some lines price daily access higher than full-week access). The <a href="/internet-at-sea.html">Internet at Sea guide</a> on this site walks through current package options by cruise line.</p>
+
+      <p>The shore-side safety net should not depend on your phone working perfectly. The handoff already gives your shore-side person the institutional channels (cruise line, State Department, embassy) they can use without needing to reach you first. Your phone is the convenience layer, not the safety layer.</p>
+
+      <h2 id="legal-protections">Legal protections on U.S.-calling ships</h2>
+
+      <p>The Cruise Vessel Security and Safety Act of 2010 — Public Law 111-207, signed into law July 27, 2010 — established baseline safety standards for every cruise ship that visits a U.S. port. The Act's protections apply regardless of the ship's flag of registry, because the trigger is U.S. port calls, not vessel ownership.</p>
+
+      <p>Specific requirements established by the Act:</p>
+
+      <p><strong>Incident logging and reporting.</strong> Disappearances, alleged sexual assaults, theft above $10,000, and deaths must be logged onboard and reported to the FBI. Quarterly public reports are published by the U.S. Coast Guard.</p>
+
+      <p><strong>Physical security.</strong> Cabin doors must have peepholes and security latches. Surveillance equipment must be present in common areas. Time-sensitive safety information must be provided to passengers.</p>
+
+      <p><strong>Sexual-assault response.</strong> Trained personnel must be available to handle reports onboard. Evidence collection procedures are standardized.</p>
+
+      <p>These protections matter for two reasons. First, they establish that an incident on a U.S.-calling ship has a federal-channel record beyond the cruise line's internal system — useful to know when a family member needs to verify what has been recorded. Second, they distinguish ships that visit U.S. ports from ships on purely international itineraries, where regulatory frameworks vary by flag and port country.</p>
+
+      <h2 id="faq">Frequently asked questions</h2>
+
+      <details class="section-divider">
+        <summary><strong>What is the single most important pre-cruise safety preparation?</strong></summary>
+        <p class="list-indent">Set up the shore-side safety net. Identify one trusted person back home, give them the handoff information (ship name, cabin, itinerary, contact channels, medical info, document copies), and share the <a href="/reaching-someone-at-sea.html">Reaching Someone at Sea</a> page so they have the contact references when they need them. Ten minutes today. Could matter on the one day it does.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What number does a family member call in a cruise emergency?</strong></summary>
+        <p class="list-indent">If they don't have the cruise line's ship-to-shore family contact number, they should call the U.S. State Department's Overseas Citizens Services line — 24 hours a day, every day. From the U.S. or Canada: <strong>+1-888-407-4747</strong>. From abroad: <strong>+1-202-501-4444</strong>. The State Department can locate the ship, contact the cruise line on the family's behalf, and coordinate consular services if the situation is in port. Do not call the cruise line's general booking line — it routes to sales, not emergencies.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What information should I leave with someone back home before a cruise?</strong></summary>
+        <p class="list-indent">Ship name and cruise line. Cabin number. Sailing dates and full itinerary with port-day dates. Cruise line ship-to-shore family contact number. U.S. State Department line. Embassy phone numbers for each port. Medications, allergies, medical conditions. Copies of passport, driver's license, travel insurance policy. Travel insurance company's emergency assistance line. Names and contact information for travel companions. Where to find your will, advance directive, or power of attorney if those apply to your life stage. The handoff card on the <a href="/reaching-someone-at-sea.html">Reaching Someone at Sea</a> page collects all of this in one place.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What safety considerations are specific to solo cruisers?</strong></summary>
+        <p class="list-indent">On a solo cruise, no one in the next cabin notices if you don't come back. The shore-side safety net becomes the primary safety system, not a backup. Set up a daily check-in time with your shore-side person via the ship's Wi-Fi. Share your shore excursion plans before leaving the ship. Take a daily port photo (geolocation data and time stamps create a trail). Store document copies in a shared cloud folder. Consider a wearable medical-alert option if you have a relevant health condition. Solo doesn't mean isolated; it means you build the safety net yourself rather than relying on a travel partner to be it.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What legal protections do cruisers have on ships that visit U.S. ports?</strong></summary>
+        <p class="list-indent">The Cruise Vessel Security and Safety Act of 2010 (Public Law 111-207) requires every cruise ship calling at a U.S. port to log specific incidents (disappearances, sexual assaults, theft above $10,000, deaths) and report them to the FBI. The Act also mandates peepholes and security latches on cabin doors, surveillance equipment, time-sensitive safety information, and trained sexual-assault response personnel. The FBI logs and quarterly Coast Guard public reports mean an incident on a U.S.-calling ship is documented through a federal channel, not just through the cruise line's internal system.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Will my cell phone work on a cruise ship?</strong></summary>
+        <p class="list-indent">Inconsistently and expensively at sea — maritime roaming networks charge per-minute and per-megabyte rates that can run into hundreds of dollars for a single call. Most cruisers turn cellular off at the gangway and use the ship's Wi-Fi package for messaging and voice apps. In port, your domestic cellular plan may roam onto the local provider's network depending on your carrier. Confirm coverage before sailing. The shore-side safety net does not depend on your phone working — the institutional channels in the handoff are reachable regardless. See the <a href="/internet-at-sea.html">Internet at Sea guide</a> for current ship Wi-Fi package details.</p>
+      </details>
+
+      <h2 id="take-the-step">The ten-minute step that matters</h2>
+
+      <p>Open <a href="/reaching-someone-at-sea.html"><strong>Reaching Someone at Sea</strong></a> on your phone. Fill in the handoff card. Send it to one person back home. Add the page to your home screen so the contact references are available offline.</p>
+
+      <p>If you'd rather print a copy for the refrigerator or the glove box, download the <a href="/admin/voyage-packs/emergency-handoff-card-agnostic.pdf"><strong>free printable handoff card PDF</strong></a> instead — same information, fill in the blanks for your cruise, give it to one trusted person ashore.</p>
+
+      <p>If you're sailing solo, do this today. If you're sailing with family, do it together. If you've sailed dozens of times without ever needing any of it, do it anyway — the people on every sailing where one of these scenarios plays out had also never needed it before that day.</p>
+
+      <p>Ten minutes. Send it to one person. That's the safety net.</p>
+
+      <h2 id="related">Related reading</h2>
+
+      <ul>
+        <li><a href="/reaching-someone-at-sea.html">Reaching Someone at Sea</a> — the full emergency contact reference and on-page handoff card (stays on your device, works offline after first load)</li>
+        <li><a href="/admin/voyage-packs/emergency-handoff-card-agnostic.pdf">Emergency Handoff Card — printable PDF</a> — sailing-agnostic, free, fill in for your cruise, print for the trusted person ashore</li>
+        <li><a href="/voyage-packs.html">Voyage Packs</a> — itinerary-specific planning packs ($19-$29) that include the same handoff card pre-filled with embassy phone numbers for your exact ports and the right cruise-line emergency desk for your specific line</li>
+        <li><a href="/solo/solo-cruising-practical-guide.html">Solo Cruising: A Practical Guide</a> — broader solo-traveler guidance beyond safety setup</li>
+        <li><a href="/solo/solo-cruisers-companion.html">The Solo Cruiser's Companion</a> — making the most of a solo sailing</li>
+        <li><a href="/accessibility.html">Accessibility on Cruises</a> — adjacent guidance for disabled travelers and traveling caregivers</li>
+        <li><a href="/internet-at-sea.html">Internet at Sea</a> — Wi-Fi package details for staying connected to your shore-side person</li>
+        <li><a href="/first-cruise.html">Your First Cruise</a> — broader pre-cruise planning</li>
+      </ul>
+
+      </div>
+    </article>
+  </main>
+
+  <!-- ================= FOOTER ================= -->
+  <footer class="wrap footer" role="contentinfo">
+    <p>&copy; 2026 In the Wake. All rights reserved.</p>
+    <p class="trust-badge">✓ No ads. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+    <nav aria-label="Footer navigation">
+      <ul style="list-style:none;padding:0;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
+        <li><a href="/about-us.html">About</a></li>
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/reaching-someone-at-sea.html">Reach Family at Sea</a></li>
+        <li><a href="/affiliate-disclosure.html">Affiliate Disclosure</a></li>
+      </ul>
+    </nav>
+    <p class="tiny center" style="margin-top:.5rem;opacity:0.7">
+      Soli Deo Gloria — Every pixel and part of this project is offered as worship to God.
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/articles/msc-voyagers-club-status-match-from-rcl-diamond.html
+++ b/articles/msc-voyagers-club-status-match-from-rcl-diamond.html
@@ -1,0 +1,418 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+  <!-- ======================================================
+       In the Wake — Article
+       Page: RCL Diamond to MSC Voyagers Club — Status Match Guide
+       Version: 3.010.400  |  Standards baseline: 3.010.x
+       Content Protocol: ICP-2
+       ====================================================== -->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer"/>
+  <meta name="ai-summary" content="A practical guide to taking the MSC Voyagers Club status match from Royal Caribbean Diamond tier, written by a Royal Caribbean Diamond cruiser who just completed his first MSC sailing on the status match. MSC's program is among the most generous in cruise loyalty — RCL Diamond matches into a Voyagers Club tier with priority embarkation, dedicated check-in, lounge access, and included perks. The match is asymmetric: RCL doesn't match outbound, MSC's program is designed to convert RCL loyalists. The article frames the match as an invitation to evaluate MSC over multiple sailings, not a guarantee MSC will clear the bar on the first sailing. Practical advice: take the match (it costs nothing), sail once to evaluate on the touchpoints that matter (service ethic, cabin steward, dining flow, problem resolution), then decide. Don't book back-to-back match sailings before the first one finishes. If the first sailing has friction, give the line a second shot on a different ship before deciding — n=1 cuts both ways. The strategic critique for MSC's loyalty team: deploying untrained entry-level crew at the touchpoints where match cruisers evaluate forward bookings is the gap that turns a generous status match from a conversion into a one-way door."/>
+  <meta name="last-reviewed" content="2026-05-24"/>
+  <meta name="content-protocol" content="ICP-2"/>
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light dark"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
+  <meta name="author" content="Ken Baker"/>
+
+  <!-- SEO -->
+  <title>RCL Diamond to MSC Voyagers Club: How the Status Match Actually Works in 2026 — In the Wake</title>
+  <meta name="description" content="A practical guide to taking the MSC Voyagers Club status match from Royal Caribbean Diamond — what the match actually gets you, what it doesn't, what to evaluate on your first MSC sailing, and what to do if the first sailing goes sideways."/>
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://cruisinginthewake.com/articles/msc-voyagers-club-status-match-from-rcl-diamond.html"/>
+
+  <!-- Social -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="RCL Diamond to MSC Voyagers Club: How the Status Match Actually Works in 2026"/>
+  <meta property="og:description" content="A practical first-person guide to taking the MSC status match from Royal Caribbean Diamond — what it delivers, what to evaluate, and how to read your first match sailing."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles/msc-voyagers-club-status-match-from-rcl-diamond.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="article:section" content="Cruise Planning"/>
+  <meta property="article:published_time" content="2026-05-24"/>
+  <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="RCL Diamond to MSC Voyagers Club: How the Status Match Actually Works in 2026"/>
+  <meta name="twitter:description" content="Take the match. Sail once. Decide on the evidence. A first-person guide for RCL Diamond cruisers."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Structured data: Article -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"RCL Diamond to MSC Voyagers Club: How the Status Match Actually Works in 2026",
+    "description":"A practical guide to taking the MSC Voyagers Club status match from Royal Caribbean Diamond tier — what the match delivers, what to evaluate on your first MSC sailing, and how to decide whether to come back.",
+    "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
+    "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
+    "datePublished":"2026-05-24",
+    "dateModified":"2026-05-24",
+    "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
+    "mainEntityOfPage":"https://cruisinginthewake.com/articles/msc-voyagers-club-status-match-from-rcl-diamond.html",
+    "articleSection":"Cruise Planning",
+    "about":[
+      {"@type":"Thing","name":"MSC Cruises"},
+      {"@type":"Thing","name":"MSC Voyagers Club"},
+      {"@type":"Thing","name":"Royal Caribbean Crown and Anchor Society"},
+      {"@type":"Thing","name":"Cruise Loyalty Programs"},
+      {"@type":"Thing","name":"Status Match"}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ken Baker",
+    "url":"https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle":"Pastor, Cruise Writer",
+    "description":"Reformed Baptist pastor and cruise writer specializing in accessible travel, grief support, and compassionate cruise guidance.",
+    "worksFor":{"@type":"Organization","name":"In the Wake"},
+    "knowsAbout":["Royal Caribbean","MSC Cruises","Cruise Loyalty Programs","MSC Voyagers Club","Crown and Anchor Society","Cruise Planning"]
+  }
+  </script>
+
+  <!-- Structured data: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {
+        "@type":"Question",
+        "name":"Does MSC honor Royal Caribbean Diamond status?",
+        "acceptedAnswer":{"@type":"Answer","text":"Yes. MSC's Voyagers Club status-match program accepts Royal Caribbean Crown & Anchor Society Diamond tier (and most other major-line top-tier loyalty cards) and grants equivalent or near-equivalent status in Voyagers Club. The match is one-way only — Royal Caribbean does not offer an outbound match to MSC. Submission is via MSC's status-match page on the MSC for Me portal; processing typically takes a few days to a couple of weeks. The match is free."}
+      },
+      {
+        "@type":"Question",
+        "name":"How long does the MSC status match take?",
+        "acceptedAnswer":{"@type":"Answer","text":"Submission is a short online form. Processing time ranges from a few business days to about two weeks. Email confirmation arrives when the new Voyagers Club tier is active on your MSC profile. You can then book a sailing with the matched status applied."}
+      },
+      {
+        "@type":"Question",
+        "name":"What does the MSC status match get me on my first sailing?",
+        "acceptedAnswer":{"@type":"Answer","text":"Day-1 benefits typically include priority embarkation lane access, dedicated check-in, Voyagers Club lounge access (where available on the ship), priority tendering, and a tier-specific gift package delivered to your cabin (welcome amenity, sometimes a bottle of sparkling wine, tier-specific items). The match does not get you a fare discount on the sailing itself — it's a tier benefit set, not a pricing discount. Whether the matched tier delivers anything more substantial than the day-1 perks depends on which MSC ship you sail; Yacht Club access remains a separate paid tier even with the match."}
+      },
+      {
+        "@type":"Question",
+        "name":"Should I take the MSC status match?",
+        "acceptedAnswer":{"@type":"Answer","text":"Yes. It costs nothing, takes about ten minutes to submit, and gives you a meaningful tier benefit set on your first MSC sailing if you choose to try one. The match is an invitation to evaluate MSC over multiple sailings, not a commitment to switch loyalty programs. Take the match. Sail once. Decide on the evidence. Don't book back-to-back match sailings before the first one finishes — the smart move is one sailing, evaluation, then a decision."}
+      },
+      {
+        "@type":"Question",
+        "name":"Does the MSC status match include Yacht Club access?",
+        "acceptedAnswer":{"@type":"Answer","text":"No. MSC's Yacht Club is a separate paid tier — a ship-within-a-ship product with its own restaurant, sun deck, private elevator, butler, and included drinks. It is sold as part of the cabin booking, not as a loyalty-tier benefit. Status-matched Voyagers Club guests sail in standard MSC fare classes (Bella, Fantastica, or Aurea) unless they specifically book a Yacht Club cabin. The status match gives you Voyagers Club perks across the ship; it does not grant access to the Yacht Club restricted areas."}
+      },
+      {
+        "@type":"Question",
+        "name":"Does the MSC status match expire?",
+        "acceptedAnswer":{"@type":"Answer","text":"The matched tier typically holds for an initial period (often through the end of the following year), after which MSC requires you to sail on MSC to maintain the status. The exact retention rules are published in MSC's Voyagers Club terms and can change; check the current rules on MSC's website before assuming a particular renewal mechanism. If you take the match and never sail MSC, the matched tier will eventually be downgraded."}
+      },
+      {
+        "@type":"Question",
+        "name":"What if my first MSC sailing on the match goes badly?",
+        "acceptedAnswer":{"@type":"Answer","text":"Give MSC a second shot on a different ship before deciding. n=1 cuts both ways: one sailing isn't enough to judge the line, just as a single Royal Caribbean sailing wouldn't be either. The author's first MSC sailing on the match had a frustrating cabin-steward arc (documented in detail in the linked service review), but the structural lesson generalizes only so far — a different ship, different cabin, different crew rotation may produce a different experience. Take the verdict on the sailing you had. Leave the verdict on the line open until you've sailed at least twice."}
+      }
+    ]
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <!-- ================= HEADER ================= -->
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Tools <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/cruise-tipping-calculator.html">Tipping Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Onboard <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="MSC Voyagers Club status match guide">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">RCL Diamond to MSC Voyagers Club</div>
+    </div>
+  </header>
+
+  <main id="main-content" class="page" role="main">
+    <article itemscope itemtype="https://schema.org/Article" class="logbook">
+      <header style="max-width:min(860px,92%);margin-inline:auto">
+        <h1 itemprop="headline">RCL Diamond to MSC Voyagers Club: How the Status Match Actually Works in 2026</h1>
+        <p class="dek" itemprop="description">A practical guide to taking the MSC status match from Royal Caribbean Diamond — what the match actually delivers, what to evaluate on your first MSC sailing, and how to decide whether to come back. Written by an RCL Diamond cruiser who just completed his first MSC sailing on the match.</p>
+        <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-05-24">May 24, 2026</time></p>
+      </header>
+
+      <div itemprop="articleBody" style="max-width:min(860px,92%);margin-inline:auto">
+
+      <!-- Answer-first lede -->
+      <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
+        <strong>Answer first:</strong> Take the match. MSC's Voyagers Club status-match program is among the most generous in cruise loyalty, and Royal Caribbean Diamond cruisers are exactly the demographic MSC's program is built to convert. The match costs nothing, takes about ten minutes to submit, and delivers a meaningful tier benefit set on your first MSC sailing. Sail once. Decide on the evidence. Don't book back-to-back match sailings before the first one finishes — and if the first sailing has friction, give the line a second shot on a different ship before deciding.
+      </p>
+
+      <!-- TOC -->
+      <nav class="article-toc" aria-label="In this article" style="max-width:min(860px,92%);margin:1.5rem auto;padding:1rem 1.25rem;background:#f8fbfc;border-left:3px solid #d0e4f0;border-radius:4px">
+        <h2 style="margin-top:0;font-size:1.05rem">In this article</h2>
+        <ol style="margin:0.5rem 0 0;padding-left:1.25rem;line-height:1.8">
+          <li><a href="#what-the-match-is">What the match is, mechanically</a></li>
+          <li><a href="#why-the-match-exists">Why MSC built the match the way they did</a></li>
+          <li><a href="#what-you-get">What the match actually gets you on Day 1</a></li>
+          <li><a href="#what-to-evaluate">What to evaluate on your first match sailing</a></li>
+          <li><a href="#the-decision">The decision after sailing one</a></li>
+          <li><a href="#what-msc-should-know">What MSC's loyalty team should know</a></li>
+          <li><a href="#practical-advice">Practical advice if you take the match</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ol>
+      </nav>
+
+      <h2 id="what-the-match-is">What the match is, mechanically</h2>
+
+      <p>MSC's Voyagers Club status-match program accepts loyalty status from other major cruise lines — Royal Caribbean's Crown &amp; Anchor Society, Norwegian's Latitudes, Carnival's VIFP, Princess's Captain's Circle, Holland America's Mariner Society, and others — and grants equivalent or near-equivalent status in Voyagers Club. Submission is a short online form on MSC's website. Processing time is typically a few business days to about two weeks. Email confirmation arrives when the matched tier is active on your MSC for Me profile, and you can then book a sailing with the matched status applied.</p>
+
+      <p>For Royal Caribbean Diamond cruisers specifically, the match lands at one of the upper Voyagers Club tiers — high enough to deliver the meaningful Day-1 perks (priority embarkation, dedicated check-in lane, lounge access on ships where one exists). The exact tier label varies by program iteration; check MSC's current published terms before booking, since the program structure is updated periodically.</p>
+
+      <p>One critical asymmetry: the match is one-way. MSC matches inbound from Royal Caribbean; Royal Caribbean does not match outbound from MSC. This is not an accident. MSC's program is designed to convert Royal Caribbean loyalists. Royal Caribbean's program is designed to retain them.</p>
+
+      <h2 id="why-the-match-exists">Why MSC built the match the way they did</h2>
+
+      <p>MSC's status-match program exists for a specific business reason: it is the cheapest way the line can acquire the high-frequency, multi-cruise-per-year demographic that is otherwise sailing Royal Caribbean. A Royal Caribbean Diamond cruiser has, by definition, completed at least seven hundred-and-forty cruise-night-credit equivalents — most of them with one cruise line. They are predictable, high-spending, retention-stable customers. Acquiring them through normal marketing channels is expensive. Offering them an asymmetric loyalty match that lets them sail MSC at their existing comfort tier is cheap by comparison and addresses the single largest barrier to trying a new cruise line (losing accumulated loyalty status).</p>
+
+      <p>The investment math works for MSC only if the matched cruiser sticks around. A status-matched cruiser who sails one MSC trip and never comes back is a marketing cost the program did not amortize. A status-matched cruiser who books a second sailing, then a third, then bases their cruise calendar on MSC instead of RCL, is the program's defining win.</p>
+
+      <p>Which means: the match is not a gift. It is an invitation. The line is investing a tier in you so that you will give them a sailing's worth of evaluation. What happens on that first sailing decides whether the match converts or doesn't. That framing changes how the matched cruiser should read their first MSC trip.</p>
+
+      <h2 id="what-you-get">What the match actually gets you on Day 1</h2>
+
+      <p>Day-1 benefits at the matched tier typically include:</p>
+
+      <p><strong>Priority embarkation lane access.</strong> Worth more than it sounds. On a fully-loaded boarding day at a busy port like PortMiami or Port Everglades, the difference between the general boarding line and the priority lane can be the difference between aboard-by-noon and aboard-by-2pm. The savings compound across a multi-night cruise because you start the sailing rested and unhurried rather than fried.</p>
+
+      <p><strong>Dedicated check-in.</strong> A separate desk, shorter wait, often staffed by a more senior team member. The processing speed alone justifies the program.</p>
+
+      <p><strong>Voyagers Club lounge access</strong> on ships that have one. The lounge is not as elaborate as a Royal Caribbean Diamond Lounge on a Quantum- or Oasis-class ship, but it provides a quiet space, complimentary morning coffee and light snacks, and in some implementations a dedicated concierge desk.</p>
+
+      <p><strong>Priority tendering at tender ports.</strong> If your itinerary includes a tender port (Cabo San Lucas, some of the smaller Mediterranean stops, the off-CocoCay private islands), priority tender boarding moves you to the front of the queue.</p>
+
+      <p><strong>Welcome amenity in cabin.</strong> Tier-specific gift package delivered to your cabin on embarkation day. Often includes a welcome card, sometimes a bottle of sparkling wine, sometimes branded merchandise.</p>
+
+      <p>Notably <strong>not</strong> included in the standard status match: fare discount on the sailing itself, Yacht Club access (separate paid tier), free internet (depends on the specific tier mapping and is variable by program iteration), free specialty dining (sometimes offered as a tier-specific perk at higher levels but not guaranteed). The match is a tier benefit set, not a pricing discount.</p>
+
+      <h2 id="what-to-evaluate">What to evaluate on your first match sailing</h2>
+
+      <p>The matched cruiser arriving for their first MSC sailing is — whether they realize it or not — running an evaluation. The line is hoping the sailing clears the bar that the same cruiser has set on Royal Caribbean. The cruiser is checking whether MSC's strengths are real and whether MSC's weaknesses are tolerable.</p>
+
+      <p>The categories that matter for that evaluation are not the headline marketing categories. They are the day-to-day service touchpoints where the comparison between lines actually lives.</p>
+
+      <p><strong>Cabin-steward service.</strong> The single most important touchpoint of the sailing. Does the steward introduce themselves on Day 1? Do they remember your preferences from Day 2 onward? Do they respect the Do Not Disturb light without exception? The <a href="/articles/msc-seaside-service-review.html">MSC Seaside service review</a> is the cautionary case study here — the cabin-steward arc on that sailing is the case-in-point of what can go wrong when this touchpoint isn't well-trained.</p>
+
+      <p><strong>Dining service flow.</strong> Drinks topped up before they are empty? Card-checking handled cleanly at the table, or do you need to track down a server to ask? Specialty restaurants worth the upgrade? Same-category cabin space comparable to Royal Caribbean? (On at least the MSC Seaside, MSC wins this one — meaningfully more spacious than the Royal Caribbean equivalent at the same fare class.)</p>
+
+      <p><strong>Problem resolution.</strong> If something goes wrong — a noisy cabin, a billing error, a dietary need not handled cleanly — does Guest Services move toward the structural fix, or do they apologize and leave the underlying issue in place? The structural-fix follow-through is the single biggest predictor of whether the line is worth coming back to.</p>
+
+      <p><strong>Embarkation and disembarkation flow.</strong> MSC genuinely wins embarkation in most American ports — smoother, faster, less queue chaos than the Royal Caribbean equivalent. Disembarkation flow varies. Evaluate both.</p>
+
+      <p><strong>Buffet and pool deck.</strong> MSC's buffet (the Marketplace on Seaside-class) is consistently stronger than Royal Caribbean's Windjammer. The pool deck on MSC Seaside specifically runs calmer than Royal Caribbean equivalents — whether that's under-capacity or cultural difference is debatable, but the lived experience is more empty chairs and less competition for shade.</p>
+
+      <p>The broader category-by-category comparison is in the <a href="/articles/royal-caribbean-vs-msc.html">Royal Caribbean vs MSC article</a>. The short version: MSC wins on embarkation, buffet, cabin space at the same category, pool-deck culture, the multilingual international passenger mix, and the disembarkation send-off warmth. Royal Caribbean wins decisively on the day-to-day service ethic, problem resolution, gangway accessibility, and gratuity flexibility. The categories MSC wins are close calls. The service ethic isn't.</p>
+
+      <h2 id="the-decision">The decision after sailing one</h2>
+
+      <p>Three outcomes from the first match sailing.</p>
+
+      <p><strong>First sailing clears the bar.</strong> Book the second one. Probably book a third within twelve months. The match converts; the cruise calendar starts to rebalance toward MSC. You don't need to abandon Royal Caribbean (in fact don't — keep both programs active because RCL doesn't match outbound and your Diamond status retains value), but the marginal sailing tilts MSC.</p>
+
+      <p><strong>First sailing is mixed.</strong> Some categories clear the bar; some don't. The MSC strengths are real (embarkation, buffet, cabin space) and the MSC weaknesses are real (service-ethic touchpoints, problem resolution). Book a second sailing on a different ship before deciding. n=1 cuts both ways: one sailing can't judge the line definitively in either direction.</p>
+
+      <p><strong>First sailing fails the bar materially.</strong> The cabin-steward arc was rough. Problem resolution didn't produce structural fixes. You are tempted to write off MSC entirely. The disciplined move is the same as the mixed case: a second sailing on a different ship, different cabin, different crew rotation, before declaring the line a one-way door. The author of this article had a service-frustrated first MSC sailing (the cabin-steward arc and luggage-tag coincidence documented in the linked service review) and is still planning a second sailing on a different ship to test whether the patterns generalize or stay specific.</p>
+
+      <p>The wrong move in every case is to book back-to-back match sailings before the first one finishes. The match is a free invitation; the second sailing should be a decision informed by the first, not a commitment made before the evidence is in.</p>
+
+      <h2 id="what-msc-should-know">What MSC's loyalty team should know</h2>
+
+      <p>This section is directed at MSC's loyalty and operations teams who may read this article via the post-cruise survey feedback loop.</p>
+
+      <p>The status-match program is structurally excellent. The match is generous, the inbound asymmetry against Royal Caribbean is well-calibrated, the matched tier delivers the right Day-1 perks, and the conversion math works on paper. The first-sailing experience is the variable that determines whether the program's strategic investment converts.</p>
+
+      <p>The matched cruiser arriving for their first MSC sailing is evaluating the line on the touchpoints where the comparison with Royal Caribbean is closest — service ethic, problem resolution, the cabin-steward relationship, the way the line responds when something doesn't go right. Those touchpoints depend disproportionately on entry-level crew training and the hotel manager's authority to take structural action when a problem escalates.</p>
+
+      <p>Deploying undertrained entry-level crew at the touchpoints where match cruisers evaluate forward bookings is the gap that turns a generous status match from a conversion into a one-way door. Training entry-level crew is a real industry challenge for every mainstream line — Royal Caribbean, Norwegian, Carnival, Princess, all of them. The differentiator isn't whether the challenge exists. It is whether the line aims the training gap at its acquisition channel or away from it.</p>
+
+      <p>MSC's status-match program is the acquisition channel. The crew deployed against it is the channel's enabling layer or its weakest link. Calibrate accordingly.</p>
+
+      <h2 id="practical-advice">Practical advice if you take the match</h2>
+
+      <p>Submit the match before you book your first MSC sailing, not after. The matched tier needs to be active on your profile when you book in order for the booking-level perks (priority embarkation, dedicated check-in routing) to attach cleanly. Submitting after the booking sometimes results in tier benefits not being fully applied without a follow-up call to MSC Guest Services.</p>
+
+      <p>Book a four-to-seven-night sailing for the first match trip, not a longer cruise. Long sailings amplify both strengths and weaknesses. A shorter trip gives you a fair evaluation window without the commitment of a transatlantic or a two-week Mediterranean if the line turns out not to be a fit.</p>
+
+      <p>Sail on a ship MSC considers a current flagship class. The MSC Seaside, MSC Seashore, MSC Meraviglia, MSC World Europa, and MSC World America (when delivered) are the current-generation hardware. Older MSC ships exist (Lirica-class, Musica-class, Fantasia-class) and they are perfectly adequate, but a first sailing on a current-flagship hull gives the line its best foot forward, which is the right calibration for an evaluation.</p>
+
+      <p>If you have any flexibility on cabin tier, consider Fantastica or Aurea over Bella. Bella is the cheapest fare class and a guarantee category — the cabin gets assigned, not chosen. The status match perks attach to your tier regardless of cabin class, but a Fantastica or Aurea cabin lets you pick a location away from high-traffic corridors and gives you the dining flexibility that makes the sailing easier to compare on equal footing with your usual Royal Caribbean booking. The <a href="/articles/royal-caribbean-vs-msc.html#cabin-tier">cabin tier strategy section</a> in the comparison article covers this in detail.</p>
+
+      <p>Sail. Evaluate honestly. Decide on the evidence. The match doesn't ask anything more of you than that.</p>
+
+      <h2 id="faq">Frequently asked questions</h2>
+
+      <details class="section-divider">
+        <summary><strong>Does MSC honor Royal Caribbean Diamond status?</strong></summary>
+        <p class="list-indent">Yes. MSC's Voyagers Club status-match program accepts Royal Caribbean Crown &amp; Anchor Society Diamond tier (and most other major-line top-tier loyalty cards). The match is one-way only — Royal Caribbean does not offer an outbound match. Submission is via MSC's status-match page; processing typically takes a few days to a couple of weeks. The match is free.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>How long does the MSC status match take?</strong></summary>
+        <p class="list-indent">Submission is a short online form. Processing time ranges from a few business days to about two weeks. Email confirmation arrives when the matched tier is active on your MSC for Me profile.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What does the match actually get me on my first sailing?</strong></summary>
+        <p class="list-indent">Priority embarkation, dedicated check-in, Voyagers Club lounge access where available, priority tendering, and a tier-specific welcome amenity in your cabin. The match does not get you a fare discount or Yacht Club access — it is a tier benefit set, not a pricing discount.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Should I take the MSC status match?</strong></summary>
+        <p class="list-indent">Yes. It costs nothing, takes about ten minutes to submit, and gives you a meaningful tier benefit set on your first MSC sailing if you choose to try one. Take the match. Sail once. Decide on the evidence. Don't book back-to-back match sailings before the first one finishes.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Does the status match include Yacht Club access?</strong></summary>
+        <p class="list-indent">No. MSC's Yacht Club is a separate paid tier — a ship-within-a-ship product with its own restaurant, sun deck, private elevator, butler, and included drinks. It is sold as part of the cabin booking, not as a loyalty-tier benefit.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Does the MSC status match expire?</strong></summary>
+        <p class="list-indent">The matched tier typically holds for an initial period (often through the end of the following year), after which MSC requires you to sail on MSC to maintain the status. Check MSC's current Voyagers Club terms before assuming a particular renewal mechanism, since program rules are updated periodically.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What if my first MSC sailing on the match goes badly?</strong></summary>
+        <p class="list-indent">Give MSC a second shot on a different ship before deciding. n=1 cuts both ways: one sailing isn't enough to judge the line, just as a single Royal Caribbean sailing wouldn't be. The author's first MSC sailing on the match had a frustrating cabin-steward arc (documented in the <a href="/articles/msc-seaside-service-review.html">MSC Seaside service review</a>), but the structural lesson generalizes only so far. Take the verdict on the sailing you had. Leave the verdict on the line open until you've sailed at least twice.</p>
+      </details>
+
+      <h2 id="related">Related reading</h2>
+
+      <ul>
+        <li><a href="/articles/royal-caribbean-vs-msc.html">Royal Caribbean vs MSC: Side by Side from the Deck</a> — the category-by-category comparison that informs what to evaluate on your first match sailing</li>
+        <li><a href="/articles/msc-seaside-service-review.html">MSC Seaside Service Review: The Apology That Wasn't a Plan</a> — the cabin-steward case study from a status-matched first MSC sailing</li>
+        <li><a href="/articles/cruise-tipping-2026.html">Cruise Tipping for 2026</a> — including the structural difference in tipping flexibility between RCL and MSC</li>
+        <li><a href="/ships/msc/msc-seaside.html">MSC Seaside</a> — the current-generation MSC ship the author sailed for the first match trip</li>
+        <li><a href="/articles/perfect-day-mexico-rejected-2026.html">Perfect Day Mexico, Rejected</a> — context on the private-destination strategic difference between the two lines</li>
+      </ul>
+
+      </div>
+    </article>
+  </main>
+
+  <!-- ================= FOOTER ================= -->
+  <footer class="wrap footer" role="contentinfo">
+    <p>&copy; 2026 In the Wake. All rights reserved.</p>
+    <p class="trust-badge">✓ No ads. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+    <nav aria-label="Footer navigation">
+      <ul style="list-style:none;padding:0;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
+        <li><a href="/about-us.html">About</a></li>
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/reaching-someone-at-sea.html">Reach Family at Sea</a></li>
+        <li><a href="/affiliate-disclosure.html">Affiliate Disclosure</a></li>
+      </ul>
+    </nav>
+    <p class="tiny center" style="margin-top:.5rem;opacity:0.7">
+      Soli Deo Gloria — Every pixel and part of this project is offered as worship to God.
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/articles/perfect-day-mexico-rejected-2026.html
+++ b/articles/perfect-day-mexico-rejected-2026.html
@@ -1,0 +1,393 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+  <!-- ======================================================
+       In the Wake — Article
+       Page: Perfect Day Mexico, Rejected — Royal Caribbean's $600M Setback
+       Version: 3.010.400  |  Standards baseline: 3.010.x
+       Content Protocol: ICP-2
+       ====================================================== -->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer"/>
+  <meta name="ai-summary" content="On May 22, 2026, Mexico's Secretariat of Environment and Natural Resources (SEMARNAT) rejected Royal Caribbean's Perfect Day Mexico project — a planned $600 million private destination near Mahahual, Quintana Roo, sited about 30 kilometers from the Banco Chinchorro Biosphere Reserve. The rejection followed a 4.8-million-signature Change.org petition, public Greenpeace pressure, and a direct statement from President Claudia Sheinbaum. Environmental concerns named: mangroves, coral reefs, groundwater systems. Royal Caribbean's official response was disappointed but emphatically not final — the company said it will 'continue to believe in Mexico' and 'over the coming weeks' will 're-engage stakeholders to move forward in a way that delivers shared prosperity through the development of essential environmental infrastructure, the creation of thousands of local jobs, and community programs that support the people of Mexico.' That is the language of Round 2, not surrender. The article's editorial thesis: any redesigned project will need to honor three constituencies the original design slighted — the reef and its ecosystem, the community of Mahahual and its coastal Quintana Roo economy, and the Royal Caribbean Group stockholders who committed the capital. Round 2 likely arrives within 90 days as scaled-down development at the same site with a Mexican conservation co-management partner and formal community-benefit agreements. The structural lesson the article draws: the cruise industry now has two visible private-destination patterns — the theme-park model (CocoCay, blocked Perfect Day Mexico) and the conservation-partnership model (MSC's Ocean Cay with its Mission Blue Hope Spot designation and MSC Foundation Marine Conservation Center). The second pattern is increasingly a regulatory shield. Cruise lines that pair private destinations with credible conservation partnerships and community endorsement will face less political friction going forward."/>
+  <meta name="last-reviewed" content="2026-05-24"/>
+  <meta name="content-protocol" content="ICP-2"/>
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light dark"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
+  <meta name="author" content="Ken Baker"/>
+
+  <!-- SEO -->
+  <title>Perfect Day Mexico, Rejected: What Royal Caribbean's $600M Setback Actually Means — In the Wake</title>
+  <meta name="description" content="Mexico's environment ministry rejected Royal Caribbean's $600M Perfect Day Mexico project on May 22, 2026 — but RCL's response language signals Round 2, not surrender. What the SEMARNAT decision means for cruisers, the Mesoamerican Reef, and the future of private cruise destinations."/>
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://cruisinginthewake.com/articles/perfect-day-mexico-rejected-2026.html"/>
+
+  <!-- Social -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Perfect Day Mexico, Rejected: What Royal Caribbean's $600M Setback Actually Means"/>
+  <meta property="og:description" content="Mexico rejected Royal Caribbean's Perfect Day Mexico project on environmental grounds. RCL's response language tells you they're not walking away — they're entering Round 2 of a longer negotiation."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles/perfect-day-mexico-rejected-2026.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="article:section" content="Cruise News"/>
+  <meta property="article:published_time" content="2026-05-24"/>
+  <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Perfect Day Mexico, Rejected: Royal Caribbean's $600M Setback"/>
+  <meta name="twitter:description" content="Mexico blocked the project. RCL's response says Round 2. What it means for cruisers and the reef."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Structured data: Article -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"NewsArticle",
+    "headline":"Perfect Day Mexico, Rejected: What Royal Caribbean's $600M Setback Actually Means",
+    "description":"Mexico's environment ministry SEMARNAT rejected Royal Caribbean's Perfect Day Mexico project on May 22, 2026, citing environmental risks to coral reefs and mangroves. Royal Caribbean's response signals Round 2, not surrender.",
+    "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
+    "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
+    "datePublished":"2026-05-24",
+    "dateModified":"2026-05-24",
+    "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
+    "mainEntityOfPage":"https://cruisinginthewake.com/articles/perfect-day-mexico-rejected-2026.html",
+    "articleSection":"Cruise News",
+    "about":[
+      {"@type":"Thing","name":"Royal Caribbean Group"},
+      {"@type":"Thing","name":"Perfect Day Mexico"},
+      {"@type":"Thing","name":"Mesoamerican Reef"},
+      {"@type":"Thing","name":"SEMARNAT"},
+      {"@type":"Thing","name":"Mahahual"},
+      {"@type":"Thing","name":"Private cruise destinations"}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ken Baker",
+    "url":"https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle":"Pastor, Cruise Writer",
+    "description":"Reformed Baptist pastor and cruise writer specializing in accessible travel, grief support, and compassionate cruise guidance.",
+    "worksFor":{"@type":"Organization","name":"In the Wake"},
+    "knowsAbout":["Royal Caribbean","MSC Cruises","Private Cruise Destinations","Cruise Line Strategy","Cruise Planning"]
+  }
+  </script>
+
+  <!-- Structured data: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {
+        "@type":"Question",
+        "name":"Why did Mexico reject Royal Caribbean's Perfect Day Mexico project?",
+        "acceptedAnswer":{"@type":"Answer","text":"Mexico's Secretariat of Environment and Natural Resources (SEMARNAT) rejected the project on May 22, 2026, citing environmental risks to mangroves, coral reefs, and groundwater systems near the Banco Chinchorro Biosphere Reserve. The rejection followed sustained public pressure: a Change.org petition that gathered approximately 4.8 million signatures, public engagement from Greenpeace, and a direct statement from Mexican President Claudia Sheinbaum that 'we are not going to do anything that puts the ecological balance of that area at risk.' Environment Minister Alicia Bárcena Ibarra's formal announcement followed: 'We, at SEMARNAT, will not approve it.'"}
+      },
+      {
+        "@type":"Question",
+        "name":"What was Perfect Day Mexico supposed to be?",
+        "acceptedAnswer":{"@type":"Answer","text":"Royal Caribbean's planned $600 million private destination on the Caribbean coast of Mexico's Quintana Roo state, in Mahahual village. The 80+ hectare (200+ acre) project was modeled on the company's Perfect Day at CocoCay in the Bahamas — pools, beach clubs, water slides, restaurants — and was expected to host up to 21,000 guests per day when it opened. Original planned opening was fall 2027."}
+      },
+      {
+        "@type":"Question",
+        "name":"Does this affect my current Royal Caribbean cruise?",
+        "acceptedAnswer":{"@type":"Answer","text":"No. Perfect Day Mexico was not operational yet — it was a future-state asset planned for fall 2027. No itineraries currently routed to it, and none affected by the rejection. If you have a 2027 or 2028 Royal Caribbean Caribbean itinerary that was expected to include Mahahual as a stop, expect the itinerary to be modified to a different port. Royal Caribbean has not announced any timeline for resubmission or relocation."}
+      },
+      {
+        "@type":"Question",
+        "name":"Will Royal Caribbean try again somewhere else?",
+        "acceptedAnswer":{"@type":"Answer","text":"Almost certainly. Royal Caribbean's official statement is the clearest signal: the company said it 'continues to believe in Mexico' and that 'over the coming weeks, we will re-engage stakeholders to move forward in a way that delivers shared prosperity through the development of essential environmental infrastructure, the creation of thousands of local jobs, and community programs that support the people of Mexico.' That is the language of resubmission, not withdrawal. A $600 million investment commitment does not get walked away from after one regulatory setback. Expect scaled-down plans, environmental concessions, possible relocation within Mexico, or a longer timeline — but expect Royal Caribbean to find a path."}
+      },
+      {
+        "@type":"Question",
+        "name":"What's the difference between CocoCay and Perfect Day Mexico's planned model?",
+        "acceptedAnswer":{"@type":"Answer","text":"Operationally, very little — both follow the Royal Caribbean theme-park model: high amenity density, exclusive guest access, branded experiences. The difference is the regulatory environment around them. CocoCay sits in the Bahamas where the regulatory framework was more permissive when it was developed and expanded. Perfect Day Mexico proposed to develop adjacent to a UNESCO-affiliated coral reef system in a regulatory environment with active environmental ministry oversight. The cruise industry now has two visible private-destination patterns: the theme-park model (CocoCay, blocked Perfect Day Mexico) and the conservation-partnership model (MSC's Ocean Cay, which holds a Mission Blue Hope Spot designation and operates a Marine Conservation Center under the MSC Foundation). Going forward, cruise lines pairing private destinations with credible conservation partnerships will face less political friction; lines proposing entertainment-density on coral reefs will face the kind of pressure that just rejected Mahahual."}
+      }
+    ]
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <!-- ================= HEADER ================= -->
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Tools <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/cruise-tipping-calculator.html">Tipping Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Onboard <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="Perfect Day Mexico rejected news article">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">Perfect Day Mexico, Rejected</div>
+    </div>
+  </header>
+
+  <main id="main-content" class="page" role="main">
+    <article itemscope itemtype="https://schema.org/NewsArticle" class="logbook">
+      <header style="max-width:min(860px,92%);margin-inline:auto">
+        <h1 itemprop="headline">Perfect Day Mexico, Rejected: What Royal Caribbean's $600M Setback Actually Means</h1>
+        <p class="dek" itemprop="description">Mexico's environment ministry blocked the project on May 22, 2026, after a 4.8-million-signature petition and a direct statement from President Sheinbaum. Royal Caribbean's response says Round 2, not surrender — and a $600 million investment commitment doesn't get walked away from after one regulatory setback. What this means for cruisers, the Mesoamerican Reef, and the future shape of private cruise destinations.</p>
+        <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-05-24">May 24, 2026</time></p>
+      </header>
+
+      <div itemprop="articleBody" style="max-width:min(860px,92%);margin-inline:auto">
+
+      <!-- Answer-first lede -->
+      <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
+        <strong>Answer first:</strong> Mexico's Secretariat of Environment and Natural Resources (SEMARNAT) rejected Royal Caribbean's $600 million Perfect Day Mexico project on May 22, 2026, citing risks to mangroves, coral reefs, and groundwater systems near the Banco Chinchorro Biosphere Reserve. The rejection followed a 4.8-million-signature Change.org petition and a direct statement from President Claudia Sheinbaum. Royal Caribbean's response was disappointed but emphatically not final: the company said it will "continue to believe in Mexico" and over the coming weeks will "re-engage stakeholders" to move forward. That is the language of Round 2, not withdrawal. This article reads the rejection as a setback in a longer game — and argues that the cruise industry now has two visible private-destination patterns (theme-park vs. conservation-partnership) and that the second is increasingly a regulatory shield.
+      </p>
+
+      <!-- TOC -->
+      <nav class="article-toc" aria-label="In this article" style="max-width:min(860px,92%);margin:1.5rem auto;padding:1rem 1.25rem;background:#f8fbfc;border-left:3px solid #d0e4f0;border-radius:4px">
+        <h2 style="margin-top:0;font-size:1.05rem">In this article</h2>
+        <ol style="margin:0.5rem 0 0;padding-left:1.25rem;line-height:1.8">
+          <li><a href="#what-happened">What happened and what was rejected</a></li>
+          <li><a href="#the-environmental-case">The environmental case SEMARNAT made</a></li>
+          <li><a href="#how-the-rejection-happened">How the rejection happened — petition, Greenpeace, president</a></li>
+          <li><a href="#rcl-response">Royal Caribbean's response, read carefully</a></li>
+          <li><a href="#round-two">What Round 2 likely looks like</a></li>
+          <li><a href="#structural-lesson">The structural lesson: two private-destination patterns</a></li>
+          <li><a href="#what-it-means-for-cruisers">What this means for cruisers</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ol>
+      </nav>
+
+      <h2 id="what-happened">What happened and what was rejected</h2>
+
+      <p>On Thursday, May 22, 2026, Mexico's Secretariat of Environment and Natural Resources — known by its Spanish acronym SEMARNAT — formally rejected Royal Caribbean's Perfect Day Mexico development. Environment Minister Alicia Bárcena Ibarra's announcement was direct: <em>"We, at SEMARNAT, will not approve it."</em></p>
+
+      <p>The project would have sat in Mahahual, a fishing-village-turned-cruise-stop on the Caribbean coast of Quintana Roo state, about 30 kilometers from the Banco Chinchorro Biosphere Reserve. The development footprint exceeded 80 hectares (more than 200 acres). The budget — widely reported across cruise industry coverage and confirmed by Mexican environmental NGOs — was approximately $600 million USD. Capacity was planned at up to 21,000 guests per day. The model was a transplant of Royal Caribbean's existing <a href="/ports/cococay.html">Perfect Day at CocoCay</a> in the Bahamas: pools, water slides, beach clubs, branded restaurants, and exclusive Royal Caribbean guest access. Original planned opening was fall 2027.</p>
+
+      <p>The rejection was not a procedural delay. It was a substantive decision by Mexico's environment ministry, made one day after President Claudia Sheinbaum publicly stated her concerns about the project's location. The political signal preceded the regulatory one by hours.</p>
+
+      <h2 id="the-environmental-case">The environmental case SEMARNAT made</h2>
+
+      <p>The technical objections clustered around three categories: mangroves, coral reefs, and groundwater systems. The site sits within an ecologically connected coastal zone that includes part of the <a href="/articles/costa-maya-mesoamerican-reef-diving.html">Mesoamerican Reef System</a> — the second-largest barrier reef in the world, stretching from Mexico's Yucatán Peninsula through Belize, Guatemala, and Honduras. The Banco Chinchorro Biosphere Reserve nearby is a UNESCO-listed protected area that has been a Mexican federal conservation priority for decades.</p>
+
+      <p>Mangroves matter here for two reasons. They are themselves federally protected under Mexico's environmental law, and they function as natural nurseries for the reef fish populations that the surrounding tourism economy depends on. Removing or compromising mangrove habitat at the scale Perfect Day Mexico required would have measurable downstream consequences for the reef ecosystem.</p>
+
+      <p>Groundwater concerns were specific to this geography. The Yucatán Peninsula's karst geology means surface water and aquifer systems are tightly coupled; large-scale resort development changes recharge patterns and can introduce contamination paths into the cave systems that ultimately discharge into the sea. SEMARNAT cited these systemic concerns in the technical rejection.</p>
+
+      <p>None of these objections were new. The same concerns have been raised about every major resort development on this coast for the last twenty years. What was new was the political alignment that gave them decisive weight.</p>
+
+      <h2 id="how-the-rejection-happened">How the rejection happened — petition, Greenpeace, president</h2>
+
+      <p>A Change.org petition demanding the project be halted launched in July 2025. By mid-May 2026 it had gathered approximately 4.8 million signatures — a scale that no Mexican environmental petition had previously reached. The signature count alone was sufficient to make the project a domestic Mexican political issue, not a quiet regulatory matter.</p>
+
+      <p>Greenpeace engaged formally in the week before the rejection, amplifying the coverage and bringing international media attention. Mongabay, the conservation-focused environmental news outlet, ran detailed coverage of the technical objections. Mexican domestic press carried the story across both pro- and anti-government outlets.</p>
+
+      <p>President Sheinbaum's public statement on May 21 — <em>"We are not going to do anything that puts the ecological balance of that area at risk"</em> — was the political pivot. When a Mexican president takes a public position on a specific project the day before the environmental ministry rules on it, the ministry's ruling becomes the formalization of a decision already made at the executive level. SEMARNAT's announcement the next day completed the sequence.</p>
+
+      <h2 id="rcl-response">Royal Caribbean's response, read carefully</h2>
+
+      <p>Royal Caribbean issued a formal statement the same day. The full text deserves close reading, because the framing tells you what comes next:</p>
+
+      <p><em>"We are disappointed by SEMARNAT's decision and respect the role of Mexico's environmental authorities. Mahahual is a special place that deserves care and protection. We continue to believe in Mexico, and are optimistic in the potential to advance our investment responsibly. Over the coming weeks, we will re-engage stakeholders to move forward in a way that delivers shared prosperity through the development of essential environmental infrastructure, the creation of thousands of local jobs, and community programs that support the people of Mexico."</em></p>
+
+      <p>Three signals worth noting:</p>
+
+      <p><strong>"We continue to believe in Mexico."</strong> Translation: the location commitment is not abandoned. Royal Caribbean is not pivoting to a different country (Dominican Republic, Honduras, Jamaica were all rumored as alternative sites if Mexico fell through). The investment stays inside Mexico.</p>
+
+      <p><strong>"Advance our investment responsibly."</strong> Translation: Royal Caribbean retains its capital commitment and the regulatory frame is now part of the project plan rather than a hurdle. Expect a redesigned development that incorporates environmental concessions — smaller footprint, mangrove protection clauses, capped daily capacity, possibly a co-management arrangement with a Mexican conservation entity.</p>
+
+      <p><strong>"Shared prosperity through the development of essential environmental infrastructure, the creation of thousands of local jobs, and community programs that support the people of Mexico."</strong> This is the line that names the three constituencies the redesigned project will need to satisfy: <strong>the reef, the community, and the stockholders</strong>. The reef is the environmental case. The community is Mahahual itself — a fishing village that becomes either an economic partner or an economic casualty depending on how the project is structured. The stockholders are the Royal Caribbean Group's investors, who funded a $600 million commitment that needs to produce returns. A Round-2 design that honors all three is the only kind that gets built.</p>
+
+      <p><strong>"Over the coming weeks, we will re-engage stakeholders."</strong> Translation: a Round-2 announcement is on a near-term timeline, not a multi-year shelf. The phrase "essential environmental infrastructure" earlier in the same sentence is the tell — Royal Caribbean is signaling that a Round-2 version will pair the resort development with conservation infrastructure spending, the same model that built political support for the project before the rejection turned the politics against it.</p>
+
+      <p>A $600 million investment commitment does not get walked away from after one regulatory setback. It gets redesigned to honor all three constituencies the original design slighted.</p>
+
+      <h2 id="round-two">What Round 2 likely looks like</h2>
+
+      <p>Three patterns to watch over the next 90 days. Each is a different way of honoring the three constituencies — reef, community, stockholders — that any redesigned project will need to satisfy.</p>
+
+      <p><strong>Scaled-down development at the same site.</strong> The 80-hectare footprint becomes 40 or 50. The 21,000-daily-guest capacity becomes 12,000 or 14,000. The mangrove zone is left untouched and protected with a federally-recognized conservation easement. The reef-facing infrastructure shifts inland. Local hiring commitments are written into the agreement at quotas rather than aspirations. The case to SEMARNAT becomes: a smaller project with explicit conservation and community commitments. This is the cheapest path for Royal Caribbean and the most face-saving for the Mexican government.</p>
+
+      <p><strong>Relocation within Mexico.</strong> A different site on the same Caribbean coast — further north toward Costa Maya proper, or south near the Belize border — could carry the brand without the Banco Chinchorro adjacency. Royal Caribbean's "we continue to believe in Mexico" line keeps this option open. The trade-off: site acquisition restarts, environmental review restarts, the Mahahual community loses the economic opportunity (which means the company loses the community-stakeholder argument that helped justify the original site), and the fall 2027 opening slips by two or more years.</p>
+
+      <p><strong>Hybrid model with a Mexican conservation partner.</strong> The single most politically durable structure is a joint development with a Mexican environmental authority or NGO that publicly co-manages the conservation side of the property, paired with formal community-benefit agreements with Mahahual itself — local sourcing quotas, training and apprenticeship commitments, a community-controlled portion of the revenue stream. This is roughly what MSC built into Ocean Cay through the MSC Foundation and the Mission Blue Hope Spot designation, just with Mexican federal entities and Mahahual residents instead of an international marine-protection network. If Royal Caribbean takes this path, the redesigned project arrives with conservation credibility and community endorsement baked in rather than bolted on after the rejection.</p>
+
+      <p>The most likely outcome is some combination of one and three: scaled-down at the same site, with a Mexican conservation co-management structure and explicit community-benefit guarantees. That's the design that lets Royal Caribbean honor the reef without abandoning the community, and lets the company honor both without abandoning the stockholders who funded the original commitment.</p>
+
+      <h2 id="structural-lesson">The structural lesson: two private-destination patterns</h2>
+
+      <p>The cruise industry has built more than two dozen private destinations across the Caribbean and Bahamas over the past three decades. They cluster into two patterns that the Mahahual rejection has now made visible.</p>
+
+      <p>The first is the theme-park model. Maximum amenity density. Pools, water slides, zip lines, beach clubs, branded restaurants. Environmental concessions secondary. Royal Caribbean's CocoCay is the cleanest current example; the proposed Perfect Day Mexico was a transplant of the same model into Mexican waters. The model maximizes guest revenue per port-day. It also maximizes the regulatory surface area when the destination sits near a sensitive marine ecosystem.</p>
+
+      <p>The second is the conservation-partnership model. The example most directly relevant here is MSC's Ocean Cay Marine Reserve in the Bahamas — a private destination that holds a Mission Blue Hope Spot designation (the marine-protection network founded by oceanographer Dr. Sylvia Earle) and operates an on-island Marine Conservation Center under the MSC Foundation, the philanthropic arm of the Aponte family. <a href="/articles/royal-caribbean-vs-msc.html#msc-wins">The comparison article on Royal Caribbean vs MSC</a> covers this institutional layer in detail. Amenities are still present — beaches, food venues, included activities — but the conservation infrastructure is the core architecture of the property rather than a marketing afterthought.</p>
+
+      <p>The Mahahual rejection is the first major regulatory event that distinguishes these patterns in market consequence. A theme-park-model proposal near a UNESCO-affiliated reef got blocked. A conservation-partnership-model property next to a Marine Reserve gets sustained operating approval and a Mission Blue affiliation. The pattern that pairs amenity density with institutional conservation credibility is increasingly a regulatory shield. The pattern that doesn't is increasingly a regulatory target.</p>
+
+      <p>This is going to harden over the next several years. Every cruise line proposing private destinations near sensitive marine ecosystems — and that is the only kind of location worth developing because the warm-water beach-with-clear-water is the product — will need to decide which pattern they are choosing. Royal Caribbean's <a href="/articles/royal-beach-club-collection-2026.html">Royal Beach Club Collection</a> expansion into Paradise Island, Santorini, Cozumel, and Antigua is the company's near-term commitment to the theme-park model. The Mahahual rejection forces the question of whether the next Royal Beach Club proposal arrives with conservation infrastructure built in.</p>
+
+      <h2 id="what-it-means-for-cruisers">What this means for cruisers</h2>
+
+      <p>For most current cruisers, no immediate operational impact. Perfect Day Mexico was a future-state asset planned for fall 2027 — no itineraries currently route to it, no bookings affected, no embarkation-day changes. If your 2027 or 2028 Royal Caribbean Caribbean itinerary included Mahahual as an expected port call, expect it to be replaced with a different Mexican Caribbean port (Cozumel, Costa Maya, Progreso) until the redesigned project is approved.</p>
+
+      <p>For cruisers who care about the Mesoamerican Reef, this is a meaningful structural win. The reef ecosystem is under sustained pressure from coastal development across the entire western Caribbean. A successful pushback against a $600 million project from a major American cruise line is the kind of precedent that changes how the next dozen proposals get scoped.</p>
+
+      <p>For cruisers who follow the private-destination arms race between the major lines, this is the moment that the conservation-partnership pattern moves from "nice editorial detail" to "material strategic advantage." MSC's Ocean Cay just became a more durable asset than it was last week.</p>
+
+      <p>For Royal Caribbean specifically, the next 90 days are the test of how quickly the company can redesign and resubmit. The longer the Round-2 announcement takes, the more pressure builds inside Royal Caribbean's strategic planning for the 2028 fleet additions — Star of the Seas and the next Icon-class ship — both of which need a Caribbean private-destination footprint that can absorb their guest capacity. Mahahual was the planned absorption capacity. Without it, the load falls on CocoCay and the Royal Beach Club Collection, neither of which has the same daily-throughput design.</p>
+
+      <p>The cruise line will find a way. They have invested too much not to. The harder question — and the more interesting one — is whether the redesigned project honors all three constituencies the original design tried to handle as afterthoughts: the reef and its ecosystem, the community of Mahahual and the coastal Quintana Roo economy it sits inside, and the Royal Caribbean Group's stockholders who committed the capital that built the project on paper. A Round 2 that honors all three is the only kind that gets built. Watch June and July 2026 announcements closely.</p>
+
+      <h2 id="faq">Frequently asked questions</h2>
+
+      <details class="section-divider">
+        <summary><strong>Why did Mexico reject Royal Caribbean's Perfect Day Mexico project?</strong></summary>
+        <p class="list-indent">Mexico's environment ministry SEMARNAT rejected the project on May 22, 2026, citing environmental risks to mangroves, coral reefs, and groundwater systems near the Banco Chinchorro Biosphere Reserve. The rejection followed a 4.8-million-signature petition, public Greenpeace engagement, and a direct statement from President Claudia Sheinbaum that "we are not going to do anything that puts the ecological balance of that area at risk."</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What was Perfect Day Mexico supposed to be?</strong></summary>
+        <p class="list-indent">Royal Caribbean's planned $600 million private destination on the Caribbean coast of Mexico's Quintana Roo state, in Mahahual village. The 80+ hectare project was modeled on Perfect Day at CocoCay in the Bahamas and expected to host up to 21,000 guests per day at fall 2027 opening.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Does this affect my current Royal Caribbean cruise?</strong></summary>
+        <p class="list-indent">No. Perfect Day Mexico was not operational yet — no itineraries currently route there. If you have a 2027 or 2028 Royal Caribbean Caribbean itinerary that was expected to include Mahahual, expect it to be modified to a different Mexican port until any redesigned project is approved.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Will Royal Caribbean try again somewhere else?</strong></summary>
+        <p class="list-indent">Almost certainly. The company's official statement said it "continues to believe in Mexico" and that "over the coming weeks, we will re-engage stakeholders to move forward." A $600 million investment commitment does not get walked away from after one regulatory setback. Expect scaled-down plans, environmental concessions, possible co-management with a Mexican conservation entity, or a relocated site within Mexico.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What's the difference between CocoCay and what Perfect Day Mexico was planned to be?</strong></summary>
+        <p class="list-indent">Operationally very little — both follow the theme-park model. The difference is the regulatory environment around them. CocoCay sits in the Bahamas; Perfect Day Mexico proposed development adjacent to a UNESCO-affiliated coral reef under active Mexican environmental ministry oversight. The cruise industry now has two visible private-destination patterns: the theme-park model (CocoCay, blocked Perfect Day Mexico) and the conservation-partnership model (MSC's Ocean Cay with its Mission Blue Hope Spot designation and Marine Conservation Center). The second pattern is increasingly a regulatory shield.</p>
+      </details>
+
+      <h2 id="related">Related reading</h2>
+
+      <ul>
+        <li><a href="/articles/royal-beach-club-collection-2026.html">The Royal Beach Club Collection in 2026</a> — Royal Caribbean's broader private-destination expansion strategy and what the Mahahual rejection means for it</li>
+        <li><a href="/articles/royal-caribbean-vs-msc.html">Royal Caribbean vs MSC: Side by Side from the Deck</a> — including the §Private island comparison section on Ocean Cay's Mission Blue Hope Spot designation</li>
+        <li><a href="/articles/costa-maya-mesoamerican-reef-diving.html">Costa Maya and the Mesoamerican Reef</a> — the reef system Mahahual sits adjacent to</li>
+        <li><a href="/ports/cococay.html">Perfect Day at CocoCay</a> — the existing Royal Caribbean private destination Perfect Day Mexico was modeled after</li>
+        <li><a href="/articles/msc-seaside-service-review.html">MSC Seaside Service Review: The Apology That Wasn't a Plan</a> — a related case study on the line that's pursuing the conservation-partnership pattern</li>
+      </ul>
+
+      </div>
+    </article>
+  </main>
+
+  <!-- ================= FOOTER ================= -->
+  <footer class="wrap footer" role="contentinfo">
+    <p>&copy; 2026 In the Wake. All rights reserved.</p>
+    <p class="trust-badge">✓ No ads. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+    <nav aria-label="Footer navigation">
+      <ul style="list-style:none;padding:0;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
+        <li><a href="/about-us.html">About</a></li>
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/reaching-someone-at-sea.html">Reach Family at Sea</a></li>
+        <li><a href="/affiliate-disclosure.html">Affiliate Disclosure</a></li>
+      </ul>
+    </nav>
+    <p class="tiny center" style="margin-top:.5rem;opacity:0.7">
+      Soli Deo Gloria — Every pixel and part of this project is offered as worship to God.
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -55,6 +55,24 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://cruisinginthewake.com/articles/perfect-day-mexico-rejected-2026.html</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://cruisinginthewake.com/articles/msc-voyagers-club-status-match-from-rcl-diamond.html</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/articles/cruise-ship-size-explained.html</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>


### PR DESCRIPTION
## What this PR does

Re-lands three articles that are currently **404 on the live site** because a force-push on `origin/main` (between `e662b9dd` and `32296f1d`) reverted PR merges `#1572`, `#1573`, and `#1574`. The articles were intact on `claude/review-website-docs-W1n7w` but no longer reachable on the live site after the force-push deployed.

## Articles being restored

| URL | Status before this PR |
|---|---|
| `/articles/cruise-travel-safety-shore-side-net.html` | 404 |
| `/articles/perfect-day-mexico-rejected-2026.html` | 404 |
| `/articles/msc-voyagers-club-status-match-from-rcl-diamond.html` | 404 |

## What's in this PR

This is a **surgical recovery** — branched from current `origin/main` with **only** the three article files restored, plus the two index updates needed to surface them:

- `articles/cruise-travel-safety-shore-side-net.html` (new file, restored from W1n7w branch)
- `articles/perfect-day-mexico-rejected-2026.html` (new file, restored)
- `articles/msc-voyagers-club-status-match-from-rcl-diamond.html` (new file, restored)
- `articles.html` (added 3 entries to Popular Guides list)
- `sitemap.xml` (added 3 URL entries)

## What's NOT in this PR

The force-push also reverted other content that's missing from main but I did NOT include here, in case the revert was intentional:

- The AI-Tell Detection Framework v3 additions to `.claude/skills/voice-audit/SKILL.md` and `.claude/skills/like-a-human/SKILL.md`
- The new file `.claude/skills/voice-audit/falsification-test.md`
- Field-notes addenda on six port/ship pages (`ports/cabo-san-lucas.html`, `ports/ensenada.html`, `ports/nassau.html`, `ports/cococay.html`, `ships/rcl/quantum-of-the-seas.html`, `ships/rcl/radiance-of-the-seas.html`)
- Iterative edits to `articles/royal-caribbean-vs-msc.html` (sharpened service-ethic verdict, compressed §Cabin steward subsection, second-shot framing, status-match conversion-funnel thesis, cabin-tier strategy section)
- Updates to `reaching-someone-at-sea.html` (removed §"When the news is the worst kind")

Each of these is documented in `admin/SESSION_HANDOFF_2026-05-25_W1n7w.md` on the W1n7w branch. If you want any of them recovered, that's a separate decision per item.

## Before merging — please confirm

The force-push that dropped these articles — was it intentional?

- **If yes** (e.g., the articles needed editing before going live): close this PR; the dropped content needs whatever editing prompted the revert rather than direct re-land.
- **If no** (the force-push was accidental or stale-state revert): merge this PR and the three URLs will serve again within a few minutes via GitHub Pages.

## Post-merge verification

After merging, verify the three URLs return HTTP 200:
- https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html
- https://cruisinginthewake.com/articles/perfect-day-mexico-rejected-2026.html
- https://cruisinginthewake.com/articles/msc-voyagers-club-status-match-from-rcl-diamond.html

The IndexNow auto-hook will fire on the merge commit and re-notify Bing/Yandex/Naver/Seznam/Yep of the restored URLs.

---

*Soli Deo Gloria*

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDs7C5zpVocz5ZHURhEnbp)_