### PR TITLE
articles/cruise-itinerary-changes-what-to-do: new article — the third…

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -313,6 +313,7 @@
       <div class="key-facts" style="background: #f0f7ff; border-color: #d0e4f0;">
         <h2>Popular Guides</h2>
         <ul style="line-height: 1.8;">
+          <li><a href="https://cruisinginthewake.com/articles/cruise-itinerary-changes-what-to-do.html">Cruise Itinerary Changes: What to Do When a Port Is Missed, Diverted, or Cancelled</a></li>
           <li><a href="https://cruisinginthewake.com/articles/cruise-travel-insurance-2026.html">Cruise Travel Insurance in 2026: What You Actually Need, How the Major Plans Compare</a></li>
           <li><a href="https://cruisinginthewake.com/articles/cruise-travel-safety-shore-side-net.html">Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing</a></li>
           <li><a href="https://cruisinginthewake.com/articles/perfect-day-mexico-rejected-2026.html">Perfect Day Mexico, Rejected: What Royal Caribbean's $600M Setback Actually Means</a></li>

--- a/articles/cruise-itinerary-changes-what-to-do.html
+++ b/articles/cruise-itinerary-changes-what-to-do.html
@@ -1,0 +1,500 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+  <!-- ======================================================
+       In the Wake — Article
+       Page: Cruise Itinerary Changes — What to Do
+       Version: 3.010.400  |  Standards baseline: 3.010.x
+       Content Protocol: ICP-2
+       ====================================================== -->
+
+  <meta charset="utf-8"/>
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="no-referrer"/>
+  <meta name="ai-summary" content="A practical guide to handling cruise itinerary changes — missed ports, diverted sailings, full cancellations, and embark-port substitutions. Itinerary changes happen on roughly one in eight Caribbean sailings and one in five Alaska sailings, driven by weather, mechanical issues, medical evacuations, geopolitical port closures, and operational decisions. The cruise contract gives lines broad latitude to change itineraries without notice; passenger remedies are limited to what the line offers as goodwill compensation (typically port fees refunded as onboard credit, plus 25-50% future cruise credit for a substantively changed sailing). Travel insurance trip-interruption coverage rarely triggers for a missed port because the interruption is to the line's itinerary, not the passenger's trip; specific cruise-line plans (Nationwide Universal Cruise, BHTP WaveCare) include cruise-specific itinerary-change benefits worth $250-$500. Full cancellation triggers cruise contract refund obligations (100% cash or 125% future cruise credit, passenger's choice on most major lines). Embark-port substitution requires the cruise line to cover transport to the new departure port. The article walks the four scenarios in detail with what each looks like, what the line owes you legally vs. as goodwill, how to file travel insurance claims when applicable, when and how to escalate, the shore-side notification protocol for keeping your home contact informed, and the practical decision framework for accepting compensation vs. pursuing further claims. Includes pastoral framing — disappointment over a missed port is real but the cruise line's commercial latitude is also real; the article helps cruisers separate what they're owed from what they hoped for."/>
+  <meta name="last-reviewed" content="2026-05-27"/>
+  <meta name="content-protocol" content="ICP-2"/>
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light dark"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
+  <meta name="author" content="Ken Baker"/>
+
+  <!-- SEO -->
+  <title>Cruise Itinerary Changes: What to Do When a Port Is Missed, Diverted, or Cancelled — In the Wake</title>
+  <meta name="description" content="What to do when your cruise itinerary changes. Missed ports, diverted sailings, full cancellations, embark-port substitutions — what the cruise line owes you, what travel insurance covers, when to escalate, and how to file a claim cleanly."/>
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://cruisinginthewake.com/articles/cruise-itinerary-changes-what-to-do.html"/>
+
+  <!-- Social -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Cruise Itinerary Changes: What to Do When a Port Is Missed, Diverted, or Cancelled"/>
+  <meta property="og:description" content="The cruise contract gives lines broad latitude. The travel insurance language is specific. A practical guide to the four scenarios and what each one is actually worth."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles/cruise-itinerary-changes-what-to-do.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="article:section" content="Cruise Planning"/>
+  <meta property="article:published_time" content="2026-05-27"/>
+  <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Cruise Itinerary Changes: What to Do"/>
+  <meta name="twitter:description" content="Missed ports, diverted sailings, cancellations. What the line owes you. What insurance covers. When to escalate."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Structured data: Article -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Cruise Itinerary Changes: What to Do When a Port Is Missed, Diverted, or Cancelled",
+    "description":"A practical guide to handling cruise itinerary changes — missed ports, diverted sailings, full cancellations, and embark-port substitutions.",
+    "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
+    "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
+    "datePublished":"2026-05-27",
+    "dateModified":"2026-05-27",
+    "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
+    "mainEntityOfPage":"https://cruisinginthewake.com/articles/cruise-itinerary-changes-what-to-do.html",
+    "articleSection":"Cruise Planning",
+    "about":[
+      {"@type":"Thing","name":"Cruise Itinerary Changes"},
+      {"@type":"Thing","name":"Missed Cruise Port"},
+      {"@type":"Thing","name":"Cruise Contract Passenger Rights"},
+      {"@type":"Thing","name":"Travel Insurance Claims"},
+      {"@type":"Thing","name":"Cruise Line Compensation"}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ken Baker",
+    "url":"https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle":"Pastor, Cruise Writer",
+    "description":"Reformed Baptist pastor and cruise writer specializing in accessible travel, grief support, and compassionate cruise guidance.",
+    "worksFor":{"@type":"Organization","name":"In the Wake"},
+    "knowsAbout":["Cruise Travel Disruptions","Travel Insurance Claims","Cruise Line Compensation","Cruise Contract Terms","Cruise Planning"]
+  }
+  </script>
+
+  <!-- Structured data: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {
+        "@type":"Question",
+        "name":"What happens if my cruise ship skips a port?",
+        "acceptedAnswer":{"@type":"Answer","text":"The cruise contract gives the line near-complete latitude to change itineraries without notice. When a port is skipped, you typically receive a refund of port fees and taxes for that specific port (usually $15-$50 per person, returned as onboard credit during the sailing or applied to your folio). Many cruise lines add a goodwill credit on top: $25-$100 per cabin in onboard credit is common, occasionally more for popular missed ports. Some lines offer a substitute port or extend hours at the next port. Travel insurance trip-interruption coverage usually does not trigger for a missed port because the interruption is to the line's itinerary, not your trip. Specific cruise insurance plans (Nationwide Universal Cruise, BHTP WaveCare) include itinerary-change benefits of $250-$500 worth filing."}
+      },
+      {
+        "@type":"Question",
+        "name":"What is my cruise line legally required to do if it changes the itinerary?",
+        "acceptedAnswer":{"@type":"Answer","text":"In the United States, very little. Every major cruise line's contract includes language giving the line the right to change the itinerary, substitute ports, or cancel the cruise without notice and without liability beyond a refund of cruise fare in cases of full cancellation. Federal cruise law (the Cruise Vessel Security and Safety Act of 2010) covers onboard safety and incident reporting but does not regulate itinerary changes. EU Regulation 1177/2010 gives more passenger rights for cruises departing EU ports, including the right to information, alternative transport, or refunds for significant delays. Outside EU-departing cruises, what the line gives you is goodwill, not law. The good news: major U.S. cruise lines have developed consistent goodwill standards because the alternative is reputation damage."}
+      },
+      {
+        "@type":"Question",
+        "name":"What is the difference between a missed port and a diverted sailing?",
+        "acceptedAnswer":{"@type":"Answer","text":"A missed port skips one scheduled stop, with the ship continuing to the next scheduled port (often becoming an extra sea day). A diverted sailing changes the route substantially, typically replacing multiple ports — for example, a Western Caribbean itinerary diverted to the Eastern Caribbean during a hurricane. Missed port compensation is usually port fees plus modest onboard credit ($25-$100 per cabin). Diverted sailing compensation tends to be larger: $100-$300 per cabin in onboard credit plus sometimes a future-cruise-credit gesture of 10-25% for a significant change. Full sailing cancellation triggers a different contract clause entirely: 100% cash refund or 125% future cruise credit on most major lines (your choice)."}
+      },
+      {
+        "@type":"Question",
+        "name":"Does travel insurance pay for a missed cruise port?",
+        "acceptedAnswer":{"@type":"Answer","text":"Standard trip-interruption coverage usually does not pay for a missed port because the interruption is to the cruise line's itinerary, not your trip — you're still on the cruise, the ship just sailed past the port. Trip-cancellation coverage triggers only if YOU cancel for a covered reason before sailing. Two types of coverage do help: (1) cruise-specific plans with explicit Itinerary Change Inconvenience or Missed Port benefits (Nationwide Universal Cruise pays an itinerary-change benefit; BHTP WaveCare pays cruise-diversion benefits; some Allianz tiers offer missed-port coverage), typically $75-$500 per claim; (2) Trip Interruption coverage when you yourself must leave the cruise early due to a covered reason (medical emergency, family emergency, etc.) — that's still a real trip interruption claim. For a missed port that doesn't affect your ability to remain on the cruise, file the cruise line's onboard-credit goodwill and stop there."}
+      },
+      {
+        "@type":"Question",
+        "name":"What happens if my entire cruise is cancelled before sailing?",
+        "acceptedAnswer":{"@type":"Answer","text":"Most major cruise lines offer two refund paths and let you choose: 100% cash refund of your cruise fare, or 125-150% future cruise credit toward a different sailing. Cash refunds typically process within 30-90 days. Future cruise credits expire (usually 12-24 months) and are not transferable. Independently-booked components (flights, hotels, pre/post-cruise) are not refunded by the cruise line — that's where travel insurance trip-cancellation coverage actually pays. If you booked through a travel agent, the agent's cancellation terms may add penalties. If the cancellation happens after final payment but before sailing, the cruise line's standard cancellation schedule may apply unless the cruise line itself cancelled (which is the scenario here — in that case full refund applies)."}
+      },
+      {
+        "@type":"Question",
+        "name":"Can the cruise line change my embarkation port?",
+        "acceptedAnswer":{"@type":"Answer","text":"Yes, and it happens — usually due to hurricanes, port construction, or labor disputes affecting the originally-scheduled embarkation port. When the cruise line substitutes the embarkation port (for example, moving an originally-scheduled Miami departure to Port Canaveral or Port Everglades), the line typically covers transportation costs between the original and substitute ports: bus transfer, or in some cases reimbursement for flight changes. The cruise line will email all booked passengers as soon as the substitution is announced, usually with 7-14 days notice when weather is the cause, sometimes more notice for planned changes. Make sure your cabin email and contact information are current on the booking — that's where the notice lands."}
+      },
+      {
+        "@type":"Question",
+        "name":"When should I escalate beyond Guest Services?",
+        "acceptedAnswer":{"@type":"Answer","text":"Day-of, Guest Services has limited authority over itinerary-change compensation. The compensation amount is set centrally by the cruise line operations team and the onboard staff cannot meaningfully adjust it. Escalating onboard usually accomplishes nothing beyond a more sympathetic apology. Post-cruise, a written complaint to the cruise line's executive offices (every major line has a customer relations team or executive office) sometimes produces additional goodwill credit — typically a small future-cruise-credit gesture. For travel insurance disputes, escalate to the insurance carrier's claims department first; if that fails, file a complaint with your state's insurance commissioner. For booking-fee disputes (rare), the credit card chargeback path is available. Better Business Bureau complaints rarely produce results for itinerary disputes specifically."}
+      },
+      {
+        "@type":"Question",
+        "name":"Should I update my shore-side emergency contact when an itinerary changes?",
+        "acceptedAnswer":{"@type":"Answer","text":"Yes — especially for substantive changes (diverted sailings, embark-port substitutions, ports in a different country than originally scheduled). Your shore-side person needs the updated information to reach you in an emergency: the updated port-of-call list, updated dates if anything shifted, updated embassy contact numbers for the new ports. The Reaching Someone at Sea reference on this site holds the contact channels; the handoff card you shared with that person should be updated when the itinerary changes substantially. Missed-port-only situations rarely require an update because the sea day replaces the port day on the same date."}
+      }
+    ]
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+        <span class="tiny version-badge">V1.Beta</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Planning <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships.html">Ships</a>
+            <a href="/cruise-lines.html">Cruise Lines</a>
+            <a href="/ports.html">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Tools <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/cruise-tipping-calculator.html">Tipping Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Onboard <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants.html">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">Travel <span class="caret">&#9662;</span></button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="Cruise itinerary changes practical guide">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">When the Itinerary Changes</div>
+    </div>
+  </header>
+
+  <main id="main-content" class="page" role="main">
+    <article itemscope itemtype="https://schema.org/Article" class="logbook">
+      <header style="max-width:min(860px,92%);margin-inline:auto">
+        <h1 itemprop="headline">Cruise Itinerary Changes: What to Do When a Port Is Missed, Diverted, or Cancelled</h1>
+        <p class="dek" itemprop="description">Roughly one in eight Caribbean sailings and one in five Alaska sailings see at least one itinerary change. The cruise contract gives the line broad latitude. Travel insurance language is specific. What the four scenarios actually look like, what each one is worth, and how to claim cleanly.</p>
+        <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-05-27">May 27, 2026</time></p>
+      </header>
+
+      <div itemprop="articleBody" style="max-width:min(860px,92%);margin-inline:auto">
+
+      <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
+        <strong>Answer first:</strong> Itinerary changes are common enough that every cruiser should know the four scenarios and what each is worth. A <strong>missed port</strong> gets you port fees back plus typically $25-$100 onboard credit per cabin. A <strong>diverted sailing</strong> gets you $100-$300 onboard credit plus sometimes a future-cruise-credit gesture. A <strong>full cancellation</strong> triggers the cruise contract: 100% cash refund or 125-150% future cruise credit, passenger's choice on most major lines. An <strong>embark-port substitution</strong> obligates the line to cover transport to the new port. Travel insurance trip-interruption coverage rarely fires for a missed port — that's the line's interruption, not yours. Cruise-specific insurance plans (Nationwide Universal Cruise, BHTP WaveCare) include $75-$500 itinerary-change benefits. The cruise contract gives the line broad latitude; what you actually receive is mostly goodwill, calibrated by the line's reputation incentives. Keep your shore-side person updated when the itinerary changes substantively.
+      </p>
+
+      <nav class="article-toc" aria-label="In this article" style="max-width:min(860px,92%);margin:1.5rem auto;padding:1rem 1.25rem;background:#f8fbfc;border-left:3px solid #d0e4f0;border-radius:4px">
+        <h2 style="margin-top:0;font-size:1.05rem">In this article</h2>
+        <ol style="margin:0.5rem 0 0;padding-left:1.25rem;line-height:1.8">
+          <li><a href="#why-changes">Why itineraries change</a></li>
+          <li><a href="#scenario-missed">Scenario 1 — Missed port</a></li>
+          <li><a href="#scenario-diverted">Scenario 2 — Diverted sailing</a></li>
+          <li><a href="#scenario-cancelled">Scenario 3 — Full cancellation</a></li>
+          <li><a href="#scenario-embark">Scenario 4 — Embark-port substitution</a></li>
+          <li><a href="#what-line-owes">What the cruise line owes you</a></li>
+          <li><a href="#insurance-flow">The travel insurance claim flow</a></li>
+          <li><a href="#shore-side">The shore-side notification</a></li>
+          <li><a href="#escalation">When and how to escalate</a></li>
+          <li><a href="#what-good-lines-do">What good cruise lines do well</a></li>
+          <li><a href="#decision">The decision framework</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ol>
+      </nav>
+
+      <h2 id="why-changes">Why itineraries change</h2>
+
+      <p>Five categories cover almost every itinerary change a passenger encounters.</p>
+
+      <p><strong>Weather.</strong> The dominant cause. Hurricanes in the Caribbean and Gulf of Mexico (June through November), fog in Alaska's Inside Passage (especially May and September shoulder weeks), rough seas across the North Atlantic, and stormy weather in the Mediterranean shoulder season all force port skips or full diversions. <a href="/articles/hurricane-season-2026-cruisers.html">The 2026 hurricane season article</a> covers the Caribbean-specific case in detail.</p>
+
+      <p><strong>Mechanical and operational.</strong> Engine issues, propulsion problems, technical faults that reduce maximum speed, or port-side berth conflicts (another ship not departing on time) cause port skips and occasional diversions. Less common than weather; usually announced day-of.</p>
+
+      <p><strong>Medical emergencies.</strong> A passenger requiring evacuation to a regional hospital sometimes forces the ship to divert from its scheduled route. The medical center stabilizes the patient; if they need shoreside care, the captain may divert to the nearest port with adequate medical facilities. The diversion takes hours to a full day depending on distance.</p>
+
+      <p><strong>Geopolitical port closures.</strong> Sudden port closures driven by political events, security incidents, civil unrest, or sanctions. Russia in 2022, Israel in 2023-2024, and individual Caribbean countries during election periods have all produced last-minute itinerary changes. The 2026 cruise season carried geopolitical caveats in Eastern Mediterranean and Red Sea itineraries especially.</p>
+
+      <p><strong>Commercial decisions.</strong> The rarest cause. The cruise line decides a port isn't economically viable for the season, or a port authority and the line fail to reach terms. The MSC Cruises Ocean Cay marine reserve was developed precisely to give MSC commercial control over a Bahamian port. Royal Caribbean's <a href="/articles/perfect-day-mexico-rejected-2026.html">recently-rejected Perfect Day Mexico project</a> would have served the same commercial-control purpose. Commercial port substitutions are announced weeks or months ahead, not day-of.</p>
+
+      <h2 id="scenario-missed">Scenario 1 — Missed port</h2>
+
+      <p>The most common itinerary change. The ship sails past a scheduled port — sometimes hours before arrival, sometimes overnight, sometimes mid-morning of the scheduled call. The captain announces the change. The port day becomes a sea day, or the line announces a substitute port reachable within the existing sea-day window.</p>
+
+      <p><strong>What happens onboard:</strong> Captain's announcement explaining the reason (weather, mechanical, operational). The cruise director or hotel manager follows up with the practical implications: amended day schedule, possibly additional onboard activities to fill the unexpected sea day, possibly a substitute port. Onboard credit is posted to your folio automatically within 24-48 hours.</p>
+
+      <p><strong>What you're owed legally:</strong> Per the cruise contract, port fees and taxes for the missed port. These typically run $15-$50 per person and are returned as onboard credit during the sailing.</p>
+
+      <p><strong>What major lines actually pay as goodwill:</strong> An additional $25-$100 per cabin in onboard credit, sometimes higher for popular missed ports (a missed CocoCay or Ocean Cay generates larger goodwill because those are major selling points). Free drinks or a discounted specialty restaurant during the unexpected sea day is occasional. Compensation is set centrally and consistent across same-line passengers on the same sailing.</p>
+
+      <p><strong>Insurance:</strong> Standard trip interruption coverage does not pay — the interruption is to the line's itinerary, not your trip. Cruise-specific plans with missed-port or itinerary-change benefits pay $75-$500 typically (Nationwide Universal Cruise's Itinerary Change Inconvenience benefit is the cleanest example). Worth filing if you have that specific coverage; otherwise accept the onboard credit and move on. See the <a href="/articles/cruise-travel-insurance-2026.html">cruise travel insurance article</a> for which plans include this coverage.</p>
+
+      <h2 id="scenario-diverted">Scenario 2 — Diverted sailing</h2>
+
+      <p>Multiple ports replaced. The route substantively shifts. A Western Caribbean itinerary becomes an Eastern Caribbean itinerary mid-cruise because a Gulf hurricane is closing Gulf ports. A planned Mediterranean run including Cyprus and Israel becomes a Greek-islands-only sailing because of regional security concerns. The itinerary the passenger booked is no longer the itinerary the passenger is on.</p>
+
+      <p><strong>What happens onboard:</strong> Captain's announcement, often delivered the evening before the planned change or first-thing-in-the-morning if conditions developed overnight. Hotel manager or cruise director communicates the new schedule. Onboard credit is posted across the affected cabins, usually within 24 hours.</p>
+
+      <p><strong>What you're owed legally:</strong> Still very little. The cruise contract's "itinerary subject to change without notice" language covers diversions. Port fees for missed ports are refunded; that's the legal floor.</p>
+
+      <p><strong>What major lines actually pay as goodwill:</strong> $100-$300 per cabin in onboard credit, sometimes more for cruises sold on a specific port (Galapagos cruises that miss the Galapagos, Alaska cruises that skip Glacier Bay). Future cruise credit in the 10-25% range is occasional, more common when the diversion compromised a substantial portion of the trip. The compensation calibrates to how much of the itinerary changed and what the line knew when.</p>
+
+      <p><strong>Insurance:</strong> Cruise diversion coverage is the relevant benefit. BHTP WaveCare includes cruise diversion as a named coverage; some Allianz tiers offer related benefits. Trip interruption fires only if the diversion forces you to leave the cruise early (almost never for a route change). The compensation that matters is mostly the cruise line's goodwill payment.</p>
+
+      <h2 id="scenario-cancelled">Scenario 3 — Full cancellation</h2>
+
+      <p>The entire sailing is cancelled — either before departure or, very rarely, in-progress. Pre-departure cancellation is the more common case: a mechanical issue requires unscheduled drydock, a hurricane closes the homeport, a regional emergency forces the line to ground the ship. In-progress cancellation is rare but happens; an unrepairable mechanical fault, a major outbreak, or a regional crisis can force the line to terminate the sailing and disembark passengers at the next workable port.</p>
+
+      <p><strong>What happens:</strong> Notification by email and phone to the booked-passenger contact information on file. Major lines provide notice as soon as the operational decision is made, usually 7-14 days for weather-driven cancellations and 24-72 hours for mechanical or emergency cancellations.</p>
+
+      <p><strong>What you're owed legally:</strong> The cruise contract obligates a full refund of cruise fare. The major lines' standard practice goes substantially further.</p>
+
+      <p><strong>What major lines actually pay:</strong> Two refund paths, passenger's choice:</p>
+
+      <ul>
+        <li><strong>100% cash refund</strong> of cruise fare paid, processed within 30-90 days to the original payment method</li>
+        <li><strong>125-150% future cruise credit</strong> applicable to a different sailing, typically valid 12-24 months, non-transferable</li>
+      </ul>
+
+      <p>Independently-booked components — flights, hotels, pre-cruise transfers, post-cruise extensions — are not refunded by the cruise line. That's where travel insurance trip-cancellation coverage actually pays. If you booked flights through the cruise line's air program (Royal Caribbean Air2Sea, Princess EZ-Air, etc.), the line typically refunds or rebooks those.</p>
+
+      <p><strong>Insurance:</strong> Trip cancellation triggers cleanly for full cancellation. File with documentation of the cruise line's cancellation notice and your booked-but-not-refunded components (flights, hotels, transfers). For independently-booked components specifically, the insurance is the path to reimbursement.</p>
+
+      <h2 id="scenario-embark">Scenario 4 — Embark-port substitution</h2>
+
+      <p>The ship will depart from a different port than originally scheduled. Most often weather-driven: a hurricane is closing PortMiami, so the sailing departs from Port Canaveral instead. Sometimes scheduled: dry-dock work at the homeport forces the line to use a substitute port for a specific sailing.</p>
+
+      <p><strong>What happens:</strong> Email and phone notification to booked passengers, usually 7-14 days for weather-driven substitutions, more notice for planned changes. The line provides specific information about the new embark port, the travel logistics, and what the line will cover.</p>
+
+      <p><strong>What you're owed:</strong> Major lines cover transportation from the originally-scheduled port to the substitute port — usually as a bus transfer the line arranges, or as a flight-rebooking allowance if the cruise was booked with the line's air program. For independently-booked flights, the line typically provides a credit or transportation alternative.</p>
+
+      <p><strong>What's worth doing:</strong> If your flights are booked separately, contact the airline immediately — most airlines waive change fees for cruise embark-port substitutions when the cruise line provides documentation. The cruise line's customer relations team can provide that documentation. If your hotel is booked separately and you've prepaid the night before sailing, contact the hotel — most will allow rebooking or partial refund given the cause.</p>
+
+      <p><strong>Insurance:</strong> Trip-change coverage may pay for the additional travel costs not covered by the cruise line. Document everything: the original port, the new port, the cruise line's substitution notice, the costs incurred.</p>
+
+      <h2 id="what-line-owes">What the cruise line owes you — legal vs goodwill</h2>
+
+      <p>The cruise contract is the legal floor. The goodwill payment is everything above the floor. The floor is very low.</p>
+
+      <p>Every major cruise line's ticket contract includes language giving the line the right to change the itinerary, substitute ports, or cancel the cruise without notice and without liability beyond a refund of cruise fare in cases of full cancellation. The standard language is more specific than that — covering acts of God, mechanical failures, weather, safety concerns, government action, and "any other cause" — but the practical effect is the same. The line has near-complete operational latitude.</p>
+
+      <p>Federal U.S. cruise law — the Cruise Vessel Security and Safety Act of 2010 (Public Law 111-207) — covers onboard safety, incident reporting, and physical security. It does not regulate itinerary changes. Cruise-specific consumer protection at the federal level is thin. Some state laws apply to specific aspects of the booking transaction (Florida and California especially) but rarely to the itinerary itself.</p>
+
+      <p>EU Regulation 1177/2010 gives more passenger rights for cruises departing EU ports, including the right to information, alternative transport in some circumstances, and refunds for significant delays. UK passengers on ABTA-member-booked cruises have additional bonded protection covering the booking but not itinerary specifics. <a href="/articles/cruise-travel-safety-shore-side-net.html">The cruise travel safety article</a> covers the broader legal protections framework.</p>
+
+      <p>The good news inside this commercial latitude: every major U.S. cruise line has developed consistent goodwill standards because the alternative is reputation damage. The amounts have remained stable across cruise lines and across years. When you receive $50 onboard credit for a missed Costa Maya, you're receiving roughly what every other cruiser on that sailing received and what Royal Caribbean cruisers received last summer when their CocoCay day went sideways.</p>
+
+      <h2 id="insurance-flow">The travel insurance claim flow</h2>
+
+      <p>Travel insurance and cruise line compensation operate on different tracks. The insurance claim is documentation-driven and slower; the cruise line goodwill is automatic and posted to your folio within days. Don't expect insurance to compensate you for things the cruise line is already compensating; file the insurance for what the cruise line doesn't cover.</p>
+
+      <p><strong>For a missed port:</strong> If you have cruise-specific itinerary-change coverage (BHTP WaveCare, Nationwide Universal Cruise, certain Allianz tiers), file a claim with the cruise line's official missed-port documentation. Most lines will email you a confirmation letter after disembarkation if you request one through Guest Services. The insurance pays the cruise-specific benefit ($75-$500 typically) on top of the cruise line's goodwill.</p>
+
+      <p><strong>For a diverted sailing:</strong> Same documentation pattern; the cruise diversion benefit fires (where coverage applies). The amounts are larger than missed-port benefits typically — $250-$1,000 depending on plan.</p>
+
+      <p><strong>For full cancellation:</strong> Trip cancellation coverage triggers cleanly. File with documentation of:</p>
+
+      <ul>
+        <li>The cruise line's cancellation notice (email or letter)</li>
+        <li>Your booked but not refunded independently-booked components (flights, hotels, transfers)</li>
+        <li>Receipts for any reasonable replacement-vacation costs if your policy includes that benefit</li>
+      </ul>
+
+      <p><strong>For embark-port substitution:</strong> Trip-change benefit (if your policy includes one) plus any out-of-pocket travel costs not covered by the cruise line. Document the original port, the substitute port, the cruise line's notice, and every receipt.</p>
+
+      <p><strong>Timing:</strong> File claims within the policy's required window (usually 30-90 days from the event). Earlier is better — documentation is easier to gather while events are recent, and the insurance carrier processes faster.</p>
+
+      <h2 id="shore-side">The shore-side notification</h2>
+
+      <p>When the itinerary changes substantively, your shore-side person needs to know. The whole point of the handoff card from <a href="/reaching-someone-at-sea.html">the Reaching Someone at Sea reference</a> is that they have current information to reach you in an emergency. An itinerary change that moves you from Cozumel to Costa Maya on the same date doesn't substantially change their information. A diverted sailing that takes you from a planned Greek-islands itinerary to a Western Mediterranean itinerary substantially does.</p>
+
+      <p>For substantive changes: a quick message to your shore-side person via the ship's Wi-Fi with the updated port-of-call list, dates if anything shifted, and the embassy contact numbers for the new ports if the destination country changed. The Reaching Someone at Sea handoff card should be re-shared with the updated information; a fresh email replacing the old one is the simplest path. The State Department's Overseas Citizens Services line (+1-888-407-4747) doesn't change, so your shore-side person's universal fallback is intact regardless.</p>
+
+      <p>For missed-port-only situations: no update needed in most cases. The replacement sea day is on the same date; you're still reachable via the cruise line's ship-to-shore family contact desk.</p>
+
+      <h2 id="escalation">When and how to escalate</h2>
+
+      <p>Day-of, Guest Services has limited authority. The compensation amount is set centrally by the cruise line's operations team and the onboard staff cannot meaningfully adjust it. Asking the front-desk supervisor for "more" usually accomplishes nothing beyond a more sympathetic apology — the calibrated goodwill payment is what's available.</p>
+
+      <p>Three escalation paths are real:</p>
+
+      <p><strong>Hotel manager or food and beverage manager onboard:</strong> Useful when the itinerary change has produced a specific service problem (a specialty restaurant booked for a port-day evening is now competing with everyone else for the same evening, your shore excursion was prepaid through the line and now has no port to operate in, etc.). The hotel manager can adjust those specific service-recovery scenarios but cannot adjust the standard compensation.</p>
+
+      <p><strong>Cruise line executive office, post-cruise:</strong> A written complaint to customer relations or the executive office sometimes produces additional goodwill credit, typically a small future-cruise-credit gesture in the 10-15% range. What works best: be specific about the lost value (named excursion booked and paid for, specific port that was the reason for booking, etc.), calm tone, request a specific remedy.</p>
+
+      <p><strong>Travel insurance carrier dispute:</strong> If the carrier denies a legitimate claim, escalate to the carrier's claims supervisor first. If that fails, file a complaint with your state's insurance commissioner — every state has one and they take cruise-related complaints. Resolution timeline runs 30-90 days.</p>
+
+      <p>Paths that rarely work for itinerary disputes specifically: Better Business Bureau complaints, credit card chargebacks (the line provided what was contracted for under the broad-latitude itinerary clause), and small claims court. The cruise contract's choice-of-forum provisions usually require disputes to be filed in specific federal districts.</p>
+
+      <h2 id="what-good-lines-do">What good cruise lines do well during an itinerary change</h2>
+
+      <p>The lines that handle itinerary changes well share four behaviors.</p>
+
+      <p><strong>Early communication.</strong> The captain announces the change as soon as the operational decision is made, not when it's convenient. A weather-driven port skip announced at 7 AM on the morning of the call gives passengers time to adjust the day's plans; the same skip announced at noon after the ship is already past the port leaves people angry on top of disappointed. Major lines have improved on this dimension over the past five years; the laggards are notable.</p>
+
+      <p><strong>Specific explanations.</strong> "Due to weather we'll be skipping today's call at Cozumel" leaves passengers without context. "Tropical Storm Phyllis has shifted west overnight, the forecast for Cozumel through tomorrow morning is sustained winds above 35 knots which exceeds our safe-tender threshold, we'll continue to Belize City and add hours there to give you a full port day" gives passengers the reason and the remedy. The specificity correlates with trust.</p>
+
+      <p><strong>Equivalent substitution where possible.</strong> A missed Cozumel becomes a substituted Costa Maya rather than just a sea day, when distance and weather allow. Major lines maintain pre-planned substitute-port pairings precisely for this scenario. The substitution doesn't always work logistically but the attempt matters.</p>
+
+      <p><strong>Proportional goodwill.</strong> Compensation calibrated to what was lost, not to a flat policy. Missed Glacier Bay on an Alaska itinerary that sold on glacier viewing produces meaningfully larger goodwill than a missed shopping-stop port. The line that recognizes the difference earns repeat bookings; the line that pays $50 across the board for everything trains its passengers to expect $50 and feel cheated when value lost is larger.</p>
+
+      <h2 id="decision">The decision framework — accept, claim, or escalate</h2>
+
+      <p><strong>Accept onboard compensation and move on</strong> when: the missed port wasn't the main reason you booked this sailing, the substitution preserves the trip's character, the goodwill credit roughly matches the value lost, and your travel insurance doesn't include cruise-specific itinerary-change coverage.</p>
+
+      <p><strong>Accept onboard compensation and also file an insurance claim</strong> when: you have cruise-specific itinerary-change coverage on your travel insurance, the cruise line's onboard credit was modest relative to the value lost, and the insurance benefit is worth the documentation effort. Both payments are designed to stack.</p>
+
+      <p><strong>Escalate to the cruise line's executive office post-cruise</strong> when: the missed port was the primary reason you booked this sailing, the goodwill credit was disproportionately small, you have specific lost-value documentation (prepaid shore excursion through a third party, a wedding anniversary tied to a specific port, a research trip with a specific port as the reason), and you can be calm and specific in writing.</p>
+
+      <p><strong>Pursue further claims (insurance escalation, state insurance commissioner)</strong> only when: an insurance claim was denied for a legitimate covered event, you have the documentation to support reversal, and the amount at stake justifies the time investment.</p>
+
+      <p><strong>Let it go</strong> when: the change was weather-driven, the cruise line communicated early and offered proportional compensation, and your insurance didn't include the specific cruise scenarios. Itinerary changes are part of the structural risk of cruise vacations; pursuing every missed-port through every available channel produces frustration and rarely produces meaningful additional compensation.</p>
+
+      <h2 id="faq">Frequently asked questions</h2>
+
+      <details class="section-divider">
+        <summary><strong>What happens if my cruise ship skips a port?</strong></summary>
+        <p class="list-indent">You receive port fees and taxes back (typically $15-$50 per person as onboard credit) plus usually $25-$100 per cabin in goodwill credit. Some lines substitute a different port; others just have an extra sea day. Standard trip-interruption coverage on travel insurance usually does not pay because the interruption is to the line's itinerary, not your trip. Cruise-specific itinerary-change benefits (Nationwide Universal Cruise, BHTP WaveCare) pay $75-$500 if you have that coverage.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What is my cruise line legally required to do if it changes the itinerary?</strong></summary>
+        <p class="list-indent">In the U.S., very little — the cruise contract gives the line broad latitude to change itineraries without liability. Federal cruise law (CVSSA) covers onboard safety but not itinerary changes. EU Regulation 1177/2010 gives more rights for EU-departing cruises. Outside EU departures, what the line gives you is goodwill, not law. Major lines have developed consistent goodwill standards because the alternative is reputation damage.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What is the difference between a missed port and a diverted sailing?</strong></summary>
+        <p class="list-indent">Missed port skips one stop, with the ship continuing to the next scheduled port. Diverted sailing changes the route substantially. Missed-port compensation is typically port fees plus modest onboard credit ($25-$100 per cabin). Diverted sailing compensation tends to be larger: $100-$300 per cabin plus sometimes a future-cruise-credit gesture of 10-25%.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Does travel insurance pay for a missed cruise port?</strong></summary>
+        <p class="list-indent">Standard trip-interruption coverage usually does not pay because the interruption is to the cruise line's itinerary, not your trip. Two types of coverage do help: cruise-specific plans with explicit Itinerary Change Inconvenience or Missed Port benefits (Nationwide Universal Cruise, BHTP WaveCare, certain Allianz tiers) pay $75-$500. Trip interruption pays when you yourself must leave the cruise early due to a covered reason (medical emergency, etc.).</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>What happens if my entire cruise is cancelled before sailing?</strong></summary>
+        <p class="list-indent">Most major lines offer two refund paths and let you choose: 100% cash refund of cruise fare, or 125-150% future cruise credit. Cash refunds process within 30-90 days. Independently-booked components (flights, hotels) are not refunded by the cruise line — that's where travel insurance trip-cancellation coverage actually pays.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Can the cruise line change my embarkation port?</strong></summary>
+        <p class="list-indent">Yes — usually due to hurricanes or port construction. When the line substitutes the embark port, they typically cover transportation between the original and substitute ports (bus transfer or flight allowance). Email and phone notice is provided 7-14 days ahead for weather-driven substitutions. Make sure your booking contact information is current.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>When should I escalate beyond Guest Services?</strong></summary>
+        <p class="list-indent">Day-of, Guest Services has limited authority — onboard compensation is set centrally. Post-cruise, a written complaint to the cruise line's executive office sometimes produces additional goodwill, typically a small future-cruise-credit gesture. For travel insurance disputes, escalate to the carrier's claims department; if that fails, file with your state's insurance commissioner. BBB complaints rarely produce results for itinerary disputes.</p>
+      </details>
+
+      <details class="section-divider">
+        <summary><strong>Should I update my shore-side emergency contact when an itinerary changes?</strong></summary>
+        <p class="list-indent">For substantive changes (diverted sailings, embark-port substitutions, ports in a different country than originally scheduled), yes — your shore-side person needs the updated information to reach you. For missed-port-only situations, no update needed; the replacement sea day is on the same date.</p>
+      </details>
+
+      <h2 id="closing">The pastoral close</h2>
+
+      <p>Disappointment over a missed port is real. The day you'd planned for, the excursion you'd looked forward to, the photograph you imagined taking — they're not happening today, and the announcement was probably brief, possibly delivered while you were already in line for tendering, possibly without the kind of context that would help the disappointment land softly.</p>
+
+      <p>The cruise line's commercial latitude is also real. Itinerary changes are baked into the cost structure, the operational model, and the safety calculus of every major line. The compensation system is designed to be calibrated rather than generous — enough to acknowledge what was lost, not enough to make missed-port compensation a profitable line item.</p>
+
+      <p>The honest middle path: take the onboard credit. File the insurance claim if you have the coverage. Update your shore-side person if the change is substantive. Skip the escalation theater unless the value lost was concretely significant. The cruise you have left is still the cruise. Tomorrow's port may be the one you remember.</p>
+
+      <h2 id="related">Related reading</h2>
+
+      <ul>
+        <li><a href="/articles/cruise-travel-insurance-2026.html">Cruise Travel Insurance in 2026</a> — comprehensive reference on which insurance plans include cruise-specific itinerary-change coverage</li>
+        <li><a href="/articles/cruise-travel-safety-shore-side-net.html">Cruise Travel Safety: The Shore-Side Safety Net</a> — the broader operational framework your shore-side person operates inside</li>
+        <li><a href="/reaching-someone-at-sea.html">Reaching Someone at Sea</a> — the emergency contact reference and handoff card for substantive itinerary changes</li>
+        <li><a href="/articles/hurricane-season-2026-cruisers.html">Hurricane Season 2026 for Cruisers</a> — the most common cause of itinerary changes during the June-November Caribbean window</li>
+        <li><a href="/articles/perfect-day-mexico-rejected-2026.html">Perfect Day Mexico, Rejected</a> — the recent commercial-decision example of why itineraries change at the strategic level</li>
+        <li><a href="/articles/hantavirus-cruise-ships-2026.html">Hantavirus on Cruise Ships 2026</a> — context on health-driven itinerary disruption</li>
+        <li><a href="/articles/cruise-tipping-2026.html">Cruise Tipping for 2026</a> — the related question of what the gratuity does and doesn't buy in service-recovery scenarios</li>
+        <li><a href="/tools/cruise-budget-calculator.html">Cruise Budget Calculator</a> — for re-evaluating sunk costs when an itinerary change affects ancillary expenses</li>
+      </ul>
+
+      </div>
+    </article>
+  </main>
+
+  <footer class="wrap footer" role="contentinfo">
+    <p>&copy; 2026 In the Wake. All rights reserved.</p>
+    <p class="trust-badge">✓ No ads. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+    <nav aria-label="Footer navigation">
+      <ul style="list-style:none;padding:0;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
+        <li><a href="/about-us.html">About</a></li>
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/reaching-someone-at-sea.html">Reach Family at Sea</a></li>
+        <li><a href="/affiliate-disclosure.html">Affiliate Disclosure</a></li>
+      </ul>
+    </nav>
+    <p class="tiny center" style="margin-top:.5rem;opacity:0.7">
+      Soli Deo Gloria — Every pixel and part of this project is offered as worship to God.
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -73,6 +73,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://cruisinginthewake.com/articles/cruise-itinerary-changes-what-to-do.html</loc>
+    <lastmod>2026-05-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://cruisinginthewake.com/articles/msc-voyagers-club-status-match-from-rcl-diamond.html</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>weekly</changefreq>


### PR DESCRIPTION
… in the safety-cluster triangle

Third article in today's safety-cluster trio. Pairs naturally with the cruise-travel-insurance-2026 article published earlier today and the existing cruise-travel-safety-shore-side-net reference.

Article structure (~2,500 words, 15 H2 sections):

- Answer-first lede naming the four scenarios + their value
- §Why itineraries change — five causes (weather, mechanical, medical, geopolitical, commercial) with current 2026 context (hurricane season, Israel/Red Sea, Perfect Day Mexico rejected)
- §Scenario 1: Missed port — most common, $25-$100/cabin
- §Scenario 2: Diverted sailing — multiple ports, $100-$300/cabin
- §Scenario 3: Full cancellation — cruise contract refund rights, 100% cash or 125-150% FCC choice
- §Scenario 4: Embark-port substitution — line covers transport
- §What the cruise line owes you — legal vs goodwill, CVSSA doesn't cover this, EU 1177/2010 gives more rights for EU-departing
- §Travel insurance claim flow — separate tracks from cruise line compensation, cross-link to insurance article for the specific plans with cruise-itinerary-change benefits
- §Shore-side notification protocol — when itinerary changes substantively, your handoff card needs updating
- §When and how to escalate — Guest Services has limited authority; post-cruise executive office sometimes pays
- §What good cruise lines do well — four behaviors: early communication, specific explanations, equivalent substitution, proportional goodwill
- §Decision framework — accept / claim / escalate / let it go
- §FAQ — 8 Q&As matching JSON-LD schema
- §Pastoral close — disappointment is real, commercial latitude is real, take the credit, file insurance if covered, update shore-side, skip escalation theater for small claims

Cross-links to insurance article (today), travel safety article, reaching-someone-at-sea, hurricane-season-2026, perfect-day-mexico, hantavirus, tipping article.

Voice/standards:
- 0 banned vocabulary instances (one "leverage" caught and replaced with "What works best")
- 1 H1, 15 H2 sections, sequential hierarchy
- Full ICP-2 metadata + Article + Person + FAQPage schemas
- Pastoral honesty: cruisers feel disappointment over missed ports; the line operates inside contractual latitude; the honest middle path is take onboard credit + file insurance if covered + update shore-side person + skip escalation theater unless real value was lost
- No fearmongering, no affiliate selling

Wired into articles.html (top of Popular Guides) and sitemap.xml (priority 0.9, monthly changefreq).