### PR TITLE
fix(#1625): update stale counts in manifest.webmanifest

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -14,7 +14,7 @@
     { "src": "/assets/icons/icon-512-maskable.png?v=14.2.0", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
   ],
   "lang": "en-US",
-  "description": "9 cruise planning tools, 380 port guides, 294 ship profiles, 472 dining venues, and offline-ready resources from In the Wake. Soli Deo Gloria.",
+  "description": "11 cruise planning tools, 388 port guides, 296 ship profiles, 472 dining venues, and offline-ready resources from In the Wake. Soli Deo Gloria.",
   "categories": ["travel", "lifestyle"],
   "shortcuts": [
     {
@@ -26,12 +26,12 @@
     {
       "name": "Port Guides",
       "url": "/ports.html",
-      "description": "380 cruise port guides with maps and tips"
+      "description": "388 cruise port guides with maps and tips"
     },
     {
       "name": "Ship Profiles",
       "url": "/ships.html",
-      "description": "297 ship profiles across 15 cruise lines"
+      "description": "296 ship profiles across 15 cruise lines"
     },
     {
       "name": "Stateroom Check",


### PR DESCRIPTION
- description: 9→11 tools, 380→388 ports, 294→296 ships
- Port Guides shortcut: 380→388 ports
- Ship Profiles shortcut: 297→296 ships

Counts verified against disk:
- 296 ship HTML files (find ships/ -name '*.html' ! -name 'index.html')
- 388 port HTML files (find ports/ -name '*.html' ! -name 'index.html')
- 11 tools confirmed in grid (index.html)

Note: 472 dining venues unchanged; actual count is 478 (flagged separately)