### PR TITLE
assets/data/articles/index.json: register 6 missing articles in the r…

### DIFF
--- a/assets/data/articles/index.json
+++ b/assets/data/articles/index.json
@@ -2,6 +2,159 @@
   "version": "v3.010.400",
   "articles": [
     {
+      "id": "cruise-itinerary-changes-what-to-do",
+      "slug": "cruise-itinerary-changes-what-to-do",
+      "title": "Cruise Itinerary Changes: What to Do When a Port Is Missed, Diverted, or Cancelled",
+      "url": "/articles/cruise-itinerary-changes-what-to-do.html",
+      "date": "2026-05-27",
+      "published": "2026-05-27",
+      "status": "published",
+      "excerpt": "Roughly one in eight Caribbean sailings and one in five Alaska sailings see at least one itinerary change. The cruise contract gives the line broad latitude. Travel insurance language is specific. A practical guide to the four scenarios — missed port, diverted sailing, full cancellation, embark-port substitution — what each is worth, and how to claim cleanly.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {
+        "name": "Ken Baker",
+        "url": "/authors/ken-baker.html",
+        "image": "/authors/img/ken1.jpg?v=3.009.023"
+      },
+      "keywords": [
+        "cruise-itinerary-changes",
+        "missed-port",
+        "cruise-cancellation",
+        "travel-insurance-claims",
+        "cruise-contract",
+        "cruise-planning"
+      ]
+    },
+    {
+      "id": "cruise-travel-insurance-2026",
+      "slug": "cruise-travel-insurance-2026",
+      "title": "Cruise Travel Insurance in 2026: What You Actually Need, How the Major Plans Compare",
+      "url": "/articles/cruise-travel-insurance-2026.html",
+      "date": "2026-05-27",
+      "published": "2026-05-27",
+      "status": "published",
+      "excerpt": "An ad-free comprehensive reference. Side-by-side coverage comparison of cruise line in-house plans (Royal Caribbean, Carnival, Norwegian, MSC, Princess, Holland America, Celebrity, Disney) and the major third-party insurers (Allianz, BHTP WaveCare, Travel Guard, Travelex, Nationwide, Generali, Seven Corners, IMG). Plus Medjet, credit card coverage, CFAR, and pre-existing condition waivers.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {
+        "name": "Ken Baker",
+        "url": "/authors/ken-baker.html",
+        "image": "/authors/img/ken1.jpg?v=3.009.023"
+      },
+      "keywords": [
+        "cruise-travel-insurance",
+        "trip-insurance",
+        "medical-evacuation",
+        "cancel-for-any-reason",
+        "pre-existing-condition-waiver",
+        "cruise-planning"
+      ]
+    },
+    {
+      "id": "cruise-travel-safety-shore-side-net",
+      "slug": "cruise-travel-safety-shore-side-net",
+      "title": "Cruise Travel Safety: The Shore-Side Safety Net Every Traveler Should Set Up Before Sailing",
+      "url": "/articles/cruise-travel-safety-shore-side-net.html",
+      "date": "2026-05-24",
+      "published": "2026-05-24",
+      "status": "published",
+      "excerpt": "The single most important piece of pre-cruise preparation isn't a packing list — it's a person back home with the right information. One trusted person back home with the right info can resolve almost any at-sea or in-port emergency through three institutional channels — the cruise line ship-to-shore desk, your country's consular service, and the embassy in the affected port. Ten minutes today. Could matter on the one day it does.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {
+        "name": "Ken Baker",
+        "url": "/authors/ken-baker.html",
+        "image": "/authors/img/ken1.jpg?v=3.009.023"
+      },
+      "keywords": [
+        "cruise-travel-safety",
+        "solo-travel-safety",
+        "emergency-contacts",
+        "shore-side-handoff",
+        "cruise-planning",
+        "accessibility"
+      ]
+    },
+    {
+      "id": "perfect-day-mexico-rejected-2026",
+      "slug": "perfect-day-mexico-rejected-2026",
+      "title": "Perfect Day Mexico, Rejected: What Royal Caribbean's $600M Setback Actually Means",
+      "url": "/articles/perfect-day-mexico-rejected-2026.html",
+      "date": "2026-05-24",
+      "published": "2026-05-24",
+      "status": "published",
+      "excerpt": "Mexico's environment ministry blocked Royal Caribbean's $600M Perfect Day Mexico project on May 22, 2026, after a 4.8-million-signature petition and a direct statement from President Sheinbaum. Royal Caribbean's response says Round 2, not surrender. A $600 million investment commitment doesn't get walked away from after one regulatory setback. What this means for cruisers, the Mesoamerican Reef, and the future of private cruise destinations.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {
+        "name": "Ken Baker",
+        "url": "/authors/ken-baker.html",
+        "image": "/authors/img/ken1.jpg?v=3.009.023"
+      },
+      "keywords": [
+        "royal-caribbean",
+        "perfect-day-mexico",
+        "mahahual",
+        "mesoamerican-reef",
+        "semarnat",
+        "private-cruise-destinations",
+        "cruise-news"
+      ]
+    },
+    {
+      "id": "msc-voyagers-club-status-match-from-rcl-diamond",
+      "slug": "msc-voyagers-club-status-match-from-rcl-diamond",
+      "title": "RCL Diamond to MSC Voyagers Club: How the Status Match Actually Works in 2026",
+      "url": "/articles/msc-voyagers-club-status-match-from-rcl-diamond.html",
+      "date": "2026-05-24",
+      "published": "2026-05-24",
+      "status": "published",
+      "excerpt": "A practical guide to taking the MSC status match from Royal Caribbean Diamond — what the match actually delivers, what it doesn't, what to evaluate on your first MSC sailing, and what to do if the first sailing goes sideways. Written by an RCL Diamond cruiser who just completed his first MSC sailing on the match.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {
+        "name": "Ken Baker",
+        "url": "/authors/ken-baker.html",
+        "image": "/authors/img/ken1.jpg?v=3.009.023"
+      },
+      "keywords": [
+        "msc-cruises",
+        "msc-voyagers-club",
+        "royal-caribbean",
+        "status-match",
+        "cruise-loyalty",
+        "msc-seaside",
+        "cruise-planning"
+      ]
+    },
+    {
+      "id": "msc-seaside-service-review",
+      "slug": "msc-seaside-service-review",
+      "title": "MSC Seaside Service Review: The Apology That Wasn't a Plan",
+      "url": "/articles/msc-seaside-service-review.html",
+      "date": "2026-05-22",
+      "published": "2026-05-22",
+      "status": "published",
+      "excerpt": "A cabin-steward case study from a 2026 MSC Seaside sailing. What service recovery looks like when 'it won't happen again' isn't paired with a structural fix. The status-match conversion-funnel critique MSC's loyalty team should read.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {
+        "name": "Ken Baker",
+        "url": "/authors/ken-baker.html",
+        "image": "/authors/img/ken1.jpg?v=3.009.023"
+      },
+      "keywords": [
+        "msc-cruises",
+        "msc-seaside",
+        "cruise-service-recovery",
+        "cabin-steward",
+        "msc-voyagers-club",
+        "cruise-line-loyalty",
+        "cruise-case-study"
+      ]
+    },
+    {
       "id": "royal-caribbean-vs-msc",
       "slug": "royal-caribbean-vs-msc",
       "title": "Royal Caribbean vs MSC: Side by Side from the Deck",
@@ -17,7 +170,15 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["royal-caribbean", "msc-cruises", "cruise-line-comparison", "msc-seaside", "radiance-of-the-seas", "mega-ship", "cruise-planning"]
+      "keywords": [
+        "royal-caribbean",
+        "msc-cruises",
+        "cruise-line-comparison",
+        "msc-seaside",
+        "radiance-of-the-seas",
+        "mega-ship",
+        "cruise-planning"
+      ]
     },
     {
       "id": "cruise-ship-size-explained",
@@ -35,7 +196,15 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["ship-size-atlas", "gross-tonnage", "space-ratio", "cruise-ship-comparison", "icon-of-the-seas", "radiance-of-the-seas", "tool-demo"]
+      "keywords": [
+        "ship-size-atlas",
+        "gross-tonnage",
+        "space-ratio",
+        "cruise-ship-comparison",
+        "icon-of-the-seas",
+        "radiance-of-the-seas",
+        "tool-demo"
+      ]
     },
     {
       "id": "port-day-that-doesnt-go-sideways",
@@ -53,7 +222,16 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["port-day-planner", "shore-excursion", "cruise-planning", "tool-demo", "all-aboard", "cozumel", "nassau", "budget"]
+      "keywords": [
+        "port-day-planner",
+        "shore-excursion",
+        "cruise-planning",
+        "tool-demo",
+        "all-aboard",
+        "cozumel",
+        "nassau",
+        "budget"
+      ]
     },
     {
       "id": "radiance-of-the-seas-5-night-bahamas",
@@ -71,7 +249,17 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["radiance-of-the-seas", "royal-caribbean", "radiance-class", "bahamas", "nassau", "cococay", "port-everglades", "accessibility", "trip-logbook"]
+      "keywords": [
+        "radiance-of-the-seas",
+        "royal-caribbean",
+        "radiance-class",
+        "bahamas",
+        "nassau",
+        "cococay",
+        "port-everglades",
+        "accessibility",
+        "trip-logbook"
+      ]
     },
     {
       "id": "quantum-of-the-seas-pacific-coastal",
@@ -89,7 +277,17 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["quantum-of-the-seas", "royal-caribbean", "cabo-san-lucas", "ensenada", "pacific-coastal", "back-to-back", "whale-watching", "paipai-zoo", "trip-logbook"]
+      "keywords": [
+        "quantum-of-the-seas",
+        "royal-caribbean",
+        "cabo-san-lucas",
+        "ensenada",
+        "pacific-coastal",
+        "back-to-back",
+        "whale-watching",
+        "paipai-zoo",
+        "trip-logbook"
+      ]
     },
     {
       "id": "what-cruise-actually-costs-2026",
@@ -107,7 +305,14 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["cruise-cost", "cruise-budget", "budget-calculator", "cruise-planning", "real-cost", "hidden-costs"]
+      "keywords": [
+        "cruise-cost",
+        "cruise-budget",
+        "budget-calculator",
+        "cruise-planning",
+        "real-cost",
+        "hidden-costs"
+      ]
     },
     {
       "id": "hurricane-season-2026-cruisers",
@@ -125,7 +330,14 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["hurricane-season", "el-nino", "caribbean", "cruise-planning", "travel-insurance", "itinerary-changes"]
+      "keywords": [
+        "hurricane-season",
+        "el-nino",
+        "caribbean",
+        "cruise-planning",
+        "travel-insurance",
+        "itinerary-changes"
+      ]
     },
     {
       "id": "stateroom-sanity-check",
@@ -143,7 +355,14 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["stateroom-check", "cruise-cabin", "cabin-noise", "royal-caribbean", "cabin-selection", "tool"]
+      "keywords": [
+        "stateroom-check",
+        "cruise-cabin",
+        "cabin-noise",
+        "royal-caribbean",
+        "cabin-selection",
+        "tool"
+      ]
     },
     {
       "id": "is-drink-package-worth-it",
@@ -161,7 +380,14 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["drink-package", "drink-calculator", "royal-caribbean", "deluxe-beverage-package", "budget", "break-even"]
+      "keywords": [
+        "drink-package",
+        "drink-calculator",
+        "royal-caribbean",
+        "deluxe-beverage-package",
+        "budget",
+        "break-even"
+      ]
     },
     {
       "id": "hantavirus-cruise-ships-2026",
@@ -179,7 +405,14 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["health", "hantavirus", "expedition", "safety", "outbreak", "antarctic"]
+      "keywords": [
+        "health",
+        "hantavirus",
+        "expedition",
+        "safety",
+        "outbreak",
+        "antarctic"
+      ]
     },
     {
       "id": "royal-beach-club-collection-2026",
@@ -197,7 +430,15 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["royal-caribbean", "royal-beach-club", "private-destinations", "cococay", "paradise-island", "cozumel", "santorini"]
+      "keywords": [
+        "royal-caribbean",
+        "royal-beach-club",
+        "private-destinations",
+        "cococay",
+        "paradise-island",
+        "cozumel",
+        "santorini"
+      ]
     },
     {
       "id": "costa-maya-mesoamerican-reef-diving",
@@ -215,7 +456,15 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["costa-maya", "diving", "mesoamerican-reef", "mahahual", "banco-chinchorro", "scuba", "mexico"]
+      "keywords": [
+        "costa-maya",
+        "diving",
+        "mesoamerican-reef",
+        "mahahual",
+        "banco-chinchorro",
+        "scuba",
+        "mexico"
+      ]
     },
     {
       "id": "south-pacific-cruise-primer-2026",
@@ -233,7 +482,16 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["south-pacific", "mystery-island", "vanuatu", "new-caledonia", "sydney", "brisbane", "fiji", "first-cruise"]
+      "keywords": [
+        "south-pacific",
+        "mystery-island",
+        "vanuatu",
+        "new-caledonia",
+        "sydney",
+        "brisbane",
+        "fiji",
+        "first-cruise"
+      ]
     },
     {
       "id": "cruise-tipping-2026",
@@ -251,7 +509,13 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["tipping", "gratuity", "budget", "money", "first-cruise"]
+      "keywords": [
+        "tipping",
+        "gratuity",
+        "budget",
+        "money",
+        "first-cruise"
+      ]
     },
     {
       "id": "caribbean-cruise-trends-2026",
@@ -269,7 +533,13 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["caribbean", "trends", "first-cruise", "ports", "data"]
+      "keywords": [
+        "caribbean",
+        "trends",
+        "first-cruise",
+        "ports",
+        "data"
+      ]
     },
     {
       "id": "cruise-cabin-organization",
@@ -287,7 +557,12 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["packing", "cabin", "organization", "practical"]
+      "keywords": [
+        "packing",
+        "cabin",
+        "organization",
+        "practical"
+      ]
     },
     {
       "id": "cruise-tech-photography-guide",
@@ -305,7 +580,12 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["tech", "photography", "packing", "practical"]
+      "keywords": [
+        "tech",
+        "photography",
+        "packing",
+        "practical"
+      ]
     },
     {
       "id": "cruise-duck-tradition",
@@ -323,7 +603,11 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["tradition", "fun", "community"]
+      "keywords": [
+        "tradition",
+        "fun",
+        "community"
+      ]
     },
     {
       "id": "solo-cruising-practical-guide",
@@ -341,7 +625,13 @@
         "url": "/about-us.html",
         "image": "/assets/logo_wake.png?v=3.010.300"
       },
-      "keywords": ["solo", "practical", "logistics", "dining", "safety"]
+      "keywords": [
+        "solo",
+        "practical",
+        "logistics",
+        "dining",
+        "safety"
+      ]
     },
     {
       "id": "freedom-of-your-own-wake",
@@ -359,7 +649,10 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["solo", "travel"]
+      "keywords": [
+        "solo",
+        "travel"
+      ]
     },
     {
       "id": "why-i-started-solo-cruising",
@@ -377,7 +670,9 @@
         "url": "/authors/tina-maulsby.html",
         "image": "/authors/img/tina3.png?v=3.009.023"
       },
-      "keywords": ["solo"]
+      "keywords": [
+        "solo"
+      ]
     },
     {
       "id": "top-20-first-cruise-questions",
@@ -395,7 +690,9 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["travel"]
+      "keywords": [
+        "travel"
+      ]
     },
     {
       "id": "visiting-the-united-states-before-your-cruise",
@@ -413,7 +710,11 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["travel", "solo", "usa"]
+      "keywords": [
+        "travel",
+        "solo",
+        "usa"
+      ]
     },
     {
       "id": "in-the-wake-of-grief",
@@ -431,7 +732,11 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["solo", "grief", "healing"]
+      "keywords": [
+        "solo",
+        "grief",
+        "healing"
+      ]
     },
     {
       "id": "accessible-cruising",
@@ -449,7 +754,11 @@
         "url": "/authors/ken-baker.html",
         "image": "/authors/img/ken1.jpg?v=3.009.023"
       },
-      "keywords": ["accessibility", "travel", "solo"]
+      "keywords": [
+        "accessibility",
+        "travel",
+        "solo"
+      ]
     }
   ]
 }


### PR DESCRIPTION
…ails manifest

Article rails on the site (homepage, /articles, internal grids) read from /assets/data/articles/index.json, which the articles-hub.js loader fetches at runtime. Six articles I published over the last five days were committed as HTML files and added to articles.html + sitemap.xml but NOT added to this manifest, so they never appeared in the dynamic rails.

Added at the top of the articles array (newest first):

- cruise-itinerary-changes-what-to-do (2026-05-27)
- cruise-travel-insurance-2026 (2026-05-27)
- cruise-travel-safety-shore-side-net (2026-05-24)
- perfect-day-mexico-rejected-2026 (2026-05-24)
- msc-voyagers-club-status-match-from-rcl-diamond (2026-05-24)
- msc-seaside-service-review (2026-05-22)

Manifest count: 25 → 31.

Each entry follows the existing schema (id, slug, title, url, date, published, status, excerpt, thumbnail, image, author{name,url,image}, keywords[]). JSON validated with jq empty.

Root cause: the article publishing workflow has multiple registers (HTML file + articles.html static list + sitemap.xml + this JSON manifest). I missed the manifest on the six articles. The rails loader at /assets/js/articles-hub.js fetches /assets/data/articles/ index.json on page load; without the entry, the article doesn't appear in any rail regardless of whether the HTML file is live.

To prevent next time: when publishing a new article, the wire-up checklist is HTML file + articles.html + sitemap.xml + assets/data/articles/index.json (this file). Adding to all four is required for the article to be both reachable and discoverable.