### PR TITLE
seo: reframe carnivale-1956 title for SERP differentiation

### DIFF
--- a/ships/carnival/carnivale-1956.html
+++ b/ships/carnival/carnivale-1956.html
@@ -21,13 +21,13 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
      answer-first: TSS Carnivale (1975-1993) was Carnival's second ship. Ex-RMS Empress of Britain. 31,500 GT. 52 total years of service across multiple owners.
      -->
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>TSS Carnivale (1956) — Carnival's Second Ship | In The Wake</title>
+<title>TSS Carnivale: From Empress of Britain to Carnival Fun Ship | In The Wake</title>
 <meta name="description" content="Memorial tribute to TSS Carnivale — Carnival's second ship (1975-1993). Originally RMS Empress of Britain. The silver sister that proved Fun Ships could scale.">
 <link rel="canonical" href="https://cruisinginthewake.com/ships/carnival/carnivale-1956.html">
   <!-- OpenGraph -->
   <meta property="og:type" content="article"/>
   <meta property="og:site_name" content="In the Wake"/>
-  <meta property="og:title" content="TSS Carnivale (1956) — Carnival's Second Ship"/>
+  <meta property="og:title" content="TSS Carnivale: From Empress of Britain to Carnival Fun Ship"/>
   <meta property="og:description" content="Memorial tribute to TSS Carnivale — Carnival's second ship (1975-1993). Originally RMS Empress of Britain. The silver sister that proved Fun Ships could scale."/>
   <meta property="og:url" content="https://cruisinginthewake.com/ships/carnival/carnivale-1956.html"/>
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/carnivale-1956.jpg"/>
@@ -83,7 +83,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:title" content="TSS Carnivale (1956) — Carnival's Second Ship"/>
+  <meta name="twitter:title" content="TSS Carnivale: From Empress of Britain to Carnival Fun Ship"/>
   <meta name="twitter:description" content="Memorial tribute to TSS Carnivale — Carnival's second ship (1975-1993). Originally RMS Empress of Britain. The silver sister that proved Fun Ships could scale."/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/carnivale-1956.jpg"/>
 


### PR DESCRIPTION
GSC: 15 impressions, 0 clicks at position 1.87 (≈ #2 on the SERP). Industry CTR at that position is ~15%. Zero clicks at #2 is not a ranking problem; it's intent mismatch + SERP competition.

The SERP for "TSS Carnivale 1956" is dominated by photo archives (Florida Memory, Wikimedia Commons, Midshipcentury) and a "where are they now" listicle (Cruise Hive). The current title "Carnival's Second Ship" is a factoid, not a hook — and competes badly against Mardi Gras 1972's "Founding Ship" frame (which IS a superlative and converts at 1.14× expected on the same template).

New title leads with the cross-search hook (Empress of Britain — the ship's original name pre-Carnival) and frames the lifecycle transformation, competing against the listicle by being a single-ship deep cut rather than a roundup. H1 stays bare (TSS Carnivale) — Pattern B remains the page's overall shape.

Updates title, og:title, twitter:title together. Meta description unchanged (already mentions "Originally RMS Empress of Britain").