### PR TITLE
fix(#1680,#1681): remove broken htaccess redirects pointing to non-ex…

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -99,9 +99,6 @@
   RewriteRule ^disability\.html$ /disability-at-sea.html [R=301,L]
   RewriteRule ^cruise-lines/rcl\.html$ /cruise-lines/royal-caribbean.html [R=301,L]
   RewriteRule ^solo/visitingtheunitedstates\.html$ /solo/visiting-the-united-states-before-your-cruise.html [R=301,L]
-  # Pastoral-URL collision: /solo/accessible-cruising.html was a gear-list page using a disability-adjacent URL.
-  # Genuine accessibility content lives at /solo/articles/accessible-cruising.html.
-  RewriteRule ^solo/accessible-cruising\.html$ /solo/articles/accessible-cruising.html [R=301,L]
   RewriteRule ^drinks\.html$ /drink-packages.html [R=301,L]
   RewriteRule ^packing\.html$ /packing-lists.html [R=301,L]
   RewriteRule ^contact\.html$ /about-us.html [R=301,L]
@@ -125,7 +122,7 @@
   RewriteRule ^ships/carnival-cruise-line/index\.html$ /ships/carnival/ [R=301,L]
 
   # Legacy restaurant URLs with encoding issues (em-dash → hyphen)
-  RewriteRule ^restaurants/main-dining-room[—–-]+radiance.*\.html$ /restaurants/main-dining-room.html [R=301,L,NC]
+  RewriteRule ^restaurants/main-dining-room[—–-]+radiance.*\.html$ /restaurants.html [R=301,L,NC]
   RewriteRule ^restaurants/chops-grille[—–-]+radiance.*\.html$ /restaurants/chops.html [R=301,L,NC]
 
   # Phantom chops-grille ship-specific pages (only chops.html exists)


### PR DESCRIPTION
…istent targets

#1680: Remove accessible-cruising redirect (solo/articles/ dir doesn't exist;
       file already lives at /solo/accessible-cruising.html — 301→404 chain)
#1681: Update main-dining-room-radiance redirect to /restaurants.html
       (/restaurants/main-dining-room.html doesn't exist; restaurants.html does)