### PR TITLE
fix(nav): strip leftover (V1.Beta) from admin report title

### DIFF
--- a/admin/reports/articles.html
+++ b/admin/reports/articles.html
@@ -29,7 +29,7 @@ Page: /admin/reports/articles.html · v3.008 · Built: 2025-10-17T00:00:00Z
   <meta name="ai-summary" content="Internal report tracking article consistency and status across In the Wake content.">
   <meta name="last-reviewed" content="2025-11-19">
   <meta name="content-protocol" content="ICP-Lite v1.4">
-  <title>Articles Consistency Report (V1.Beta) — In the Wake</title>
+  <title>Articles Consistency Report — In the Wake</title>
 
   <!-- Canonical -->
   <link rel="canonical" href="https://cruisinginthewake.com/admin/reports/articles.html"/>


### PR DESCRIPTION
## What

One-line cleanup: removes the leftover `(V1.Beta)` suffix from the `<title>` of `admin/reports/articles.html`.

```diff
-  <title>Articles Consistency Report (V1.Beta) — In the Wake</title>
+  <title>Articles Consistency Report — In the Wake</title>
```

## Why it's down to one line

This branch was originally auto-opened carrying three larger fix commits that **duplicated** the homepage-audit work merged concurrently via the `nifty-mendel` PRs (#1806/#1808/#1810). Those redundant commits were dropped (branch reset to `main`, then rebased onto current `main` at `589618a2`).

In the meantime `main` also went after the V1.Beta **root cause** — stripping the badge from the 7 page generators (`3a0add99`) and removing stray badges from admin/draft pages (`053e4259`), which incidentally fixed the `rocket-launch-from-cruise-ship-2026.html` article I'd also patched. So that part is now a no-op against `main`, leaving only this admin-report title as the genuine remaining delta.

## Verification

- `git diff main..HEAD` = this one file, one line.
- On current `main`: `admin/reports/articles.html` title still carries `V1.Beta` (confirmed), so this PR is not redundant.
- Branch is 0 behind / 1 ahead of `main`; no other files touched.

Relevant to **#1612**.

🤖 https://claude.ai/code/session_01XfmJjR5qDxcXhSGGc3QGWF