### PR TITLE
Finish two reopened homepage issues: GA preconnect + stray V1.Beta metas

### DIFF
--- a/cruise-lines/costa.html
+++ b/cruise-lines/costa.html
@@ -24,7 +24,7 @@ All work on this project is offered as a gift to God.
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Costa Cruises | In the Wake</title>
-  <meta name="version" content="V1.Beta"/>
+  <meta name="version" content="3.010.400"/>
   <meta name="description" content="Costa Cruises guide: Italian-heritage cruise line with vibrant ships, Mediterranean itineraries, and la dolce vita dining. Explore ships, planning tools, and onboard experiences."/>
   <meta name="robots" content="index,follow"/>
 

--- a/cruise-lines/cunard.html
+++ b/cruise-lines/cunard.html
@@ -24,7 +24,7 @@ All work on this project is offered as a gift to God.
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Cunard | In the Wake</title>
-  <meta name="version" content="V1.Beta"/>
+  <meta name="version" content="3.010.400"/>
   <meta name="description" content="Cunard guide: British ocean liner heritage since 1840 with white-glove service, Transatlantic crossings, and Grill-class dining aboard 4 legendary Queens."/>
   <meta name="robots" content="index,follow"/>
 

--- a/cruise-lines/explora-journeys.html
+++ b/cruise-lines/explora-journeys.html
@@ -24,7 +24,7 @@ All work on this project is offered as a gift to God.
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Explora Journeys | In the Wake</title>
-  <meta name="version" content="V1.Beta"/>
+  <meta name="version" content="3.010.400"/>
   <meta name="description" content="Explora Journeys guide: luxury all-suite cruise line from MSC Group with 18 dining experiences, inclusive pricing, and refined European elegance. Explore ships, planning tools, and onboard experiences."/>
   <meta name="robots" content="index,follow"/>
 

--- a/cruise-lines/oceania.html
+++ b/cruise-lines/oceania.html
@@ -24,7 +24,7 @@ All work on this project is offered as a gift to God.
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Oceania Cruises | In the Wake</title>
-  <meta name="version" content="V1.Beta"/>
+  <meta name="version" content="3.010.400"/>
   <meta name="description" content="Oceania Cruises guide: upper-premium line delivering The Finest Cuisine at Sea with intimate mid-size ships, Jacques Pepin-inspired dining, and destination-focused itineraries across 7 vessels."/>
   <meta name="robots" content="index,follow"/>
 

--- a/cruise-lines/regent.html
+++ b/cruise-lines/regent.html
@@ -24,7 +24,7 @@ All work on this project is offered as a gift to God.
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Regent Seven Seas Cruises | In the Wake</title>
-  <meta name="version" content="V1.Beta"/>
+  <meta name="version" content="3.010.400"/>
   <meta name="description" content="Regent Seven Seas Cruises guide: ultra-luxury all-inclusive cruise line with all-suite ships, included shore excursions, fine dining, unlimited drinks, Wi-Fi, and gratuities across 7 intimate vessels."/>
   <meta name="robots" content="index,follow"/>
 

--- a/cruise-lines/royal-caribbean.html
+++ b/cruise-lines/royal-caribbean.html
@@ -24,7 +24,7 @@ All work on this project is offered as a gift to God.
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Royal Caribbean — In the Wake</title>
-  <meta name="version" content="V1.Beta"/>
+  <meta name="version" content="3.010.400"/>
   <meta name="description" content="Royal Caribbean delivers vacation revolution with 7 ship classes, neighborhood-style variety, and bucket-list-worthy experiences. Explore ships, dining, and planning resources."/>
   <meta name="theme-color" content="#0e6e8e"/>
   <meta name="robots" content="index,follow"/>

--- a/cruise-lines/seabourn.html
+++ b/cruise-lines/seabourn.html
@@ -24,7 +24,7 @@ All work on this project is offered as a gift to God.
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Seabourn | In the Wake</title>
-  <meta name="version" content="V1.Beta"/>
+  <meta name="version" content="3.010.400"/>
   <meta name="description" content="Seabourn guide: ultra-luxury cruise line with intimate 450-600 guest ships, The Grill by Thomas Keller, all-inclusive service, and expedition voyages to Antarctica and the Arctic."/>
   <meta name="robots" content="index,follow"/>
 

--- a/cruise-lines/silversea.html
+++ b/cruise-lines/silversea.html
@@ -24,7 +24,7 @@ All work on this project is offered as a gift to God.
   <script>document.documentElement.classList.remove('no-js');</script>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Silversea Cruises | In the Wake</title>
-  <meta name="version" content="V1.Beta"/>
+  <meta name="version" content="3.010.400"/>
   <meta name="description" content="Silversea Cruises guide: ultra-luxury Italian-heritage cruise line with all-suite butler service, S.A.L.T. culinary program, and expedition ships reaching all 7 continents across 12 intimate vessels."/>
   <meta name="robots" content="index,follow"/>
 

--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -29,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Virgin Voyages — In the Wake</title>
   <meta name="description" content="Virgin Voyages: adults-only, all dining included, chef-forward eateries, big-night entertainment, and late-night energy."/>
-  <meta name="page:version" content="V1.Beta"/>
+  <meta name="page:version" content="3.010.400"/>
 
   <!-- ICP-Lite v1.0: AI-First Metadata -->
   <meta name="ai-summary" content="Virgin Voyages guide: adults-only (18+) Lady Class ships with all restaurants included, chef-forward cuisine, modern design, festival-style entertainment, and late-night energy that turns sea days into city nights."/>

--- a/disability-at-sea.html
+++ b/disability-at-sea.html
@@ -40,8 +40,8 @@ ADDENDUM: Facebook Domain Verification v3.008.021
 
   <!-- Title / Version Trinity -->
   <title>Accessibility & Inclusion — In the Wake</title>
-  <meta name="version" content="V1.Beta"/>
-  <meta name="page:version" content="V1.Beta"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
   <meta name="standards:baseline" content="3.008"/>
 
   <!-- Canonical & Description -->

--- a/index.html
+++ b/index.html
@@ -240,6 +240,9 @@
   <link rel="sitemap" type="application/xml" href="/sitemap.xml"/>
 
   <!-- Performance: DNS Prefetch & Preconnect -->
+  <!-- Preconnect to the Google Analytics origin the page actually loads (gtag.js). Third-party origins only — never the first-party domain. -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin/>
+  <link rel="dns-prefetch" href="https://www.googletagmanager.com"/>
   <link rel="dns-prefetch" href="https://www.flickersofmajesty.com"/>
 
   <!-- Styles -->

--- a/solo.html
+++ b/solo.html
@@ -41,8 +41,8 @@
   <!-- SEO: Theme & Appearance -->
   <meta name="color-scheme" content="light"/>
   <meta name="theme-color" content="#0e6e8e">
-  <meta name="page:version" content="V1.Beta">
-  <meta name="version" content="V1.Beta">
+  <meta name="page:version" content="3.010.400">
+  <meta name="version" content="3.010.400">
   <meta name="standards:baseline" content="3.010">
   <meta name="author" content="In the Wake"/>
   <meta name="publisher" content="In the Wake"/>


### PR DESCRIPTION
#1602: self-preconnect was already removed; this adds the Google Analytics preconnect the issue asked for (preconnect + dns-prefetch to googletagmanager.com, the origin the page actually loads). Third-party origins only.

#1612: the visible "V1.Beta" navbar badge was already gone site-wide, but 11 public pages (9 cruise-line guides, disability-at-sea, solo) still carried stale <meta name="version" content="V1.Beta"> tags that tripped the issue's own grep metric. Updated them to 3.010.400 — the actual site version the issue cites. Meta-context replacement only; verified no visible badge spans on these pages. 5 admin/voyage-pack drafts (own v0.1.x scheme) intentionally left for a separate decision.

https://claude.ai/code/session_014ujYyrEAZWqTiXSCgR284p