### PR TITLE
fix(nav): remove last V1.Beta residue from admin report ai-breadcrumbs

### DIFF
--- a/admin/reports/articles.html
+++ b/admin/reports/articles.html
@@ -10,7 +10,7 @@ Page: /admin/reports/articles.html · v3.008 · Built: 2025-10-17T00:00:00Z
 <html lang="en">
 <head>
 <!-- ai-breadcrumbs
-     entity: Articles Consistency Report (V1.Beta)
+     entity: Articles Consistency Report
      type: Information Page
      parent: /
      category: General Information


### PR DESCRIPTION
## What

One-line cleanup of the **last remaining `V1.Beta`** occurrence anywhere in the site's `*.html`.

```diff
 <!-- ai-breadcrumbs
-     entity: Articles Consistency Report (V1.Beta)
+     entity: Articles Consistency Report
```

## Context

The visible `<title>` of `admin/reports/articles.html` was de-badged in #1809 (merged). This was the one surface that PR didn't cover: the ai-breadcrumbs HTML-comment `entity:` field still carried the `(V1.Beta)` suffix. The entity now matches the page title.

## Verification

- `git diff main..HEAD` = this one file, one line.
- After this change: **0** `V1.Beta` occurrences site-wide across all `*.html` (was 1) — confirmed via `grep -rl 'V1\.Beta' . --include='*.html'`.
- Internal admin report page; not user-facing.

Note: the ai-breadcrumbs comment block is itself slated for removal under the ICP-2 sitewide pass (anti-pattern #8, already applied to 102 ship pages in #1792). This just clears the stale label in the interim so the V1.Beta count reaches zero now rather than waiting on that larger pass.

Closes out the `V1.Beta` remediation tracked across #1593 / #1609 / #1612.

🤖 https://claude.ai/code/session_01XfmJjR5qDxcXhSGGc3QGWF

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfmJjR5qDxcXhSGGc3QGWF)_