### PR TITLE
Tidy orphaned blank lines left by ai-breadcrumbs removal (#1792)

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -237,7 +237,6 @@ All work on this project is offered as a gift to God.
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>
 </head>
 <body>
-
   <!-- Skip Link -->
   <a href="#main-content" class="skip-link">Skip to main content</a>
 

--- a/restaurants.html
+++ b/restaurants.html
@@ -9,7 +9,6 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 -->
 <html lang="en" class="no-js">
 <head>
-
   <!-- ICP-Lite v1.4 Meta Tags -->
   <meta name="ai-summary" content="Cruise ship dining guide covering 478 venues across Royal Caribbean, Norwegian, Carnival, MSC, and Virgin Voyages — discover which restaurants are included, which cost extra, and find the venues that match your taste." />
   <meta name="last-reviewed" content="2026-02-12" />

--- a/solo/solo-cruising-practical-guide.html
+++ b/solo/solo-cruising-practical-guide.html
@@ -7,7 +7,6 @@ All work on this project is offered as a gift to God.
 -->
 <html lang="en" class="no-js">
 <head>
-
   <!-- ICP-Lite v1.0 Meta Tags -->
   <meta name="ai-summary" content="Comprehensive practical guide to solo cruising covering ship selection by personality, solo supplements, dining alone, meeting people (or not), safety, shore excursions, and emotional preparation for every type of solo traveler." />
   <meta name="last-reviewed" content="2025-11-25" />


### PR DESCRIPTION
Three files retained a single blank line directly after <head>/<body> where the removed breadcrumb block had sat with no preceding blank in the original. Restored the original tight spacing.

Scoped precisely: scanned all 544 branch-edited files; the <body>+blank in authors/tina-maulsby.html and disability-at-sea.html pre-existed (verified against merge-base) and were left untouched. Pure blank-line deletions, zero content change.