### PR TITLE
ICP-2 cleanup: remove ai-breadcrumbs + dead meta keywords sitewide; fix duplicate doctypes

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -48,7 +48,6 @@ All work on this project is offered as a gift to God.
   <!-- Title & SEO -->
   <title>About Us — In the Wake | Cruise Planning & Travel Tips</title>
   <meta name="description" content="Meet the crew behind In the Wake — real cruisers writing from real voyages to help you plan smoother sailings."/>
-  <meta name="keywords" content="cruise planning, cruise tips, travel guide, about us, Ken Baker, Tina Maulsby"/>
   <link rel="canonical" href="https://cruisinginthewake.com/about-us.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/accessibility.html
+++ b/accessibility.html
@@ -42,7 +42,6 @@
   <!-- Title & SEO -->
   <title>Accessibility & Inclusion — In the Wake | Cruise Planning & Travel Tips</title>
   <meta name="description" content="Our commitment to accessibility: WCAG 2.1 AA and ADA-informed design so every traveler can plan and cruise with confidence."/>
-  <meta name="keywords" content="cruise accessibility, disability cruising, WCAG 2.1 AA, ADA compliance, accessible travel"/>
   <link rel="canonical" href="https://cruisinginthewake.com/accessibility.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/admin/reports/articles.html
+++ b/admin/reports/articles.html
@@ -9,16 +9,6 @@ Page: /admin/reports/articles.html · v3.008 · Built: 2025-10-17T00:00:00Z
 <!doctype html>
 <html lang="en">
 <head>
-<!-- ai-breadcrumbs
-     entity: Articles Consistency Report (V1.Beta)
-     type: Information Page
-     parent: /
-     category: General Information
-     updated: 2025-11-15
-     expertise: Cruise travel, planning, research
-     target-audience: Cruise travelers, vacation planners, research-oriented cruisers
-     answer-first: Soli Deo Gloria — All work on this project is offered to God.
-     -->
   <!-- Core meta -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>

--- a/admin/reports/articles.html
+++ b/admin/reports/articles.html
@@ -6,7 +6,6 @@ All work on this project is offered as a gift to God.
 “Whatever you do, work heartily, as for the Lord and not for men.” — Colossians 3:23
 Page: /admin/reports/articles.html · v3.008 · Built: 2025-10-17T00:00:00Z
 -->
-<!doctype html>
 <html lang="en">
 <head>
   <!-- Core meta -->

--- a/admin/reports/sw-health.html
+++ b/admin/reports/sw-health.html
@@ -7,16 +7,6 @@ All work on this project is offered as a gift to God.
 -->
 <html lang="en">
 <head>
-<!-- ai-breadcrumbs
-     entity: Service Worker Cache Health
-     type: Information Page
-     parent: /
-     category: General Information
-     updated: 2025-11-15
-     expertise: Cruise travel, planning, research
-     target-audience: Cruise travelers, vacation planners, research-oriented cruisers
-     answer-first: Information and resources about Service Worker Cache Health.
-     -->
   <meta charset="utf-8" />
   <title>Service Worker Cache Health — In the Wake</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/admin/voyage-packs/v0.1-symphony-western-caribbean-7n.html
+++ b/admin/voyage-packs/v0.1-symphony-western-caribbean-7n.html
@@ -1,16 +1,6 @@
 <!doctype html>
 <html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     entity: Voyage Pack v0.1 — Symphony of the Seas, 7-Night Western Caribbean
-     type: Voyage Pack (one-time-purchase planning document)
-     parent: /
-     category: Cruise Planning Product
-     updated: 2026-05-06
-     expertise: Royal Caribbean, Symphony of the Seas, Oasis class, Western Caribbean, Miami homeport, family planning, accessibility, solo cruising
-     target-audience: Cruisers sailing Symphony of the Seas on a 7-night Western Caribbean from Miami
-     answer-first: A planning companion for Royal Caribbean's Symphony of the Seas on a 7-night Western Caribbean from Miami — Roatán, Costa Maya, Cozumel, Perfect Day at CocoCay. Generic itinerary; works for any sailing date that follows this loop.
-     -->
   <!-- ======================================================
        In the Wake — Voyage Pack v0.1 (HTML rendering)
        Pack: Symphony of the Seas — 7-Night Western Caribbean from Miami

--- a/admin/voyage-packs/v0.1.2-ncl-aqua-veterans-solo-group-dec-2027.html
+++ b/admin/voyage-packs/v0.1.2-ncl-aqua-veterans-solo-group-dec-2027.html
@@ -1,16 +1,6 @@
 <!doctype html>
 <html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     entity: All Aboard, Veterans — Hosted Solo Cruisers Group Cruise 2027
-     type: Voyage Pack (one-time-purchase planning document)
-     parent: /
-     category: Cruise Planning Product
-     updated: 2026-05-05
-     expertise: Norwegian Cruise Line, NCL Aqua, Western Caribbean, solo cruising, veterans travel, group cruise hosting
-     target-audience: U.S. military veterans, solo cruisers, hosted group cruise participants
-     answer-first: A planning companion for the December 12-19, 2027 Norwegian Aqua Western Caribbean group cruise hosted by Tina Maulsby of Maulsby Travel Co. Veterans-aware, solo-first, hosted-group rhythm.
-     -->
   <!-- ======================================================
        In the Wake — Voyage Pack v0.1.2 (HTML rendering)
        Pack: NCL Aqua Veterans Solo Group Cruise — Dec 12-19, 2027

--- a/admin/voyage-packs/v0.1.3-virgin-sisters-sea-feb-2027.html
+++ b/admin/voyage-packs/v0.1.3-virgin-sisters-sea-feb-2027.html
@@ -1,16 +1,6 @@
 <!doctype html>
 <html lang="en" class="no-js">
 <head>
-<!-- ai-breadcrumbs
-     entity: Sisters at Sea — A Valentine's Getaway for Solo Cruisers Who Love to Cruise
-     type: Voyage Pack (one-time-purchase planning document)
-     parent: /
-     category: Cruise Planning Product
-     updated: 2026-05-10
-     expertise: Virgin Voyages, Resilient Lady, Western Caribbean + Bahamas, solo women cruising, hosted group cruise
-     target-audience: Solo women cruisers, 18+, Valentine's-themed group cruise participants
-     answer-first: A planning companion for the February 14-21, 2027 Resilient Lady Western Caribbean + Bahamas group cruise hosted by Tina Maulsby of Maulsby Travel Co. Solo-women-first. Adults-only by design. Valentine's-themed.
-     -->
   <!-- ======================================================
        In the Wake — Voyage Pack v0.1.3 (HTML rendering)
        Pack: Sisters at Sea — Resilient Lady, Feb 14-21, 2027

--- a/articles.html
+++ b/articles.html
@@ -39,7 +39,6 @@
   <!-- Title & SEO -->
   <title>Articles — In the Wake | Cruise Planning & Travel Stories</title>
   <meta name="description" content="Read thoughtful cruise planning guides, solo travel stories, accessibility tips, and honest travel insights from real voyages."/>
-  <meta name="keywords" content="cruise articles, solo cruising, accessible travel, cruise planning, travel stories, cruise tips"/>
   <link rel="canonical" href="https://cruisinginthewake.com/articles.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/articles/cruise-duck-tradition.html
+++ b/articles/cruise-duck-tradition.html
@@ -24,7 +24,6 @@ All work on this project is offered as a gift to God.
   <title>Cruise Duck Tradition: How to Hide & Find Ducks on Your Cruise — In the Wake</title>
   <meta name="description" content="Learn about the beloved cruise duck tradition: hiding rubber ducks around ships for fellow passengers to find. How to participate, best ducks to bring, and where to hide them."/>
   <link rel="canonical" href="https://cruisinginthewake.com/articles/cruise-duck-tradition.html"/>
-  <meta name="keywords" content="cruise ducks, rubber ducks cruise, duck hiding cruise, cruise ship ducks, duck tradition, cruising with ducks"/>
 
   <!-- OpenGraph -->
   <meta property="og:type" content="article"/>

--- a/authors/ken-baker.html
+++ b/authors/ken-baker.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <!-- Invocation: Author page — may everything we ship be true, beautiful, and helpful. Soli Deo Gloria. -->
-<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>

--- a/authors/tina-maulsby.html
+++ b/authors/tina-maulsby.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <!-- Invocation: Author page — may everything we ship be true, beautiful, and helpful. Soli Deo Gloria. -->
-<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>

--- a/countdown.html
+++ b/countdown.html
@@ -39,7 +39,6 @@
   <!-- Title & SEO -->
   <title>30-Day Pre-Cruise Countdown Checklist | In the Wake</title>
   <meta name="description" content="Interactive pre-cruise countdown checklist: 30 days of tasks from final payments to embarkation day. Never forget a crucial step before your cruise."/>
-  <meta name="keywords" content="cruise countdown, pre-cruise checklist, cruise preparation, cruise planning, embarkation checklist"/>
   <link rel="canonical" href="https://cruisinginthewake.com/countdown.html"/>
 
   <!-- OpenGraph / Facebook -->

--- a/cruise-lines.html
+++ b/cruise-lines.html
@@ -62,7 +62,6 @@
   <!-- Title & SEO -->
   <title>Cruise Lines — In the Wake</title>
   <meta name="description" content="Browse 15 cruise line guides from mainstream to ultra-luxury. Compare Royal Caribbean, Carnival, Celebrity, Princess, Norwegian, MSC, Holland America, Cunard, Costa, Virgin, Oceania, Regent, Seabourn, Silversea, and Explora."/>
-  <meta name="keywords" content="cruise lines, Royal Caribbean, Carnival, Celebrity, Princess, Norwegian, MSC, Holland America, Cunard, Costa, Virgin Voyages, Oceania, Regent Seven Seas, Seabourn, Silversea, Explora Journeys"/>
   <link rel="canonical" href="https://cruisinginthewake.com/cruise-lines.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -6,7 +6,6 @@ All work on this project is offered as a gift to God.
 “Whatever you do, work heartily, as for the Lord and not for men.” — Colossians 3:23
 -->
 
-<!doctype html>
 <html lang="en" class="no-js">
 <head>
   <!-- Core meta -->

--- a/disability-at-sea.html
+++ b/disability-at-sea.html
@@ -4,7 +4,6 @@ Soli Deo Gloria
 STANDARDS: Every Page v3.008 · Root/Main v3.008 · Unified Nav v3.008 · A11y/WCAG Addendum v3.100
 ADDENDUM: Facebook Domain Verification v3.008.021
 -->
-<!doctype html>
 <html lang="en" class="no-js">
 <head>
   <!-- Consent Manager (must be first) -->

--- a/first-cruise.html
+++ b/first-cruise.html
@@ -36,7 +36,6 @@
   <!-- Title & SEO -->
   <title>Your First Cruise — Complete Beginner's Guide | In the Wake</title>
   <meta name="description" content="Everything first-time cruisers need to know: booking tips, what to pack, embarkation day, onboard life, and how to make the most of your maiden voyage."/>
-  <meta name="keywords" content="first cruise, first time cruiser, cruise beginner, new to cruising, cruise tips, cruise guide"/>
   <link rel="canonical" href="https://cruisinginthewake.com/first-cruise.html"/>
 
   <!-- OpenGraph / Facebook -->

--- a/index.html
+++ b/index.html
@@ -48,7 +48,6 @@
   <!-- Title & SEO -->
   <title>In the Wake — A Cruise Traveler's Logbook | Planning Tools & Travel Tips</title>
   <meta name="description" content="Planning tools, travel tips, and faith-scented reflections for smoother sailings. Compare ships, scan menus, scout cabins, and find accessibility notes."/>
-  <meta name="keywords" content="cruise planning, cruise tips, travel guide, Royal Caribbean, cruising, ship comparison, cruise menus, accessibility"/>
   <link rel="canonical" href="https://cruisinginthewake.com/"/>
 
   <!-- SEO: Author & Copyright -->

--- a/index.html
+++ b/index.html
@@ -259,25 +259,6 @@
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.400" fetchpriority="high"/>
 </head>
 <body class="page">
-  <!-- ai-breadcrumbs
-       entity: In the Wake Homepage
-       type: Website Homepage
-       category: Cruise Planning Hub
-       updated: 2026-05-30
-       version: 3.010.400
-       expertise: Royal Caribbean specialist, 150+ days at sea, accessibility advocate, pastor, photographer
-       primary-tools: Drink Calculator, Ships Database, Restaurant Guide, Stateroom Check
-       target-audience: Cruise planners, Royal Caribbean travelers, solo cruisers, accessibility-focused travelers
-       faith-perspective: Christian-integrated travel writing (Soli Deo Gloria)
-       answer-first: Cruise planning tools and real-voyage insights for smoother sailings
-
-       subject: In the Wake is a cruise planning hub offering practical tools, ship comparisons, dining guides, and travel reflections to help travelers plan smoother sailings
-       intended-reader: Cruisers planning their next voyage, comparing ships or dining options, researching accessibility features, or seeking practical travel wisdom
-       core-facts: Free planning tools, Royal Caribbean focus, real-voyage insights, accessibility advocacy, faith-integrated perspective, no affiliate sales
-       decisions-informed: Which ship class suits your travel style, whether drink packages are worth it, how to navigate solo cruising, accessibility options available
-       cautions: Information current as of last-reviewed date, cruise line policies and prices change frequently, always verify critical details with your cruise line before booking
-       -->
-
   <!-- Skip Link -->
   <a href="#main-content" class="skip-link">Skip to main content</a>
 

--- a/packing-lists.html
+++ b/packing-lists.html
@@ -42,7 +42,6 @@
   <!-- Title & SEO -->
   <title>Packing Lists — In the Wake | Cruise Planning & Travel Tips</title>
   <meta name="description" content="Cruise packing checklists for carry-on, families, and everyone — practical, accessible, and based on real sailings."/>
-  <meta name="keywords" content="cruise packing, packing lists, cruise checklist, travel packing, cruise tips"/>
   <link rel="canonical" href="https://cruisinginthewake.com/packing-lists.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/planning.html
+++ b/planning.html
@@ -51,7 +51,6 @@ All work on this project is offered as a gift to God.
   <!-- Title & SEO -->
   <title>Planning — In the Wake | Cruise Planning & Travel Tips</title>
   <meta name="description" content="Planning that feels like smooth water — ports, airports, timing, and steady answers for your cruise journey."/>
-  <meta name="keywords" content="cruise planning, cruise ports, airport transfers, cruise timing, cruise tips"/>
   <link rel="canonical" href="https://cruisinginthewake.com/planning.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/ports.html
+++ b/ports.html
@@ -7,7 +7,6 @@ All work on this project is offered as a gift to God.
 
 STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.300 · A11y/WCAG 2.1 AA Compliant
 -->
-<!doctype html>
 <html lang="en" class="no-js">
 <head>
   <!-- ======================================================

--- a/restaurants/aquadome-market.html
+++ b/restaurants/aquadome-market.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>AquaDome Market — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="AquaDome Market on Royal Caribbean’s Icon class — the first food hall at sea with five complimentary stalls and ocean views. Full menu breakdown, ships, tips, and 2025 cruiser reviews.">
-  <meta name="keywords" content="AquaDome Market, Icon of the Seas, Star of the Seas, food hall at sea, Royal Caribbean, complimentary dining, stalls, pad thai, gyros, crepes, BBQ, tacos">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
   <meta name="author" content="In the Wake">

--- a/restaurants/basecamp.html
+++ b/restaurants/basecamp.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>Basecamp — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="Basecamp on Royal Caribbean’s Icon class — the Thrill Island refuel hub with complimentary nuggets, smash burgers, tots, and more. Menu, hours, ships, tips, and 2025 cruiser reviews.">
-  <meta name="keywords" content="Basecamp, Thrill Island, Icon of the Seas, Star of the Seas, Royal Caribbean, smash burger, waffle chicken nuggets, cheese curds, quick service, pool deck food">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/restaurants/cafe-promenade.html
+++ b/restaurants/cafe-promenade.html
@@ -25,7 +25,6 @@ All work on this project is offered as a gift to God.
   <meta name="ai-summary" content="24/7 café hub on the Royal Promenade. Complimentary baked goods, sandwiches, and snacks. Premium coffee drinks ($4–10). Pastoral gathering place for day and night browsing.">
   <meta name="last-reviewed" content="2025-11-18">
   <meta name="content-protocol" content="ICP-Lite v1.4">
-  <meta name="keywords" content="Cafe Promenade, Royal Caribbean Cafe, free snacks cruise, Royal Promenade coffee, croissandwich, muffaletta, cookies, 24/7 cafe, Royal Roast">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/restaurants/cafe-two70.html
+++ b/restaurants/cafe-two70.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>Café @ Two70 — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="Café @ Two70 on Royal Caribbean — complimentary sandwiches, custom salads, soups, pastries, and panoramic wake views. Breakfast & lunch daily; light dinner on select sailings. Menu, hours, and 2025 cruiser reviews.">
-  <meta name="keywords" content="Cafe @ Two70, Café @ Two70, Royal Caribbean, Odyssey of the Seas, Anthem of the Seas, Ovation of the Seas, Quantum class dining, free lunch, salads, hot-pressed sandwiches, soups, pastries, views">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
   <meta name="author" content="In the Wake">

--- a/restaurants/coastal-kitchen.html
+++ b/restaurants/coastal-kitchen.html
@@ -25,7 +25,6 @@ All work on this project is offered as a gift to God.
   <meta name="ai-summary" content="Suite-exclusive Mediterranean-California fusion restaurant. Complimentary access for Junior Suite+ and Pinnacle members. Pastoral breakfast, lunch, and themed dinners at sea.">
   <meta name="last-reviewed" content="2025-11-18">
   <meta name="content-protocol" content="ICP-Lite v1.4">
-  <meta name="keywords" content="Coastal Kitchen, Royal Suite Class, Icon of the Seas, Utopia of the Seas, Oasis class, Pinnacle, suite dining, Med-Cal, complimentary restaurant">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/restaurants/diamond-lounge.html
+++ b/restaurants/diamond-lounge.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>Crown Lounge (Formerly Diamond Lounge) — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="Crown Lounge (ex-Diamond Lounge) on Royal Caribbean — an exclusive retreat for Crown & Anchor Diamond and above. Access rules, hours, snacks, drink vouchers, ships, tips, and 2025 cruiser reviews.">
-  <meta name="keywords" content="Crown Lounge, Diamond Lounge, Crown & Anchor, Royal Caribbean loyalty, Icon of the Seas, Wonder of the Seas, Diamond Plus, Pinnacle, drink vouchers, concierge, happy hour">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/restaurants/dog-house.html
+++ b/restaurants/dog-house.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>The Dog House — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="The Dog House on Royal Caribbean — complimentary hot dogs and global sausages on the Boardwalk. Menu, toppings, hours, tips, and 2025 cruiser reviews.">
-  <meta name="keywords" content="The Dog House, Boardwalk Dog House, Royal Caribbean, hot dogs, sausages, bratwurst, Thuringer, Coney Island dog, Oasis class, Wonder of the Seas, Utopia of the Seas, free food">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/restaurants/el-loco-fresh.html
+++ b/restaurants/el-loco-fresh.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>El Loco Fresh — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="El Loco Fresh on Royal Caribbean — complimentary tacos, burritos, quesadillas, nachos, salsas, and pool-deck vibes. Breakfast & lunch daily (hours vary). Full menu, tips, and 2025 cruiser reviews.">
-  <meta name="keywords" content="El Loco Fresh, Royal Caribbean, tacos, burritos, nachos, quesadillas, Mexican, pool deck dining, Wonder of the Seas, Utopia of the Seas, Icon class, Oasis class, free food">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
   <meta name="author" content="In the Wake">

--- a/restaurants/izumi.html
+++ b/restaurants/izumi.html
@@ -23,8 +23,6 @@ All work on this project is offered as a gift to God.
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description"
         content="Izumi Sushi & Hibachi on Royal Caribbean — authentic Japanese dining at sea. Fresh sushi, sizzling teppanyaki shows, 2025 menus, prices & real reviews.">
-  <meta name="keywords"
-        content="izumi sushi royal caribbean, izumi hibachi, royal caribbean japanese dining, teppanyaki cruise, izumi menu 2025">
 
   <meta name="referrer" content="no-referrer">
   <meta name="ai-summary" content="Izumi Sushi & Hibachi on Royal Caribbean offers authentic Japanese dining at sea with two experiences: Izumi Sushi (à la carte sushi bar, $39.99 prix fixe) and Izumi Hibachi (interactive teppanyaki with chef shows, $45.99-49.99 combos).">

--- a/restaurants/latte-tudes.html
+++ b/restaurants/latte-tudes.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>Café Latte-tudes — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="Café Latte-tudes on Royal Caribbean — Starbucks-style espresso drinks with complimentary pastries in a cozy, central café. Hours, prices, ships, and 2025 cruiser notes.">
-  <meta name="keywords" content="Café Latte-tudes, Cafe Latte tudes, Royal Caribbean, Starbucks coffee, espresso, pastries, Radiance of the Seas, Vision of the Seas, Brilliance, Serenade, Jewel, Grandeur, Rhapsody, Enchantment">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/restaurants/pearl-cafe.html
+++ b/restaurants/pearl-cafe.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>Pearl Café — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="Pearl Café on Royal Caribbean’s Icon class — a 24/7 elevated grab-and-go with ocean views. Full menu breakdown, ships, tips, and 2025 cruiser reviews.">
-  <meta name="keywords" content="Pearl Café, Icon of the Seas, Star of the Seas, Royal Caribbean, 24 hour cafe, complimentary dining, sandwiches, salads, pastries, cinnamon roll, steak and eggs">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
   <meta name="author" content="In the Wake">

--- a/restaurants/solarium-bistro.html
+++ b/restaurants/solarium-bistro.html
@@ -25,7 +25,6 @@ All work on this project is offered as a gift to God.
   <meta name="ai-summary" content="Adults-only Solarium Bistro serves fresh Mediterranean cuisine with wellness focus. Complimentary breakfast and lunch, optional premium dinner upgrades. Serene ocean views, pastoral dining at sea.">
   <meta name="last-reviewed" content="2026-02-01">
   <meta name="content-protocol" content="ICP-Lite v1.4">
-  <meta name="keywords" content="Solarium Bistro, Royal Caribbean dining, Mediterranean food, healthy cruise restaurant, adults only, Oasis class, Symphony, wellness dining, spa cuisine">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/restaurants/sorrentos.html
+++ b/restaurants/sorrentos.html
@@ -26,7 +26,6 @@ All work on this project is offered as a gift to God.
   <!-- Canonical SEO -->
   <link rel="canonical" href="https://cruisinginthewake.com/restaurants/sorrentos.html">
   <meta name="description" content="Royal Caribbean Sorrento’s Pizza — complimentary New York-style slices on the Royal Promenade. Daily rotating specialties, late-night hours, tips, and real cruiser review.">
-  <meta name="keywords" content="Sorrento's, Sorrentos, Royal Caribbean pizza, complimentary pizza, Royal Promenade, late night food, pepperoni slice, Margherita, BBQ chicken pizza">
   <meta name="version" content="3.010.300">
   <meta name="referrer" content="no-referrer">
 

--- a/restaurants/surfside-eatery.html
+++ b/restaurants/surfside-eatery.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>Surfside Eatery — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="Surfside Eatery on Royal Caribbean’s Icon class — the family-first buffet in the Surfside neighborhood. Menus, hours, ships, tips, and 2025 cruiser reviews.">
-  <meta name="keywords" content="Surfside Eatery, Icon of the Seas, Star of the Seas, Royal Caribbean, family dining, buffet, kids food, sundaes, dino nuggets, Surfside neighborhood">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/restaurants/the-grove.html
+++ b/restaurants/the-grove.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>The Grove — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="The Grove on Royal Caribbean — suite-exclusive al fresco Mediterranean small plates in the Suite Neighborhood. Hours, access rules, menus, ships, and 2025 guest reviews.">
-  <meta name="keywords" content="The Grove, Royal Suite Neighborhood, Icon of the Seas, Star of the Seas, suite dining, Mediterranean, mezze, al fresco, complimentary restaurant">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/restaurants/vitality-cafe.html
+++ b/restaurants/vitality-cafe.html
@@ -22,7 +22,6 @@ All work on this project is offered as a gift to God.
   <title>Vitality Café — Royal Caribbean | In the Wake</title>
 
   <meta name="description" content="Royal Caribbean Vitality Café — smoothies, juices, and wellness snacks inside the Vitality Spa & Fitness Center. Menu, pricing, and 2025 cruiser reviews.">
-  <meta name="keywords" content="Vitality Café, Royal Caribbean, smoothies, healthy dining, spa cafe, Wonder of the Seas, wellness, juice bar, protein shakes">
   <meta name="referrer" content="no-referrer">
   <meta name="version" content="3.010.300">
 

--- a/ships.html
+++ b/ships.html
@@ -65,7 +65,6 @@ All work on this project is offered as a gift to God.
   <!-- Title & SEO -->
   <title>Cruise Ship Fleet — 290+ Ships Across 15 Lines | In the Wake</title>
   <meta name="description" content="Explore cruise ships at a glance: classes, debut years, and quick links—rendered from a live fleet dataset." />
-  <meta name="keywords" content="Royal Caribbean ships, cruise ships, ship comparison, fleet guide, cruise planning"/>
   <link rel="canonical" href="https://cruisinginthewake.com/ships.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/solo/in-the-wake-of-grief-meta.html
+++ b/solo/in-the-wake-of-grief-meta.html
@@ -19,7 +19,6 @@
 <!-- SEO: Title & Description -->
 <title>In the Wake of Grief: When Loss Needs Water | In the Wake</title>
 <meta name="description" content="A pastoral guide for widows, widowers, and bereaved travelers navigating first cruises after loss. Covers timing, triggers, finding community, and permission to feel joy."/>
-<meta name="keywords" content="grief travel, widow cruise, widower travel, cruise after loss, bereavement travel, first cruise after death, solo travel widow, holiday grief, cruising alone after spouse death"/>
 <link rel="canonical" href="https://cruisinginthewake.com/solo/in-the-wake-of-grief.html"/>
 
 <!-- SEO: Author & Copyright -->

--- a/solo/in-the-wake-of-grief.html
+++ b/solo/in-the-wake-of-grief.html
@@ -36,7 +36,6 @@ All work on this project is offered as a gift to God.
   <!-- Title & SEO -->
   <title>In the Wake of Grief: When Loss Needs Water — Solo Travel | In the Wake</title>
   <meta name="description" content="A pastoral guide for widows, widowers, and bereaved travelers navigating first cruises after loss. Covers timing, triggers, finding community, and permission to feel joy."/>
-  <meta name="keywords" content="grief travel, widow cruise, widower travel, cruise after loss, bereavement travel, first cruise after death, solo travel widow, holiday grief, cruising alone after spouse death"/>
 
   <!-- Canonical -->
   <link rel="canonical" href="https://cruisinginthewake.com/solo/in-the-wake-of-grief.html"/>

--- a/tools/cruise-budget-calculator.html
+++ b/tools/cruise-budget-calculator.html
@@ -64,7 +64,6 @@ All work on this project is offered as a gift to God.
   <!-- Title & SEO -->
   <title>Cruise Budget Calculator — Estimate Your Total Trip Cost | In the Wake</title>
   <meta name="description" content="Estimate your total cruise vacation cost — cabin fare, excursions, drinks, dining, gratuities, internet, and travel. See where your money goes." />
-  <meta name="keywords" content="cruise budget calculator, cruise cost estimator, how much does a cruise cost, cruise vacation budget, cruise trip cost"/>
   <link rel="canonical" href="https://cruisinginthewake.com/tools/cruise-budget-calculator.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/tools/port-day-planner.html
+++ b/tools/port-day-planner.html
@@ -65,7 +65,6 @@ All work on this project is offered as a gift to God.
   <!-- Title & SEO -->
   <title>Port Day Planner — Plan Your Perfect Shore Day | In the Wake</title>
   <meta name="description" content="Plan your cruise port day with an interactive timeline, budget tracker, and packing checklist. Print your plan and take it ashore." />
-  <meta name="keywords" content="cruise port day planner, shore excursion planner, cruise port schedule, port day budget, cruise planning worksheet"/>
   <link rel="canonical" href="https://cruisinginthewake.com/tools/port-day-planner.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/tools/release-notes.html
+++ b/tools/release-notes.html
@@ -40,7 +40,6 @@
   <!-- Title & SEO -->
   <title>Tool Release Notes — In the Wake | Cruise Planning Tools Changelog</title>
   <meta name="description" content="Changelog and release notes for In the Wake's cruise planning tools: Drink Calculator, Stateroom Check, Port Logbook, Ship Logbook, and more."/>
-  <meta name="keywords" content="cruise tools, drink calculator updates, stateroom check, changelog, release notes"/>
   <link rel="canonical" href="https://cruisinginthewake.com/tools/release-notes.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/tools/ship-size-atlas.html
+++ b/tools/ship-size-atlas.html
@@ -65,7 +65,6 @@ All work on this project is offered as a gift to God.
   <!-- Title & SEO -->
   <title>Ship Size Atlas — Cruise Ship Size Comparison 2026 | In the Wake</title>
   <meta name="description" content="Compare cruise ships across Royal Caribbean, MSC, Norwegian, Carnival, Holland America, Princess, and more — by gross tonnage, length, beam, draft, and passenger capacity." />
-  <meta name="keywords" content="cruise ship size comparison, ship GT, cruise ship dimensions, biggest cruise ships, ship capacity, cruise ship length"/>
   <link rel="canonical" href="https://cruisinginthewake.com/tools/ship-size-atlas.html"/>
 
   <!-- SEO: Author & Copyright -->

--- a/travel.html
+++ b/travel.html
@@ -8,7 +8,6 @@ All work on this project is offered as a gift to God.
 STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.300 · A11y/WCAG 2.1 AA Compliant
 GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER.
 -->
-<!doctype html>
 <html lang="en" class="no-js">
 <head>
   <!-- ======================================================


### PR DESCRIPTION
## Summary

ICP-2 v2.1 metadata cleanup across the site. Three anti-patterns removed and one structural defect fixed — all pure deletions/structural corrections, **no content rewrites**.

`553 files changed, 175 insertions(+), 6170 deletions(-)` — the insertion count is almost entirely structural re-joins (e.g. `<head>` lines reflowed where a comment was removed); net effect is removal of dead metadata.

## What's in here

### 1. ai-breadcrumbs removal — `#1792` (anti-pattern #8)
Removed the legacy `<!-- ai-breadcrumbs ... -->` HTML comment block from **every page on the site** ("no AI crawler reads HTML comments"). **0 blocks remain sitewide.**

| Area | Pages |
|---|---|
| restaurants/ | 478 |
| cruise-lines/ | 16 |
| solo/ | 7 |
| root + articles/ + tools/ + ships/ + authors/ | 35 |
| admin/ | 5 |
| homepage (`index.html`) | 1 |

Plus a follow-up commit tidying 3 orphaned blank lines left where a `<body>`/`<head>`-top block was removed.

### 2. Dead `<meta name="keywords">` removal — `#1812` + sitewide remainder (anti-pattern #4)
Removed the `keywords` meta tag ("dead since 2009, no engine reads them") from **33 pages** (16 restaurant via #1812, 17 non-restaurant). **0 remain sitewide.**

### 3. Duplicate `<!doctype html>` fix — `#1825` + `#1826`
7 pages had two `<!doctype html>` declarations (a stray second one between the attribution comment and `<html>`). Removed the redundant one; single valid doctype now. **0 duplicates remain sitewide.**

## Method — careful, not clever
- **Every file was read in-session before editing.** No blind regex sweeps. (An early bulk-regex attempt on the restaurants was rolled back and redone read-then-edit per file.)
- Each edit anchored on the file's actual surrounding text — structural variants were handled individually, not forced to one pattern (e.g. breadcrumbs found in `<body>` vs `<head>` vs mid-head; wrapped multi-line `keywords` tags; the `audit-log.html` body-prose mention of "ai-breadcrumbs" was deliberately **preserved**).
- Verified after every batch: zero-remaining grep, comment-delimiter balance, deletions-only diff, orphan-blank scan.
- Preserved all Soli Deo Gloria attribution comments, standards banners, and `travel.html`'s `GUARD RAIL` verbiage.

## Issues closed
Closes #1792 · Closes #1812 · Closes #1825 · Closes #1826

## Notes for reviewer
- Provenance was verified before editing `admin/` pages: no generator emits that HTML (the only build script produces PDFs from markdown), so the edits won't be regenerated away.
- All commits are scoped one-anti-pattern-per-commit for reviewability.

https://claude.ai/code/session_014ujYyrEAZWqTiXSCgR284p

---
_Generated by [Claude Code](https://claude.ai/code/session_014ujYyrEAZWqTiXSCgR284p)_