### PR TITLE
voice skills: add local-model tell patterns (Qwen/Gemma accents)

### DIFF
--- a/.claude/skills/like-a-human/SKILL.md
+++ b/.claude/skills/like-a-human/SKILL.md
@@ -191,6 +191,19 @@ AI repeats the same sentence structure across consecutive sentences: Subject-Ver
 
 **Rule: if three consecutive sentences have the same grammatical shape, break one.**
 
+### Local-Model Accents (Qwen / Gemma)
+
+Everything above guards against general AI-slop and the Claude/GPT tells. A draft from a *local* model (Qwen, Gemma) carries its own accent. While writing or editing such a draft, also strip:
+
+- **The both-sides reflex (most important on vulnerable-audience pages).** Local models reflexively soften an honest call by appending the opposite view — "however, it's worth considering…", "it's a balance between…", "some travelers may disagree." On a page whose job is a real verdict (is this accessible? is this worth the money?), that neutralizes the guidance the reader came for. This is not the conditional hedge ("may offer") already covered — it is a reflex to avoid taking a side. Make the honest call.
+- **Manufactured drama (Gemma).** One-line contrast sentences and trailing ellipses ("And then the bill came…") to fake urgency. It *mimics* the native compressed chains ("Five decks. Five bars.") — but the real move reports; the fake one performs. Hold ellipses to at most one per page.
+- **Translationese (Qwen).** Formal "dictionary" diction: *utilize, manifestation, a multitude of, individuals.* Use the word a traveler says: use, sign, a lot of, people.
+- **Self-correction leakage (Qwen).** "Actually, to clarify…", "let me restate," "or rather" — reasoning residue. A published page has already decided. Cut.
+- **Numbered scaffolding (Qwen).** "Firstly… Secondly…", "In terms of…", "When it comes to…" inside narrative prose. The page's headings carry the order; a real packing list is fine.
+- **Summary loops (Gemma).** "In short… / Essentially…" restating the prior sentence. Say it once.
+
+Full grep-able detection lives in `voice-audit`; these are the during-writing reflexes to catch first.
+
 ## Native Moves (Protect These)
 
 - **First-person attestation with a date.** "I sailed Allure in March 2024." "We tendered in Cabo last fall." Date the experience.
@@ -307,5 +320,6 @@ When in doubt, trust the specific. Cut the crutch. The reader feels the differen
 
 ## Version History
 
+- **v3.2.0 (2026-06-02)** — Added "Local-Model Accents (Qwen / Gemma)" under Plain Language Discipline: during-writing reflexes for the both-sides conviction-neutralizing reflex, Gemma manufactured drama, Qwen translationese, self-correction leakage, numbered scaffolding, and summary loops. Full grep detection lives in `voice-audit`.
 - **v3.1.0 (2026-05-10)** — Lifted ten sub-disciplines from Romans's `like-a-human` (in cruise voice): copula avoidance with replacement table, decorative adverb kill list, rule of three, low-probability details, dead metaphor, one-point dilution, syntactic template repetition, punctuation fingerprint, the controlled flaw, the building pattern with concrete examples, cadence escalation (two kinds of acceleration + pause-and-pivot). Reorganized Plain Language Discipline as the spine of the document.
 - **v3.0.0** — Initial cruise-voice version: hard-banned vocabulary, native moves, three borrowed moves, pastoral guardrails.

--- a/.claude/skills/voice-audit/SKILL.md
+++ b/.claude/skills/voice-audit/SKILL.md
@@ -84,6 +84,64 @@ Count images, metaphors, and surprise phrases per paragraph. Run especially on c
 
 **Test for cleverness vs. truth:** say the plain version aloud. Then say the surprising version aloud. If the plain version lands, keep it. If the surprising version earns its keep by doing work the plain version cannot, keep the surprise. When in doubt, plain wins.
 
+#### Local-model tells (Qwen / Gemma accents)
+
+The scans above were calibrated on Claude/GPT-drafted pages. Local models (Qwen, Gemma) carry their own fingerprints those scans miss. Run this block whenever a page was generated or edited by a local model. Quote the exact phrase and line for each hit.
+
+**1. Both-sides reflex (vulnerable-audience pages: load-bearing).** RLHF trains local models to soften an honest assessment by appending the opposite view — "however, it's worth considering…", "it's a balance between…", "some travelers may disagree." On a page whose job is an honest verdict (is this ship right for a wheelchair user? is this excursion worth $200?), this neutralizes the very guidance the reader came for. Distinct from the hedge already flagged below ("may offer," "can be considered") — this is a *both-sides append*, not a single softened claim.
+
+**Grep pattern:**
+```
+"however,? it'?s (also )?(worth|important) (to )?(note|consider)|on the other hand|that said,|to be fair,|it'?s a balance between|striking a balance|some (travelers|cruisers|people) (would|might|may) (argue|disagree)|there (are|is) (also )?valid (points|concerns) on (both|the other)|reasonable people (can|may) disagree"
+```
+- Every hit is a presumptive flag. The reporter gives the honest call; it does not editorialize toward neutrality. Keep a genuine two-side comparison only when both sides carry real, specific evidence the reader needs. **Threshold:** zero on a page's core recommendation.
+
+**2. Manufactured drama (Gemma).** Strings of one-line contrast sentences and trailing ellipses ("And then the bill came…") to fake urgency. This *collides with the native voice* — compressed declarative chains are baseline here ("Five decks. Five bars. Five different crowds."). The test is earned-ness.
+- For each cluster of 2+ consecutive ultra-short (<6-word) sentences: does the rhythm serve real reporting, or manufacture drama? Manufactured → cut.
+- **Ellipsis grep:** count `…` and `...`. **Threshold:** at most one per page, for a genuine trailing pause.
+
+**3. Translationese / precision-bias (Qwen).** Overly formal "dictionary" diction with no traveler idiom — "manifestation" / "utilize" / "a multitude of" where a person says "sign" / "use" / "a lot of."
+
+**Grep pattern:**
+```
+"\b(utilize|manifestation|endeavou?r|commence|prior to|subsequent to|in order to|a multitude of|a plethora of|individuals|possess(es|ed)?|aforementioned|delineate|elucidate)\b"
+```
+- Replace with the plain word a traveler uses (use / sign / start / before / after / to / a lot of / people / have).
+
+**4. Inline self-correction (Qwen, thinking mode).** "Actually, to clarify…", "let me restate," "or rather" — reasoning-transcript leakage into a finished page.
+
+**Grep pattern:**
+```
+"Actually,? to clarify|let me restate|to be (more )?precise|on second thought|let me rephrase|or rather,|to put it (differently|another way)|correction:|what I mean (to say )?is"
+```
+- Every hit cut. A published page is not a reasoning transcript.
+
+**5. Numeric / stepwise scaffolding (Qwen).** "Firstly… Secondly…", "In terms of…", "When it comes to…" inside flowing prose where the page's own headings carry the order.
+
+**Grep pattern:**
+```
+"\b(Firstly|Secondly|Thirdly|Fourthly|First and foremost)\b|\bIn terms of\b|\bWith regard to\b|\bWhen it comes to\b|\bPoint (one|two|three|[0-9])\b|\bStep [0-9]\b"
+```
+- A genuine numbered list (packing list, step-by-step) is fine; numbered *sentences* in narrative prose are the tell.
+
+**6. Summary loop (Gemma).** "In short… / Essentially…" restating the previous sentence.
+
+**Grep pattern:**
+```
+"\b(In short|In summary|Simply put|To put it simply|The bottom line|At the end of the day|To sum up|Essentially|Basically)\b,?"
+```
+- For each hit, check the next clause: new content or restatement? Restatement → cut.
+
+**7. Markdown / tokenizer artifacts (Gemma 2).** Stray `▁`, doubled spaces, or accidental markdown bleeding into rendered HTML body copy.
+
+**Grep pattern:**
+```
+"▁|  +| _[A-Za-z]| \*[A-Za-z]"
+```
+- Strip in post-processing — these render visibly on the page.
+
+> **Coverage-architecture note:** these scans only help if they run. If a local model ever drafts or edits page copy, wire the grep patterns above (plus the existing announcement / assumed-familiarity scans) into the pre-publish path so local-model output is audited before it ships — InTheWake pages are public, and an un-audited local-model accent ships straight to a vulnerable reader.
+
 ### 2. Voice Continuity Check
 
 **Must be present** (cruise voice baseline):
@@ -285,5 +343,6 @@ When the rating is High, the recommendation is to **rewrite the page from the or
 
 ## Version History
 
+- **v2.2.0 (2026-06-02)** — Added the "Local-model tells (Qwen / Gemma accents)" scan (seven grep-able fingerprints local models carry that the Claude/GPT-tuned scans miss): the both-sides/conviction-neutralizing reflex, Gemma manufactured-drama staccato + ellipsis overuse, Qwen translationese, inline self-correction, numeric scaffolding, Gemma summary loops, and Gemma-2 markdown artifacts. Includes a coverage-architecture note: wire these into the pre-publish path if a local model ever drafts page copy. Mirrors the same addition in `like-a-human`.
 - **v2.1.0 (2026-05-10)** — Lifted four diagnostics from Romans's `voice-audit` (in cruise voice): grep pattern for announcement-before-move, grep pattern for assumed-familiarity, image-density scan with per-paragraph thresholds, must-be-absent list with explicit drift indicators. Updated risk-rating thresholds and audit-report format to reflect the new checks.
 - **v2.0.0** — Six-axis scan with cruise-marketing vocabulary list and pastoral-honesty axis.


### PR DESCRIPTION
Mirrors the Romans addition in cruise voice. Seven model-specific tells local models carry that the Claude/GPT-tuned scans miss:
1. both-sides reflex (load-bearing on vulnerable-audience pages — neutralizes the honest verdict the reader came for)
2. Gemma manufactured-drama staccato (collides with the native compressed declarative chains)
3. Qwen translationese / precision-bias
4. Qwen inline self-correction
5. Qwen numeric/stepwise scaffolding
6. Gemma summary loop
7. Gemma-2 markdown artifacts (render visibly on the page)

voice-audit v2.2.0: grep patterns + thresholds + pre-publish coverage note.
like-a-human v3.2.0: during-writing mirror. Additions only.

https://claude.ai/code/session_01PbZhbLT9MU9UK4swyrtJh5