### PR TITLE
Add four new AI-writing patterns to voice audit checklist

### DIFF
--- a/.claude/skills/like-a-human/SKILL.md
+++ b/.claude/skills/like-a-human/SKILL.md
@@ -129,6 +129,28 @@ Also watch for: "Perhaps the most striking thing is..." "It is a reminder that..
 
 "From X to Y" requires X and Y to be endpoints of a real scale. "From the pool deck to the engine room" works. "From relaxing to adventurous" does not — those are not on a meaningful scale. AI uses this construction to gesture at breadth without being specific. Name the actual items instead.
 
+### Therapeutic and Cognitive Verbs
+
+Self-help and consultant vocabulary creeps into travel writing through specific verbs: *optimize (your itinerary), unpack (your options), process (the experience), calibrate (expectations), reframe, leverage, curate.* These are brochure-and-TED-talk words, not the words of someone telling you what a week at sea was actually like.
+
+Replace with plain verbs the reporter would use: "optimize your sea days" → "plan your sea days," "unpack the dining options" → "walk through the dining options," "curate your excursions" → "pick your excursions." **Carve-out:** literal uses are fine ("the app optimizes the route"). The tell is the abstract self-help use where a plain verb works.
+
+### Stock Demographic Listicles
+
+When a page gestures at "who this cruise is for," AI reaches for a four-part traveler stack: "Some guests want to relax by the pool. Some want adventure ashore. Some are traveling with kids. Some are celebrating an anniversary." The four-part shape is the tell — exhaustive market-segment coverage, not observation. (Distinct from a real grouping under Rule of Three: there the count follows the fact; here four parallel "some guests…" clauses are a template.)
+
+Fix: name the specific reader this page actually serves, or collapse to one or two concrete clauses. "the first-time cruiser who's nervous about getting seasick" beats four parallel "some guests want…" clauses.
+
+### Composite First-Person Attestation
+
+"Having sailed this route myself…" "I've done this excursion." "Trust me, I've been there." When a first-person claim is followed by generic description with no specifics — no date, no weather, no tender time, no dish you actually ate — the claim is unsubstantiated and the reader feels it. (Pairs with Low-Probability Details: specificity is the proof of having been there.)
+
+Two honest fixes: drop the claim and report it as research ("the route runs…"), or earn it with one concrete detail only a passenger would know ("the 7:15 tender from Cabo was already full by 7:00"). The half-measure — claim plus vague gesture — is worst: it asks for testimony credit the prose can't back. This site's whole credibility rests on sounding like someone who actually sailed it; an empty "I've been there" spends that credibility for nothing.
+
+### Reader-Address Cue Filler
+
+"Picture this." "Let me tell you." "Here's the thing about Cozumel." Sparingly, at a real gear-shift, fine. Used to manufacture intimacy before an ordinary sentence, cut. Diagnostic: does the sentence after the cue need it, or land harder alone?
+
 ### Announcement-Before-Move Tells
 
 A sentence that narrates what the next sentence is about to do, instead of just doing it. Always a throat-clear. Almost always deletable.

--- a/.claude/skills/voice-audit/SKILL.md
+++ b/.claude/skills/voice-audit/SKILL.md
@@ -180,6 +180,10 @@ The scans above were calibrated on Claude/GPT-drafted pages. Local models (Qwen,
 - [ ] Hedged claims where the reporter would speak declaratively ("may offer," "can be considered," "is regarded as")
 - [ ] Antithetical-parallelism stacking beyond one instance per page
 - [ ] Cruise-marketing vocabulary (zero tolerance — see hard-banned list in `like-a-human`)
+- [ ] Therapeutic/cognitive verbs used abstractly. Grep: `\b(optimize|unpack|process|calibrate|reframe|leverage|curate)\b`. Carve-out: literal use is fine ("the app optimizes the route"); flag the self-help use ("optimize your sea days" → "plan your sea days," "curate your excursions" → "pick your excursions").
+- [ ] Stock demographic listicle — four-part "Some guests want… / Some are…" traveler stack. Name the specific reader the page serves, or collapse to one or two concrete clauses.
+- [ ] Composite first-person attestation — "having sailed this myself" / "I've done this excursion" / "trust me, I've been there" with no date, weather, tender time, or dish to back it. Drop the claim or earn it with one passenger-only detail; the half-measure spends the site's whole "actually sailed it" credibility for nothing. (See Voice Continuity: first-person attestation must carry a date.)
+- [ ] Reader-address cue filler — "Picture this," "Let me tell you," "Here's the thing about X" before an ordinary sentence. Keep at a real gear-shift; cut when the next sentence lands harder alone.
 
 **Drift indicator (strengthened in v2.2.0):** if **3 or more must-be-present markers are missing**, OR **2 or more must-be-absent items appear**, the page has drifted at minimum to Medium risk regardless of machine-tell count. Both signals are weighted equally; the absence list is *not* a soft warning.
 


### PR DESCRIPTION
## Summary
Expanded the voice audit skill with four additional patterns that commonly appear in AI-generated travel writing. These patterns have been documented in the `like-a-human` skill and are now integrated into the `voice-audit` checklist for systematic detection.

## Key Changes

- **Therapeutic and Cognitive Verbs**: Added detection for self-help vocabulary (`optimize`, `unpack`, `process`, `calibrate`, `reframe`, `leverage`, `curate`) when used abstractly rather than literally. Includes guidance on replacement with plain verbs and carve-outs for legitimate uses.

- **Stock Demographic Listicles**: Documented the four-part traveler-segment pattern ("Some guests want X. Some want Y...") as a template tell. Provides fixes: name the specific reader or collapse to one or two concrete clauses.

- **Composite First-Person Attestation**: Flagged unsubstantiated first-person claims ("I've been there") without supporting details (date, weather, specific observations). Requires either dropping the claim or earning it with one passenger-only detail.

- **Reader-Address Cue Filler**: Added detection for manufactured-intimacy phrases ("Picture this," "Let me tell you") used before ordinary sentences. Guidance: keep only at real gear-shifts; cut when the sentence lands harder alone.

## Implementation Details

- Added grep pattern for therapeutic verbs with carve-out guidance for literal uses
- Integrated all four patterns into the voice-audit checklist with specific detection criteria and remediation steps
- Maintained consistency with existing drift-indicator weighting (patterns count toward the 3+ missing markers or 2+ present items threshold)
- Cross-referenced with existing rules (Low-Probability Details, Voice Continuity) where applicable

https://claude.ai/code/session_019EfCwSC9D26kCNJPoA4PEK