### PR TITLE
restaurants/msc: swap decorative icons to pass v2 validator T01 + S05

### DIFF
--- a/restaurants/msc/asian-market-kitchen.html
+++ b/restaurants/msc/asian-market-kitchen.html
@@ -356,7 +356,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="/assets/images/restaurants/photos/sushi.webp" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail-lounge.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook &mdash; Real Guest Soundings</h2>
 

--- a/restaurants/msc/biscayne-bay-buffet.html
+++ b/restaurants/msc/biscayne-bay-buffet.html
@@ -301,7 +301,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="/assets/images/restaurants/photos/pizza.webp" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook &mdash; Real Guest Soundings</h2>
 

--- a/restaurants/msc/hola-tacos-cantina.html
+++ b/restaurants/msc/hola-tacos-cantina.html
@@ -363,7 +363,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="/assets/images/restaurants/photos/tacos.webp" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook &mdash; Real Guest Soundings</h2>
 

--- a/restaurants/msc/ipanema-restaurant.html
+++ b/restaurants/msc/ipanema-restaurant.html
@@ -263,7 +263,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Menu & Prices -->
   <section class="card" id="menu-prices">
-    <img src="/assets/images/restaurants/photos/italian.webp" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/croissant.webp" alt="" aria-hidden="true">
     <div class="card__content menu-body">
       <h2>Menu &amp; Prices</h2>
       <p class="price-note">
@@ -294,7 +294,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook &mdash; Real Guest Soundings</h2>
 

--- a/restaurants/msc/seashore-restaurant.html
+++ b/restaurants/msc/seashore-restaurant.html
@@ -306,7 +306,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/cocktail.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook &mdash; Real Guest Soundings</h2>
 

--- a/restaurants/msc/yacht-club-restaurant.html
+++ b/restaurants/msc/yacht-club-restaurant.html
@@ -356,7 +356,7 @@ All work on this project is offered as a gift to God.
 
   <!-- The Logbook — Real Guest Soundings -->
   <section class="card note-kens-logbook" id="logbook">
-    <img src="/assets/images/restaurants/photos/formal-dining.webp" alt="" aria-hidden="true">
+    <img src="/assets/images/restaurants/photos/bar-lounge.webp" alt="" aria-hidden="true">
     <div class="card__content prose">
       <h2>The Logbook &mdash; Real Guest Soundings</h2>
 


### PR DESCRIPTION
Post-merge cleanup. Fast-forward merge with origin/main brought 704 new commits and a stricter validator (admin/validate-venue-page-v2.js). Two new rule classes surfaced on the seven MSC venue pages:

- T01 Image over-duplication: any decorative icon used 2+ times on the same page is now an error (was unlimited). Six of the seven pages used the same category icon in both the Overview and the Logbook section.
- S05 Image/venue type mismatch: italian.webp on a non-Italian-slug venue is now an error. Ipanema served Italian-leaning food but the slug is "ipanema-restaurant".

Image swaps (logbook section only, 1 per page):
- asian-market-kitchen: sushi.webp → cocktail-lounge.webp
- ipanema-restaurant: formal-dining.webp → cocktail.webp; also italian.webp (Menu) → croissant.webp for the S05 fix
- seashore-restaurant: formal-dining.webp → cocktail.webp
- biscayne-bay-buffet: pizza.webp → cocktail.webp
- yacht-club-restaurant: formal-dining.webp → bar-lounge.webp
- hola-tacos-cantina: tacos.webp → cocktail.webp

(top-sail-lounge.html was already clean — no swap.)

All seven pages now pass admin/validate-venue-page-v2.js with 0 errors. Image-reuse guardrail clean (17 references checked).

KNOWN STALE: admin/validate-venue-page.sh — the OLD bash validator still requires ai-breadcrumbs HTML comment blocks, which the current active standard (ICP-2 v2.1, see .claude/skills/icp-2/SKILL.md) explicitly forbids ("no AI crawler reads HTML comments. Both GPT and Gemini confirmed. Remove them"). PR #1792 removed them from all 478 restaurant pages — zero in the corpus carry them now. My pages match the current corpus and standard; the bash validator reports false-positive errors because it has not been updated for the v2.1 migration. NOT widening or softening the bash validator in this commit — that would be the Validator Capitulation pattern named in admin/CAREFUL_NOT_CLEVER_FAILURE_2026_05_18.md. The bash validator is documented as the older validator in .claude/plan-venue-audit.md; admin/validate-venue-page-v2.js is the actual current gate and all seven pages pass it.