### PR TITLE
CSS version sweep: align styles.css?v= to canonical 3.010.400 (#1632)

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -204,7 +204,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
   <script type="application/ld+json">
   {

--- a/accessibility.html
+++ b/accessibility.html
@@ -198,7 +198,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
   <script type="application/ld+json">
   {

--- a/articles.html
+++ b/articles.html
@@ -158,7 +158,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
   <script type="application/ld+json">
   {

--- a/articles/cruise-duck-tradition.html
+++ b/articles/cruise-duck-tradition.html
@@ -116,7 +116,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.305"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- Umami (secondary analytics) -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 

--- a/articles/cruise-tech-photography-guide.html
+++ b/articles/cruise-tech-photography-guide.html
@@ -112,7 +112,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.401"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <script>
   if('serviceWorker' in navigator){
     window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));

--- a/audit-log.html
+++ b/audit-log.html
@@ -67,7 +67,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.500"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- JSON-LD: WebPage (ICP-Lite) -->
   <script type="application/ld+json">

--- a/countdown.html
+++ b/countdown.html
@@ -176,7 +176,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.500"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- LCP Optimization -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>

--- a/cruise-lines.html
+++ b/cruise-lines.html
@@ -269,7 +269,7 @@
   <link rel="dns-prefetch" href="https://www.flickersofmajesty.com"/>
 
   <!-- Unified CSS (global) -->
-  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="https://cruisinginthewake.com/assets/compass_rose.svg"/>
 
   <!-- Site Cache helper + SW registration -->

--- a/cruise-lines/carnival.html
+++ b/cruise-lines/carnival.html
@@ -148,7 +148,7 @@
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 
   <!-- Page-specific polish (uses global hero from styles.css; no duplicate hero) -->

--- a/cruise-lines/celebrity.html
+++ b/cruise-lines/celebrity.html
@@ -148,7 +148,7 @@
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 
   <!-- Page polish (uses global hero; no duplicate hero markup) -->

--- a/cruise-lines/costa.html
+++ b/cruise-lines/costa.html
@@ -121,7 +121,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 </head>
 

--- a/cruise-lines/cunard.html
+++ b/cruise-lines/cunard.html
@@ -65,7 +65,7 @@ All work on this project is offered as a gift to God.
   {"@context":"https://schema.org","@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/about/ken-baker.html","jobTitle":"Cruise Research Analyst & Data Specialist","description":"Cruise industry analyst specializing in ship comparisons, deck plan analysis, and dining venue research.","knowsAbout":["Cruise Ship Analysis","Deck Plans","Cunard","Cruise Dining","Ship Comparisons"]}
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 </head>
 

--- a/cruise-lines/explora-journeys.html
+++ b/cruise-lines/explora-journeys.html
@@ -121,7 +121,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 </head>
 

--- a/cruise-lines/holland-america.html
+++ b/cruise-lines/holland-america.html
@@ -145,7 +145,7 @@
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 
   <!-- Page polish (keeps single global hero; no duplicate hero markup) -->

--- a/cruise-lines/msc.html
+++ b/cruise-lines/msc.html
@@ -148,7 +148,7 @@
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 
   <!-- Page polish (single global hero; no duplicate heroes) -->

--- a/cruise-lines/norwegian.html
+++ b/cruise-lines/norwegian.html
@@ -153,7 +153,7 @@
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 </head>
 

--- a/cruise-lines/oceania.html
+++ b/cruise-lines/oceania.html
@@ -121,7 +121,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 </head>
 

--- a/cruise-lines/princess.html
+++ b/cruise-lines/princess.html
@@ -153,7 +153,7 @@
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 </head>
 

--- a/cruise-lines/quiz.html
+++ b/cruise-lines/quiz.html
@@ -77,7 +77,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <style>
     /* Quiz-specific styles */

--- a/cruise-lines/regent.html
+++ b/cruise-lines/regent.html
@@ -121,7 +121,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 </head>
 

--- a/cruise-lines/royal-caribbean.html
+++ b/cruise-lines/royal-caribbean.html
@@ -88,7 +88,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/item-cards.css?v=3.010.300"/>
 
   <script>if('serviceWorker' in navigator){addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));}</script>

--- a/cruise-lines/seabourn.html
+++ b/cruise-lines/seabourn.html
@@ -121,7 +121,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 </head>
 

--- a/cruise-lines/silversea.html
+++ b/cruise-lines/silversea.html
@@ -121,7 +121,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.007"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg"/>
 </head>
 

--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -26,7 +26,7 @@ All work on this project is offered as a gift to God.
 
   <!-- Canonical + CSS (absolute, cache-busted) -->
   <link rel="canonical" href="https://cruisinginthewake.com/cruise-lines/virgin.html"/>
-  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.006"/>
+  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
 
   <!-- Open Graph / Twitter -->
   <meta property="og:type" content="website"/>

--- a/data.html
+++ b/data.html
@@ -67,7 +67,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.500"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- JSON-LD: WebPage (ICP-Lite) -->
   <script type="application/ld+json">

--- a/disability-at-sea.html
+++ b/disability-at-sea.html
@@ -52,7 +52,7 @@ ADDENDUM: Facebook Domain Verification v3.008.021
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"/>
 
   <!-- Global styles -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.100"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- Preload Hero -->
   <link rel="preload" as="image" href="/assets/index_hero.jpg?v=3.010.100" fetchpriority="high"/>

--- a/drink-calculator-v1.html
+++ b/drink-calculator-v1.html
@@ -285,7 +285,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/calculator.css?v=3.010.300"/>
   
   <!-- ✅ Accessibility Styles -->

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -291,7 +291,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/calculator.css?v=3.010.300"/>
   <!-- v2: Print overrides consolidated in calculator.css Section 20 -->
   

--- a/drink-packages.html
+++ b/drink-packages.html
@@ -100,7 +100,7 @@
     "description": "Complete guide to Royal Caribbean drink packages: Coffee Card, Soda Package, Refreshment Package, and Deluxe Beverage Package. What's included, pricing, and how to choose.",
     "dateModified": "2025-11-19"
   }
-  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>

--- a/internet-at-sea.html
+++ b/internet-at-sea.html
@@ -114,7 +114,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>

--- a/offline.html
+++ b/offline.html
@@ -49,7 +49,7 @@ STANDARDS: Every Page v3.010.300 · Offline Fallback · A11y/WCAG 2.1 AA Complia
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <style>
     /* ===== Offline Page Styles ===== */

--- a/packing-lists.html
+++ b/packing-lists.html
@@ -197,7 +197,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
   <script type="application/ld+json">
   {

--- a/planning.html
+++ b/planning.html
@@ -208,7 +208,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
   <script type="application/ld+json">
   {

--- a/ports.html
+++ b/ports.html
@@ -153,7 +153,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- Dropdown Navigation Styles -->
   <!-- JSON-LD: FAQPage (ICP-Lite) -->

--- a/ports/curacao.html
+++ b/ports/curacao.html
@@ -32,7 +32,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.305">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Leaflet CSS for interactive maps -->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">

--- a/privacy.html
+++ b/privacy.html
@@ -80,7 +80,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/reaching-someone-at-sea.html
+++ b/reaching-someone-at-sea.html
@@ -67,7 +67,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.500"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/handoff-card.css"/>
   <link rel="stylesheet" href="/assets/css/handoff-card-print.css"/>
 

--- a/restaurants.html
+++ b/restaurants.html
@@ -211,7 +211,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/item-cards.css?v=1.0.0"/>
 
   <!-- Dropdown Navigation Styles -->

--- a/restaurants/adventure-ocean.html
+++ b/restaurants/adventure-ocean.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/arcade.html
+++ b/restaurants/arcade.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/carousel.html
+++ b/restaurants/carousel.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/casino.html
+++ b/restaurants/casino.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/fitness-center.html
+++ b/restaurants/fitness-center.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/north-star.html
+++ b/restaurants/north-star.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/ripcord-by-ifly.html
+++ b/restaurants/ripcord-by-ifly.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/rock-climbing.html
+++ b/restaurants/rock-climbing.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/solarium.html
+++ b/restaurants/solarium.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/vitality-spa.html
+++ b/restaurants/vitality-spa.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/restaurants/zip-line.html
+++ b/restaurants/zip-line.html
@@ -47,7 +47,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>

--- a/search.html
+++ b/search.html
@@ -63,7 +63,7 @@
     "description": "Search In the Wake for 1,200+ pages across 290+ ships, 388 ports, 478 restaurants, articles, and cruise planning tools. Instant fuzzy search results as you type.",
     "dateModified": "2026-01-02"
   }
-  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
   <script type="application/ld+json">
   {

--- a/ships-hub.html
+++ b/ships-hub.html
@@ -58,7 +58,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.008.032"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- JSON-LD: ItemList of cruise lines -->
   <script type="application/ld+json">

--- a/ships.html
+++ b/ships.html
@@ -661,7 +661,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ships-dynamic.css?v=1.000.000">
   <link rel="stylesheet" href="/assets/css/item-cards.css?v=1.0.0">
 

--- a/ships/allshipquiz.html
+++ b/ships/allshipquiz.html
@@ -72,7 +72,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/item-cards.css?v=1.0.0">
 
   <style>

--- a/ships/carnival/carnival-conquest.html
+++ b/ships/carnival/carnival-conquest.html
@@ -106,7 +106,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   

--- a/ships/carnival/carnival-dream.html
+++ b/ships/carnival/carnival-dream.html
@@ -100,7 +100,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-ecstasy.html
+++ b/ships/carnival/carnival-ecstasy.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="Carnival Ecstasy: Longest-serving Fantasy Class ship 1991-2022. 70,526 GT, 2,040 guests. 31 years, 5.5 million passengers. Charleston/Jacksonville homeports. Scrapped Aliaga Turkey Nov 2022.">
 <meta name="last-reviewed" content="2026-02-12"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/carnival-encounter.html
+++ b/ships/carnival/carnival-encounter.html
@@ -38,7 +38,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010" fetchpriority="high"/>
 
 <!-- Stylesheet -->
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
 <!-- JSON-LD: Organization -->

--- a/ships/carnival/carnival-fantasy.html
+++ b/ships/carnival/carnival-fantasy.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="Carnival Fantasy: Lead Fantasy Class ship 1990-2020. First glass-topped atrium. 70,367 GT, 2,044 guests. Godmother Tellervo Koivisto. Scrapped Aliaga Turkey July 2020.">
 <meta name="last-reviewed" content="2026-02-12"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/carnival-fascination.html
+++ b/ships/carnival/carnival-fascination.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="Carnival Fascination: Fourth Fantasy Class ship 1994-2022. Hollywood cinema theme. Godmother Mary Tyler Moore. 70,367 GT, 2,040 guests. San Juan/Mobile homeports. Scrapped Pakistan Feb 2022.">
 <meta name="last-reviewed" content="2026-02-12"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/carnival-festivale.html
+++ b/ships/carnival/carnival-festivale.html
@@ -174,7 +174,7 @@ if ('serviceWorker' in navigator) {
 }
 </script>
 
-<link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -190,7 +190,7 @@ if ('serviceWorker' in navigator) {
 }
 </script>
 
-<link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-freedom.html
+++ b/ships/carnival/carnival-freedom.html
@@ -100,7 +100,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-glory.html
+++ b/ships/carnival/carnival-glory.html
@@ -100,7 +100,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-horizon.html
+++ b/ships/carnival/carnival-horizon.html
@@ -110,7 +110,7 @@
 </script>
 
 <script>if('serviceWorker' in navigator){window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));}</script>
-<link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-imagination.html
+++ b/ships/carnival/carnival-imagination.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="Carnival Imagination: Fifth Fantasy Class ship 1995-2020. Godmother Jodi Dickinson. Long Beach legend. 70,367 GT, 2,040 guests. 25 years California service. Scrapped Aliaga Turkey 2023.">
 <meta name="last-reviewed" content="2026-02-12"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/carnival-inspiration.html
+++ b/ships/carnival/carnival-inspiration.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="Carnival Inspiration: Sixth Fantasy Class ship 1996-2020. Godmother Mary Anne Shula (NFL royalty). 70,367 GT, 2,040 guests. Long Beach homeport. Scrapped Aliaga Turkey 2022.">
 <meta name="last-reviewed" content="2026-02-12"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/carnival-legend.html
+++ b/ships/carnival/carnival-legend.html
@@ -88,7 +88,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-liberty.html
+++ b/ships/carnival/carnival-liberty.html
@@ -100,7 +100,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-miracle.html
+++ b/ships/carnival/carnival-miracle.html
@@ -88,7 +88,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -109,7 +109,7 @@
 </script>
 
 <script>if('serviceWorker' in navigator){window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));}</script>
-<link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-pride.html
+++ b/ships/carnival/carnival-pride.html
@@ -88,7 +88,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-sensation.html
+++ b/ships/carnival/carnival-sensation.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="Carnival Sensation: Third Fantasy Class ship 1993-2022. Joe Farcus seven-deck neon atrium. 70,367 GT, 2,040 guests. Miami homeport. Scrapped Aliaga Turkey Feb 2022.">
 <meta name="last-reviewed" content="2026-02-12"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/carnival-spirit.html
+++ b/ships/carnival/carnival-spirit.html
@@ -88,7 +88,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -41,7 +41,7 @@
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high">
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010" fetchpriority="high">
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- JSON-LD: Organization -->

--- a/ships/carnival/carnival-tropicale.html
+++ b/ships/carnival/carnival-tropicale.html
@@ -41,7 +41,7 @@
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high">
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010" fetchpriority="high">
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- JSON-LD: Organization -->

--- a/ships/carnival/carnival-valor.html
+++ b/ships/carnival/carnival-valor.html
@@ -100,7 +100,7 @@
 }
 </script>
 
-<link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- Twitter Card -->

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -41,7 +41,7 @@
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high">
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010" fetchpriority="high">
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 
   <!-- JSON-LD: Organization -->

--- a/ships/carnival/carnivale-1956.html
+++ b/ships/carnival/carnivale-1956.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="TSS Carnivale: Carnival's second ship 1975-1993. Ex-RMS Empress of Britain. 31,500 GT. Later Queen Anna Maria, Fiesta Marina, Olympic, The Topaz. 52 years total service. Scrapped 2008.">
 <meta name="last-reviewed" content="2026-02-13"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/celebration-1987.html
+++ b/ships/carnival/celebration-1987.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="MS Celebration (1987-2021): Final Holiday Class ship, last survivor of the trio. 47,262 GT. Built by Kockums. 21 Carnival years. 1989 rescue hero. Later Grand/Costa Celebration. Scrapped January 2021.">
 <meta name="last-reviewed" content="2026-02-13"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/festivale-1961.html
+++ b/ships/carnival/festivale-1961.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="TSS Festivale (1978-1996): Carnival's third ship, ex-Transvaal Castle. First waterslide at sea (1981). 27,000 GT. Later IslandBreeze, Big Red Boat III. Scrapped 2003-2004.">
 <meta name="last-reviewed" content="2026-02-13"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/holiday-1985.html
+++ b/ships/carnival/holiday-1985.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="MS Holiday (1985-2021): Holiday Class lead ship, first SuperLiner. 46,052 GT. Built by Aalborg Værft. Served 24 Carnival years. Later Grand Holiday, Magellan. Scrapped 2021 after 36 years.">
 <meta name="last-reviewed" content="2026-02-13"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/index.html
+++ b/ships/carnival/index.html
@@ -13,7 +13,7 @@ All work on this project is offered as a gift to God.
   <meta name="last-reviewed" content="2026-01-14">
   <meta name="content-protocol" content="ICP-Lite v1.4">
   <meta name="description" content="Carnival Cruise Line fleet guide: all 27 ships organized by class — Excel, Vista, Dream, Conquest, Spirit, Sunshine, Splendor, Venice, Grand, and Fantasy — with deck plans, dining, and signature venues.">
-  <title>Carnival Cruise Line Fleet Guide — All Ships by Class | In The Wake</title>  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=2.234"/>
+  <title>Carnival Cruise Line Fleet Guide — All Ships by Class | In The Wake</title>  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
 <style id="carnival-page-overrides">
     .brand-title{display:none!important}
 

--- a/ships/carnival/jubilee-1986.html
+++ b/ships/carnival/jubilee-1986.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="MS Jubilee (1986-2017): Holiday Class second ship. 47,262 GT. Built by Kockums, Sweden. 18 Carnival years. Later Pacific Sun (P&O Australia), Henna (HNA Cruises). First Holiday Class scrapped 2017.">
 <meta name="last-reviewed" content="2026-02-13"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/mardi-gras-1972.html
+++ b/ships/carnival/mardi-gras-1972.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="TSS Mardi Gras (1972-1993): Carnival's founding ship, ex-Empress of Canada. Launched Fun Ship era March 11, 1972 with famous grounding. 27,284 GT. Served 21 Carnival years. Later StarShip Atlantic. Scrapped 1997.">
 <meta name="last-reviewed" content="2026-02-13"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/tropicale-1981.html
+++ b/ships/carnival/tropicale-1981.html
@@ -23,7 +23,7 @@ STANDARDS: ITW-Lite v3.010 · ICP-Lite v1.0 · WCAG 2.1 AA
 
 <meta name="ai-summary" content="TSS Tropicale (1982-2000): First purpose-built Carnival ship. Introduced iconic winged funnel. 36,674 GT. Built by Aalborg Værft, Denmark. Later Costa Tropicale, Pacific Star, Ocean Dream. Scrapped 2021 after 39 years.">
 <meta name="last-reviewed" content="2026-02-20"><meta name="content-protocol" content="ICP-Lite v1.4">
-<link rel="stylesheet" href="/assets/styles.css?v=3.010">
+<link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"In the Wake","url":"https://cruisinginthewake.com","logo":"https://cruisinginthewake.com/assets/logo_wake_512.png"}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"In the Wake","url":"https://cruisinginthewake.com","potentialAction":{"@type":"SearchAction","target":"https://cruisinginthewake.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}}</script>

--- a/ships/carnival/unnamed-project-ace-1.html
+++ b/ships/carnival/unnamed-project-ace-1.html
@@ -34,7 +34,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=2.234"/>
+  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/unnamed-project-ace-2.html
+++ b/ships/carnival/unnamed-project-ace-2.html
@@ -34,7 +34,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=2.234"/>
+  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/carnival/unnamed-project-ace-3.html
+++ b/ships/carnival/unnamed-project-ace-3.html
@@ -34,7 +34,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=2.234"/>
+  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
 <style id="brand-title-hide">.brand-title{display:none!important}</style>
 

--- a/ships/holland-america-line/westerdam.html
+++ b/ships/holland-america-line/westerdam.html
@@ -88,7 +88,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
   <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
 

--- a/ships/holland-america-line/zuiderdam.html
+++ b/ships/holland-america-line/zuiderdam.html
@@ -88,7 +88,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="stylesheet" href="/assets/css/ship-page.css?v=3.010.300"/>
   <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>
 

--- a/ships/index.html
+++ b/ships/index.html
@@ -61,7 +61,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.008.032"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- Page styles -->
   <script type="application/ld+json">

--- a/ships/quiz.html
+++ b/ships/quiz.html
@@ -84,7 +84,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/item-cards.css?v=1.0.0">
 
   <style>

--- a/ships/rcl/index.html
+++ b/ships/rcl/index.html
@@ -64,7 +64,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- LCP Optimization -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>

--- a/ships/rcl/venues.html
+++ b/ships/rcl/venues.html
@@ -74,7 +74,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
 
   <!-- Stylesheet -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- LCP Optimization -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>

--- a/ships/rooms.html
+++ b/ships/rooms.html
@@ -39,7 +39,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="https://jsschrstrcks1.github.io/InTheWake/assets/styles.css?v=2.201"/>
+  <link rel="stylesheet" href="https://jsschrstrcks1.github.io/InTheWake/assets/styles.css?v=3.010.400"/>
   
   <link rel="stylesheet" href="https://jsschrstrcks1.github.io/InTheWake/assets/vendor/swiper-bundle.min.css?v=2.201"/>
   <script defer src="https://jsschrstrcks1.github.io/InTheWake/assets/vendor/swiper-bundle.min.js?v=2.201"></script>

--- a/ships/template.html
+++ b/ships/template.html
@@ -64,7 +64,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=2.245"/>
+  <link rel="stylesheet" href="https://cruisinginthewake.com/assets/styles.css?v=3.010.400"/>
 
   <!-- Swiper CSS -->
   <link rel="stylesheet" href="https://unpkg.com/swiper@10/swiper-bundle.min.css"/>

--- a/solo.html
+++ b/solo.html
@@ -229,7 +229,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- SOLO hero + inline-hero card treatment (scoped) -->
   <style id="solo-host-hero-fix">

--- a/solo/accessible-cruising.html
+++ b/solo/accessible-cruising.html
@@ -109,7 +109,7 @@ All work on this project is offered as a gift to God.
     "description": "Comprehensive guide to cruising with disabilities — accessible ships, booking accommodations, mobility equipment, and advocating for inclusive travel experiences.",
     "dateModified": "2025-11-18"
   }
-  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- Service Worker Registration -->
   <script>
   if('serviceWorker' in navigator){

--- a/solo/freedom-of-your-own-wake.html
+++ b/solo/freedom-of-your-own-wake.html
@@ -116,7 +116,7 @@ All work on this project is offered as a gift to God.
     "description": "A gentle case for sailing alone — rest, rhythm, and room to breathe when the sea becomes both your mirror and your companion.",
     "dateModified": "2025-11-18"
   }
-  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/solo/in-the-wake-of-grief.html
+++ b/solo/in-the-wake-of-grief.html
@@ -176,7 +176,7 @@ All work on this project is offered as a gift to God.
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/solo/solo-cruisers-companion.html
+++ b/solo/solo-cruisers-companion.html
@@ -131,7 +131,7 @@ All work on this project is offered as a gift to God.
     "description": "Practical guide for solo cruising — covers ship selection matrix, dining strategies, activities for introverts, managing anxiety at sea, and logbook stories from real solo cruisers.",
     "dateModified": "2025-11-19"
   }
-  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.300" fetchpriority="high"/>

--- a/solo/solo-cruising-practical-guide.html
+++ b/solo/solo-cruising-practical-guide.html
@@ -107,7 +107,7 @@ All work on this project is offered as a gift to God.
   </script>
 
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image"/>

--- a/solo/visiting-the-united-states-before-your-cruise.html
+++ b/solo/visiting-the-united-states-before-your-cruise.html
@@ -58,7 +58,7 @@ All work on this project is offered as a gift to God.
   <!-- Preload LCP hero -->
   <link rel="preload" as="image" href="/solo/images/flickersofmajesty.webp" fetchpriority="high"/>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <link rel="preload" as="image" href="/assets/logo_wake.png">
 
 <!-- JSON-LD: Person (E-E-A-T - Article Author) -->

--- a/solo/why-i-started-solo-cruising.html
+++ b/solo/why-i-started-solo-cruising.html
@@ -106,7 +106,7 @@ All work on this project is offered as a gift to God.
     "description": "Personal story of discovering solo cruising — from first nervous gangway walk to finding community and freedom at sea.",
     "dateModified": "2025-11-18"
   }
-  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/stateroom-check.html
+++ b/stateroom-check.html
@@ -152,7 +152,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
   <link rel="manifest" href="/manifest.webmanifest"/>
 
   <!-- Global CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- Page-specific CSS -->
   <style>

--- a/support.html
+++ b/support.html
@@ -68,7 +68,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.500"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- JSON-LD: WebPage (ICP-Lite) -->
   <script type="application/ld+json">

--- a/terms.html
+++ b/terms.html
@@ -37,7 +37,7 @@ All work on this project is offered as a gift to God.
 
   <link rel="stylesheet" href="./assets/css/styles.css">
 
-    <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+    <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/tools/cruise-budget-calculator.html
+++ b/tools/cruise-budget-calculator.html
@@ -223,7 +223,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- LCP preload -->
   <link rel="preload" as="image" href="/assets/index_hero.jpg?v=3.010.300" fetchpriority="high">

--- a/tools/cruise-tipping-calculator.html
+++ b/tools/cruise-tipping-calculator.html
@@ -207,7 +207,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/tools/cruise-tipping-calculator.css?v=3.010.300">
 
   <!-- LCP preload -->

--- a/tools/port-day-planner.html
+++ b/tools/port-day-planner.html
@@ -198,7 +198,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
   <!-- LCP preload -->
   <link rel="preload" as="image" href="/assets/index_hero.jpg?v=3.010.300" fetchpriority="high">

--- a/tools/ship-size-atlas.html
+++ b/tools/ship-size-atlas.html
@@ -255,7 +255,7 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300">
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="/assets/css/item-cards.css?v=1.0.0">
   <link rel="stylesheet" href="/assets/css/ships-atlas.css?v=1.0.0">
 

--- a/travel.html
+++ b/travel.html
@@ -279,7 +279,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
   <script src="/assets/js/site-cache.js?v=3.010.300" defer></script>
 
   <!-- Global CSS -->
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.300"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- Preload LCP image (hero) -->
   <link rel="preload" as="image" href="/assets/index_hero.jpg?v=3.010.300" imagesrcset="/assets/index_hero.jpg?v=3.010.300" fetchpriority="high"/>

--- a/voyage-packs.html
+++ b/voyage-packs.html
@@ -68,7 +68,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/assets/styles.css?v=3.010.500"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- JSON-LD: WebPage (ICP-Lite) -->
   <script type="application/ld+json">


### PR DESCRIPTION
Swept 113 of the 114 pages the nav-css-js validator flagged CSS_STALE_VERSION so /assets/styles.css uses the canonical ?v=3.010.400.

Scoped: only /assets/styles.css?v= query strings rewritten. Left untouched: unversioned styles.css refs (not flagged), the separate /assets/css/ship-page.css?v= asset, and all non-CSS refs. One line changed per file; diff is nothing but version strings.

Canonical 3.010.400 verified independently (799 pages, homepage, validator), not taken on the validator's word. 7 pages numerically higher (6x 3.010.500, 1x 3.010.401) were aligned down -- safe because ?v= is a cache-bust key, not a file selector; the served file is always /assets/styles.css.

Deferred: ports/royal-beach-club-nassau.html (the 114th). Its CSS change is correct but committing it is blocked by the image-reuse guardrail -- the page uses assets/ships/placeholder-ship.webp (md5 cdf8bd1f), a placeholder shared across many port/ship entities. That is a pre-existing content gap unrelated to CSS; not bypassing the guard or scope-creeping into image sourcing here. Needs a unique image (or an image-coverage-audit gap entry) first.

Verified: CSS_STALE_VERSION 114 -> 1 (only the deferred page remains); no other validator code changed.