### PR TITLE
Fix CSS_STYLES_MISSING: load canonical stylesheet on 10 critical pages

### DIFF
--- a/authors/ken-baker.html
+++ b/authors/ken-baker.html
@@ -16,6 +16,7 @@
   <title>Ken Baker — Founder & Editor | In the Wake</title>
   <meta name="description" content="Ken Baker is the founder of In the Wake. With many+ cruises sailed, he shares practical cruise planning tools, accessibility advocacy, and faith-scented travel reflections."/>
   <link rel="canonical" href="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- OpenGraph -->
   <meta property="og:type" content="profile"/>

--- a/authors/tina-maulsby.html
+++ b/authors/tina-maulsby.html
@@ -16,6 +16,7 @@
   <title>Tina Maulsby — Solo Cruising Contributor | In the Wake</title>
   <meta name="description" content="Tina Maulsby shares solo cruising stories, safety tips, and community building at sea. A featured contributor at In the Wake with firsthand solo travel experience."/>
   <link rel="canonical" href="https://cruisinginthewake.com/authors/tina-maulsby.html"/>
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
 
   <!-- OpenGraph -->
   <meta property="og:type" content="profile"/>

--- a/ports/incheon.html
+++ b/ports/incheon.html
@@ -108,7 +108,7 @@ Soli Deo Gloria
     }
     </script>
 
-    <link rel="stylesheet" href="/css/main.css">
+    <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <!-- Leaflet CSS for interactive maps -->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">

--- a/ports/luanda.html
+++ b/ports/luanda.html
@@ -16,7 +16,7 @@ Soli Deo Gloria
     <meta name="content-protocol" content="ICP-Lite v1.4">
   <meta name="author" content="In the Wake">
 
-    <link rel="stylesheet" href="/assets/css/main.css">
+    <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
     <!-- Leaflet CSS for interactive maps -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
     <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">

--- a/ports/mindelo.html
+++ b/ports/mindelo.html
@@ -26,7 +26,7 @@ Soli Deo Gloria
     <meta name="content-protocol" content="ICP-Lite v1.4">
   <meta name="author" content="In the Wake">
 
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <!-- Leaflet CSS for interactive maps -->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">

--- a/ports/mombasa.html
+++ b/ports/mombasa.html
@@ -119,7 +119,7 @@ Soli Deo Gloria
     }
     </script>
 
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
 
   <!-- Twitter Card -->

--- a/ports/port-moresby.html
+++ b/ports/port-moresby.html
@@ -26,7 +26,7 @@ Soli Deo Gloria
     <meta name="content-protocol" content="ICP-Lite v1.4">
   <meta name="author" content="In the Wake">
 
-    <link rel="stylesheet" href="/css/main.css">
+    <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
     <link rel="stylesheet" href="/css/ports.css">
 
     <!-- Leaflet CSS for interactive maps -->

--- a/ports/praia.html
+++ b/ports/praia.html
@@ -23,7 +23,7 @@ Soli Deo Gloria
     <meta name="last-reviewed" content="2026-02-01">
     <meta name="content-protocol" content="ICP-Lite v1.4">
   <meta name="author" content="In the Wake">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
 
     <!-- Leaflet CSS for interactive maps -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">

--- a/ports/sihanoukville.html
+++ b/ports/sihanoukville.html
@@ -25,7 +25,7 @@ Soli Deo Gloria
     <meta property="og:url" content="https://cruisinginthewake.com/ports/sihanoukville">
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/port-hero.jpg">
 
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
     <!-- Leaflet CSS for interactive maps -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
     <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">

--- a/ports/yangon.html
+++ b/ports/yangon.html
@@ -26,7 +26,7 @@ Soli Deo Gloria
     <meta name="content-protocol" content="ICP-Lite v1.4">
   <meta name="author" content="In the Wake">
 
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
     <!-- Leaflet CSS for interactive maps -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
     <link rel="stylesheet" href="/assets/css/components/port-map.css?v=2.0.0">


### PR DESCRIPTION
These pages rendered essentially unstyled in production. Fixed by loading the canonical /assets/styles.css?v=3.010.400:

- 8 port pages (incheon, luanda, mindelo, mombasa, port-moresby, praia, sihanoukville, yangon) referenced a DEAD base stylesheet (/css/style.css, /css/main.css, /assets/css/main.css, /assets/css/style.css -- all 404, none exist on disk). Swapped the dead base ref for the canonical stylesheet. These 8 are from an alternate/older port template (Leaflet + Swiper + /css/* base); they share the site's core classes (navbar, hero-header, port-hero) so styles.css covers most of each page, but some layout wrappers (container/main-container vs canonical wrap/page-grid) diverge. Loading the real 74KB stylesheet cannot be worse than a 404 for any element; full fidelity would need regeneration to the canonical dubai template (flagged).

- 2 author pages (ken-baker, tina-maulsby) had NO stylesheet at all. They use site classes (navbar, hero-header), so inserted the canonical stylesheet after the <link canonical>.

Excluded: solo/in-the-wake-of-grief-meta.html -- a FALSE POSITIVE. It is a meta-tag FRAGMENT ('META TAGS ... Add to page <head> when template is built'), not a page; no <html>/<body>/nav. Injecting a stylesheet would corrupt a build artifact to game the validator. Left untouched; recommend excluding it from page validation or removing if confirmed dead scratch.

Verified: CSS_STYLES_MISSING 11 -> 1 (only the excluded fragment remains); no validator code regressed; diff is stylesheet-link-only (ports +1/-1, authors +1/0); image-reuse guard clean on all 10.