### PR TITLE
Fix nav-JS path/version: canonical unversioned dropdown.js (4 pages)

### DIFF
--- a/ports/tender-ports.html
+++ b/ports/tender-ports.html
@@ -567,7 +567,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
     </div>
   </footer>
 
-  <script src="/assets/js/nav-dropdown.js" defer=""></script>
+  <script src="/assets/js/dropdown.js" defer=""></script>
   <script src="/assets/js/ship-port-links.js" defer=""></script>
   <!-- Port Weather Widget -->
   <script type="module" src="/assets/js/port-weather.js"></script>

--- a/tools/cruise-budget-calculator.html
+++ b/tools/cruise-budget-calculator.html
@@ -717,6 +717,6 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- Dropdown nav JS -->
-  <script src="/assets/js/dropdown.js?v=3.010.300" defer></script>
+  <script src="/assets/js/dropdown.js" defer></script>
 </body>
 </html>

--- a/tools/cruise-tipping-calculator.html
+++ b/tools/cruise-tipping-calculator.html
@@ -518,6 +518,6 @@ All work on this project is offered as a gift to God.
   <script type="module" src="/assets/js/tools/cruise-tipping-calculator/main.js"></script>
 
   <!-- Dropdown nav JS -->
-  <script src="/assets/js/dropdown.js?v=3.010.300" defer></script>
+  <script src="/assets/js/dropdown.js" defer></script>
 </body>
 </html>

--- a/tools/port-day-planner.html
+++ b/tools/port-day-planner.html
@@ -702,6 +702,6 @@ All work on this project is offered as a gift to God.
   </script>
 
   <!-- Dropdown nav JS -->
-  <script src="/assets/js/dropdown.js?v=3.010.300" defer></script>
+  <script src="/assets/js/dropdown.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
- ports/tender-ports.html loaded /assets/js/nav-dropdown.js (404 -- file does not exist; nav dropdowns were broken). Pointed to canonical /assets/js/dropdown.js.
- 3 tools pages (cruise-budget-calculator, cruise-tipping-calculator, port-day-planner) loaded /assets/js/dropdown.js?v=3.010.300. Stripped the version query to the canonical unversioned path.

Canonical confirmed: /assets/js/dropdown.js exists (4847 bytes); site convention is overwhelmingly unversioned (998 unversioned vs 3 versioned vs 1 wrong-path). defer attribute preserved on all 4.

Verified: NAV_JS_WRONG_PATH 1->0, NAV_JS_STALE_VERSION 3->0; no code regressed; diff is dropdown.js-src-only (1 line per file).