### PR TITLE
beta4 ship page: rebuild as substance + discipline (board verdict)

### DIFF
--- a/shipbeta4.html
+++ b/shipbeta4.html
@@ -14,12 +14,12 @@ All work on this project is offered as a gift to God.
 <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <meta name="theme-color" content="#0e6e8e"/>
 <link rel="canonical" href="https://cruisinginthewake.com/shipbeta4.html"/>
-<title>Wonder of the Seas — In the Wake</title>
-<meta name="ai-summary" content="Wonder of the Seas: the highest-capacity Oasis-class ship (236,857 GT, 5,734 guests at double occupancy, 2022), built by Chantiers de l'Atlantique. A beta4 layout demo for ship pages, with its own photography."/>
+<title>Wonder of the Seas — deck plans, dining, live tracker | In the Wake</title>
+<meta name="ai-summary" content="Wonder of the Seas: Oasis-class Royal Caribbean ship (236,857 GT, 5,734 guests at double occupancy, 2022, built by Chantiers de l'Atlantique). Honest read on who she's for, dining, onboard activities, neighborhoods, deck plans, and live tracking."/>
 <meta name="last-reviewed" content="2026-06-07"/>
 <meta name="content-protocol" content="ICP-2"/>
 <meta property="og:title" content="Wonder of the Seas — In the Wake"/>
-<meta property="og:description" content="The highest-capacity Oasis-class ship: 236,857 GT, 5,734 guests at double occupancy, debuted 2022, built by Chantiers de l'Atlantique."/>
+<meta property="og:description" content="Oasis-class Royal Caribbean ship: 236,857 GT, 5,734 guests at double occupancy, debuted 2022. Dining, activities, deck plans, and live tracking."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://cruisinginthewake.com/shipbeta4.html"/>
 <meta property="og:image" content="https://cruisinginthewake.com/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas.webp"/>
@@ -35,8 +35,19 @@ All work on this project is offered as a gift to God.
   "name": "Wonder of the Seas",
   "category": "Cruise ship",
   "brand": {"@type": "Brand", "name": "Royal Caribbean International"},
-  "description": "Wonder of the Seas is the highest-capacity ship in Royal Caribbean's Oasis Class (236,857 GT, 5,734 guests at double occupancy, debuted 2022), built by Chantiers de l'Atlantique in France.",
+  "description": "Wonder of the Seas is an Oasis-class Royal Caribbean cruise ship (236,857 GT, 5,734 guests at double occupancy, entered service 2022), built by Chantiers de l'Atlantique in Saint-Nazaire, France.",
   "dateModified": "2026-06-07"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type":"Question","name":"What makes Wonder of the Seas unique?","acceptedAnswer":{"@type":"Answer","text":"She is the highest-capacity ship in the Oasis Class (5,734 guests at double occupancy) with Royal Caribbean's seven-neighborhood layout, including Central Park with over 12,000 live plants, the Boardwalk and its hand-carved carousel, and the AquaTheater high-diving shows."}},
+    {"@type":"Question","name":"Which ships share her class?","acceptedAnswer":{"@type":"Answer","text":"The Oasis Class: Oasis of the Seas, Allure of the Seas, Harmony of the Seas, Symphony of the Seas, and Utopia of the Seas."}},
+    {"@type":"Question","name":"Where does she sail?","acceptedAnswer":{"@type":"Answer","text":"Typically Caribbean itineraries from Port Canaveral and other ports; deployments vary by season."}}
+  ]
 }
 </script>
 </head>
@@ -62,66 +73,194 @@ All work on this project is offered as a gift to God.
     <span aria-current="page">Wonder of the Seas</span>
   </nav>
 
-  <article class="content-hero">
-    <figure class="ch-media">
-      <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas.webp"
-           width="1280" height="853" fetchpriority="high" decoding="async"
-           alt="Wonder of the Seas, an Oasis-class cruise ship, berthed at a cruise terminal with her name on the hull."/>
-      <figcaption class="ch-credit">Photo: Intermerker &middot; CC BY-SA 4.0 &middot; <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas.jpg" target="_blank" rel="noopener">Wikimedia</a></figcaption>
-    </figure>
-    <div class="ch-title">
+  <!-- The vessel is the decisive event: full-bleed, name overlaid on her own photo -->
+  <section class="hero hero--ship">
+    <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas.webp"
+         width="1280" height="853" fetchpriority="high" decoding="async"
+         alt="Wonder of the Seas, an Oasis-class cruise ship, in full starboard profile with her name on the hull."/>
+    <div class="scrim"></div>
+    <p class="credit">Photo: Intermerker &middot; CC BY-SA 4.0 &middot; <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas.jpg" target="_blank" rel="noopener">Wikimedia</a></p>
+    <div class="moment">
       <p class="kicker">Royal Caribbean &middot; Oasis Class</p>
       <h1 class="serif">Wonder of the Seas</h1>
+      <p class="purpose">One of the largest ships at sea &mdash; seven neighborhoods, an open-air park, and a dive theater built over the wake.</p>
     </div>
-  </article>
+  </section>
 
   <section class="hub-keyfacts" aria-label="Key facts at a glance">
     <div><b>236,857</b><span>gross tons</span></div>
-    <div><b>5,734</b><span>guests (double occupancy)</span></div>
+    <div><b>5,734</b><span>guests (double occ.)</span></div>
+    <div><b>2,300</b><span>crew</span></div>
     <div><b>2022</b><span>maiden voyage</span></div>
-    <div><b>Oasis</b><span>class</span></div>
   </section>
 
   <div class="content-grid">
     <main class="prose" id="main">
-      <p>When she entered service in 2022, <strong>Wonder of the Seas</strong> became the highest-capacity ship in Royal Caribbean&rsquo;s Oasis Class &mdash; 236,857 gross tons, room for 5,734 guests at double occupancy, and built by Chantiers de l&rsquo;Atlantique in Saint-Nazaire, France. She is one of the largest cruise ships in the world.</p>
+      <p><strong>Quick answer:</strong> Wonder of the Seas (236,857 GT &middot; 5,734 guests at double occupancy &middot; 2022) is an Oasis-class Royal Caribbean ship built by Chantiers de l&rsquo;Atlantique in Saint-Nazaire, France. She carries the class&rsquo;s seven-neighborhood layout &mdash; Central Park, the Boardwalk, the Royal Promenade &mdash; and is one of the largest cruise ships in the world. This page covers who she suits, dining, onboard activities, deck plans, and live tracking.</p>
 
-      <p>This page is a beta4 layout demo for ship guides. What makes it different from the generic template is simple: the photographs are <em>hers</em>. The hero above and the gallery below show Wonder of the Seas specifically &mdash; never a stand-in or a sister ship &mdash; each image identity-verified by the lettering on the hull, and credited to its photographer.</p>
-
-      <h2 class="serif">What she&rsquo;s like to sail</h2>
-      <p>The Oasis Class is organized into seven &ldquo;neighborhoods,&rdquo; and Wonder carries the full set. Central Park sits open to the sky amidships with more than 12,000 live plants; the Boardwalk runs aft to the AquaTheater, an open-air dive and acrobatics stage built over the wake. The ship&rsquo;s own additions over earlier Oasis sisters include The Mason Jar &mdash; a Southern restaurant and bar &mdash; and Wonder Playscape, a kids&rsquo; play area. Dining runs to more than twenty venues across the ship.</p>
+      <h2 class="serif">Who she&rsquo;s for</h2>
+      <p><strong>You&rsquo;ll love her if</strong> you want grand-scale cruising with room to find something new each day: the neighborhood concept (Central Park, Boardwalk, Royal Promenade), the AquaTheater diving shows, the Ultimate Abyss slide, and a full spread of dining and activities.</p>
+      <p><strong>You may prefer another ship if</strong> 5,000-plus-guest vessels feel overwhelming, or you want a smaller, quieter ship &mdash; in which case look at Royal&rsquo;s <a href="https://cruisinginthewake.com/cruise-lines/royal-caribbean.html#radiance">Radiance</a>, <a href="https://cruisinginthewake.com/cruise-lines/royal-caribbean.html#voyager">Voyager</a>, or <a href="https://cruisinginthewake.com/cruise-lines/royal-caribbean.html#vision">Vision</a> class instead.</p>
 
       <h2 class="serif">First look</h2>
-      <p>Three photographs of Wonder of the Seas &mdash; from her build in France to a recent call at Nassau:</p>
+      <p>Three photographs of Wonder &mdash; from her build in France to a recent call at Nassau:</p>
       <figure class="media-row">
         <figure>
-          <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas_in_St-Nazaire_(2020).webp" loading="lazy" decoding="async"
-               alt="Wonder of the Seas fitting out at the Chantiers de l'Atlantique shipyard in Saint-Nazaire, 2020."/>
-          <figcaption class="tiny">Fitting out at Saint-Nazaire, 2020. Photo by ND44 via <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas_in_St-Nazaire_(2020).jpg" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0).</figcaption>
-        </figure>
-        <figure>
           <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas_bow_Nassau_2026-05-19.webp" loading="lazy" decoding="async"
-               alt="The Oasis-class bow of Wonder of the Seas with the AquaDome on the top deck, seen at Nassau."/>
-          <figcaption class="tiny">Bow and AquaDome at Nassau, May 2026. Photo: In the Wake.</figcaption>
+               alt="Wonder of the Seas' bow and AquaDome seen from the pier at Nassau."/>
+          <figcaption class="tiny">Bow and AquaDome at Nassau, May 2026. Photo: Ken Baker, In the Wake.</figcaption>
         </figure>
         <figure>
           <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas_alongside_Carnival_Sunrise_Nassau_2026-05-19.webp" loading="lazy" decoding="async"
-               alt="Wonder of the Seas berthed alongside Carnival Sunrise at Nassau."/>
-          <figcaption class="tiny">Alongside Carnival Sunrise at Nassau, May 2026. Photo: In the Wake.</figcaption>
+               alt="Wonder of the Seas berthed alongside Carnival Sunrise at Nassau, with passengers on the pier."/>
+          <figcaption class="tiny">Alongside Carnival Sunrise at Nassau, May 2026. Photo: Ken Baker, In the Wake.</figcaption>
+        </figure>
+        <figure>
+          <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas_in_St-Nazaire_(2020).webp" loading="lazy" decoding="async"
+               alt="Wonder of the Seas at the Chantiers de l'Atlantique shipyard in Saint-Nazaire during her 2020 build."/>
+          <figcaption class="tiny">Fitting out at Saint-Nazaire, 2020. Photo by ND44 via <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas_in_St-Nazaire_(2020).jpg" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0).</figcaption>
         </figure>
       </figure>
 
-      <p>This is a layout prototype. For the full profile &mdash; deck plans, dining, staterooms, accessibility notes, and the complete logbook read &mdash; see the <a href="https://cruisinginthewake.com/ships/rcl/wonder-of-the-seas.html">current Wonder of the Seas page</a>.</p>
+      <h2 class="serif">Dining</h2>
+      <p>A working snapshot of her venues. Specialty restaurants and some bars carry an extra charge; complimentary venues are included in your fare. <a href="https://cruisinginthewake.com/restaurants/">Browse all restaurants &rarr;</a></p>
+      <div class="cols">
+        <h3>Complimentary</h3>
+        <ul>
+          <li>Main Dining Room</li>
+          <li>Windjammer Marketplace</li>
+          <li>El Loco Fresh</li>
+          <li>Park Caf&eacute;</li>
+          <li>Sorrento&rsquo;s</li>
+          <li>Solarium Bistro</li>
+        </ul>
+        <h3>Specialty</h3>
+        <ul>
+          <li>Giovanni&rsquo;s Italian Kitchen &amp; Bar</li>
+          <li>Chops Grille</li>
+          <li>Izumi Sushi &amp; Hibachi</li>
+          <li>Coastal Kitchen</li>
+          <li>Hooked Seafood</li>
+          <li>Wonderland</li>
+          <li>Johnny Rockets</li>
+        </ul>
+        <h3>Bars &amp; lounges</h3>
+        <ul>
+          <li>The Lime &amp; Coconut</li>
+          <li>Rising Tide Bar</li>
+          <li>Bionic Bar</li>
+          <li>Playmakers Sports Bar</li>
+          <li>Boleros</li>
+          <li>Schooner Bar</li>
+          <li>Crown Lounge</li>
+        </ul>
+      </div>
+
+      <h2 class="serif">Onboard</h2>
+      <p>The signature draws and the everyday ones, by category.</p>
+      <div class="cols">
+        <h3>Entertainment</h3>
+        <ul>
+          <li>Royal Theater</li>
+          <li>AquaTheater (high-diving)</li>
+          <li>Studio B (ice shows)</li>
+          <li>Music Hall</li>
+          <li>Spotlight Karaoke</li>
+          <li>The Attic</li>
+        </ul>
+        <h3>Activities</h3>
+        <ul>
+          <li>Ultimate Abyss slide</li>
+          <li>The Perfect Storm waterslides</li>
+          <li>FlowRider surf simulator</li>
+          <li>Rock-climbing wall</li>
+          <li>Zip line</li>
+          <li>Mini golf &amp; sports court</li>
+          <li>Splashaway Bay (kids)</li>
+          <li>Vitality Spa &amp; fitness center</li>
+          <li>Casino Royale</li>
+        </ul>
+        <h3>Neighborhoods</h3>
+        <ul>
+          <li>Central Park (12,000+ live plants)</li>
+          <li>The Boardwalk (carousel)</li>
+          <li>Royal Promenade</li>
+          <li>Solarium</li>
+          <li>Library</li>
+          <li>Chapel</li>
+        </ul>
+      </div>
+
+      <h2 class="serif">From the logbook</h2>
+      <figure class="logbook" style="border-left:3px solid var(--gold);padding-left:1.1rem;margin:1.5rem 0;">
+        <blockquote class="serif" style="font-style:italic;margin:0;">I expected to be lost in a crowd of 7,000. Instead, I found my people. A ship so large it felt like it should swallow you whole &mdash; and somehow it was the easiest place I&rsquo;ve ever struck up a conversation.</blockquote>
+        <figcaption class="byline" style="margin-top:.6rem;color:var(--muted);font-size:.92rem;">&mdash; Amanda K., Nashville, TN &middot; <span class="tiny">guest story, lightly condensed</span></figcaption>
+      </figure>
+
+      <h2 class="serif">Deck plans</h2>
+      <p>We don&rsquo;t reproduce Royal&rsquo;s deck plans &mdash; they revise them, and the official version is the one to trust.</p>
+      <p><a class="hub-cta" href="https://www.royalcaribbean.com/cruise-ships/wonder-of-the-seas/deck-plans" target="_blank" rel="nofollow noopener">Open official deck plans &rarr;</a></p>
+
+      <h2 class="serif">Where is she right now?</h2>
+      <p>Track Wonder&rsquo;s live position, speed, and next port. It opens in a new tab.</p>
+      <p><a class="hub-cta" href="https://www.vesselfinder.com/vessels/WONDER-OF-THE-SEAS-IMO-9838345" target="_blank" rel="noopener">Open the live tracker (IMO 9838345) &rarr;</a></p>
+
+      <h2 class="serif">Common questions</h2>
+      <div class="faq-wrap">
+        <details>
+          <summary>What makes Wonder of the Seas unique?</summary>
+          <p>She&rsquo;s the highest-capacity ship in the Oasis Class (5,734 guests at double occupancy), with Royal Caribbean&rsquo;s seven-neighborhood layout: Central Park&rsquo;s 12,000-plus live plants, the Boardwalk and its hand-carved carousel, and the AquaTheater&rsquo;s high-diving shows.</p>
+        </details>
+        <details>
+          <summary>Which ships are in the same class?</summary>
+          <p>The Oasis Class: <a href="https://cruisinginthewake.com/ships/rcl/oasis-of-the-seas.html">Oasis</a>, <a href="https://cruisinginthewake.com/ships/rcl/allure-of-the-seas.html">Allure</a>, <a href="https://cruisinginthewake.com/ships/rcl/harmony-of-the-seas.html">Harmony</a>, <a href="https://cruisinginthewake.com/ships/rcl/symphony-of-the-seas.html">Symphony</a>, and <a href="https://cruisinginthewake.com/ships/rcl/utopia-of-the-seas.html">Utopia of the Seas</a>.</p>
+        </details>
+        <details>
+          <summary>Where does she sail?</summary>
+          <p>Typically Caribbean itineraries from Port Canaveral and other ports. Deployments shift by season &mdash; the live tracker above shows where she is today.</p>
+        </details>
+        <details>
+          <summary>How current is this page?</summary>
+          <p>Stats are from her profile and reviewed periodically; the deck plans and tracker link out to live, official sources rather than a stale local copy.</p>
+        </details>
+      </div>
+
+      <h2 class="serif">Image credits</h2>
+      <ul class="tiny">
+        <li>Full starboard profile (hero): Intermerker via <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas.jpg" target="_blank" rel="noopener">Wikimedia Commons</a>, CC BY-SA 4.0.</li>
+        <li>Nassau bow &amp; alongside Carnival Sunrise: Ken Baker, In the Wake, May 2026 &middot; all rights reserved.</li>
+        <li>Saint-Nazaire build: ND44 via <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas_in_St-Nazaire_(2020).jpg" target="_blank" rel="noopener">Wikimedia Commons</a>, CC BY-SA 4.0.</li>
+      </ul>
     </main>
 
     <aside class="rail" aria-label="At a glance">
       <div class="card">
         <h2>At a glance</h2>
-        <p class="counts"><b>Line</b> Royal Caribbean<br/><b>Class</b> Oasis<br/><b>Tonnage</b> 236,857 GT<br/><b>Guests</b> 5,734 (double occupancy)<br/><b>Debut</b> 2022<br/><b>Built</b> Chantiers de l&rsquo;Atlantique</p>
+        <p class="counts"><b>Line</b> Royal Caribbean<br/>
+        <b>Class</b> Oasis<br/>
+        <b>Entered service</b> 2022<br/>
+        <b>Gross tonnage</b> 236,857 GT<br/>
+        <b>Guests</b> 5,734 double &middot; ~6,988 max<br/>
+        <b>Crew</b> 2,300<br/>
+        <b>Length</b> 1,188 ft (362 m)<br/>
+        <b>Beam</b> 156 ft (47.4 m)<br/>
+        <b>Registry</b> Bahamas<br/>
+        <b>Builder</b> Chantiers de l&rsquo;Atlantique<br/>
+        <b>IMO</b> 9838345</p>
       </div>
       <div class="card">
-        <h2>Compare</h2>
-        <p class="tiny"><a href="https://cruisinginthewake.com/tools/ship-size-atlas.html">Ship Size Atlas &mdash; space ratios</a><br/><a href="https://cruisinginthewake.com/ships/rcl/">More Royal Caribbean ships</a><br/><a href="https://cruisinginthewake.com/shiphubbeta4.html">All ships hub</a></p>
+        <h2>Oasis-class sisters</h2>
+        <p class="tiny"><a href="https://cruisinginthewake.com/ships/rcl/oasis-of-the-seas.html">Oasis of the Seas</a><br/>
+        <a href="https://cruisinginthewake.com/ships/rcl/allure-of-the-seas.html">Allure of the Seas</a><br/>
+        <a href="https://cruisinginthewake.com/ships/rcl/harmony-of-the-seas.html">Harmony of the Seas</a><br/>
+        <a href="https://cruisinginthewake.com/ships/rcl/symphony-of-the-seas.html">Symphony of the Seas</a><br/>
+        <a href="https://cruisinginthewake.com/ships/rcl/utopia-of-the-seas.html">Utopia of the Seas</a></p>
+      </div>
+      <div class="card">
+        <h2>Compare &amp; plan</h2>
+        <p class="tiny"><a href="https://cruisinginthewake.com/tools/ship-size-atlas.html">Ship Size Atlas &mdash; space ratios</a><br/>
+        <a href="https://cruisinginthewake.com/ships/rcl/">More Royal Caribbean ships</a><br/>
+        <a href="https://cruisinginthewake.com/shiphubbeta4.html">All ships hub</a></p>
       </div>
     </aside>
   </div>

--- a/stylesbeta4.css
+++ b/stylesbeta4.css
@@ -39,7 +39,11 @@ img { max-width: 100%; height: auto; }
 .hero .purpose { margin: 1rem 0 1.6rem; color: #eaf6fb; font-size: var(--t-lead); max-width: 46ch; text-shadow: 0 1px 14px rgba(0,0,0,.5); }
 /* Hub gateway moment — one level down from the homepage, still immersive. Kicker rides the scrim. */
 .hero--hub { min-height: clamp(22rem, 66svh, 40rem); }
+/* Ship page moment — the vessel is the decisive event, name overlaid on its own photo. */
+.hero--ship { min-height: clamp(22rem, 70svh, 42rem); }
 .hero .kicker { font-size: var(--t-fine); letter-spacing: .14em; text-transform: uppercase; color: #bfe7f6; margin: 0 0 .5rem; text-shadow: 0 1px 14px rgba(0,0,0,.5); }
+.hero .credit { position: absolute; top: .6rem; right: .6rem; z-index: 1; margin: 0; padding: .12rem .55rem; font-size: .68rem; line-height: 1.5; color: #eef7fb; background: rgba(8,48,65,.55); border-radius: 3px; }
+.hero .credit a { color: #eef7fb; }
 
 /* Path-finder — clear button affordance (gold-accented, not gold-roped). */
 .pathfinder { display: flex; flex-wrap: wrap; gap: .8rem; }
@@ -85,12 +89,23 @@ img { max-width: 100%; height: auto; }
 .prose blockquote { border-left: 3px solid var(--gold); margin: 1.5rem 0; padding: .25rem 0 .25rem 1.1rem; font-style: italic; color: var(--muted); }
 .prose ul, .prose ol { padding-left: 1.3rem; }
 .prose li { margin: .35rem 0; }
+.prose details { border-top: 1px solid var(--rule); padding: .85rem 0; margin: 0; }
+.prose details summary { cursor: pointer; font-weight: 600; color: var(--ink); }
+.prose details[open] summary { color: var(--sea); }
+.prose details > p { margin: .6rem 0 0; color: var(--muted); }
+/* venue columns: dining / onboard lists sit two-up on wide screens, one-up on narrow */
+.cols { columns: 2; column-gap: 2rem; }
+.cols ul { margin: 0; }
+.cols li { break-inside: avoid; }
+@media (max-width: 540px) { .cols { columns: 1; } }
 .prose table { width: 100%; border-collapse: collapse; font-size: .95rem; }
 .prose th, .prose td { text-align: left; padding: .55rem .6rem; border-bottom: 1px solid var(--rule); }
 .prose th { color: var(--sea); }
 /* multimedia row (e.g. ship "first look" gallery) — fluid, no breakpoint ladder */
 .media-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem,1fr)); gap: .9rem; margin: 1.5rem 0; }
 .media-row figure { margin: 0; }
+.media-row img { width: 100%; aspect-ratio: 4 / 3; object-fit: cover; border-radius: 4px; display: block; }
+.media-row figcaption { margin-top: .4rem; }
 .rail { font-size: .95rem; }
 .rail .card { background: var(--panel); border: 1px solid var(--rule); border-radius: 4px; padding: 1rem 1.1rem; margin-bottom: 1rem; }
 .rail h2 { font-size: 1rem; color: var(--sea); margin: 0 0 .5rem; font-weight: 600; }


### PR DESCRIPTION
The prior shipbeta4 was a clean shell that culled the legacy page content. This rebuild keeps the substance and adds the composition discipline:
- Ship-scale full-bleed hero (.hero--ship): the vessel is the decisive event, name overlaid on her own verified photo with inline credit.
- All real, already-sourced content ported from the legacy page: who-she-is-for, dining (complimentary/specialty/bars), onboard (entertainment/activities/ neighborhoods) in two-up columns, a guest logbook story, deck-plan + live-tracker links out to official sources, a 4-question FAQ, full at-a-glance stats and Oasis-class sisters in the rail, and image credits.
- Gallery fixed: .media-row images now carry aspect-ratio so heights are equal and captions align (was ragged + a CLS bug).
- Did not propagate the legacy page neighborhood-count inconsistency (7 vs 8); used the FAQ-canonical "seven neighborhoods" and described named ones. Stats kept to already-published values; no new unsourced claims.