### PR TITLE
beta4 ship page: compose for rhythm, stop enumerating

### DIFF
--- a/shipbeta4.html
+++ b/shipbeta4.html
@@ -15,11 +15,11 @@ All work on this project is offered as a gift to God.
 <meta name="theme-color" content="#0e6e8e"/>
 <link rel="canonical" href="https://cruisinginthewake.com/shipbeta4.html"/>
 <title>Wonder of the Seas — deck plans, dining, live tracker | In the Wake</title>
-<meta name="ai-summary" content="Wonder of the Seas: Oasis-class Royal Caribbean ship (236,857 GT, 5,734 guests at double occupancy, 2022, built by Chantiers de l'Atlantique). Honest read on who she's for, dining, onboard activities, neighborhoods, deck plans, and live tracking."/>
+<meta name="ai-summary" content="Wonder of the Seas: Oasis-class Royal Caribbean ship (236,857 GT, 5,734 guests at double occupancy, 2022, built by Chantiers de l'Atlantique). Honest read on who she's for, the experiences you'll remember, dining, deck plans, and live tracking."/>
 <meta name="last-reviewed" content="2026-06-07"/>
 <meta name="content-protocol" content="ICP-2"/>
 <meta property="og:title" content="Wonder of the Seas — In the Wake"/>
-<meta property="og:description" content="Oasis-class Royal Caribbean ship: 236,857 GT, 5,734 guests at double occupancy, debuted 2022. Dining, activities, deck plans, and live tracking."/>
+<meta property="og:description" content="Oasis-class Royal Caribbean ship: 236,857 GT, 5,734 guests at double occupancy, debuted 2022. The experiences, dining, deck plans, and live tracking."/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="https://cruisinginthewake.com/shipbeta4.html"/>
 <meta property="og:image" content="https://cruisinginthewake.com/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas.webp"/>
@@ -73,7 +73,7 @@ All work on this project is offered as a gift to God.
     <span aria-current="page">Wonder of the Seas</span>
   </nav>
 
-  <!-- The vessel is the decisive event: full-bleed, name overlaid on her own photo -->
+  <!-- MOMENT: the vessel, full-bleed, name overlaid on her own photo -->
   <section class="hero hero--ship">
     <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas.webp"
          width="1280" height="853" fetchpriority="high" decoding="async"
@@ -83,187 +83,184 @@ All work on this project is offered as a gift to God.
     <div class="moment">
       <p class="kicker">Royal Caribbean &middot; Oasis Class</p>
       <h1 class="serif">Wonder of the Seas</h1>
-      <p class="purpose">One of the largest ships at sea &mdash; seven neighborhoods, an open-air park, and a dive theater built over the wake.</p>
+      <p class="purpose">One of the largest ships at sea &mdash; a park open to the sky, and a dive theater built over the wake.</p>
     </div>
   </section>
 
-  <section class="hub-keyfacts" aria-label="Key facts at a glance">
-    <div><b>236,857</b><span>gross tons</span></div>
-    <div><b>5,734</b><span>guests (double occ.)</span></div>
-    <div><b>2,300</b><span>crew</span></div>
-    <div><b>2022</b><span>maiden voyage</span></div>
+  <!-- BEAT: the numbers, designed -->
+  <section class="statband" aria-label="Key facts at a glance">
+    <div class="inner">
+      <div><b>236,857</b><span>gross tons</span></div>
+      <div><b>5,734</b><span>guests, double occupancy</span></div>
+      <div><b>2,300</b><span>crew</span></div>
+      <div><b>1,188&nbsp;ft</b><span>length overall</span></div>
+      <div><b>2022</b><span>maiden voyage</span></div>
+    </div>
   </section>
 
-  <div class="content-grid">
-    <main class="prose" id="main">
-      <p><strong>Quick answer:</strong> Wonder of the Seas (236,857 GT &middot; 5,734 guests at double occupancy &middot; 2022) is an Oasis-class Royal Caribbean ship built by Chantiers de l&rsquo;Atlantique in Saint-Nazaire, France. She carries the class&rsquo;s seven-neighborhood layout &mdash; Central Park, the Boardwalk, the Royal Promenade &mdash; and is one of the largest cruise ships in the world. This page covers who she suits, dining, onboard activities, deck plans, and live tracking.</p>
+  <main id="main">
 
-      <h2 class="serif">Who she&rsquo;s for</h2>
-      <p><strong>You&rsquo;ll love her if</strong> you want grand-scale cruising with room to find something new each day: the neighborhood concept (Central Park, Boardwalk, Royal Promenade), the AquaTheater diving shows, the Ultimate Abyss slide, and a full spread of dining and activities.</p>
-      <p><strong>You may prefer another ship if</strong> 5,000-plus-guest vessels feel overwhelming, or you want a smaller, quieter ship &mdash; in which case look at Royal&rsquo;s <a href="https://cruisinginthewake.com/cruise-lines/royal-caribbean.html#radiance">Radiance</a>, <a href="https://cruisinginthewake.com/cruise-lines/royal-caribbean.html#voyager">Voyager</a>, or <a href="https://cruisinginthewake.com/cruise-lines/royal-caribbean.html#vision">Vision</a> class instead.</p>
+    <div class="ship-wrap">
+      <p class="lede">Wonder of the Seas is the highest-capacity ship in Royal Caribbean&rsquo;s Oasis Class &mdash; built by Chantiers de l&rsquo;Atlantique in Saint-Nazaire and delivered in 2022. She carries the class&rsquo;s seven-neighborhood layout and the scale that comes with it: room to find something new each day, and enough people aboard to fill a small town.</p>
 
-      <h2 class="serif">First look</h2>
-      <p>Three photographs of Wonder &mdash; from her build in France to a recent call at Nassau:</p>
-      <figure class="media-row">
-        <figure>
-          <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas_bow_Nassau_2026-05-19.webp" loading="lazy" decoding="async"
-               alt="Wonder of the Seas' bow and AquaDome seen from the pier at Nassau."/>
-          <figcaption class="tiny">Bow and AquaDome at Nassau, May 2026. Photo: Ken Baker, In the Wake.</figcaption>
-        </figure>
-        <figure>
-          <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas_alongside_Carnival_Sunrise_Nassau_2026-05-19.webp" loading="lazy" decoding="async"
-               alt="Wonder of the Seas berthed alongside Carnival Sunrise at Nassau, with passengers on the pier."/>
-          <figcaption class="tiny">Alongside Carnival Sunrise at Nassau, May 2026. Photo: Ken Baker, In the Wake.</figcaption>
-        </figure>
-        <figure>
-          <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas_in_St-Nazaire_(2020).webp" loading="lazy" decoding="async"
-               alt="Wonder of the Seas at the Chantiers de l'Atlantique shipyard in Saint-Nazaire during her 2020 build."/>
-          <figcaption class="tiny">Fitting out at Saint-Nazaire, 2020. Photo by ND44 via <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas_in_St-Nazaire_(2020).jpg" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0).</figcaption>
-        </figure>
-      </figure>
+      <h2 class="serif">Is she your ship?</h2>
+      <div class="fork">
+        <div class="yes">
+          <h3>Yes, if&hellip;</h3>
+          <p>you want grand-scale cruising &mdash; the neighborhood concept, the AquaTheater dive shows, the Ultimate Abyss, and a different corner of the ship to explore every day.</p>
+        </div>
+        <div class="no">
+          <h3>Maybe not, if&hellip;</h3>
+          <p>a 5,000-plus-guest ship feels overwhelming, or you want something quieter. Look instead at Royal&rsquo;s <a href="https://cruisinginthewake.com/cruise-lines/royal-caribbean.html#radiance">Radiance</a>, <a href="https://cruisinginthewake.com/cruise-lines/royal-caribbean.html#voyager">Voyager</a>, or <a href="https://cruisinginthewake.com/cruise-lines/royal-caribbean.html#vision">Vision</a> class.</p>
+        </div>
+      </div>
 
+      <h2 class="serif">What you&rsquo;ll remember</h2>
+      <div class="signature">
+        <div class="sig">
+          <h3 class="serif">Central Park</h3>
+          <p>An open-to-the-sky garden amidships with more than 12,000 live plants and trees.</p>
+        </div>
+        <div class="sig">
+          <h3 class="serif">The AquaTheater</h3>
+          <p>An open-air theater at the stern where divers perform over the water.</p>
+        </div>
+        <div class="sig">
+          <h3 class="serif">The Ultimate Abyss</h3>
+          <p>A tall, twisting dry slide that drops off the back of the ship.</p>
+        </div>
+        <div class="sig">
+          <h3 class="serif">The Boardwalk</h3>
+          <p>A seaside-style promenade with a hand-carved carousel.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- VISTA: the scale, from the pier (owner photography) -->
+    <figure class="vista">
+      <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas_alongside_Carnival_Sunrise_Nassau_2026-05-19.webp"
+           loading="lazy" decoding="async"
+           alt="Wonder of the Seas berthed alongside Carnival Sunrise at Nassau, dwarfing the pier and the people on it."/>
+      <figcaption>The scale, from the pier &mdash; alongside Carnival Sunrise at Nassau, May 2026. Photo: Ken Baker, In the Wake.</figcaption>
+    </figure>
+
+    <div class="ship-wrap">
       <h2 class="serif">Dining</h2>
-      <p>A working snapshot of her venues. Specialty restaurants and some bars carry an extra charge; complimentary venues are included in your fare. <a href="https://cruisinginthewake.com/restaurants/">Browse all restaurants &rarr;</a></p>
-      <div class="cols">
-        <h3>Complimentary</h3>
-        <ul>
-          <li>Main Dining Room</li>
-          <li>Windjammer Marketplace</li>
-          <li>El Loco Fresh</li>
-          <li>Park Caf&eacute;</li>
-          <li>Sorrento&rsquo;s</li>
-          <li>Solarium Bistro</li>
-        </ul>
-        <h3>Specialty</h3>
-        <ul>
-          <li>Giovanni&rsquo;s Italian Kitchen &amp; Bar</li>
-          <li>Chops Grille</li>
-          <li>Izumi Sushi &amp; Hibachi</li>
-          <li>Coastal Kitchen</li>
-          <li>Hooked Seafood</li>
-          <li>Wonderland</li>
-          <li>Johnny Rockets</li>
-        </ul>
-        <h3>Bars &amp; lounges</h3>
-        <ul>
-          <li>The Lime &amp; Coconut</li>
-          <li>Rising Tide Bar</li>
-          <li>Bionic Bar</li>
-          <li>Playmakers Sports Bar</li>
-          <li>Boleros</li>
-          <li>Schooner Bar</li>
-          <li>Crown Lounge</li>
-        </ul>
+      <p>A working snapshot of her venues. Specialty rooms and some bars carry an extra charge; the complimentary venues are included in your fare. <a href="https://cruisinginthewake.com/restaurants/">Browse every restaurant &rarr;</a></p>
+      <div class="venues">
+        <section>
+          <h3>Complimentary</h3>
+          <ul>
+            <li>Main Dining Room</li>
+            <li>Windjammer Marketplace</li>
+            <li>El Loco Fresh</li>
+            <li>Park Caf&eacute;</li>
+            <li>Sorrento&rsquo;s</li>
+            <li>Solarium Bistro</li>
+          </ul>
+        </section>
+        <section>
+          <h3>Specialty</h3>
+          <ul>
+            <li>Giovanni&rsquo;s Italian Kitchen</li>
+            <li>Chops Grille</li>
+            <li>Izumi Sushi &amp; Hibachi</li>
+            <li>Coastal Kitchen</li>
+            <li>Hooked Seafood</li>
+            <li>Wonderland</li>
+            <li>Johnny Rockets</li>
+          </ul>
+        </section>
+        <section>
+          <h3>Bars &amp; lounges</h3>
+          <ul>
+            <li>The Lime &amp; Coconut</li>
+            <li>Rising Tide Bar</li>
+            <li>Bionic Bar</li>
+            <li>Playmakers Sports Bar</li>
+            <li>Boleros</li>
+            <li>Schooner Bar</li>
+            <li>Crown Lounge</li>
+          </ul>
+        </section>
+      </div>
+    </div>
+
+    <!-- PULL-QUOTE: the one beat of silence + scale -->
+    <div class="pullquote">
+      <blockquote>I expected to be lost in a crowd of seven thousand. Instead, on the biggest ship I&rsquo;d ever seen, it was the easiest place I&rsquo;ve ever struck up a conversation.</blockquote>
+      <p class="by">&mdash; Amanda K., Nashville &middot; <span class="tiny">guest story, lightly condensed</span></p>
+    </div>
+
+    <!-- VISTA: her bow at Nassau (owner photography) -->
+    <figure class="vista">
+      <img src="/assets/ships/rcl/wonder-of-the-seas/Wonder_of_the_Seas_bow_Nassau_2026-05-19.webp"
+           loading="lazy" decoding="async"
+           alt="The bow and AquaDome of Wonder of the Seas seen from the pier at Nassau."/>
+      <figcaption>Bow and AquaDome at Nassau, May 2026. Photo: Ken Baker, In the Wake.</figcaption>
+    </figure>
+
+    <div class="ship-wrap">
+      <h2 class="serif">Plan it</h2>
+      <div class="planband">
+        <a href="https://www.royalcaribbean.com/cruise-ships/wonder-of-the-seas/deck-plans" target="_blank" rel="nofollow noopener">
+          <b>Official deck plans &rarr;</b><span>We link to Royal&rsquo;s live plans rather than a stale copy.</span>
+        </a>
+        <a href="https://www.vesselfinder.com/vessels/WONDER-OF-THE-SEAS-IMO-9838345" target="_blank" rel="noopener">
+          <b>Where is she now? &rarr;</b><span>Live position, speed, and next port. IMO 9838345.</span>
+        </a>
       </div>
 
-      <h2 class="serif">Onboard</h2>
-      <p>The signature draws and the everyday ones, by category.</p>
-      <div class="cols">
-        <h3>Entertainment</h3>
-        <ul>
-          <li>Royal Theater</li>
-          <li>AquaTheater (high-diving)</li>
-          <li>Studio B (ice shows)</li>
-          <li>Music Hall</li>
-          <li>Spotlight Karaoke</li>
-          <li>The Attic</li>
-        </ul>
-        <h3>Activities</h3>
-        <ul>
-          <li>Ultimate Abyss slide</li>
-          <li>The Perfect Storm waterslides</li>
-          <li>FlowRider surf simulator</li>
-          <li>Rock-climbing wall</li>
-          <li>Zip line</li>
-          <li>Mini golf &amp; sports court</li>
-          <li>Splashaway Bay (kids)</li>
-          <li>Vitality Spa &amp; fitness center</li>
-          <li>Casino Royale</li>
-        </ul>
-        <h3>Neighborhoods</h3>
-        <ul>
-          <li>Central Park (12,000+ live plants)</li>
-          <li>The Boardwalk (carousel)</li>
-          <li>Royal Promenade</li>
-          <li>Solarium</li>
-          <li>Library</li>
-          <li>Chapel</li>
-        </ul>
+      <h2 class="serif">At a glance</h2>
+      <div class="facts">
+        <div><span class="k">Line</span><span class="v">Royal Caribbean</span></div>
+        <div><span class="k">Class</span><span class="v">Oasis</span></div>
+        <div><span class="k">Entered service</span><span class="v">2022</span></div>
+        <div><span class="k">Gross tonnage</span><span class="v">236,857 GT</span></div>
+        <div><span class="k">Guests</span><span class="v">5,734 double &middot; ~6,988 max</span></div>
+        <div><span class="k">Crew</span><span class="v">2,300</span></div>
+        <div><span class="k">Length</span><span class="v">1,188 ft (362 m)</span></div>
+        <div><span class="k">Beam</span><span class="v">156 ft (47.4 m)</span></div>
+        <div><span class="k">Registry</span><span class="v">Bahamas</span></div>
+        <div><span class="k">Builder</span><span class="v">Chantiers de l&rsquo;Atlantique</span></div>
+        <div><span class="k">IMO</span><span class="v">9838345</span></div>
       </div>
+      <p style="margin-top:1.25rem"><strong>Oasis-class sisters:</strong>
+        <a href="https://cruisinginthewake.com/ships/rcl/oasis-of-the-seas.html">Oasis</a> &middot;
+        <a href="https://cruisinginthewake.com/ships/rcl/allure-of-the-seas.html">Allure</a> &middot;
+        <a href="https://cruisinginthewake.com/ships/rcl/harmony-of-the-seas.html">Harmony</a> &middot;
+        <a href="https://cruisinginthewake.com/ships/rcl/symphony-of-the-seas.html">Symphony</a> &middot;
+        <a href="https://cruisinginthewake.com/ships/rcl/utopia-of-the-seas.html">Utopia of the Seas</a>
+      </p>
+    </div>
 
-      <h2 class="serif">From the logbook</h2>
-      <figure class="logbook" style="border-left:3px solid var(--gold);padding-left:1.1rem;margin:1.5rem 0;">
-        <blockquote class="serif" style="font-style:italic;margin:0;">I expected to be lost in a crowd of 7,000. Instead, I found my people. A ship so large it felt like it should swallow you whole &mdash; and somehow it was the easiest place I&rsquo;ve ever struck up a conversation.</blockquote>
-        <figcaption class="byline" style="margin-top:.6rem;color:var(--muted);font-size:.92rem;">&mdash; Amanda K., Nashville, TN &middot; <span class="tiny">guest story, lightly condensed</span></figcaption>
-      </figure>
-
-      <h2 class="serif">Deck plans</h2>
-      <p>We don&rsquo;t reproduce Royal&rsquo;s deck plans &mdash; they revise them, and the official version is the one to trust.</p>
-      <p><a class="hub-cta" href="https://www.royalcaribbean.com/cruise-ships/wonder-of-the-seas/deck-plans" target="_blank" rel="nofollow noopener">Open official deck plans &rarr;</a></p>
-
-      <h2 class="serif">Where is she right now?</h2>
-      <p>Track Wonder&rsquo;s live position, speed, and next port. It opens in a new tab.</p>
-      <p><a class="hub-cta" href="https://www.vesselfinder.com/vessels/WONDER-OF-THE-SEAS-IMO-9838345" target="_blank" rel="noopener">Open the live tracker (IMO 9838345) &rarr;</a></p>
-
+    <div class="ship-wrap faq">
       <h2 class="serif">Common questions</h2>
-      <div class="faq-wrap">
-        <details>
-          <summary>What makes Wonder of the Seas unique?</summary>
-          <p>She&rsquo;s the highest-capacity ship in the Oasis Class (5,734 guests at double occupancy), with Royal Caribbean&rsquo;s seven-neighborhood layout: Central Park&rsquo;s 12,000-plus live plants, the Boardwalk and its hand-carved carousel, and the AquaTheater&rsquo;s high-diving shows.</p>
-        </details>
-        <details>
-          <summary>Which ships are in the same class?</summary>
-          <p>The Oasis Class: <a href="https://cruisinginthewake.com/ships/rcl/oasis-of-the-seas.html">Oasis</a>, <a href="https://cruisinginthewake.com/ships/rcl/allure-of-the-seas.html">Allure</a>, <a href="https://cruisinginthewake.com/ships/rcl/harmony-of-the-seas.html">Harmony</a>, <a href="https://cruisinginthewake.com/ships/rcl/symphony-of-the-seas.html">Symphony</a>, and <a href="https://cruisinginthewake.com/ships/rcl/utopia-of-the-seas.html">Utopia of the Seas</a>.</p>
-        </details>
-        <details>
-          <summary>Where does she sail?</summary>
-          <p>Typically Caribbean itineraries from Port Canaveral and other ports. Deployments shift by season &mdash; the live tracker above shows where she is today.</p>
-        </details>
-        <details>
-          <summary>How current is this page?</summary>
-          <p>Stats are from her profile and reviewed periodically; the deck plans and tracker link out to live, official sources rather than a stale local copy.</p>
-        </details>
-      </div>
+      <details>
+        <summary>What makes Wonder of the Seas unique?</summary>
+        <p>She&rsquo;s the highest-capacity ship in the Oasis Class (5,734 guests at double occupancy), with Royal Caribbean&rsquo;s seven-neighborhood layout: Central Park&rsquo;s 12,000-plus live plants, the Boardwalk and its hand-carved carousel, and the AquaTheater&rsquo;s high-diving shows.</p>
+      </details>
+      <details>
+        <summary>Which ships are in the same class?</summary>
+        <p>The Oasis Class: <a href="https://cruisinginthewake.com/ships/rcl/oasis-of-the-seas.html">Oasis</a>, <a href="https://cruisinginthewake.com/ships/rcl/allure-of-the-seas.html">Allure</a>, <a href="https://cruisinginthewake.com/ships/rcl/harmony-of-the-seas.html">Harmony</a>, <a href="https://cruisinginthewake.com/ships/rcl/symphony-of-the-seas.html">Symphony</a>, and <a href="https://cruisinginthewake.com/ships/rcl/utopia-of-the-seas.html">Utopia of the Seas</a>.</p>
+      </details>
+      <details>
+        <summary>Where does she sail?</summary>
+        <p>Typically Caribbean itineraries from Port Canaveral and other ports. Deployments shift by season &mdash; the live tracker above shows where she is today.</p>
+      </details>
+      <details>
+        <summary>How current is this page?</summary>
+        <p>Stats are from her profile and reviewed periodically; deck plans and tracking link out to live, official sources rather than a stale local copy.</p>
+      </details>
+    </div>
 
-      <h2 class="serif">Image credits</h2>
-      <ul class="tiny">
-        <li>Full starboard profile (hero): Intermerker via <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas.jpg" target="_blank" rel="noopener">Wikimedia Commons</a>, CC BY-SA 4.0.</li>
-        <li>Nassau bow &amp; alongside Carnival Sunrise: Ken Baker, In the Wake, May 2026 &middot; all rights reserved.</li>
-        <li>Saint-Nazaire build: ND44 via <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas_in_St-Nazaire_(2020).jpg" target="_blank" rel="noopener">Wikimedia Commons</a>, CC BY-SA 4.0.</li>
-      </ul>
-    </main>
+    <div class="shipfoot">
+      <p class="tiny" style="color:var(--muted)"><strong>Image credits:</strong>
+        full profile by Intermerker via <a href="https://commons.wikimedia.org/wiki/File:Wonder_of_the_Seas.jpg" target="_blank" rel="noopener">Wikimedia Commons</a> (CC BY-SA 4.0);
+        Nassau photographs by Ken Baker, In the Wake (May 2026, all rights reserved).</p>
+    </div>
 
-    <aside class="rail" aria-label="At a glance">
-      <div class="card">
-        <h2>At a glance</h2>
-        <p class="counts"><b>Line</b> Royal Caribbean<br/>
-        <b>Class</b> Oasis<br/>
-        <b>Entered service</b> 2022<br/>
-        <b>Gross tonnage</b> 236,857 GT<br/>
-        <b>Guests</b> 5,734 double &middot; ~6,988 max<br/>
-        <b>Crew</b> 2,300<br/>
-        <b>Length</b> 1,188 ft (362 m)<br/>
-        <b>Beam</b> 156 ft (47.4 m)<br/>
-        <b>Registry</b> Bahamas<br/>
-        <b>Builder</b> Chantiers de l&rsquo;Atlantique<br/>
-        <b>IMO</b> 9838345</p>
-      </div>
-      <div class="card">
-        <h2>Oasis-class sisters</h2>
-        <p class="tiny"><a href="https://cruisinginthewake.com/ships/rcl/oasis-of-the-seas.html">Oasis of the Seas</a><br/>
-        <a href="https://cruisinginthewake.com/ships/rcl/allure-of-the-seas.html">Allure of the Seas</a><br/>
-        <a href="https://cruisinginthewake.com/ships/rcl/harmony-of-the-seas.html">Harmony of the Seas</a><br/>
-        <a href="https://cruisinginthewake.com/ships/rcl/symphony-of-the-seas.html">Symphony of the Seas</a><br/>
-        <a href="https://cruisinginthewake.com/ships/rcl/utopia-of-the-seas.html">Utopia of the Seas</a></p>
-      </div>
-      <div class="card">
-        <h2>Compare &amp; plan</h2>
-        <p class="tiny"><a href="https://cruisinginthewake.com/tools/ship-size-atlas.html">Ship Size Atlas &mdash; space ratios</a><br/>
-        <a href="https://cruisinginthewake.com/ships/rcl/">More Royal Caribbean ships</a><br/>
-        <a href="https://cruisinginthewake.com/shiphubbeta4.html">All ships hub</a></p>
-      </div>
-    </aside>
-  </div>
+  </main>
 
 
   <footer>In the Wake &middot; honest, calm, concrete cruise planning &middot; no ads, independent of cruise lines &middot; Soli Deo Gloria</footer>

--- a/stylesbeta4.css
+++ b/stylesbeta4.css
@@ -178,3 +178,78 @@ footer .counts b { color: var(--ink); font-family: Georgia,serif; }
   .ship-card img { transition: transform .6s ease; }
   .ship-card > a:hover img, .ship-card > a:focus-visible img { transform: scale(1.04); }
 }
+
+/* ============================================================
+   Ship editorial page (shipbeta4) — composed rhythm, not enumeration.
+   Alternates monumental / text / image-vista / designed-cards / quote.
+   ============================================================ */
+.ship-wrap { max-width: 62rem; margin: 0 auto; padding: 0 clamp(1.25rem,4vw,2.5rem); }
+.ship-wrap > h2 { font-size: clamp(1.5rem,3vw,2.1rem); font-weight: 400; color: var(--sea); margin: clamp(2rem,5vw,3rem) 0 .6rem; line-height: 1.15; }
+.ship-wrap > p { margin: 0 0 1.1rem; }
+.ship-wrap .lede { font-size: var(--t-lead); line-height: 1.5; color: var(--ink); margin: clamp(1.5rem,4vw,2.25rem) 0 0; }
+
+/* numeric band — a designed full-width beat right after the hero */
+.statband { background: linear-gradient(180deg,#eaf6fb,var(--paper)); border-bottom: 1px solid var(--rule); }
+.statband .inner { max-width: 72rem; margin: 0 auto; padding: clamp(1.3rem,3.2vw,2.1rem) clamp(1.25rem,4vw,2.5rem);
+  display: grid; grid-template-columns: repeat(auto-fit,minmax(8rem,1fr)); gap: 1.25rem 1.5rem; }
+.statband b { display: block; font-family: Georgia,serif; font-size: clamp(1.9rem,3.6vw,2.8rem); color: var(--sea); line-height: 1; }
+.statband span { color: var(--muted); font-size: .88rem; }
+
+/* who-she's-for as a decision fork, not two bold paragraphs */
+.fork { display: grid; grid-template-columns: 1fr 1fr; gap: 1.1rem; margin: 1.25rem 0; }
+.fork div { padding: 1.1rem 1.3rem; border-radius: 6px; background: var(--panel); border: 1px solid var(--rule); }
+.fork .yes { border-top: 3px solid var(--accent); }
+.fork .no { border-top: 3px solid var(--gold); }
+.fork h3 { margin: 0 0 .5rem; font-size: .85rem; letter-spacing: .08em; text-transform: uppercase; color: var(--sea); }
+.fork p { margin: 0; color: var(--ink); }
+@media (max-width:560px){ .fork { grid-template-columns: 1fr; } }
+
+/* the memorable handful — given weight, not buried in a 9-item list */
+.signature { display: grid; grid-template-columns: repeat(auto-fit,minmax(12rem,1fr)); gap: 1rem; margin: 1.25rem 0; }
+.sig { background: var(--panel); border: 1px solid var(--rule); border-left: 3px solid var(--gold); border-radius: 6px; padding: 1.1rem 1.2rem; }
+.sig h3 { margin: 0 0 .3rem; font-size: 1.2rem; font-weight: 400; color: var(--sea); }
+.sig p { margin: 0; color: var(--muted); font-size: .95rem; line-height: 1.5; }
+
+/* full-bleed image vista — the horizon / rhythm break */
+.vista { position: relative; margin: clamp(2.5rem,7vw,4.5rem) 0; overflow: hidden; }
+.vista img { width: 100%; height: clamp(15rem,52vh,30rem); object-fit: cover; display: block; }
+.vista figcaption { position: absolute; right: .6rem; bottom: .6rem; margin: 0; padding: .15rem .55rem;
+  font-size: .7rem; color: #eef7fb; background: rgba(8,48,65,.55); border-radius: 3px; }
+.vista figcaption a { color: #eef7fb; }
+
+/* monumental pull-quote — the one beat of silence + scale */
+.pullquote { max-width: 52rem; margin: clamp(2.5rem,7vw,4.5rem) auto; padding: 0 clamp(1.25rem,4vw,2.5rem); }
+.pullquote blockquote { margin: 0; font-family: Georgia,serif; font-style: italic; font-size: clamp(1.5rem,3.2vw,2.4rem); line-height: 1.25; color: var(--sea); }
+.pullquote .by { margin: 1rem 0 0; color: var(--muted); font-size: .95rem; }
+
+/* dining as a typographic set, not bullet dumps */
+.venues { columns: 3; column-gap: 2rem; margin: 1rem 0; }
+.venues section { break-inside: avoid; margin: 0 0 1rem; }
+.venues h3 { margin: 0 0 .35rem; font-size: .8rem; letter-spacing: .1em; text-transform: uppercase; color: var(--accent); }
+.venues ul { list-style: none; margin: 0; padding: 0; }
+.venues li { padding: .12rem 0; color: var(--ink); font-size: .98rem; }
+@media (max-width:680px){ .venues { columns: 2; } }
+@media (max-width:440px){ .venues { columns: 1; } }
+
+/* plan band — two decisive outbound actions */
+.planband { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.25rem 0; }
+.planband a { display: block; padding: 1.1rem 1.25rem; border: 1px solid var(--rule); border-bottom: 3px solid var(--gold);
+  border-radius: 6px; text-decoration: none; background: var(--panel); }
+.planband a:hover, .planband a:focus-visible { border-bottom-color: var(--accent); }
+.planband b { display: block; color: var(--sea); font-size: 1.05rem; }
+.planband span { color: var(--muted); font-size: .9rem; }
+@media (max-width:560px){ .planband { grid-template-columns: 1fr; } }
+
+/* at-a-glance facts table */
+.facts { display: grid; grid-template-columns: repeat(auto-fit,minmax(15rem,1fr)); gap: 0 2.5rem; margin: 1rem 0 0; padding: 0; list-style: none; }
+.facts div { display: flex; justify-content: space-between; gap: 1rem; padding: .55rem 0; border-bottom: 1px solid var(--rule); }
+.facts .k { color: var(--muted); }
+.facts .v { color: var(--ink); font-weight: 600; text-align: right; }
+
+/* faq outside .prose */
+.faq details { border-top: 1px solid var(--rule); padding: .85rem 0; }
+.faq details summary { cursor: pointer; font-weight: 600; color: var(--ink); }
+.faq details[open] summary { color: var(--sea); }
+.faq details p { margin: .6rem 0 0; color: var(--muted); }
+.shipfoot { max-width: 62rem; margin: clamp(2rem,5vw,3rem) auto 0; padding: 0 clamp(1.25rem,4vw,2.5rem); }
+.shipfoot a { margin-right: 1.3rem; line-height: 2.2; }


### PR DESCRIPTION
Prior version was substance poured into six stacked bullet lists - the flat-rhythm failure the board named. This is a composed editorial flow:
- Monumental full-bleed hero (the vessel as the moment)
- Designed numeric band (serif numerals, full-width tint)
- "Is she your ship?" decision fork instead of two bold paragraphs
- "What you will remember" - the four signature experiences given weight as cards, not buried in a 9-item list
- Two full-bleed photo vistas (owner Nassau photography) as horizon/rhythm breaks between text
- Dining as a typographic three-column set, not bullet dumps
- A monumental pull-quote (the logbook story) as the beat of silence
- Plan-it action band, at-a-glance facts table, FAQ, credits New CSS: .statband .fork .signature .vista .pullquote .venues .planband .facts .faq .ship-wrap. Content unchanged in substance; only already-sourced facts; rhythm and hierarchy are the work.