### PR TITLE
fix(articles): remove V1.Beta badge from 2 new articles + flag root-cause gap (#1612)

### DIFF
--- a/articles/caribbean-princess-power-loss-2026.html
+++ b/articles/caribbean-princess-power-loss-2026.html
@@ -163,7 +163,6 @@ Soli Deo Gloria
     <div class="navbar">
       <div class="brand">
         <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
-        <span class="tiny version-badge">V1.Beta</span>
       </div>
       <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
         <span class="nav-toggle-icon"><span></span><span></span><span></span></span>

--- a/articles/liberty-of-the-seas-royal-amplification-2026.html
+++ b/articles/liberty-of-the-seas-royal-amplification-2026.html
@@ -163,7 +163,6 @@ Soli Deo Gloria
     <div class="navbar">
       <div class="brand">
         <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
-        <span class="tiny version-badge">V1.Beta</span>
       </div>
       <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
         <span class="nav-toggle-icon"><span></span><span></span><span></span></span>


### PR DESCRIPTION
## What

Removes the stale `V1.Beta` `version-badge` span from two production article pages. Found by a post-merge regression sweep: site-wide `V1.Beta` count in `*.html` had gone from **0 → 2**.

```diff
   <img ... alt="In the Wake wordmark" decoding="async"/>
-  <span class="tiny version-badge">V1.Beta</span>
   </div>
```

Affected:
- `articles/liberty-of-the-seas-royal-amplification-2026.html`
- `articles/caribbean-princess-power-loss-2026.html`

## Why it was back — not a nav-pass regression

Both articles were **born with the badge** in `8d491471` (the new Liberty / Caribbean-Princess content), carrying a stale `version-badge` span from a hand-authored pattern. Confirmed: at `ef7804da` both already had it (`before=1, now=1`), so the recent nav migration didn't introduce it.

## Root-cause gap (flagged, not fixed here)

#1612 was closed as "root cause fixed (7 generators)", but the remediation tool `admin/fix-v1beta.cjs` only scans `ships/` (`SHIPS_DIR = path.join(__dirname, '..', 'ships')`). It **structurally cannot catch hand-authored articles**, which is why the badge keeps reappearing on new article pages — this is the third instance (the rocket-launch article was the same leak, fixed in #1828). Recommend either widening `fix-v1beta.cjs` beyond `ships/` or adding a CI guard (like the new Meta Keywords Guard) that fails on any `version-badge">V1.Beta` in `*.html`.

## Verification

- `grep -rl 'V1\.Beta' . --include='*.html' | wc -l` → **0** (site-wide).
- Remaining matches are only in `admin/validate-ship-page.js` (which *checks for* the badge) and `admin/fix-v1beta.cjs` (which *removes* it) — legitimate tool logic, not rendered badges.
- Both `brand` divs intact (logo img present, badge removed); 1 line removed per file; no other change.

Relates to #1612.

🤖 https://claude.ai/code/session_01XfmJjR5qDxcXhSGGc3QGWF

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfmJjR5qDxcXhSGGc3QGWF)_