### PR TITLE
ci(quality): add V1.Beta Guard to block recurring article badge leak (#1612)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -177,6 +177,32 @@ jobs:
           fi
           echo "✓ No dead meta keywords tags found"
 
+  # V1.Beta badge guard — blocks the recurring article leak (#1612, #1828, #1869)
+  v1beta-guard:
+    name: V1.Beta Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Fail on V1.Beta in HTML
+        run: |
+          echo "🔍 Checking for V1.Beta in HTML (version badge / title / meta)..."
+          # Site-wide *.html V1.Beta was driven to 0; any reappearance is a regression.
+          # --include=*.html excludes the admin tools that legitimately contain the
+          # string (validate-ship-page.js checks for it; fix-v1beta.cjs removes it).
+          HITS=$(grep -rIl --include="*.html" 'V1\.Beta' . 2>/dev/null || true)
+          if [ -n "$HITS" ]; then
+            echo "❌ Found V1.Beta in HTML — remove it (stale pre-release badge):"
+            echo "$HITS"
+            echo ""
+            echo "Background: removed sitewide, but new hand-authored articles keep"
+            echo "reintroducing the version-badge span (#1612, #1828, #1869) because the"
+            echo "fix-v1beta.cjs cleanup only scans ships/. This guard catches it at PR time."
+            exit 1
+          fi
+          echo "✓ No V1.Beta found in HTML"
+
   # Validator spec lint (anti-zombie check)
   validator-spec-lint:
     name: Validator Spec Lint
@@ -200,7 +226,7 @@ jobs:
   summary:
     name: Quality Summary
     runs-on: ubuntu-latest
-    needs: [link-check, placeholder-check, validate-html, meta-keywords-guard, validator-spec-lint]
+    needs: [link-check, placeholder-check, validate-html, meta-keywords-guard, v1beta-guard, validator-spec-lint]
     if: always()
     steps:
       - name: Summary
@@ -213,6 +239,7 @@ jobs:
           echo "| Placeholder Check | ${{ needs.placeholder-check.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| HTML Validation | ${{ needs.validate-html.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Meta Keywords Guard | ${{ needs.meta-keywords-guard.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| V1.Beta Guard | ${{ needs.v1beta-guard.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Validator Spec Lint | ${{ needs.validator-spec-lint.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "See individual job logs for details." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What

Adds a blocking CI guard that fails on any `V1.Beta` in `*.html`. Mirrors the Meta Keywords Guard (#1866), closing the second recurring-regression gap surfaced this session.

## Why

Site-wide `*.html` `V1.Beta` was driven to 0, but new **hand-authored articles keep reintroducing** the `version-badge` span — three times now:
- #1612 closed as "root cause fixed (7 generators)" — but only generators were covered
- #1828 — rocket-launch article shipped with the badge
- #1869 — Liberty / Caribbean-Princess articles shipped with the badge

Root cause: `admin/fix-v1beta.cjs` only scans `ships/` (`SHIPS_DIR = ../ships`), so the article authoring path is unguarded. Each leak has been caught by a manual post-merge `grep`. This guard moves the catch to PR time.

## Change

New `v1beta-guard` job in `.github/workflows/quality.yml`, wired into the `summary` job's `needs[]` and status table:

```bash
HITS=$(grep -rIl --include="*.html" 'V1\.Beta' . || true)
[ -n "$HITS" ] && { echo "$HITS"; exit 1; }
```

Broad `V1\.Beta` match catches all surfaces (badge span, `<title>` suffix, `<meta>`, comment) — appropriate since the site-wide `*.html` count is already 0, so any reappearance is a regression.

## Verification (both directions, outcome-level)

- **YAML valid**; `v1beta-guard` present and wired into `summary.needs[]` + table (parsed with `yaml.safe_load`).
- **Pass:** current tree (0 `V1.Beta` in `*.html`) → exit 0.
- **Fail:** injected a temp `<span class="...version-badge">V1.Beta</span>` → exit 1, flags the file; removed after.
- **No false positives:** the admin tools that legitimately contain the string (`validate-ship-page.js` checks for it; `fix-v1beta.cjs` removes it) are `.js`/`.cjs` and excluded by `--include=*.html` — verified 0 hits in `admin/`.

Relates to #1612 / #1869.

🤖 https://claude.ai/code/session_01XfmJjR5qDxcXhSGGc3QGWF

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfmJjR5qDxcXhSGGc3QGWF)_