### PR TITLE
Jerusha: fix stale-shell SW (gallery bug) + location/persistence plans

### DIFF
--- a/admin/claude/plans/jerusha-location-share.md
+++ b/admin/claude/plans/jerusha-location-share.md
@@ -1,0 +1,178 @@
+# Jerusha page — live location share (your travel breadcrumb)
+
+**Status:** Planned. Not built. Rides the same Cloudflare Worker + KV as the
+notes relay ([`jerusha-write-back.md`](jerusha-write-back.md)) and push
+([`jerusha-pwa-push.md`](jerusha-pwa-push.md)). New build order entry: **Slice 4**
+(see `../../jerusha-worker/README.md`).
+**Target page:** `admin/weather-jerusha.html` (renders on the existing Leaflet
+radar map, inside the encrypted payload).
+**Goal:** Jerusha can open the page and see roughly where you are — a 10-day
+trail of your phone's location, drawn on the same map that already shows the
+ship route. As you travel (flights, transfers, the cruise), the trail extends.
+**Last updated:** 2026-06-18
+
+---
+
+## The load-bearing reality (read first)
+
+**A web page cannot relay your location in the background.** The browser
+Geolocation API (`getCurrentPosition` / `watchPosition`) only runs while the
+page is *open and foregrounded*. The moment your phone locks or you switch apps,
+it stops. There is no web API — on iOS or Android — that lets a website report
+GPS while it's closed. So the Jerusha page on **your** phone cannot be the
+location source. It can only be the **viewer** (on her phone).
+
+The source has to be a small **background location reporter** on your phone that
+POSTs coordinates to the Worker. That is a separate app, not web code.
+
+### Recommended source: OwnTracks (free, open-source, iOS + Android)
+
+- Configure OwnTracks in **HTTP mode** to POST to `https://<worker>/loc` with an
+  `Authorization: Bearer <token>` header (custom header support is built in).
+- **Move/cadence:** "significant change" or a fixed interval (e.g. every 15–30
+  min) is plenty and battery-friendly. No need for high-frequency tracking.
+- It runs in the background using the OS location-permission model (the same one
+  Maps uses), which is exactly the thing a website can't do.
+- One-time setup on your phone before the trip; nothing to babysit after.
+
+**Alternatives considered (and why not):**
+- *iOS Shortcuts personal automation* — can't run on a reliable background timer;
+  no true periodic background fire. Manual-only.
+- *Tasker* (Android) — works, but Android-only and more fiddly than OwnTracks.
+- *Google Maps "share location"* — can't be fed into our own map; it's a
+  walled link, and points it at Google, not at the page. Defeats the purpose.
+
+If you'd rather not install OwnTracks, the fallback is **manual**: a "drop my
+location now" button on *your* copy of the page that captures one fix while
+open and POSTs it. Honest tradeoff — it only updates when you remember to open
+the page and tap, so the trail is sparse. Documented as the no-app option.
+
+---
+
+## Architecture
+
+```
+Your phone (OwnTracks, background) ──POST /loc {lat,lon,ts}──▶ Worker ──▶ KV (one key per fix, 10-day TTL)
+Her page (radar map) ◀── GET /loc?since= ◀──                         (breadcrumb polyline + "here now" marker)
+```
+
+- **Source:** OwnTracks on your phone → `POST /loc`. Bearer token (same bot-filter
+  model as `/notes`), origin **not** enforced on `/loc` (the reporter app has no
+  browser Origin header — auth is the token + a tight body schema instead).
+- **Worker:** validates token + shape + a sane coordinate range, writes one KV
+  record per fix with a **10-day TTL** (KV native expiry — auto-prunes, no cron
+  needed). `GET /loc?since=` returns fixes for the map.
+- **Page:** the radar map already draws the planned ship route (cyan). Add a
+  **second, warm-gold** polyline for your *actual* track + a pulsing "here now"
+  marker at the latest fix, with the time in both zones (yours + her Lahore time).
+
+## Data model (KV)
+
+- Key `loc:<isots>` → `{v:1, lat, lon, ts, acc?, alt?}`. One key per fix.
+  - `expirationTtl: 864000` (10 days) on `put` — KV deletes it automatically.
+  - One-key-per-fix mirrors the notes design (no read-modify-write race; a fix is
+    a pure append). `GET /loc?since=` lists the `loc:` prefix, filters by `since`.
+- Coordinates are **rounded** before storage (≈3 decimals, ~110 m) — enough to
+  show "he's in Skagway," not enough to pin a street address. Privacy by default.
+
+## Worker API (additions to the existing Worker)
+
+- `POST /loc` — body `{lat, lon, tst|ts, acc?}` (OwnTracks sends `_type:"location",
+  lat, lon, tst`). Auth `Authorization: Bearer <token>`. Validate `-90≤lat≤90`,
+  `-180≤lon≤180`. Round, write `loc:<isots>` with 10-day TTL. Accept the OwnTracks
+  JSON shape directly so no transform app is needed. Return `{ok:true}` (OwnTracks
+  ignores the body).
+- `GET /loc?since=<isots>` — origin-locked (browser read, like `/notes`), bearer
+  auth. Returns `{points:[{lat,lon,ts}, …]}` oldest-first, capped (e.g. last 1000).
+- **No new secret.** Reuses `NOTES_TOKEN`. No VAPID, no cron.
+
+## Page — rendering on the radar map (inside the encrypted payload)
+
+- On the **map tab**, after the ship route draws: `GET /loc?since=` (10 days back
+  on first open), then poll every few minutes while the tab is visible (same
+  visibility-gated pattern as the notes thread).
+- Draw a **warm-gold** breadcrumb polyline (`#e7c27d`, distinct from the cyan ship
+  route) + a "here now" marker at the most recent fix. Tooltip: "Ken — <time
+  yours> · <time Lahore>". Empty state: a quiet "No location yet — he'll appear
+  here once he's moving. 💛" so it never looks broken.
+- A tiny legend line so the two lines aren't confused: cyan = the ship's path,
+  gold = where Ken actually is.
+- **CSP:** the Worker origin is already in `connect-src` from the notes slice —
+  `/loc` is the same origin, so **no CSP change**.
+
+## Privacy & sensitivity (this is real-person location — treat it with care)
+
+- This is **your real-time whereabouts**, shared intentionally with one person.
+  Lower-sensitivity than pastoral content, but still personal — handle deliberately.
+- **Retention is the trip window:** 10-day KV TTL, hard. Nothing older survives.
+- **Coarsened:** rounded to ~110 m before storage. No street-level precision.
+- **Auth + transport:** bearer token on both ends, HTTPS always, read path
+  origin-locked to the page. Coordinates are **never logged**.
+- **Pause control:** a "pause sharing" toggle — practically, you just stop
+  OwnTracks (or flip its reporting off); the trail simply stops extending and
+  ages out in 10 days. Document this as the off-switch.
+
+### E2EE decision (open — recommend symmetric-skip for v1)
+
+The notes thread is end-to-end encrypted so the Worker is zero-knowledge.
+Location **can't** match that cleanly, because OwnTracks can't run our
+AES-GCM-to-the-page-key crypto — it posts plaintext JSON. Two options:
+
+- **(A) Plaintext coords in KV (recommended for v1).** Worker sees rounded
+  coordinates. Tradeoff accepted: it's your own location, coarsened, 10-day TTL,
+  token+origin locked. Mirrors how the notes plan shipped symmetric-now /
+  public-key-later. Simplest, works with stock OwnTracks today.
+- **(B) Re-encrypting relay.** A tiny always-on shim (e.g. on the M4 mini) pulls
+  from OwnTracks, encrypts to the notes key, and pushes ciphertext to the Worker;
+  the page decrypts. Keeps zero-knowledge, but adds a moving part that must stay
+  up while you travel, and the mini isn't in the path once you've left home.
+  Note as a Phase-2 hardening, not v1.
+
+**Recommendation:** (A) for the trip; revisit (B) only if zero-knowledge for
+location turns out to matter.
+
+## Build order (where this slots in)
+
+This is **Slice 4** in `../../jerusha-worker/README.md`. It is independent of
+Slice 3 (itinerary prompts) and can ship before or after it. Given the trip is
+**Jun 29 – Jul 6**, its value is time-boxed — worth doing before departure so the
+travel days (the Tampa→Seattle and return flights especially) actually draw.
+
+1. **Worker:** add `POST /loc` + `GET /loc?since=` (10-day TTL, round, validate).
+   Redeploy. Test with a manual `curl` POST, then a real OwnTracks fix.
+2. **Your phone:** install + configure OwnTracks (HTTP mode, endpoint, token,
+   cadence, location permission "always"). Confirm a fix lands (`GET /loc`).
+3. **Page (decrypt → edit → re-encrypt):** map-tab fetch + gold breadcrumb +
+   here-now marker + legend + dual-zone tooltip + empty state. Verify on her
+   Android against the live origin.
+
+## Open questions to confirm before build
+
+1. **Source app:** OwnTracks (recommended) vs. the manual "drop my location"
+   button vs. both? (Both is cheap — the manual button is a few lines and a nice
+   fallback if OwnTracks misbehaves mid-trip.)
+2. **E2EE:** plaintext-coords v1 (recommended) or hold for the re-encrypting relay?
+3. **Cadence/precision:** ~110 m rounding + 15–30 min interval OK, or do you want
+   tighter (more battery, more precise) / looser?
+4. **Visibility window:** show the full 10 days, or just "today + last fix"? (Full
+   trail is the better keepsake; last-fix is the cleaner glance.)
+
+---
+
+## Install-button fix (folded in here — small, ties to the PWA slice)
+
+You reported no install button on Android. Two causes, both addressable:
+
+1. **Not live yet.** Android Chrome only offers "Install app" when the manifest +
+   service worker are served over HTTPS from the real origin. Until the branch is
+   published to `cruisinginthewake.com`, there's nothing to install. **This is
+   almost certainly the main reason.** First check after publish: Chrome ⋮ menu →
+   "Install app" / "Add to Home screen" should already be there with no code change.
+2. **No custom button + `document.write` gotcha.** For a nicer in-page "Install 💛"
+   button we must capture `beforeinstallprompt` — but the gate's
+   `document.open()/write()/close()` replaces the document, so the handler has to
+   live **inside the payload** (post-unlock), not in the gate. Plan: in the payload,
+   add a hidden "Install 💛" button; on `beforeinstallprompt` (preventDefault +
+   stash the event), reveal it; on tap, call `prompt()`. Also add the iOS
+   `apple-mobile-web-app-*` meta + an "Add to Home Screen" hint for iOS (which has
+   no `beforeinstallprompt` at all). Tracked as **Slice 2c** in the Worker README.

--- a/admin/claude/plans/jerusha-notes-persistence.md
+++ b/admin/claude/plans/jerusha-notes-persistence.md
@@ -1,0 +1,104 @@
+# Jerusha page — notes persistence & durability
+
+**Status:** Planned. Not built. Hardens the notes thread from
+[`jerusha-write-back.md`](jerusha-write-back.md) so the conversation is a true
+keepsake — it survives cleared phones, a dropped network, and even loss of the
+Cloudflare account.
+**Target:** the Worker (`admin/jerusha-worker/`) + the encrypted page
+(`admin/weather-jerusha.html`).
+**Goal:** never lose a note. Not on her phone, not on yours, not if Cloudflare
+goes away. The thread is a record of the distance you crossed — treat it like one.
+**Last updated:** 2026-06-18
+**Build order:** **Slice 5** in `../../jerusha-worker/README.md` (folds the export
+half of the deferred Slice 3 into a fuller durability story).
+
+---
+
+## Where notes can be lost today (the threat list)
+
+The current Slice 1 design already persists better than it might look, but there
+are real gaps. Each row is a way the keepsake could vanish:
+
+| # | Loss path | Today | Fix (this plan) |
+|---|---|---|---|
+| 1 | **Unsent note** (composed offline, app closed before flush) | localStorage outbox, flush on `online`/load | Confirm outbox is durable (localStorage, not memory); flush on `online` **and** on next open; never clear until the POST returns `{ok}` |
+| 2 | **Her phone wiped / site data cleared** | thread re-fetched from KV via `GET /notes` | Already covered **as long as KV holds** — but that's the single point of failure below |
+| 3 | **KV record dropped** | one-key-per-note, **no TTL** → persists indefinitely | Verify no TTL on `note:` keys (unlike `loc:`); document that notes are write-once-keep-forever |
+| 4 | **Cloudflare account/namespace lost** | **nothing** — KV is the only copy | **The real gap.** Add an off-Cloudflare backup (export + periodic pull) |
+| 5 | **Passphrase lost** | notes are E2EE under the passphrase → **unrecoverable** | Out of scope to "fix" (that's the security model), but document it bluntly so it's a known, accepted risk |
+
+The headline: **notes already persist server-side (no TTL) and re-sync to a
+wiped phone. The one thing missing is a copy that survives Cloudflare itself.**
+
+---
+
+## What "persist" means here (three layers)
+
+1. **Server-durable (KV).** Notes are stored one-key-per-note with **no
+   expiration** — they live until explicitly deleted. (Contrast Slice 4 location,
+   which is deliberately 10-day TTL.) This layer already works once the Worker is
+   deployed. Action: *verify and document* that `note:` keys carry no TTL.
+2. **Re-syncable (page).** A wiped or new device rebuilds the full thread from
+   `GET /notes?since=` (empty `since` = from the beginning). The local copy is a
+   cache, not the source of truth. Action: ensure first open with no local state
+   pulls the **entire** history, not just "recent."
+3. **Off-Cloudflare keepsake (export + backup).** The part that makes it a
+   permanent record independent of any provider — below.
+
+## Layer 3 — the keepsake (the actual new work)
+
+### 3a. In-page export ("Save our notes")
+
+- A button on the "Us" tab: **decrypt the full thread in the browser** and offer
+  it as a download. Two formats:
+  - **`.txt` / `.md`** — human-readable transcript (sender, both-timezone stamps,
+    text). This is the thing you'd actually want to re-read in ten years.
+  - **`.json`** — the raw `{id,sender,ts,iv,ct}` records (still encrypted), so the
+    export can be **re-imported** and decrypted later with the passphrase.
+- Runs entirely client-side (the page already holds the key via `window.__JPW`).
+  Nothing new leaves the device. Works offline against the local cache.
+
+### 3b. Re-import / restore
+
+- An "import notes" action that reads a previously exported `.json` and `POST`s
+  any missing records back to the Worker (de-dupe by `id`). Lets you rebuild KV
+  from a backup if a namespace is ever lost or recreated. Low effort, high payoff.
+
+### 3c. Periodic off-site backup (belt-and-suspenders)
+
+- A small scheduled pull — e.g. a `keeper`/cron job on the M4 mini, or a manual
+  monthly habit — that `GET /notes` (ciphertext) and writes it to durable storage
+  **outside Cloudflare** (the private repo's gitignored store, or local disk).
+  - Stores **ciphertext only** — the backup is as zero-knowledge as KV. Safe to
+    sit in a private repo or a backup drive; useless without the passphrase.
+  - This is the copy that survives a Cloudflare outage, billing lapse, or account
+    loss — the gap row #4 above.
+- Optional Worker side: a `GET /notes/all` (bearer-only, no `since`) convenience
+  endpoint for the backup job to grab everything in one call.
+
+## Decisions / open questions
+
+1. **Retention cap:** the write-back plan floated "cap at last ~1000." For a
+   keepsake, recommend **keep everything, no cap** (two people, tiny volume — KV
+   free tier is ample). Confirm.
+2. **Backup cadence:** manual export only (simplest), or an automated periodic
+   pull on the mini? Recommend: ship export/import first (3a/3b), add the
+   automated pull (3c) only if you want it hands-off.
+3. **Export trigger:** a button you tap, or also an automatic export-on-open into
+   the page's own IndexedDB as a second local copy? (Button is enough for v1.)
+4. **Passphrase loss is accepted as unrecoverable** — confirm you're OK with that
+   (it's the price of E2EE; the alternative is the Worker being able to read your
+   notes, which the whole design refuses).
+
+## Build order
+
+This is **Slice 5**. It subsumes the "decrypt-to-file keepsake export" that was
+parked inside Slice 3, and adds the import + off-site backup that make the thread
+genuinely provider-independent.
+
+1. **Verify layers 1–2 (no code, just confirmation):** `note:` keys have no TTL;
+   a fresh page load with cleared local state pulls the whole history. Document.
+2. **3a export** (page, decrypt→edit→re-encrypt): "Save our notes" → `.txt` + `.json`.
+3. **3b import** (page): read `.json`, POST missing records, de-dupe by `id`.
+4. **3c backup** (optional): `GET /notes/all` + a scheduled ciphertext pull to
+   off-Cloudflare storage.

--- a/admin/jerusha-worker/README.md
+++ b/admin/jerusha-worker/README.md
@@ -82,11 +82,26 @@ Then, on the page side (Slice 1b, a decrypt→edit→re-encrypt cycle):
 
 ## Build order (board-approved)
 
-1. **Slice 1 (this):** notes relay + "Us" tab thread + E2EE + offline outbox. Works
+1. **Slice 1 (DONE):** notes relay + "Us" tab thread + E2EE + offline outbox. Works
    as a refresh-on-open thread the moment the Worker is deployed. **No push needed.**
-2. **Slice 2:** Web Push — VAPID, subscribe-on-unlock, contentless push on new note,
-   Cron pushes in her Lahore-morning windows.
+2. **Slice 2 (DONE):** Web Push — VAPID, subscribe-on-unlock, contentless push on new
+   note, Cron pushes in her Lahore-morning windows.
+   - **Slice 2c (planned):** in-page "Install 💛" button — capture
+     `beforeinstallprompt` *inside the payload* (the gate's `document.write` resets
+     the document) + iOS Add-to-Home-Screen meta/hint. See
+     `../claude/plans/jerusha-location-share.md` (install-button section). Note: on
+     Android the OS install offer appears in Chrome's ⋮ menu once the page is live
+     on `cruisinginthewake.com` over HTTPS — the custom button is polish.
 3. **Slice 3:** itinerary-keyed daily prompts + a decrypt-to-file keepsake export.
+4. **Slice 4:** live location share — `POST /loc` + `GET /loc?since=` (10-day KV TTL,
+   coarsened coords), source = OwnTracks on your phone (background), rendered as a
+   warm-gold breadcrumb on the radar map. Independent of Slice 3; **time-boxed to the
+   trip — worth doing before departure.** Full plan:
+   `../claude/plans/jerusha-location-share.md`.
+5. **Slice 5:** notes persistence & durability — verify `note:` keys carry no TTL,
+   full-history re-sync to a wiped device, in-page export/import keepsake, and an
+   off-Cloudflare ciphertext backup so the thread survives even account loss. Full
+   plan: `../claude/plans/jerusha-notes-persistence.md`.
 
 ## Decisions needed before deploy
 

--- a/admin/jerusha-worker/wrangler.toml
+++ b/admin/jerusha-worker/wrangler.toml
@@ -2,6 +2,13 @@ name = "jerusha-notes"
 main = "worker.js"
 compatibility_date = "2026-06-01"
 
+# IMPORTANT: NOTES holds the keepsake thread. The `id` MUST be your real, STABLE
+# namespace id and must NEVER change between deploys — if it changes, the worker
+# binds an EMPTY namespace and the thread "disappears" (it's still in the old
+# namespace, just not bound). This is the most likely cause of a vanished note.
+#   List/confirm the id:  wrangler kv namespace list
+#   Create once (first):  wrangler kv namespace create NOTES
+#   Inspect what's there: wrangler kv key list --binding NOTES
 kv_namespaces = [
   { binding = "NOTES", id = "PASTE_KV_NAMESPACE_ID_HERE" }
 ]

--- a/admin/sw-jerusha.js
+++ b/admin/sw-jerusha.js
@@ -7,7 +7,7 @@
       assets so the page opens and decrypts without a connection.
    Single-user personal page, so skipWaiting/clients.claim are intentional. */
 
-const CACHE = "jerusha-v1";
+const CACHE = "jerusha-v3";
 const PRECACHE = [
   "/admin/weather-jerusha.html",
   "/admin/jerusha-icons/icon-192.png",
@@ -35,7 +35,27 @@ self.addEventListener("fetch", (e) => {
   if (req.method !== "GET") return;
   const url = new URL(req.url);
   if (NO_CACHE.some((h) => url.hostname.endsWith(h))) return; // network passthrough
-  // cache-first for the shell + static assets (same-origin + cdnjs libs)
+
+  // The HTML shell is NETWORK-FIRST: always try the live page so content updates
+  // (gallery fixes, new tabs, the encrypted payload) actually reach an installed
+  // device. A cache-first shell with a frozen cache name pins the user to a stale
+  // page forever — that was the bug. Fall back to cache only when offline.
+  const isShell = req.mode === "navigate" ||
+    (url.origin === self.location.origin && url.pathname === "/admin/weather-jerusha.html");
+  if (isShell) {
+    e.respondWith(
+      fetch(req).then((res) => {
+        if (res && res.status === 200) {
+          const copy = res.clone();
+          caches.open(CACHE).then((c) => c.put("/admin/weather-jerusha.html", copy));
+        }
+        return res;
+      }).catch(() => caches.match("/admin/weather-jerusha.html"))
+    );
+    return;
+  }
+
+  // Static assets (icons, cdnjs libs) stay CACHE-FIRST — they're versioned/stable.
   e.respondWith(
     caches.match(req).then((hit) =>
       hit ||


### PR DESCRIPTION
Bug fix — service worker served a stale page forever:
- sw-jerusha.js was CACHE-FIRST on the HTML shell with a frozen cache name (jerusha-v1), so an installed device kept serving the pre-fix page — the gallery fix (and all future updates) never reached it.
- Now NETWORK-FIRST for the shell (always fetch the live page; fall back to cache only offline); static assets (icons, cdnjs) stay cache-first. Bump CACHE jerusha-v1 -> jerusha-v3 to force re-precache on update.

Diagnostics captured this session:
- Production serves the latest payload (CT byte-for-byte matches the committed page); gallery image returns 200 — so the gallery fix IS live. The "still messed up" report is the stale SW above, not the page.
- GET /notes on the deployed worker returns 200 with 0 notes — the sent note never persisted to KV. Most likely the KV namespace binding changed across a redeploy. wrangler.toml now warns loudly that the NOTES `id` must be real and stable, with the commands to confirm/inspect it.

Plans appended to the slices list (jerusha-worker/README.md build order):
- Slice 4: live location share — OwnTracks (background, on your phone) ->
  POST /loc, 10-day KV TTL, coarsened coords, gold breadcrumb on the radar map.
  Documents why a web page CANNOT report location in the background.
- Slice 5: notes persistence & durability — no-TTL note keys, full re-sync to a wiped device, in-page export/import keepsake, off-Cloudflare ciphertext backup.
- Slice 2c (noted): in-page "Install" button must capture beforeinstallprompt INSIDE the payload (the gate's document.write resets the document); Android's OS install offer appears in Chrome's menu once the page is live over HTTPS.


Claude-Session: https://claude.ai/code/session_01PTWPvNGN8mPUezVekUM8ew