### PR TITLE
Jerusha: fix notes — gate-shell CSP blocked the worker (the real bug)

### DIFF
--- a/admin/weather-jerusha.html
+++ b/admin/weather-jerusha.html
@@ -10,7 +10,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https:; worker-src 'self'; manifest-src 'self'; connect-src https://api.open-meteo.com https://api.rainviewer.com https://api.weather.gov; font-src 'self'; base-uri 'none'; form-action 'none'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https:; worker-src 'self'; manifest-src 'self'; connect-src 'self' https://*.workers.dev https://api.open-meteo.com https://api.rainviewer.com https://api.weather.gov; font-src 'self'; base-uri 'none'; form-action 'none'">
 <meta name="referrer" content="no-referrer">
 <meta name="color-scheme" content="dark">
 <meta name="theme-color" content="#03060c">


### PR DESCRIPTION
Root cause of "we'll send when you're back online" + empty wrangler tail + empty KV: the notes POST/GET to the Cloudflare worker was blocked by Content- Security-Policy before it ever left the browser.

Two CSPs exist: the encrypted payload's own <meta> CSP correctly allowed https://*.workers.dev, but a <meta> CSP injected via document.write (after the gate unlocks) is ignored — the ORIGINAL gate-shell CSP keeps enforcing, and its connect-src listed only the Open-Meteo / RainViewer / weather.gov hosts. So every fetch to jerusha-notes.*.workers.dev was a CSP violation: silently blocked, never sent (hence nothing in `wrangler tail`, nothing in KV), and _usSend fell into its offline branch.

Fix: add 'self' https://*.workers.dev to the GATE-SHELL connect-src (line 13), matching the payload. Plaintext edit — encrypted blob untouched (CT unchanged, SDG at line 3, no getbets). Notes (and push subscribe) can now reach the worker.


Claude-Session: https://claude.ai/code/session_01PTWPvNGN8mPUezVekUM8ew