### PR TITLE
Remove stale V1.Beta badge from 3 news articles

### DIFF
--- a/articles/jewel-of-the-seas-mobility-scooter-lawsuit-2026.html
+++ b/articles/jewel-of-the-seas-mobility-scooter-lawsuit-2026.html
@@ -163,7 +163,6 @@ Soli Deo Gloria
     <div class="navbar">
       <div class="brand">
         <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
-        <span class="tiny version-badge">V1.Beta</span>
       </div>
       <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
         <span class="nav-toggle-icon"><span></span><span></span><span></span></span>

--- a/articles/nassau-brawls-cruise-passenger-arrests-2026.html
+++ b/articles/nassau-brawls-cruise-passenger-arrests-2026.html
@@ -163,7 +163,6 @@ Soli Deo Gloria
     <div class="navbar">
       <div class="brand">
         <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
-        <span class="tiny version-badge">V1.Beta</span>
       </div>
       <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
         <span class="nav-toggle-icon"><span></span><span></span><span></span></span>

--- a/articles/tropical-storm-arthur-watch-2026.html
+++ b/articles/tropical-storm-arthur-watch-2026.html
@@ -163,7 +163,6 @@ Soli Deo Gloria
     <div class="navbar">
       <div class="brand">
         <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
-        <span class="tiny version-badge">V1.Beta</span>
       </div>
       <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
         <span class="nav-toggle-icon"><span></span><span></span><span></span></span>


### PR DESCRIPTION
Three 2026 news articles carry the pre-release `V1.Beta` version badge in the navbar brand, which trips the **V1.Beta Guard** CI check (the recurring #1612/#1828/#1869 pattern — `fix-v1beta.cjs` only scans `ships/`). Removed the `<span class="tiny version-badge">V1.Beta</span>` line from each so the brand matches compliant articles (logo only).

Files: `nassau-brawls-…`, `tropical-storm-arthur-watch-…`, `jewel-of-the-seas-mobility-scooter-lawsuit-…`. 3 one-line deletions, nothing else.

Unblocks #1965 (Jerusha worker), whose merge-test was failing on this pre-existing `main` condition.