### PR TITLE
admin: redirect stub for moved family weather page

### DIFF
--- a/admin/weather-family.html
+++ b/admin/weather-family.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+  Soli Deo Gloria. — Colossians 3:23 "And whatsoever ye do, do it heartily, as to the Lord."
+  This page moved to /admin/family/weather-family.html (now an installable PWA in its
+  own folder). This stub only redirects so existing bookmarks, shared links, the
+  installed home-screen icon, and the old service worker keep working. No content here.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<meta name="referrer" content="no-referrer">
+<meta name="color-scheme" content="dark">
+<meta name="theme-color" content="#03060c">
+<meta http-equiv="refresh" content="0; url=/admin/family/weather-family.html">
+<link rel="canonical" href="/admin/family/weather-family.html">
+<title>In the Wake</title>
+</head>
+<body style="margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#03060c;color:#cfe9f2;font:14px ui-monospace,Menlo,Consolas,monospace;padding:20px;text-align:center">
+<p>Taking you to the page…<br><a href="/admin/family/weather-family.html" style="color:#e7c27d">tap here</a> if it doesn’t open.</p>
+<script>location.replace("/admin/family/weather-family.html" + location.search + location.hash);</script>
+</body>
+</html>


### PR DESCRIPTION
weather-family.html moved to /admin/family/ (#1994) with no redirect -> old widely-shared URL 404s. Add a redirect stub at the old path (mirrors the Jerusha stub) so bookmarks/links/installed icons keep working.