### PR TITLE
Fix drink-calculator CSP blocking GA4 + Umami (fixes #1755)

### DIFF
--- a/drink-calculator-v1.html
+++ b/drink-calculator-v1.html
@@ -31,7 +31,7 @@
   </script>
 
   <!-- ✅ PHASE 2: Content Security Policy -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.frankfurter.app; worker-src 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.googletagmanager.com https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.frankfurter.app https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://cloud.umami.is; worker-src 'self';">
   
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="referrer" content="strict-origin-when-cross-origin"/>

--- a/drink-calculator.html
+++ b/drink-calculator.html
@@ -31,7 +31,7 @@
   </script>
 
   <!-- ✅ PHASE 2: Content Security Policy -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.frankfurter.app; worker-src 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.googletagmanager.com https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.frankfurter.app https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://cloud.umami.is; worker-src 'self';">
   
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <meta name="referrer" content="strict-origin-when-cross-origin"/>


### PR DESCRIPTION
## What

`drink-calculator.html` and `drink-calculator-v1.html` shipped a CSP meta tag that blocked the very analytics the pages load — GA4 (`www.googletagmanager.com`) and Umami (`cloud.umami.is`) both silently failed on the site's highest-traffic tool page.

Fix (issue option 1 — keep the CSP, repair the allowlist):
- `script-src` += `https://www.googletagmanager.com https://cloud.umami.is`
- `connect-src` += `https://www.google-analytics.com https://*.google-analytics.com` (regional beacons) `https://www.googletagmanager.com https://cloud.umami.is`

Chose not to delete the CSP (issue option 2): `default-src`/`connect-src`/`worker-src` restrictions retain value even with `unsafe-inline` present.

## Verification

Headless Chromium probe (local server + console capture):
- **Control (pre-fix page):** exactly the 2 `Refused to load` CSP violations from the issue (gtag.js, umami script.js) — probe proven able to detect the bug
- **Both fixed pages:** 0 analytics CSP violations

HLS: task `itw-gh-1755` (P0), checked out to claude-code.

Fixes #1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F85vgz7aCJ4sx3HqkxMHBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01F85vgz7aCJ4sx3HqkxMHBk)_