### PR TITLE
Disable unconfigured "Email My Results" placeholder in prod (fixes #1758)

### DIFF
--- a/assets/js/calculator.v10-extras.js
+++ b/assets/js/calculator.v10-extras.js
@@ -328,9 +328,10 @@
     form.appendChild(el('input',{type:'hidden', name:'CALC_URL', id:'itw-email-url'}));
     form.addEventListener('submit',(e)=>{
       e.preventDefault();
-      // You can wire your Brevo/Formspree endpoint here:
-
-      alert('Email capture is not configured in this demo.');
+      // #1758: no email endpoint is wired yet, and the feature is gated OFF in maybeShowEmail
+      // (EMAIL_CAPTURE_ENABLED=false) so this card never shows in production. If it is ever
+      // reached, fail silently — NEVER surface "demo"/placeholder text to a real user. To ship
+      // the feature: wire a Brevo/Formspree POST here and flip EMAIL_CAPTURE_ENABLED to true.
     });
     card.appendChild(form);
     return card;
@@ -469,7 +470,12 @@
     const savings = Math.max(0, (alc - best));
     const totalDrinksPerDay = Object.values(store.get('inputs')?.drinks||{}).reduce((a,b)=>a+(Number(b)||0),0);
 
-    const shouldShow = (savings > 30) || (totalDrinksPerDay > 4);
+    // #1758: email capture has no endpoint wired. Keep the whole feature hidden in production
+    // rather than showing a form whose submit told users "not configured in this demo" — a
+    // trust-killing placeholder on the site's highest-traffic tool. Flip this to true only once
+    // a real Brevo/Formspree endpoint is wired in the form submit handler above (issue #1758 B).
+    const EMAIL_CAPTURE_ENABLED = false;
+    const shouldShow = EMAIL_CAPTURE_ENABLED && ((savings > 30) || (totalDrinksPerDay > 4));
     card.style.display = shouldShow ? 'block' : 'none';
 
     if (shouldShow){


### PR DESCRIPTION
## What

The drink calculator's email-capture card showed to real users (when `savings > 30` or `> 4 drinks/day` — common on the site's highest-traffic tool) and its submit fired `alert('Email capture is not configured in this demo.')` — a trust-killing "demo" placeholder shipped to production.

**Option A** (owner-endorsed in #1758, no backend needed): gate the feature off. `EMAIL_CAPTURE_ENABLED = false` makes `maybeShowEmail`'s `shouldShow` always false, so the card — its **sole** show-path (verified) — never displays; and the deceptive `alert()` string is removed so no placeholder text can reach a user even if the card somehow rendered. The Brevo/Formspree wiring point is preserved with a comment for Option B (wire endpoint + flip the flag).

## Verification

- JS syntax OK
- `"not configured in this demo"` no longer exists as live code (only in an explanatory comment)
- `itw-email` has exactly one show-path (`maybeShowEmail`), now unconditionally hidden via boolean short-circuit

Fixes #1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F85vgz7aCJ4sx3HqkxMHBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01F85vgz7aCJ4sx3HqkxMHBk)_