### PR TITLE
fix(itw-gh-1768): stop leaking the build machine's filesystem path in offline.html JSON-LD

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -441,7 +441,7 @@ STANDARDS: Every Page v3.010.300 · Offline Fallback · A11y/WCAG 2.1 AA Complia
     "@context": "https://schema.org",
     "@type": "WebPage",
     "name": "You're Offline",
-    "url": "https://cruisinginthewake.com//home/user/InTheWake/offline.html",
+    "url": "https://cruisinginthewake.com/offline.html",
     "description": "Offline fallback page for In the Wake. Search cached content and access previously visited pages.",
     "dateModified": "2025-11-27",
     "isPartOf": {


### PR DESCRIPTION
The offline.html JSON-LD `url` leaked the build host's absolute path (`https://cruisinginthewake.com//home/user/InTheWake/offline.html`). Fixed to `/offline.html`. Red-teamed: whole-site sweep = 0 other affected pages, JSON-LD still valid, no remaining fs-path leak.

**Related finding (out of scope, flagged separately):** `scripts/repair-port.js:14` hardcodes `/home/user/InTheWake/assets/ships/placeholder-ship.webp` — registered as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)