### PR TITLE
fix(itw-repair-port-hardcoded-path): repair-port.js placeholder path now repo-relative

### DIFF
--- a/scripts/repair-port.js
+++ b/scripts/repair-port.js
@@ -11,7 +11,10 @@
 const fs = require('fs');
 const path = require('path');
 
-const PLACEHOLDER_IMG = '/home/user/InTheWake/assets/ships/placeholder-ship.webp';
+// Repo-relative (scripts/ -> repo root) so the placeholder-copy works on ANY machine. The old absolute
+// '/home/user/InTheWake/...' only existed on one host, so existsSync() was false everywhere else and the
+// placeholder copy silently no-op'd (itw-repair-port-hardcoded-path).
+const PLACEHOLDER_IMG = path.join(__dirname, '..', 'assets', 'ships', 'placeholder-ship.webp');
 
 class PortRepairer {
   constructor(filePath) {


### PR DESCRIPTION
`PLACEHOLDER_IMG` hardcoded `/home/user/InTheWake/...` (real on one host only), so `existsSync` was false off-host and the placeholder copy silently no-op'd. Now `path.join(__dirname, '..', 'assets', 'ships', 'placeholder-ship.webp')`. Red-teamed: resolved path `existsSync=true`, parse OK.

**Class flagged (out of scope):** ~83 scripts hardcode `/home/user/InTheWake` or `/Users/*/InTheWake` absolute repo paths — same off-host portability bug — registered as a follow-up for a coordinated sweep.