### PR TITLE
fix(itw-gh-1678): drop noindex redirect packing.html from sitemap.xml

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -397,12 +397,6 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://cruisinginthewake.com/packing.html</loc>
-    <lastmod>2026-02-13</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://cruisinginthewake.com/planning.html</loc>
     <lastmod>2026-02-12</lastmod>
     <changefreq>weekly</changefreq>


### PR DESCRIPTION
`packing.html` is a noindex redirect stub → `packing-lists.html` but was in `sitemap.xml` (the sitemap says index; the page says noindex). Removed its `<url>` block; the real page stays. Red-teamed (class sweep): of 11 noindex/redirect pages, packing.html was the ONLY one wrongly sitemapped. Valid XML, 1269→1268 URLs.