### PR TITLE
fix(itw-gh-1718): honest search counts — over-claims → robust lower bounds

### DIFF
--- a/search.html
+++ b/search.html
@@ -23,20 +23,20 @@
   <meta name="author" content="In the Wake"/>
 
   <!-- ICP-Lite v1.4 -->
-  <meta name="ai-summary" content="Search In the Wake for 1,200+ pages across 290+ ships, 388 ports, 478 restaurants, articles, and cruise planning tools. Instant fuzzy search results as you type."/>
+  <meta name="ai-summary" content="Search In the Wake for 900+ pages across 290+ ships, 380+ ports, 200+ restaurants, articles, and cruise planning tools. Instant fuzzy search results as you type."/>
   <meta name="last-reviewed" content="2026-01-02"/>
   <meta name="content-protocol" content="ICP-Lite v1.4"/>
 
   <!-- Title & SEO -->
   <title>Search | In the Wake</title>
-  <meta name="description" content="Search In the Wake for 1,200+ pages of cruise content including 290+ ships, 388 ports, 478 restaurants, articles, and planning tools."/>
+  <meta name="description" content="Search In the Wake for 900+ pages of cruise content including 290+ ships, 380+ ports, 200+ restaurants, articles, and planning tools."/>
   <link rel="canonical" href="https://cruisinginthewake.com/search.html"/>
 
   <!-- OpenGraph -->
   <meta property="og:type" content="website"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:title" content="Search | In the Wake"/>
-  <meta property="og:description" content="Search 1,200+ pages: 290+ ships, 388 ports, 478 restaurants, articles, and cruise tools."/>
+  <meta property="og:description" content="Search 900+ pages: 290+ ships, 380+ ports, 200+ restaurants, articles, and cruise tools."/>
   <meta property="og:url" content="https://cruisinginthewake.com/search.html"/>
   <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"/>
 
@@ -44,7 +44,7 @@
   <meta name="twitter:card" content="summary"/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"/>
   <meta name="twitter:title" content="Search | In the Wake"/>
-  <meta name="twitter:description" content="Search 1,200+ pages: 290+ ships, 388 ports, 478 restaurants, articles, and cruise tools."/>
+  <meta name="twitter:description" content="Search 900+ pages: 290+ ships, 380+ ports, 200+ restaurants, articles, and cruise tools."/>
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
@@ -60,7 +60,7 @@
     "@type": "WebPage",
     "name": "Search",
     "url": "https://cruisinginthewake.com/search.html",
-    "description": "Search In the Wake for 1,200+ pages across 290+ ships, 388 ports, 478 restaurants, articles, and cruise planning tools. Instant fuzzy search results as you type.",
+    "description": "Search In the Wake for 900+ pages across 290+ ships, 380+ ports, 200+ restaurants, articles, and cruise planning tools. Instant fuzzy search results as you type.",
     "dateModified": "2026-01-02"
   }
   </script>  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
@@ -75,7 +75,7 @@
         "name": "What can I search for?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Search across 1,200+ pages including 290+ cruise ships from multiple cruise lines, 388 ports of call, 478 restaurants and dining venues, solo travel articles, cruise line guides, and planning tools. The search uses fuzzy matching so it works even with typos."
+          "text": "Search across 900+ pages including 290+ cruise ships from multiple cruise lines, 380+ ports of call, 200+ restaurants and dining venues, solo travel articles, cruise line guides, and planning tools. The search uses fuzzy matching so it works even with typos."
         }
       },
       {
@@ -217,7 +217,7 @@
     <!-- ICP-Lite Content Structure -->
     <section class="page-intro col-full">
       <p class="answer-line">
-        <strong>Quick Answer:</strong> Search across 1,200+ pages of cruise content including ships from multiple cruise lines, restaurants, ports, articles, and planning tools. Results appear instantly as you type.
+        <strong>Quick Answer:</strong> Search across 900+ pages of cruise content including ships from multiple cruise lines, restaurants, ports, articles, and planning tools. Results appear instantly as you type.
       </p>
 
       <p class="content-text">
@@ -227,7 +227,7 @@
       <div class="callout-box">
         <h3 class="mt-0 mb-05">Key Facts</h3>
         <ul class="list-indent">
-          <li><strong>1,200+ pages</strong> — 290+ ships across 15 cruise lines, 388 ports, 478 restaurants, plus articles and tools</li>
+          <li><strong>900+ pages</strong> — 290+ ships across 15 cruise lines, 380+ ports, 200+ restaurants, plus articles and tools</li>
           <li><strong>Fuzzy matching</strong> finds results even with typos</li>
           <li><strong>Smart filtering</strong> prioritizes relevant categories based on your query</li>
         </ul>
@@ -235,7 +235,7 @@
     </section>
 
     <h1>Search In the Wake</h1>
-    <p class="search-intro">Find ships, ports, restaurants, articles, cruise lines, and planning tools across 1,200+ pages. Results appear as you type.</p>
+    <p class="search-intro">Find ships, ports, restaurants, articles, cruise lines, and planning tools across 900+ pages. Results appear as you type.</p>
 
     <div class="search-container">
       <input
@@ -253,7 +253,7 @@
     <div id="resultsContainer">
       <!-- Initial state with popular searches -->
       <div class="initial-state" id="initialState">
-        <p>Start typing to search across 1,200+ pages including 290+ ships, 388 ports, 478 restaurants, articles, and tools.</p>
+        <p>Start typing to search across 900+ pages including 290+ ships, 380+ ports, 200+ restaurants, articles, and tools.</p>
         <div class="popular-searches">
           <h3>Popular Searches</h3>
           <div class="popular-tags">
@@ -275,7 +275,7 @@
 
       <details class="faq-item">
         <summary>What can I search for?</summary>
-        <p class="faq-answer">Search across 1,200+ pages including 290+ cruise ships from multiple cruise lines, 388 ports of call, 478 restaurants and dining venues, solo travel articles, cruise line guides, and planning tools. The search uses fuzzy matching so it works even with typos.</p>
+        <p class="faq-answer">Search across 900+ pages including 290+ cruise ships from multiple cruise lines, 380+ ports of call, 200+ restaurants and dining venues, solo travel articles, cruise line guides, and planning tools. The search uses fuzzy matching so it works even with typos.</p>
       </details>
 
       <details class="faq-item">


### PR DESCRIPTION
search.html claimed '1,200+ pages / 478 restaurants / 388 ports' but the search index has **922 entries: 390 ports, 298 ships, 207 restaurants**. '478 restaurants' was >2× the real 207. **Careful, not clever + honesty:** static meta tags restale, so I used round **lower-bound `+`** values (true now, survive index growth): 900+ pages, 290+ ships, 380+ ports, 200+ restaurants. Red-teamed: every bound ≤ real count, no stale number remains, JSON-LD valid (2/2).