### PR TITLE
fix(itw-gh-1619): resolve social-preview 404s (19 pages, not 11) → default og:image

### DIFF
--- a/cruise-lines/virgin.html
+++ b/cruise-lines/virgin.html
@@ -33,11 +33,11 @@ All work on this project is offered as a gift to God.
   <meta property="og:title" content="Virgin Voyages — In the Wake"/>
   <meta property="og:description" content="Adults-only cruising with included dining and electric nightlife."/>
   <meta property="og:url" content="https://cruisinginthewake.com/cruise-lines/virgin.html"/>
-  <meta property="og:image" content="https://cruisinginthewake.com/assets/cruise-lines/virgin-hero-1.jpg"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"/>
   <meta name="twitter:card" content="summary_large_image"/>
   <meta name="twitter:title" content="Virgin Voyages — In the Wake"/>
   <meta name="twitter:description" content="Adults-only, all dining included, chef-forward eateries, and shows that run late."/>
-  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/cruise-lines/virgin-hero-1.jpg"/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"/>
 
   <!-- JSON-LD: ItemList of ships on this page -->
   <script type="application/ld+json">

--- a/ports/cairns.html
+++ b/ports/cairns.html
@@ -15,7 +15,7 @@ Soli Deo Gloria
   <meta property="og:title" content="Cairns Port Guide — Gateway to the Great Barrier Reef">
   <meta property="og:description" content="First-person logbook guide to Cairns — gateway to the Great Barrier Reef, Daintree Rainforest, Cape Tribulation, Kuranda railway, and tropical Queensland adventure.">
   <meta property="og:url" content="https://cruisinginthewake.com/ports/cairns.html">
-  <meta property="og:image" content="https://cruisinginthewake.com/assets/ports/cairns/hero.webp">
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
@@ -66,7 +66,7 @@ Soli Deo Gloria
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Cairns Port Guide — Gateway to the Great Barrier Reef">
   <meta name="twitter:description" content="First-person logbook guide to Cairns — gateway to the Great Barrier Reef, Daintree Rainforest, and tropical Queensland adventure.">
-  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/ports/cairns/hero.webp">
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
   <script async="" src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
     window.dataLayer=window.dataLayer||[];

--- a/ports/cephalonia.html
+++ b/ports/cephalonia.html
@@ -15,7 +15,7 @@ Soli Deo Gloria
   <meta property="og:title" content="Cephalonia Port Guide — Greece's Largest Ionian Island">
   <meta property="og:description" content="First-person logbook guide to Cephalonia — Greece's largest Ionian island with Melissani Cave, Myrtos Beach, and resilience after the 1953 earthquake.">
   <meta property="og:url" content="https://cruisinginthewake.com/ports/cephalonia.html">
-  <meta property="og:image" content="https://cruisinginthewake.com/assets/ports/cephalonia/hero.webp">
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png">
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
@@ -68,7 +68,7 @@ Soli Deo Gloria
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Cephalonia Port Guide — Greece's Largest Ionian Island">
   <meta name="twitter:description" content="First-person logbook guide to Cephalonia — Melissani Cave, Myrtos Beach, and 50,000 years of Greek island history.">
-  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/ports/cephalonia/hero.webp">
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
   <script async="" src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
   <script>
     window.dataLayer=window.dataLayer||[];

--- a/ports/chilean-fjords.html
+++ b/ports/chilean-fjords.html
@@ -23,7 +23,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Complete guide to cruising the Chilean Fjords. Patagonian glaciers, dramatic channels, and pristine wilderness.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/chilean-fjords">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/chilean-fjords-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/colon.html
+++ b/ports/colon.html
@@ -23,7 +23,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Complete guide to Colón cruise port. Panama Canal viewing, UNESCO sites, and Portobelo colonial ruins.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/colon">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/colon-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/copenhagen.html
+++ b/ports/copenhagen.html
@@ -23,7 +23,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Complete guide to Copenhagen cruise port. Nyhavn harbor, Tivoli Gardens, and Danish hygge culture.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/copenhagen">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/copenhagen-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/corfu.html
+++ b/ports/corfu.html
@@ -23,7 +23,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Complete guide to Corfu cruise port. UNESCO Old Town, Venetian fortresses, and Greek island beauty.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/corfu">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/corfu-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/port-said.html
+++ b/ports/port-said.html
@@ -22,7 +22,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Navigate Egypt's Suez Canal gateway. Port Said cruise guide with Cairo/pyramids excursion tips.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/port-said">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/port-said-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/puerto-montt.html
+++ b/ports/puerto-montt.html
@@ -22,7 +22,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Explore the Chilean Lake District from Puerto Montt. Osorno volcano, German heritage towns, and world-class seafood.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/puerto-montt">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/puerto-montt-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/santa-marta.html
+++ b/ports/santa-marta.html
@@ -22,7 +22,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Explore Colombia's oldest city. Santa Marta offers Sierra Nevada mountains, Tayrona beaches, and authentic Colombian culture.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/santa-marta">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/santa-marta-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/south-shetland-islands.html
+++ b/ports/south-shetland-islands.html
@@ -23,7 +23,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Complete guide to South Shetland Islands expedition landings. Deception Island volcano, research stations, and Antarctic wildlife.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/south-shetland-islands">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/south-shetland-islands-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/strait-of-magellan.html
+++ b/ports/strait-of-magellan.html
@@ -24,7 +24,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Cruise the legendary Strait of Magellan. History, wildlife, and dramatic Patagonian scenery.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/strait-of-magellan">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/strait-of-magellan-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/tobago.html
+++ b/ports/tobago.html
@@ -22,7 +22,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Discover Tobago's pristine beaches, coral reefs, and oldest protected rainforest. Complete cruise port guide.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/tobago">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/tobago-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/ports/trinidad.html
+++ b/ports/trinidad.html
@@ -22,7 +22,7 @@ ITW-Lite v3.010 | ICP-Lite v1.4
     <meta property="og:description" content="Experience Trinidad's Carnival culture, stunning beaches, and incredible biodiversity. Complete cruise port guide for Port of Spain.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cruisinginthewake.com/ports/trinidad">
-    <meta property="og:image" content="https://cruisinginthewake.com/images/ports/trinidad-og.jpg">
+    <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
     <!-- Structured Data: BreadcrumbList -->
     <script type="application/ld+json">

--- a/restaurants/chefs-table.html
+++ b/restaurants/chefs-table.html
@@ -32,7 +32,7 @@ All work on this project is offered as a gift to God.
   <meta property="og:title" content="Chef’s Table — Royal Caribbean">
   <meta property="og:description" content="Intimate, multi-course tasting with curated wine pairings. See 2025 pricing, sample menu, booking tips, and a detailed review.">
   <meta property="og:url" content="https://cruisinginthewake.com/restaurants/chefs-table.html">
-  <!-- <meta property="og:image" content="https://cruisinginthewake.com/assets/og/chefs-table-hero.jpg"> -->
+  <!-- <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"> -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:description" content="Royal Caribbean Chef's Table — intimate multi-course tasting with wine pairings, led by the Chef de Cuisine. 2025 price $95–$129.99 · limited seating · menu, booking tips & review."/>
   <meta name="twitter:title" content="Chef’s Table — Royal Caribbean"/>

--- a/restaurants/giovannis.html
+++ b/restaurants/giovannis.html
@@ -36,9 +36,9 @@ All work on this project is offered as a gift to God.
   <meta property="og:title" content="Giovanni’s Italian — Kitchen vs. Table">
   <meta property="og:description" content="Side-by-side: Giovanni’s Italian Kitchen vs. Giovanni’s Table — pricing, menus, ships, and tips for 2025 sailings.">
   <meta property="og:url" content="https://cruisinginthewake.com/restaurants/giovannis.html">
-  <meta property="og:image" content="https://cruisinginthewake.com/assets/og/giovannis.jpg">
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/og/giovannis.jpg">
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
 
   <link rel="canonical" href="https://cruisinginthewake.com/restaurants/giovannis.html">
   <!-- Service Worker Registration -->

--- a/restaurants/samba-grill.html
+++ b/restaurants/samba-grill.html
@@ -29,7 +29,7 @@ All work on this project is offered as a gift to God.
   <meta property="og:title" content="Samba Grill — Royal Caribbean">
   <meta property="og:description" content="Tableside-carved Brazilian meats, antipasto buffet, and caipirinhas at sea. See pricing, menu highlights, where it’s offered, and a real guest review.">
   <meta property="og:url" content="https://cruisinginthewake.com/restaurants/samba-grill.html">
-  <!-- <meta property="og:image" content="https://cruisinginthewake.com/assets/og/samba-grill-hero.jpg"> -->
+  <!-- <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"> -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:description" content="Royal Caribbean’s Samba Grill: a Brazilian churrascaria with gaucho-carved meats and an antipasto buffet. Dinner $34.99 (incl. gratuity). Menu, tips, ships, and an in-depth review."/>
   <meta name="twitter:title" content="Samba Grill — Royal Caribbean"/>

--- a/solo.html
+++ b/solo.html
@@ -56,7 +56,7 @@
   <meta property="og:url" content="https://cruisinginthewake.com/solo.html">
   <meta property="og:title" content="Solo Travel — In the Wake">
   <meta property="og:description" content="Solo cruising tips, faith-scented reflections, and practical guides from real sailings.">
-  <meta property="og:image" content="https://cruisinginthewake.com/assets/solo/solo-tranquility.jpg?v=3.010.300">
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
   <meta property="og:image:width" content="1200"/>
   <meta property="og:image:height" content="630"/>
   <meta property="og:image:alt" content="Serene cruise ship wake at sunset, symbolizing solo travel tranquility"/>
@@ -66,7 +66,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Solo Travel — In the Wake">
   <meta name="twitter:description" content="Solo cruising tips, faith-scented reflections, and practical guides from real sailings.">
-  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/solo/solo-tranquility.jpg?v=3.010.300">
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg">
   <meta name="twitter:image:alt" content="Serene cruise ship wake at sunset, symbolizing solo travel tranquility"/>
 
   <!-- Google Analytics -->

--- a/solo/accessible-cruising.html
+++ b/solo/accessible-cruising.html
@@ -48,7 +48,7 @@ All work on this project is offered as a gift to God.
   <meta property="og:title" content="Accessible Cruising: Five Universal Principles for Disabled Travelers"/>
   <meta property="og:description" content="Know your needs. Advocate early. Plan for barriers. You belong here. Essential guidance for disabled cruisers."/>
   <meta property="og:url" content="https://cruisinginthewake.com/solo/accessible-cruising.html"/>
-  <meta property="og:image" content="https://cruisinginthewake.com/assets/articles/accessible-cruising-hero.jpg?v=3.010.300"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/home-hero.jpg"/>
   <meta property="og:image:width" content="1600"/>
   <meta property="og:image:height" content="900"/>
   <meta property="article:section" content="Accessible Travel"/>


### PR DESCRIPTION
Reality-anchored red-team: task said 11 pages; a recursive sweep found **19 public pages** whose `og:image`+`twitter:image` pointed to **missing files** (social-share 404s). Repointed all to the verified default `/assets/social/home-hero.jpg`. **Careful, not clever:** didn't fabricate per-page heroes — many of these pages' own hero images are also missing (deeper gap, flagged). Red-teamed: recursive re-sweep = **0 broken** remaining; 24/24 surgical changes.

**Follow-ups registered:** per-page social images (default is generic) + the missing port/restaurant hero images.