### PR TITLE
fix(itw-gh-1677): travel.html title metadata still said 'Travel Tips' (page is the cruise-questions FAQ)

### DIFF
--- a/travel.html
+++ b/travel.html
@@ -12,7 +12,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
 <head>
   <meta charset="utf-8"/>
   <!-- ======================================================
-       In the Wake — Travel Tips Page
+       In the Wake — Top 20 Cruise Questions Page
        Version: 3.010.300  |  Soli Deo Gloria ✝️
 
        ✅ WCAG 2.1 Level AA Compliant
@@ -73,7 +73,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
   <meta property="og:type" content="article"/>
   <meta property="og:site_name" content="In the Wake"/>
   <meta property="og:url" content="https://cruisinginthewake.com/travel.html"/>
-  <meta property="og:title" content="Travel Tips — In the Wake"/>
+  <meta property="og:title" content="Top 20 Cruise Questions Answered — In the Wake"/>
   <meta property="og:description" content="A first sailing, twenty steady answers, and a course you can trust."/>
   <meta property="og:image" content="https://cruisinginthewake.com/assets/articles/thumbs/top-20-questions/cover.webp"/>
   <meta property="og:image:width" content="1200"/>
@@ -83,7 +83,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:title" content="Travel Tips — In the Wake"/>
+  <meta name="twitter:title" content="Top 20 Cruise Questions Answered — In the Wake"/>
   <meta name="twitter:description" content="A first sailing, twenty steady answers, and a course you can trust."/>
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/articles/thumbs/top-20-questions/cover.webp?v=3.010.300"/>
   <meta name="twitter:image:alt" content="Top 20 Questions About Cruising for the First Time"/>
@@ -199,7 +199,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "Travel Tips",
+        "name": "Cruise Questions",
         "item": "https://cruisinginthewake.com/travel.html"
       }
     ]
@@ -257,7 +257,7 @@ GUARD RAIL: DO NOT REMOVE OR CHANGE VERBIAGE THAT HAS BEEN AGREED TO BY THE USER
   {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": "Travel Tips",
+  "name": "Top 20 Cruise Questions Answered",
   "url": "https://cruisinginthewake.com/travel.html",
   "description": "Story-forward help for first voyages: passports, packing, ship time, seasickness, safety, and the 20 questions beginners ask most.",
   "dateModified": "2025-11-19"


### PR DESCRIPTION
travel.html was repurposed to 'Top 20 Cruise Questions Answered' but its og:title/twitter:title/WebPage-schema still said 'Travel Tips' — the social card + structured data misrepresented the page. Fixed all title-identity fields to match (og:title follows the site convention = `<title>` before ' | '). Red-teamed: class sweep confirms travel.html was the **only** clear og:title/title mismatch site-wide; JSON-LD 7/7 valid; 0 'Travel Tips' left.