### PR TITLE
fix(ships): SSOT-first cruise line — stop fabricating 'Unknown' on Celebrity pages

### DIFF
--- a/admin/icp_lite_ship_remediation.py
+++ b/admin/icp_lite_ship_remediation.py
@@ -37,16 +37,34 @@ def extract_ship_info(content, filepath):
     else:
         info['name'] = filepath.stem.replace('-', ' ').title()
 
-    # Cruise line from path
-    if '/rcl/' in str(filepath):
-        info['cruise_line'] = 'Royal Caribbean'
-        info['cruise_line_short'] = 'Royal Caribbean'
-    elif '/carnival/' in str(filepath):
-        info['cruise_line'] = 'Carnival Cruise Line'
-        info['cruise_line_short'] = 'Carnival'
-    else:
-        info['cruise_line'] = 'Unknown'
-        info['cruise_line_short'] = 'Unknown'
+    # Cruise line — SSOT-FIRST. Read the authoritative value from the page's own ship-stats-fallback JSON
+    # (which carries the correct cruise_line for every ship). The old code guessed ONLY from the path
+    # (/rcl/, /carnival/) and fabricated 'Unknown' for every other line — so Celebrity (/celebrity-cruises/)
+    # and all others rendered "is a Unknown ship" / "Cruise Line: Unknown" even though the real data was
+    # sitting in the same page. That is clever-not-careful: two sources of truth that drift. Never fabricate
+    # 'Unknown' when the SSOT has the answer.
+    info['cruise_line'] = None
+    info['cruise_line_short'] = None
+    stats_match = re.search(r'id=["\']ship-stats-fallback["\'][^>]*>\s*(\{.*?\})\s*</script>', content, re.DOTALL)
+    if stats_match:
+        try:
+            stats = json.loads(stats_match.group(1))
+            if stats.get('cruise_line'):
+                info['cruise_line'] = stats['cruise_line']
+                info['cruise_line_short'] = stats.get('cruise_line_short') or \
+                    re.sub(r'\s+(Cruises|Cruise Line)$', '', stats['cruise_line'], flags=re.IGNORECASE).strip() or stats['cruise_line']
+        except (ValueError, TypeError):
+            pass
+    if not info['cruise_line']:
+        # No on-page SSOT — fall back to the path map only for the two known dirs; otherwise FAIL LOUD
+        # (skip / raise) rather than silently fabricate a cruise line into the Quick Answer + Key Facts.
+        if '/rcl/' in str(filepath):
+            info['cruise_line'] = info['cruise_line_short'] = 'Royal Caribbean'
+        elif '/carnival/' in str(filepath):
+            info['cruise_line'], info['cruise_line_short'] = 'Carnival Cruise Line', 'Carnival'
+        else:
+            raise ValueError(f"{filepath}: no ship-stats-fallback SSOT and unknown path — refusing to "
+                             f"fabricate a cruise line. Add the ship-stats-fallback JSON or extend the path map.")
 
     # Description
     desc_match = re.search(r'<meta\s+(?:name=["\']description["\']\s+)?content=["\']([^"\']+)["\'](?:\s+name=["\']description["\'])?', content, re.IGNORECASE)

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -380,7 +380,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Celebrity Apex is an Edge Class cruise ship operated by Celebrity Cruises. She entered service in 2020, measures 130,818 gross tons, and carries approximately 2,910 guests at double occupancy.</p>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Apex is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Apex is a Celebrity Cruises ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
@@ -390,7 +390,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
           <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
           <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
         </ul>

--- a/ships/celebrity-cruises/celebrity-beyond.html
+++ b/ships/celebrity-cruises/celebrity-beyond.html
@@ -380,7 +380,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Celebrity Beyond is an Edge Class cruise ship operated by Celebrity Cruises. She entered service in 2022, measures 140,600 gross tons, and carries approximately 3,260 guests at double occupancy.</p>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Beyond is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Beyond is a Celebrity Cruises ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
@@ -390,7 +390,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
           <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
           <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
         </ul>

--- a/ships/celebrity-cruises/celebrity-eclipse.html
+++ b/ships/celebrity-cruises/celebrity-eclipse.html
@@ -381,7 +381,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Celebrity Eclipse is a Solstice Class cruise ship operated by Celebrity Cruises. She entered service in 2010, measures 121,878 gross tons, and carries approximately 2,850 guests at double occupancy.</p>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Eclipse is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Eclipse is a Celebrity Cruises ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
@@ -391,7 +391,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
           <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
           <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
         </ul>

--- a/ships/celebrity-cruises/celebrity-edge.html
+++ b/ships/celebrity-cruises/celebrity-edge.html
@@ -381,7 +381,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Celebrity Edge is an Edge Class cruise ship operated by Celebrity Cruises. She entered service in 2018, measures 130,818 gross tons, and carries approximately 2,918 guests at double occupancy.</p>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Edge is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Edge is a Celebrity Cruises ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
@@ -391,7 +391,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
           <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
           <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
         </ul>

--- a/ships/celebrity-cruises/celebrity-equinox.html
+++ b/ships/celebrity-cruises/celebrity-equinox.html
@@ -381,7 +381,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Celebrity Equinox is a Solstice Class cruise ship operated by Celebrity Cruises. She entered service in 2009, measures 121,878 gross tons, and carries approximately 2,850 guests at double occupancy.</p>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Equinox is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Equinox is a Celebrity Cruises ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
@@ -391,7 +391,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
           <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
           <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
         </ul>

--- a/ships/celebrity-cruises/celebrity-reflection.html
+++ b/ships/celebrity-cruises/celebrity-reflection.html
@@ -381,7 +381,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Celebrity Reflection is a Solstice Class cruise ship operated by Celebrity Cruises. She entered service in 2012, measures 126,000 gross tons, and carries approximately 3,046 guests at double occupancy.</p>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Reflection is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Reflection is a Celebrity Cruises ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
@@ -391,7 +391,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
           <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
           <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
         </ul>

--- a/ships/celebrity-cruises/celebrity-silhouette.html
+++ b/ships/celebrity-cruises/celebrity-silhouette.html
@@ -381,7 +381,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Celebrity Silhouette is a Solstice Class cruise ship operated by Celebrity Cruises. She entered service in 2011, measures 122,210 gross tons, and carries approximately 2,886 guests at double occupancy.</p>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Silhouette is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Silhouette is a Celebrity Cruises ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
@@ -391,7 +391,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
           <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
           <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
         </ul>

--- a/ships/celebrity-cruises/celebrity-solstice.html
+++ b/ships/celebrity-cruises/celebrity-solstice.html
@@ -381,7 +381,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Celebrity Solstice is a Solstice Class cruise ship operated by Celebrity Cruises. She entered service in 2008, measures 121,878 gross tons, and carries approximately 2,850 guests at double occupancy.</p>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Celebrity Solstice is a Unknown ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
+        <strong>Quick Answer:</strong> Celebrity Solstice is a Celebrity Cruises ship. This page covers deck plans, live ship tracking, dining venues, and videos to help you plan your cruise.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
@@ -391,7 +391,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: #134;">Key Facts</h3>
         <ul style="margin: 0; padding-left: 1.25rem;">
-          <li><strong>Cruise Line:</strong> Unknown</li>
+          <li><strong>Cruise Line:</strong> Celebrity Cruises</li>
           <li><strong>Resources:</strong> Deck plans, dining venues, live tracker</li>
           <li><strong>Reservations:</strong> Book via cruise line or travel advisor</li>
         </ul>


### PR DESCRIPTION
## The bug (Ken's screenshot, celebrity-apex)
The Quick Answer read **'Celebrity Apex is a Unknown ship'** and Key Facts **'Cruise Line: Unknown'** — while the same page's intro, header, JSON-LD, and `ship-stats-fallback` JSON all correctly carried **Edge Class / Celebrity Cruises**.

## Root cause (clever, not careful)
`admin/icp_lite_ship_remediation.py` detected the cruise line **only from the path** (`/rcl/`, `/carnival/`) with an `else → 'Unknown'`. Celebrity pages live at `/celebrity-cruises/` → fell through → fabricated 'Unknown'. Two sources of truth (the path guess vs the on-page SSOT) that drifted, and the loser fabricated a false answer.

## Fixes
- **Generator (root cause):** reads the cruise line **SSOT-first** from the page's own `ship-stats-fallback` JSON; the path map is a fallback for the two known dirs only; and it now **raises (fail loud)** instead of silently fabricating 'Unknown' when neither source has the answer.
- **8 affected Celebrity pages:** repaired data-drivenly, each from its own `ship-stats-fallback` → Quick Answer + Key Facts now read 'Celebrity Cruises'. **0 pages still fabricate 'Unknown'** (verified).

Registered follow-ups in the HLS: InTheWake #2501 (one ship-facts SSOT all sections render from) · #2502 (validator guard: never emit 'Unknown' where the SSOT has data) · #2503 (guest-count cross-section drift) · #2504 (a/an article).

🤖 Generated with [Claude Code](https://claude.com/claude-code)