### PR TITLE
fix(ships): resolve Unknown cruise-line fabrication cluster SSOT-first (#2500/#2502/#2503/#2504)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -124,6 +124,26 @@ jobs:
             echo "✓ No placeholder issues found"
           fi
 
+      - name: Fail on fabricated Unknown cruise-line (#2500/#2502)
+        run: |
+          echo "🔍 Guarding against fabricated 'Unknown' cruise-line render spots..."
+          # These forms are ALWAYS a fabrication: a ship page whose SSOT cruise_line is populated must
+          # never render 'Unknown' in the Quick Answer / Key Facts / comparison / website spots.
+          # Legitimate image-credit unknowns ('Unknown photographer', '| Unknown | Wikimedia',
+          # 'Unknown - FOM collection' = unknown photographer) are a DIFFERENT surface, NOT matched.
+          FOUND=0
+          for pat in 'is a Unknown ship' 'Cruise Line:</strong> Unknown' 'comparing Unknown ships' 'Check the Unknown website'; do
+            if grep -rn --include="*.html" --exclude-dir=node_modules "$pat" ships/ 2>/dev/null; then
+              echo "✗ Fabricated Unknown cruise-line render spot: \"$pat\""; FOUND=1
+            fi
+          done
+          if [ $FOUND -eq 1 ]; then
+            echo "✗ A ship page renders 'Unknown' for a cruise line that IS known in its own SSOT."
+            echo "  Resolve SSOT-first (admin/validate-ship-page.js validateNoFabricatedUnknown; #2500/#2502)."
+            exit 1
+          fi
+          echo "✓ No fabricated Unknown cruise-line render spots"
+
   # Validate changed HTML files
   validate-html:
     name: Validate HTML

--- a/admin/validate-ship-page.js
+++ b/admin/validate-ship-page.js
@@ -892,6 +892,43 @@ function validateShipStatsJSON($) {
 }
 
 /**
+ * Never fabricate "Unknown" for a field that IS populated in the page's own SSOT (#2500/#2502).
+ * The #ship-stats-fallback JSON is the single source of truth for ship facts. When its cruise_line
+ * is a real value, no rendered cruise-line spot may say "Unknown" — that is the clever-not-careful
+ * bug that showed "Unknown" cruise lines while the SSOT/JSON-LD/header held the real name.
+ * NOTE: legitimate image-credit unknowns ("Unknown - FOM collection", "| Unknown | Wikimedia" =
+ * unknown photographer) are a DIFFERENT surface and are intentionally NOT matched here.
+ */
+function validateNoFabricatedUnknown($, html) {
+  const errors = [];
+  const warnings = [];
+  const statsEl = $('#ship-stats-fallback');
+  let data = {};
+  try { data = JSON.parse(statsEl.html() || '{}'); } catch { return { valid: true, errors, warnings, data: {} }; }
+  const line = String(data.cruise_line || '').trim();
+  const populated = line && !/^(unknown|tbd|tbn|n\/a)$/i.test(line);
+  if (!populated) return { valid: true, errors, warnings, data: {} };
+  const fabrications = [
+    { re: /is a Unknown ship/g, label: 'Quick Answer "is a Unknown ship"' },
+    { re: /Cruise Line:<\/strong>\s*Unknown/g, label: 'Key Facts "Cruise Line: Unknown"' },
+    { re: /comparing Unknown ships/g, label: '"comparing Unknown ships"' },
+    { re: /Check the Unknown website/g, label: '"Check the Unknown website"' },
+  ];
+  for (const { re, label } of fabrications) {
+    const n = (html.match(re) || []).length;
+    if (n > 0) {
+      errors.push({
+        section: 'ship_facts_ssot',
+        rule: 'fabricated_unknown_cruise_line',
+        message: `${label} rendered ${n}x while SSOT cruise_line is "${line}" — never fabricate Unknown for a populated field (#2500/#2502)`,
+        severity: 'BLOCKING',
+      });
+    }
+  }
+  return { valid: errors.length === 0, errors, warnings, data: {} };
+}
+
+/**
  * Validate dining data source JSON
  */
 function validateDiningJSON($) {
@@ -2959,6 +2996,7 @@ async function validateShipPage(filepath) {
     const analyticsResult = validateAnalytics($, html);
     const contentPurityResult = validateContentPurity($, html);
     const shipStatsResult = validateShipStatsJSON($);
+    const noFabUnknownResult = validateNoFabricatedUnknown($, html);
     const diningResult = validateDiningJSON($);
     const wordCountResult = validateWordCounts($, isHistoric);
     const printButtonResult = validatePrintButton($, html);
@@ -3028,7 +3066,8 @@ async function validateShipPage(filepath) {
       ...accessibilityKeywordResult.errors,
       ...runtimeDataResult.errors, ...renderingResult.errors,
       ...mainEntityResult.errors, ...aiSummaryBoilerplateResult.errors,
-      ...internalNumericResult.errors, ...proseTicsResult.errors
+      ...internalNumericResult.errors, ...proseTicsResult.errors,
+      ...noFabUnknownResult.errors
     ];
     const preliminaryWarnings = [
       ...analyticsResult.warnings, ...soliDeoGloriaResult.warnings,
@@ -3080,7 +3119,8 @@ async function validateShipPage(filepath) {
       ...accessibilityKeywordResult.errors,
       ...runtimeDataResult.errors, ...renderingResult.errors,
       ...mainEntityResult.errors, ...aiSummaryBoilerplateResult.errors,
-      ...internalNumericResult.errors, ...proseTicsResult.errors
+      ...internalNumericResult.errors, ...proseTicsResult.errors,
+      ...noFabUnknownResult.errors
     );
 
     // Collect warnings

--- a/ships/carnival/carnival-tropicale.html
+++ b/ships/carnival/carnival-tropicale.html
@@ -227,7 +227,7 @@
   <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/carnival-tropicale.jpg"/>
 
   <!-- JSON-LD: Review -->
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Excel-class ship operated by Carnival Cruise Line.","name":"Carnival Tropicale","brand":{"@type":"Organization","name":"Carnival Cruise Line"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"Carnival Tropicale is a Excel-class vessel from Carnival Cruise Line, offering memorable cruise experiences with excellent amenities and service."}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Review","itemReviewed":{"@type":"Cruise","description":"A Excel-class ship operated by Carnival Cruise Line.","name":"Carnival Tropicale","brand":{"@type":"Organization","name":"Carnival Cruise Line"}},"author":{"@type":"Person","name":"Ken Baker"},"reviewBody":"Carnival Tropicale is an Excel-class vessel from Carnival Cruise Line, offering memorable cruise experiences with excellent amenities and service."}</script>
 
   <!-- JSON-LD: Organization -->
   <script type="application/ld+json">

--- a/ships/celebrity-cruises/celebrity-apex.html
+++ b/ships/celebrity-cruises/celebrity-apex.html
@@ -32,7 +32,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
   <meta name="version" content="3.010.400"/>
   <meta name="author" content="In the Wake"/>
   <meta name="publisher" content="In the Wake"/>
-  <meta name="ai-summary" content="Celebrity Apex is the second Edge Class ship from Celebrity Cruises, launched in 2020. At 130,818 GT with 2,918 guests, she features the Magic Carpet platform, infinite verandas, and the innovative Eden entertainment venue.">
+  <meta name="ai-summary" content="Celebrity Apex is the second Edge Class ship from Celebrity Cruises, launched in 2020. At 130,818 GT with 2,910 guests, she features the Magic Carpet platform, infinite verandas, and the innovative Eden entertainment venue.">
   <meta name="last-reviewed" content="2026-02-20">
   <meta name="content-protocol" content="ICP-2">
 <title>Celebrity Apex • Celebrity Cruises • In The Wake</title>
@@ -88,7 +88,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
     "@type": "WebPage",
     "name": "Celebrity Apex • Celebrity Cruises • In The Wake",
     "url": "https://cruisinginthewake.com/ships/celebrity-cruises/celebrity-apex.html",
-    "description": "Celebrity Apex is the second Edge Class ship from Celebrity Cruises, launched in 2020. At 130,818 GT with 2,918 guests, she features the Magic Carpet platform, infinite verandas, and the innovative Eden entertainment venue.",
+    "description": "Celebrity Apex is the second Edge Class ship from Celebrity Cruises, launched in 2020. At 130,818 GT with 2,910 guests, she features the Magic Carpet platform, infinite verandas, and the innovative Eden entertainment venue.",
     "dateModified": "2026-02-20",
     "mainEntity": {
       "@type": "Vehicle",
@@ -210,7 +210,7 @@ STANDARDS: Every Page v3.010.400 · Production Template · Unified Nav v3.010.40
     "@context": "https://schema.org",
     "@type": "Article",
     "headline": "Celebrity Apex • Celebrity Cruises",
-    "description": "Celebrity Apex is the second Edge Class ship from Celebrity Cruises, launched in 2020. At 130,818 GT with 2,918 guests, she features the Magic Carpet platform, infinite verandas, and the innovative Eden entertainment venue.",
+    "description": "Celebrity Apex is the second Edge Class ship from Celebrity Cruises, launched in 2020. At 130,818 GT with 2,910 guests, she features the Magic Carpet platform, infinite verandas, and the innovative Eden entertainment venue.",
     "dateModified": "2026-02-20",
     "author": {
         "@type": "Person",

--- a/ships/holland-america-line/amsterdam.html
+++ b/ships/holland-america-line/amsterdam.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Amsterdam sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Amsterdam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Amsterdam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -419,7 +419,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Amsterdam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Amsterdam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Amsterdam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/edam.html
+++ b/ships/holland-america-line/edam.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Edam sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Edam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Edam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Edam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Edam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Edam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/koningsdam.html
+++ b/ships/holland-america-line/koningsdam.html
@@ -378,7 +378,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Koningsdam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Koningsdam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">

--- a/ships/holland-america-line/leerdam.html
+++ b/ships/holland-america-line/leerdam.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Leerdam sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Leerdam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Leerdam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Leerdam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Leerdam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Leerdam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/maartensdijk.html
+++ b/ships/holland-america-line/maartensdijk.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Maartensdijk sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Maartensdijk or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Maartensdijk or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Maartensdijk sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Maartensdijk.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Maartensdijk.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/maasdam.html
+++ b/ships/holland-america-line/maasdam.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Maasdam sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Maasdam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Maasdam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -417,7 +417,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Maasdam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Maasdam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Maasdam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/nieuw-amsterdam-ii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-ii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Nieuw Amsterdam (II) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam (II) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam (II) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -417,7 +417,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Nieuw Amsterdam (II) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Nieuw Amsterdam (II).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Nieuw Amsterdam (II).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/nieuw-amsterdam-iii.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Nieuw Amsterdam (III) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam (III) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam (III) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -414,7 +414,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Nieuw Amsterdam (III) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Nieuw Amsterdam (III).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Nieuw Amsterdam (III).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/nieuw-amsterdam-iv.html
+++ b/ships/holland-america-line/nieuw-amsterdam-iv.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Nieuw Amsterdam (IV) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam (IV) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam (IV) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -405,7 +405,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Nieuw Amsterdam (IV) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Nieuw Amsterdam (IV).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Nieuw Amsterdam (IV).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/nieuw-amsterdam-v.html
+++ b/ships/holland-america-line/nieuw-amsterdam-v.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Nieuw Amsterdam (V) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam (V) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam (V) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -405,7 +405,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Nieuw Amsterdam (V) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Nieuw Amsterdam (V).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Nieuw Amsterdam (V).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/nieuw-amsterdam.html
+++ b/ships/holland-america-line/nieuw-amsterdam.html
@@ -360,7 +360,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Nieuw Amsterdam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -611,7 +611,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Nieuw Amsterdam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Nieuw Amsterdam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Nieuw Amsterdam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/nieuw-statendam.html
+++ b/ships/holland-america-line/nieuw-statendam.html
@@ -378,7 +378,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Nieuw Statendam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Nieuw Statendam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">

--- a/ships/holland-america-line/none-announced.html
+++ b/ships/holland-america-line/none-announced.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does None announced sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching None announced or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching None announced or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -401,7 +401,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does None announced sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for None announced.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for None announced.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/noordam-ii.html
+++ b/ships/holland-america-line/noordam-ii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Noordam (II) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Noordam (II) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Noordam (II) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -414,7 +414,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Noordam (II) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Noordam (II).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Noordam (II).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/noordam-iii.html
+++ b/ships/holland-america-line/noordam-iii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Noordam (III) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Noordam (III) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Noordam (III) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Noordam (III) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Noordam (III).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Noordam (III).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/noordam-iv.html
+++ b/ships/holland-america-line/noordam-iv.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Noordam (IV) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Noordam (IV) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Noordam (IV) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -405,7 +405,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Noordam (IV) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Noordam (IV).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Noordam (IV).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/p-caland.html
+++ b/ships/holland-america-line/p-caland.html
@@ -101,7 +101,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does P. Caland sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -302,7 +302,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching P. Caland or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching P. Caland or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -430,7 +430,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does P. Caland sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for P. Caland.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for P. Caland.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/potsdam.html
+++ b/ships/holland-america-line/potsdam.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Potsdam sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Potsdam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Potsdam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Potsdam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Potsdam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Potsdam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/prinsendam-i.html
+++ b/ships/holland-america-line/prinsendam-i.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Prinsendam (I) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Prinsendam (I) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Prinsendam (I) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -418,7 +418,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Prinsendam (I) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Prinsendam (I).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Prinsendam (I).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/prinsendam-ii.html
+++ b/ships/holland-america-line/prinsendam-ii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Prinsendam (II) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Prinsendam (II) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Prinsendam (II) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -418,7 +418,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Prinsendam (II) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Prinsendam (II).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Prinsendam (II).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/rijndam-ii.html
+++ b/ships/holland-america-line/rijndam-ii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Rijndam (II) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Rijndam (II) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Rijndam (II) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Rijndam (II) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Rijndam (II).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Rijndam (II).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/rijndam.html
+++ b/ships/holland-america-line/rijndam.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Rijndam sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Rijndam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Rijndam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -412,7 +412,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Rijndam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Rijndam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Rijndam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/rotterdam-iv.html
+++ b/ships/holland-america-line/rotterdam-iv.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Rotterdam (IV) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Rotterdam (IV) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Rotterdam (IV) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -417,7 +417,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Rotterdam (IV) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Rotterdam (IV).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Rotterdam (IV).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/rotterdam-v.html
+++ b/ships/holland-america-line/rotterdam-v.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Rotterdam (V) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Rotterdam (V) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Rotterdam (V) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -419,7 +419,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Rotterdam (V) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Rotterdam (V).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Rotterdam (V).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/rotterdam-vi.html
+++ b/ships/holland-america-line/rotterdam-vi.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Rotterdam (VI) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Rotterdam (VI) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Rotterdam (VI) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -418,7 +418,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Rotterdam (VI) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Rotterdam (VI).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Rotterdam (VI).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/rotterdam.html
+++ b/ships/holland-america-line/rotterdam.html
@@ -378,7 +378,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Rotterdam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Rotterdam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">

--- a/ships/holland-america-line/ryndam.html
+++ b/ships/holland-america-line/ryndam.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Ryndam sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Ryndam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Ryndam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -417,7 +417,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Ryndam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Ryndam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Ryndam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/statendam-ii.html
+++ b/ships/holland-america-line/statendam-ii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Statendam (II) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Statendam (II) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Statendam (II) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -417,7 +417,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Statendam (II) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Statendam (II).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Statendam (II).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/statendam-iii.html
+++ b/ships/holland-america-line/statendam-iii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Statendam (III) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Statendam (III) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Statendam (III) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -418,7 +418,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Statendam (III) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Statendam (III).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Statendam (III).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/statendam.html
+++ b/ships/holland-america-line/statendam.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Statendam sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Statendam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Statendam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Statendam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Statendam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Statendam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/veendam-ii.html
+++ b/ships/holland-america-line/veendam-ii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Veendam (II) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Veendam (II) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Veendam (II) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -416,7 +416,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Veendam (II) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Veendam (II).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Veendam (II).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/veendam-iii.html
+++ b/ships/holland-america-line/veendam-iii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Veendam (III) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Veendam (III) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Veendam (III) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Veendam (III) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Veendam (III).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Veendam (III).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/veendam-iv.html
+++ b/ships/holland-america-line/veendam-iv.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Veendam (IV) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Veendam (IV) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Veendam (IV) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -417,7 +417,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Veendam (IV) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Veendam (IV).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Veendam (IV).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/veendam.html
+++ b/ships/holland-america-line/veendam.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Veendam sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Veendam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Veendam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Veendam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Veendam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Veendam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/volendam-ii.html
+++ b/ships/holland-america-line/volendam-ii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Volendam (II) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Volendam (II) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Volendam (II) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -416,7 +416,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Volendam (II) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Volendam (II).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Volendam (II).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/volendam-iii.html
+++ b/ships/holland-america-line/volendam-iii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Volendam (III) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Volendam (III) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Volendam (III) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -413,7 +413,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Volendam (III) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Volendam (III).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Volendam (III).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/volendam.html
+++ b/ships/holland-america-line/volendam.html
@@ -360,7 +360,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Volendam or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Volendam or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -476,7 +476,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Volendam sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Volendam.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Volendam.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/w-a-scholten.html
+++ b/ships/holland-america-line/w-a-scholten.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does W.A. Scholten sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching W.A. Scholten or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching W.A. Scholten or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -414,7 +414,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does W.A. Scholten sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for W.A. Scholten.</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for W.A. Scholten.</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/westerdam-i.html
+++ b/ships/holland-america-line/westerdam-i.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Westerdam (I) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Westerdam (I) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Westerdam (I) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -417,7 +417,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Westerdam (I) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Westerdam (I).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Westerdam (I).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">

--- a/ships/holland-america-line/westerdam-ii.html
+++ b/ships/holland-america-line/westerdam-ii.html
@@ -83,7 +83,7 @@ All work on this project is offered as a gift to God.
       "name": "Where does Westerdam (II) sail?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Ship deployments vary by season. Check the Unknown website for current itineraries."
+        "text": "Ship deployments vary by season. Check the Holland America Line website for current itineraries."
       }
     }
   ]
@@ -284,7 +284,7 @@ All work on this project is offered as a gift to God.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
-        <strong>Best For:</strong> Cruisers researching Westerdam (II) or comparing Unknown ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
+        <strong>Best For:</strong> Cruisers researching Westerdam (II) or comparing Holland America ships. Use this page to explore deck layouts, dining options, and onboard features before booking.
       </p>
 
       <div class="key-facts" style="margin: 1rem 0; padding: 1rem; background: #f7fdff; border-radius: 8px; border: 1px solid #e0f0f5;">
@@ -417,7 +417,7 @@ All work on this project is offered as a gift to God.
 
       <details  class="section-divider">
         <summary>Where does Westerdam (II) sail?</summary>
-        <p  class="list-indent">Ship deployments vary by season. Check the Unknown website for current itineraries and departure ports for Westerdam (II).</p>
+        <p  class="list-indent">Ship deployments vary by season. Check the Holland America Line website for current itineraries and departure ports for Westerdam (II).</p>
       </details>
 
       <details style="margin: 0.5rem 0; padding: 0.5rem 0;">


### PR DESCRIPTION
Resolves the "clever not careful" ship-facts cluster Ken flagged (celebrity-apex screenshot): pages rendered **Unknown** cruise lines while the same page's SSOT (`#ship-stats-fallback` JSON), JSON-LD, and header held the real name.

## Changes
- **#2500** — 40 Holland America Line pages fabricated `Unknown` in 3 render spots (`comparing Unknown ships`, `Check the Unknown website`, Quick-Answer/Key-Facts). Resolved **SSOT-first**: read `cruise_line` from each page's own `#ship-stats-fallback` JSON and substitute (112 spots → "Holland America Line" / "Holland America"). Data-driven, never hardcoded, fail-loud if SSOT absent (0 skipped).
- **#2502** — never-fabricate-Unknown **guardrail**, two layers:
  - `admin/validate-ship-page.js` `validateNoFabricatedUnknown()` — **SSOT-gated BLOCKING** check (fires only when `cruise_line` IS populated; legit image-credit unknowns ignored).
  - `.github/workflows/quality.yml` **CI-blocking** grep guard on the 4 fabrication forms (image credits excluded).
- **#2503** — celebrity-apex guest-count drift: 3 spots read `2,918` vs SSOT `2,910`; aligned to SSOT.
- **#2504** — carnival-tropicale `is a Excel` → `is an Excel` (a/an; SSOT class "Excel Class" confirmed correct — the future 5th Excel-class ship).
- **#2501** (no single source of truth) is now **mitigated** by the guardrail; full render-time SSOT wiring remains as the root-cause follow-on.

## Verification
- Guard **fires BLOCKING** on a re-injected fabrication; **silent** on fixed pages + legit image credits (`Unknown photographer`, `\| Unknown \| Wikimedia`, `Unknown - FOM collection`).
- Validator before/after error counts **unchanged** (no new errors introduced).
- CI grep guard **passes** on main (0 fabrication forms remain).

Worker: vivenna. Needs sibling 2nd-verify before HLS closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)