### PR TITLE
fix(scripts): portable repo-root — replace hardcoded /home/user/InTheWake (#2489/#2483)

### DIFF
--- a/admin/add-meta-tags.py
+++ b/admin/add-meta-tags.py
@@ -3,6 +3,7 @@
 Add missing description meta and canonical link to ship pages.
 Uses og:description or title as the source for description.
 """
+from pathlib import Path
 
 import os
 import re
@@ -31,7 +32,7 @@ def extract_canonical_url(content, filepath):
 
     # Generate from filepath
     # /home/user/InTheWake/ships/cruise-line/ship-name.html -> /ships/cruise-line/ship-name.html
-    rel_path = filepath.replace('/home/user/InTheWake', '')
+    rel_path = filepath.replace(str(Path(__file__).resolve().parents[1]), '')
     return f"https://cruisinginthewake.com{rel_path}"
 
 def has_description(content):
@@ -87,7 +88,7 @@ def add_missing_tags(filepath):
 
 def main():
     """Process all ship pages."""
-    ship_dirs = glob.glob('/home/user/InTheWake/ships/*/')
+    ship_dirs = glob.glob(str(Path(__file__).resolve().parents[1] / 'ships/*/'))
 
     total = 0
     updated = 0

--- a/admin/add-ship-stats.py
+++ b/admin/add-ship-stats.py
@@ -3,6 +3,7 @@
 Add Ship Statistics section to pages that have ship-stats-fallback data
 but are missing the visible stats-grid display.
 """
+from pathlib import Path
 
 import os
 import re
@@ -123,7 +124,7 @@ def process_file(filepath):
 
 def main():
     """Process all ship pages."""
-    ship_dirs = glob.glob('/home/user/InTheWake/ships/*/')
+    ship_dirs = glob.glob(str(Path(__file__).resolve().parents[1] / 'ships/*/'))
 
     total = 0
     updated = 0

--- a/admin/add-social-images.py
+++ b/admin/add-social-images.py
@@ -29,7 +29,7 @@ def get_image_url(filepath):
     # Check for ship-specific images
     if 'ships/' in str(filepath):
         slug = path.stem
-        social_img = f'/home/user/InTheWake/assets/social/{slug}.jpg'
+        social_img = f'{Path(__file__).resolve().parents[1]}/assets/social/{slug}.jpg'
         if os.path.exists(social_img):
             return f'https://cruisinginthewake.com/assets/social/{slug}.jpg'
 
@@ -181,7 +181,7 @@ def main():
     if dry_run:
         print("DRY RUN - No files will be modified\n")
 
-    base_dir = '/home/user/InTheWake'
+    base_dir = str(Path(__file__).resolve().parents[1])
     directories = ['ports', 'restaurants', 'ships', 'solo', 'tools', 'cruise-lines', 'authors']
 
     # Also check root-level HTML files

--- a/admin/add_article_rail_sitewide.py
+++ b/admin/add_article_rail_sitewide.py
@@ -411,7 +411,7 @@ class ArticleRailDeployer:
 def main():
     import sys
     dry_run = '--dry-run' in sys.argv
-    deployer = ArticleRailDeployer('/home/user/InTheWake', dry_run=dry_run)
+    deployer = ArticleRailDeployer(str(Path(__file__).resolve().parents[1]), dry_run=dry_run)
     deployer.run()
 
 if __name__ == '__main__':

--- a/admin/add_fun_distance_units.py
+++ b/admin/add_fun_distance_units.py
@@ -138,6 +138,6 @@ class FunDistanceDeployer:
         print("="*60)
 
 if __name__ == '__main__':
-    root = Path('/home/user/InTheWake')
+    root = (Path(__file__).resolve().parents[1])
     deployer = FunDistanceDeployer(root)
     deployer.deploy()

--- a/admin/add_icp_lite_compliance.py
+++ b/admin/add_icp_lite_compliance.py
@@ -92,7 +92,7 @@ def process_file(filepath):
 
 def main():
     """Main function"""
-    root = Path('/home/user/InTheWake')
+    root = (Path(__file__).resolve().parents[1])
     html_files = list(root.rglob('*.html'))
 
     # Filter files

--- a/admin/add_missing_icp_headers.py
+++ b/admin/add_missing_icp_headers.py
@@ -7,7 +7,7 @@ import re
 import json
 from pathlib import Path
 
-SHIPS_DIR = Path('/home/user/InTheWake/ships/rcl')
+SHIPS_DIR = (Path(__file__).resolve().parents[1] / 'ships/rcl')
 
 SHIPS_NEEDING_HEADERS = [
     'nordic-prince.html',

--- a/admin/add_search_to_nav.py
+++ b/admin/add_search_to_nav.py
@@ -144,7 +144,7 @@ def process_file(filepath):
 
 def main():
     """Main function"""
-    root = Path('/home/user/InTheWake')
+    root = (Path(__file__).resolve().parents[1])
     html_files = list(root.rglob('*.html'))
 
     # Filter files

--- a/admin/apply-interior-subcategories.py
+++ b/admin/apply-interior-subcategories.py
@@ -17,8 +17,8 @@ import os
 import sys
 from pathlib import Path
 
-STATEROOMS_DIR = Path("/home/user/InTheWake/assets/data/staterooms")
-CLASSIFICATIONS_DIR = Path("/home/user/InTheWake/admin/cabin-classifications")
+STATEROOMS_DIR = (Path(__file__).resolve().parents[1] / 'assets/data/staterooms')
+CLASSIFICATIONS_DIR = (Path(__file__).resolve().parents[1] / 'admin/cabin-classifications')
 
 # Codes that are Virtual Balcony (per project definition)
 VIRTUAL_BALCONY_CODES = {"1U", "2U", "3U", "4U", "5U"}

--- a/admin/apply_icp_hubs.py
+++ b/admin/apply_icp_hubs.py
@@ -8,7 +8,7 @@ import os
 import re
 from pathlib import Path
 
-ROOT_DIR = Path('/home/user/InTheWake')
+ROOT_DIR = (Path(__file__).resolve().parents[1])
 
 # Hub pages configuration with their summaries
 HUB_PAGES = {

--- a/admin/audit_and_fix_duplicates.py
+++ b/admin/audit_and_fix_duplicates.py
@@ -192,7 +192,7 @@ class DuplicateHeroFixer:
 def main():
     import sys
     dry_run = '--dry-run' in sys.argv
-    fixer = DuplicateHeroFixer('/home/user/InTheWake', dry_run=dry_run)
+    fixer = DuplicateHeroFixer(str(Path(__file__).resolve().parents[1]), dry_run=dry_run)
     fixer.run()
 
 if __name__ == '__main__':

--- a/admin/audit_navigation_pattern.py
+++ b/admin/audit_navigation_pattern.py
@@ -281,7 +281,7 @@ class NavigationAuditor:
             print(f"{len(issues_list):2d} issues: {filepath}")
 
 def main():
-    auditor = NavigationAuditor('/home/user/InTheWake')
+    auditor = NavigationAuditor(str(Path(__file__).resolve().parents[1]))
     auditor.run_audit()
 
 if __name__ == '__main__':

--- a/admin/check_duplicate_dropdown.py
+++ b/admin/check_duplicate_dropdown.py
@@ -46,5 +46,5 @@ def check_duplicates(root_dir):
     return duplicates
 
 if __name__ == '__main__':
-    root = Path('/home/user/InTheWake')
+    root = (Path(__file__).resolve().parents[1])
     check_duplicates(root)

--- a/admin/comprehensive_site_audit.py
+++ b/admin/comprehensive_site_audit.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse, unquote
 import urllib.request
 import urllib.error
 
-BASE_DIR = Path("/home/user/InTheWake")
+BASE_DIR = (Path(__file__).resolve().parents[1])
 EXCLUDE_DIRS = {"vendors", "node_modules"}
 EXCLUDE_PATHS = {"/solo/articles/"}
 

--- a/admin/consolidate_mdr.py
+++ b/admin/consolidate_mdr.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Consolidate ship-specific main dining rooms into one MDR entry"""
+from pathlib import Path
 
 import json
 
 # Read the venues data
-with open('/home/user/InTheWake/assets/data/venues-v2.json', 'r', encoding='utf-8') as f:
+with open(str(Path(__file__).resolve().parents[1] / 'assets/data/venues-v2.json'), 'r', encoding='utf-8') as f:
     data = json.load(f)
 
 # Ship-specific dining rooms to consolidate into MDR
@@ -41,7 +42,7 @@ data['meta']['updated'] = '2025-11-21'
 data['meta']['note'] = data['meta']['note'] + ' | Consolidated MDR variations'
 
 # Write back
-with open('/home/user/InTheWake/assets/data/venues-v2.json', 'w', encoding='utf-8') as f:
+with open(str(Path(__file__).resolve().parents[1] / 'assets/data/venues-v2.json'), 'w', encoding='utf-8') as f:
     json.dump(data, f, indent=2, ensure_ascii=False)
 
 print(f"\nUpdated venues-v2.json")

--- a/admin/convert_rectangles_to_pills.py
+++ b/admin/convert_rectangles_to_pills.py
@@ -63,7 +63,7 @@ def convert_nav_buttons_to_pills(file_path):
         return False
 
 def main():
-    base_dir = Path('/home/user/InTheWake')
+    base_dir = (Path(__file__).resolve().parents[1])
     updated_files = []
 
     # Find all HTML files (excluding vendors and solo/articles)

--- a/admin/fix-article-rail-25.py
+++ b/admin/fix-article-rail-25.py
@@ -13,7 +13,7 @@ For both groups:
 import re
 from pathlib import Path
 
-BASE = Path('/home/user/InTheWake')
+BASE = (Path(__file__).resolve().parents[1])
 
 # Group A: broken (data||[]).filter pattern
 GROUP_A = [

--- a/admin/fix-hal-historicals.py
+++ b/admin/fix-hal-historicals.py
@@ -22,12 +22,13 @@ Fixes applied per file:
 
 Does NOT add eulogy content — that requires per-ship research.
 """
+from pathlib import Path
 
 import os
 import re
 import sys
 
-HAL_DIR = '/home/user/InTheWake/ships/holland-america-line'
+HAL_DIR = str(Path(__file__).resolve().parents[1] / 'ships/holland-america-line')
 TODAY = '2026-02-23'
 
 # Minimal hidden video section to satisfy validator

--- a/admin/fix_all_page_intro_grid.py
+++ b/admin/fix_all_page_intro_grid.py
@@ -48,7 +48,7 @@ def check_and_fix_page_intro(file_path):
     return False
 
 def main():
-    base_dir = Path('/home/user/InTheWake')
+    base_dir = (Path(__file__).resolve().parents[1])
 
     # Find all HTML files except vendors and solo/articles
     all_html_files = []

--- a/admin/fix_article_cards.py
+++ b/admin/fix_article_cards.py
@@ -158,7 +158,7 @@ def process_file(filepath):
     return False
 
 def main():
-    root = Path('/home/user/InTheWake')
+    root = (Path(__file__).resolve().parents[1])
     updated = 0
     skipped = 0
 

--- a/admin/fix_complete_navigation.py
+++ b/admin/fix_complete_navigation.py
@@ -236,7 +236,7 @@ def main():
     import sys
 
     dry_run = '--dry-run' in sys.argv
-    fixer = NavigationFixer('/home/user/InTheWake', dry_run=dry_run)
+    fixer = NavigationFixer(str(Path(__file__).resolve().parents[1]), dry_run=dry_run)
     fixer.run()
 
 if __name__ == '__main__':

--- a/admin/fix_duplicate_dropdown.py
+++ b/admin/fix_duplicate_dropdown.py
@@ -127,6 +127,6 @@ class DropdownDuplicateRemover:
         print("="*60)
 
 if __name__ == '__main__':
-    root = Path('/home/user/InTheWake')
+    root = (Path(__file__).resolve().parents[1])
     remover = DropdownDuplicateRemover(root)
     remover.fix_all()

--- a/admin/fix_duplicates.py
+++ b/admin/fix_duplicates.py
@@ -197,7 +197,7 @@ class DuplicateFixer:
 def main():
     import sys
     dry_run = '--dry-run' in sys.argv
-    fixer = DuplicateFixer('/home/user/InTheWake', dry_run=dry_run)
+    fixer = DuplicateFixer(str(Path(__file__).resolve().parents[1]), dry_run=dry_run)
     fixer.run()
 
 if __name__ == '__main__':

--- a/admin/fix_logo_aspect_ratio.py
+++ b/admin/fix_logo_aspect_ratio.py
@@ -2,6 +2,7 @@
 """
 Fix logo aspect ratio by cropping transparent padding and creating proper resized versions
 """
+from pathlib import Path
 
 from PIL import Image
 import os
@@ -73,5 +74,5 @@ def create_proper_logos():
     return True
 
 if __name__ == '__main__':
-    os.chdir('/home/user/InTheWake')
+    os.chdir(str(Path(__file__).resolve().parents[1]))
     create_proper_logos()

--- a/admin/fix_logo_transparency.py
+++ b/admin/fix_logo_transparency.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Create properly-sized PNG logos with transparency intact"""
+from pathlib import Path
 
 from PIL import Image
 import os
@@ -45,5 +46,5 @@ def create_sized_logos():
     return True
 
 if __name__ == '__main__':
-    os.chdir('/home/user/InTheWake')
+    os.chdir(str(Path(__file__).resolve().parents[1]))
     create_sized_logos()

--- a/admin/fix_missing_icp_lite.py
+++ b/admin/fix_missing_icp_lite.py
@@ -11,14 +11,14 @@ from pathlib import Path
 from datetime import date
 
 FILES_TO_FIX = [
-    '/home/user/InTheWake/ships/rcl/quantum-of-the-seas.html',
-    '/home/user/InTheWake/ships/rcl/sovereign-of-the-seas.html',
-    '/home/user/InTheWake/ships/rcl/spectrum-of-the-seas.html',
-    '/home/user/InTheWake/ships/rcl/symphony-of-the-seas.html',
-    '/home/user/InTheWake/ships/rcl/utopia-of-the-seas.html',
-    '/home/user/InTheWake/ships/rcl/voyager-of-the-seas.html',
-    '/home/user/InTheWake/ships/rcl/wonder-of-the-seas.html',
-    '/home/user/InTheWake/solo/in-the-wake-of-grief.html',
+    str(Path(__file__).resolve().parents[1] / 'ships/rcl/quantum-of-the-seas.html'),
+    str(Path(__file__).resolve().parents[1] / 'ships/rcl/sovereign-of-the-seas.html'),
+    str(Path(__file__).resolve().parents[1] / 'ships/rcl/spectrum-of-the-seas.html'),
+    str(Path(__file__).resolve().parents[1] / 'ships/rcl/symphony-of-the-seas.html'),
+    str(Path(__file__).resolve().parents[1] / 'ships/rcl/utopia-of-the-seas.html'),
+    str(Path(__file__).resolve().parents[1] / 'ships/rcl/voyager-of-the-seas.html'),
+    str(Path(__file__).resolve().parents[1] / 'ships/rcl/wonder-of-the-seas.html'),
+    str(Path(__file__).resolve().parents[1] / 'solo/in-the-wake-of-grief.html'),
 ]
 
 def extract_summary(content):

--- a/admin/fix_navigation_dropdowns.py
+++ b/admin/fix_navigation_dropdowns.py
@@ -154,7 +154,7 @@ def add_dropdown_js(filepath):
 
 def main():
     """Fix all restaurant and port detail pages."""
-    base_dir = Path('/home/user/InTheWake')
+    base_dir = (Path(__file__).resolve().parents[1])
 
     # Track statistics
     stats = {

--- a/admin/fix_page_grid_css.py
+++ b/admin/fix_page_grid_css.py
@@ -87,7 +87,7 @@ def process_file(filepath):
         return 'error', str(e)
 
 def main():
-    root = Path('/home/user/InTheWake')
+    root = (Path(__file__).resolve().parents[1])
 
     # Files to check
     patterns = [

--- a/admin/fix_page_intro_grid.py
+++ b/admin/fix_page_intro_grid.py
@@ -65,7 +65,7 @@ def main():
         'solo/why-i-started-solo-cruising.html'
     ]
 
-    base_dir = Path('/home/user/InTheWake')
+    base_dir = (Path(__file__).resolve().parents[1])
     updated_files = []
 
     for file_name in files_to_check:

--- a/admin/fix_port_navigation.py
+++ b/admin/fix_port_navigation.py
@@ -228,7 +228,7 @@ def add_navigation_header(filepath):
 
 def main():
     """Fix all port pages missing navigation."""
-    base_dir = Path('/home/user/InTheWake')
+    base_dir = (Path(__file__).resolve().parents[1])
     port_dir = base_dir / 'ports'
 
     # Track statistics

--- a/admin/fix_ship_duplicates.py
+++ b/admin/fix_ship_duplicates.py
@@ -38,7 +38,7 @@ def fix_duplicate_heroes(filepath):
 
 def main():
     """Fix all ship pages with duplicate heroes."""
-    base_dir = Path('/home/user/InTheWake')
+    base_dir = (Path(__file__).resolve().parents[1])
 
     # List of files to fix
     ship_dirs = [

--- a/admin/fix_ship_grid_spans.py
+++ b/admin/fix_ship_grid_spans.py
@@ -61,7 +61,7 @@ def fix_ship_page(filepath):
         return 'error', [str(e)]
 
 def main():
-    ships_dir = Path('/home/user/InTheWake/ships/rcl')
+    ships_dir = (Path(__file__).resolve().parents[1] / 'ships/rcl')
 
     print(f"\n{BOLD}{'═' * 60}{RESET}")
     print(f"{BOLD}🔧 Ship Grid Span Fixer{RESET}")

--- a/admin/fix_ship_imos.py
+++ b/admin/fix_ship_imos.py
@@ -100,7 +100,7 @@ def fix_imo_in_file(filepath: Path) -> tuple[bool, str, str]:
     return True, current_imo, correct_imo
 
 def main():
-    ships_dir = Path('/home/user/InTheWake/ships/rcl')
+    ships_dir = (Path(__file__).resolve().parents[1] / 'ships/rcl')
 
     fixed = []
     correct = []

--- a/admin/fix_ship_pages.py
+++ b/admin/fix_ship_pages.py
@@ -6,7 +6,7 @@ import os
 import re
 from pathlib import Path
 
-SHIPS_DIR = Path('/home/user/InTheWake/ships/rcl')
+SHIPS_DIR = (Path(__file__).resolve().parents[1] / 'ships/rcl')
 
 # Replacements for inline styles
 REPLACEMENTS = [

--- a/admin/fix_ship_structure.py
+++ b/admin/fix_ship_structure.py
@@ -7,7 +7,7 @@ Standardizes: H1, answer-line, fit-guidance, key-facts, FAQ with details tags.
 import re
 from pathlib import Path
 
-SHIPS_DIR = Path('/home/user/InTheWake/ships/rcl')
+SHIPS_DIR = (Path(__file__).resolve().parents[1] / 'ships/rcl')
 
 def fix_ship_page(filepath):
     """Apply proper ICP-Lite structure to a ship page."""

--- a/admin/fix_sw_registration.py
+++ b/admin/fix_sw_registration.py
@@ -56,7 +56,7 @@ def add_sw_registration(content):
     return None  # Couldn't find insertion point
 
 def main():
-    root = Path('/home/user/InTheWake')
+    root = (Path(__file__).resolve().parents[1])
 
     fixed_files = []
     skipped_files = []

--- a/admin/fix_trackers.py
+++ b/admin/fix_trackers.py
@@ -8,7 +8,7 @@ import os
 import re
 from pathlib import Path
 
-SHIPS_DIR = Path('/home/user/InTheWake/ships/rcl')
+SHIPS_DIR = (Path(__file__).resolve().parents[1] / 'ships/rcl')
 
 # New JavaScript to replace old initLiveTracker
 NEW_TRACKER_JS = """  <!-- ===== Live tracker (VesselFinder iframe: auto-centers on ship by IMO) ===== -->

--- a/admin/generate-stateroom-exceptions.py
+++ b/admin/generate-stateroom-exceptions.py
@@ -264,8 +264,8 @@ def create_baseline_exception(slug, data_dir):
 
 def main():
     # Directories
-    data_dir = "/home/user/InTheWake/assets/data/staterooms"
-    ships_dir = "/home/user/InTheWake/ships"
+    data_dir = str(Path(__file__).resolve().parents[1] / 'assets/data/staterooms')
+    ships_dir = str(Path(__file__).resolve().parents[1] / 'ships')
 
     # Get existing exception files
     existing = set()

--- a/admin/generate_search_index.py
+++ b/admin/generate_search_index.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 def get_restaurants():
     """Get all restaurants from venues-v2.json"""
-    venues_path = Path('/home/user/InTheWake/assets/data/venues-v2.json')
+    venues_path = (Path(__file__).resolve().parents[1] / 'assets/data/venues-v2.json')
     with open(venues_path) as f:
         data = json.load(f)
 
@@ -55,7 +55,7 @@ def get_restaurants():
 
 def get_ships():
     """Get all ships from all cruise lines"""
-    ships_base = Path('/home/user/InTheWake/ships')
+    ships_base = (Path(__file__).resolve().parents[1] / 'ships')
     ships = []
 
     # Cruise line directories and their display names
@@ -167,7 +167,7 @@ def get_ships():
 
 def get_ports():
     """Get all port pages"""
-    ports_dir = Path('/home/user/InTheWake/ports')
+    ports_dir = (Path(__file__).resolve().parents[1] / 'ports')
     ports = []
 
     # Region keywords for common port locations
@@ -461,7 +461,7 @@ def main():
     index.extend(get_hub_pages())
 
     # Write index
-    output_path = Path('/home/user/InTheWake/assets/data/search-index.json')
+    output_path = (Path(__file__).resolve().parents[1] / 'assets/data/search-index.json')
     with open(output_path, 'w') as f:
         json.dump(index, f, indent=2)
 

--- a/admin/generate_sitemap.py
+++ b/admin/generate_sitemap.py
@@ -6,6 +6,7 @@ Soli Deo Gloria
 Creates sitemap.xml with all public HTML pages.
 Uses git ls-tree to enumerate files (works with sparse checkout).
 """
+from pathlib import Path
 
 import subprocess
 from pathlib import PurePosixPath
@@ -108,7 +109,7 @@ def get_all_html_files():
     """Get all HTML files from git (works regardless of sparse checkout)"""
     result = subprocess.run(
         ['git', 'ls-tree', '-r', '--name-only', 'HEAD'],
-        capture_output=True, text=True, cwd='/home/user/InTheWake'
+        capture_output=True, text=True, cwd=str(Path(__file__).resolve().parents[1])
     )
     files = []
     for line in result.stdout.strip().split('\n'):
@@ -157,7 +158,7 @@ def main():
     """Main function"""
     xml_content, count = generate_sitemap()
 
-    output_path = '/home/user/InTheWake/sitemap.xml'
+    output_path = str(Path(__file__).resolve().parents[1] / 'sitemap.xml')
     with open(output_path, 'w') as f:
         f.write(xml_content)
 

--- a/admin/icp_lite_general_remediation.py
+++ b/admin/icp_lite_general_remediation.py
@@ -20,7 +20,7 @@ import argparse
 from pathlib import Path
 from datetime import date
 
-ROOT = Path('/home/user/InTheWake')
+ROOT = (Path(__file__).resolve().parents[1])
 TODAY = date.today().isoformat()
 
 # Directories to skip (already handled or excluded)

--- a/admin/icp_lite_remediation.py
+++ b/admin/icp_lite_remediation.py
@@ -25,7 +25,7 @@ from datetime import date
 from collections import defaultdict
 
 # Configuration
-ROOT = Path('/home/user/InTheWake')
+ROOT = (Path(__file__).resolve().parents[1])
 EXCLUDE_DIRS = {'vendors', 'vendor', 'solo/articles', 'admin', 'assets', 'audit-reports'}
 TODAY = date.today().isoformat()
 

--- a/admin/icp_lite_restaurant_remediation.py
+++ b/admin/icp_lite_restaurant_remediation.py
@@ -20,7 +20,7 @@ import argparse
 from pathlib import Path
 from datetime import date
 
-ROOT = Path('/home/user/InTheWake')
+ROOT = (Path(__file__).resolve().parents[1])
 TODAY = date.today().isoformat()
 
 def extract_restaurant_info(content, filepath):

--- a/admin/icp_lite_ship_remediation.py
+++ b/admin/icp_lite_ship_remediation.py
@@ -23,7 +23,7 @@ import argparse
 from pathlib import Path
 from datetime import date
 
-ROOT = Path('/home/user/InTheWake')
+ROOT = (Path(__file__).resolve().parents[1])
 TODAY = date.today().isoformat()
 
 def extract_ship_info(content, filepath):

--- a/admin/map_ship_webp_images.py
+++ b/admin/map_ship_webp_images.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 def get_webp_files():
     """Get all WebP files in assets/ships"""
-    ships_dir = Path('/home/user/InTheWake/assets/ships')
+    ships_dir = (Path(__file__).resolve().parents[1] / 'assets/ships')
     webp_files = list(ships_dir.glob('*.webp'))
     return [f.name for f in webp_files]
 
@@ -162,7 +162,7 @@ def main():
             print(f"  {ship}: {len(images)} images")
 
     # Write to file
-    output_path = '/home/user/InTheWake/admin/ship_images_js.txt'
+    output_path = str(Path(__file__).resolve().parents[1] / 'admin/ship_images_js.txt')
     with open(output_path, 'w') as f:
         f.write(js_content)
 

--- a/admin/normalize_ship_rails.py
+++ b/admin/normalize_ship_rails.py
@@ -267,7 +267,7 @@ def main():
 
     print_banner()
 
-    ships_dir = Path('/home/user/InTheWake/ships/rcl')
+    ships_dir = (Path(__file__).resolve().parents[1] / 'ships/rcl')
 
     if not ships_dir.exists():
         print(f"{Colors.RED}ERROR: Directory not found: {ships_dir}{Colors.END}")

--- a/admin/optimize_images.py
+++ b/admin/optimize_images.py
@@ -261,7 +261,7 @@ def main():
     print("IMAGE OPTIMIZATION FOR PERFORMANCE")
     print("="*60)
 
-    os.chdir('/home/user/InTheWake')
+    os.chdir(str(Path(__file__).resolve().parents[1]))
 
     results = {
         'logo': optimize_logo(),

--- a/admin/sourcing.py
+++ b/admin/sourcing.py
@@ -46,7 +46,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-ROOT = Path("/home/user/InTheWake")
+ROOT = (Path(__file__).resolve().parents[1])
 PORTS_HTML = ROOT / "ports"
 PORTS_IMG = ROOT / "ports" / "img"
 ATTR_CSV = ROOT / "attributions" / "attributions.csv"

--- a/admin/spot_check_nav.py
+++ b/admin/spot_check_nav.py
@@ -67,7 +67,7 @@ def check_page(filepath: Path) -> Dict:
 
 def main():
     """Spot check 20% of files from diverse categories"""
-    base = Path('/home/user/InTheWake')
+    base = (Path(__file__).resolve().parents[1])
     
     # Sample files from different categories
     categories = {

--- a/admin/transform_ship_pages.py
+++ b/admin/transform_ship_pages.py
@@ -8,7 +8,7 @@ import re
 import json
 from pathlib import Path
 
-SHIPS_DIR = Path('/home/user/InTheWake/ships/rcl')
+SHIPS_DIR = (Path(__file__).resolve().parents[1] / 'ships/rcl')
 
 # Ships to transform (excluding radiance-of-the-seas.html)
 SHIPS_TO_FIX = [

--- a/admin/update_html_webp.py
+++ b/admin/update_html_webp.py
@@ -35,7 +35,7 @@ def check_webp_exists(html_file_path, image_path):
     # Handle absolute paths from root
     if clean_path.startswith('/'):
         clean_path = clean_path[1:]  # Remove leading slash
-        webp_file = Path('/home/user/InTheWake') / clean_path.replace('.jpg', '.webp').replace('.jpeg', '.webp').replace('.png', '.webp').replace('.JPG', '.webp').replace('.JPEG', '.webp').replace('.PNG', '.webp')
+        webp_file = (Path(__file__).resolve().parents[1]) / clean_path.replace('.jpg', '.webp').replace('.jpeg', '.webp').replace('.png', '.webp').replace('.JPG', '.webp').replace('.JPEG', '.webp').replace('.PNG', '.webp')
     else:
         # Relative path
         html_dir = Path(html_file_path).parent

--- a/admin/update_logo_dimensions_sitewide.py
+++ b/admin/update_logo_dimensions_sitewide.py
@@ -124,6 +124,6 @@ def update_all_html_files():
     return updated
 
 if __name__ == '__main__':
-    os.chdir('/home/user/InTheWake')
+    os.chdir(str(Path(__file__).resolve().parents[1]))
     count = update_all_html_files()
     exit(0 if count >= 0 else 1)

--- a/admin/update_restaurant_images.py
+++ b/admin/update_restaurant_images.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Update restaurant pages to use SVG category images instead of watermark.png"""
+from pathlib import Path
 
 import os
 import re
@@ -81,7 +82,7 @@ def update_restaurant_page(filepath):
     return False
 
 def main():
-    restaurants_dir = '/home/user/InTheWake/restaurants'
+    restaurants_dir = str(Path(__file__).resolve().parents[1] / 'restaurants')
     updated_count = 0
 
     for filename in os.listdir(restaurants_dir):

--- a/admin/update_ships_dynamic.py
+++ b/admin/update_ships_dynamic.py
@@ -3,15 +3,16 @@
 Update ships-dynamic.js SHIP_IMAGES to use WebP
 Soli Deo Gloria
 """
+from pathlib import Path
 
 import re
 
 # Read original file
-with open('/home/user/InTheWake/assets/js/ships-dynamic.js', 'r') as f:
+with open(str(Path(__file__).resolve().parents[1] / 'assets/js/ships-dynamic.js'), 'r') as f:
     content = f.read()
 
 # Read new SHIP_IMAGES
-with open('/home/user/InTheWake/admin/ship_images_js.txt', 'r') as f:
+with open(str(Path(__file__).resolve().parents[1] / 'admin/ship_images_js.txt'), 'r') as f:
     new_ship_images = f.read()
 
 # Pattern to match entire SHIP_IMAGES object
@@ -21,7 +22,7 @@ pattern = r'const SHIP_IMAGES = \{.*?\n  \};'
 new_content = re.sub(pattern, new_ship_images.strip(), content, flags=re.DOTALL)
 
 # Write back
-with open('/home/user/InTheWake/assets/js/ships-dynamic.js', 'w') as f:
+with open(str(Path(__file__).resolve().parents[1] / 'assets/js/ships-dynamic.js'), 'w') as f:
     f.write(new_content)
 
 print("✅ Updated ships-dynamic.js with WebP image paths")

--- a/admin/verify_actual_state.py
+++ b/admin/verify_actual_state.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 from collections import defaultdict
 
-BASE = Path("/home/user/InTheWake")
+BASE = (Path(__file__).resolve().parents[1])
 
 class StateVerifier:
     def __init__(self):

--- a/admin/verify_dropdown_fixed.py
+++ b/admin/verify_dropdown_fixed.py
@@ -5,7 +5,7 @@ Verify all dropdown duplicates are fixed by counting actual dropdown initializat
 
 from pathlib import Path
 
-root = Path('/home/user/InTheWake')
+root = (Path(__file__).resolve().parents[1])
 duplicates = []
 
 for filepath in root.rglob('*.html'):

--- a/scripts/add-offline-badge.py
+++ b/scripts/add-offline-badge.py
@@ -8,7 +8,7 @@ import os
 import re
 from pathlib import Path
 
-PORTS_DIR = Path("/home/user/InTheWake/ports")
+PORTS_DIR = (Path(__file__).resolve().parents[1] / 'ports')
 
 # Pattern to match trust badge without offline messaging
 OLD_BADGE_PATTERNS = [

--- a/scripts/fix-broken-files.py
+++ b/scripts/fix-broken-files.py
@@ -131,7 +131,7 @@ def fix_file(filepath, title, main_content):
 def main():
     # Fix disability-at-sea.html
     fix_file(
-        Path('/home/user/InTheWake/disability-at-sea.html'),
+        (Path(__file__).resolve().parents[1] / 'disability-at-sea.html'),
         'Accessibility & Inclusion',
         '''
       <p>In the Wake is committed to accessibility for all travelers — honoring every ability, ensuring every voyager can plan and dream freely.</p>
@@ -149,7 +149,7 @@ def main():
 
     # Fix ken-baker.html
     fix_file(
-        Path('/home/user/InTheWake/authors/ken-baker.html'),
+        (Path(__file__).resolve().parents[1] / 'authors/ken-baker.html'),
         'Ken Baker',
         '''
       <p class="subtitle">Founder & Editor — In the Wake</p>
@@ -170,7 +170,7 @@ def main():
 
     # Fix tina-maulsby.html
     fix_file(
-        Path('/home/user/InTheWake/authors/tina-maulsby.html'),
+        (Path(__file__).resolve().parents[1] / 'authors/tina-maulsby.html'),
         'Tina Maulsby',
         '''
       <p class="subtitle">Featured Contributor — In the Wake</p>
@@ -186,7 +186,7 @@ def main():
 
     # Fix in-the-wake-of-grief-meta.html
     fix_file(
-        Path('/home/user/InTheWake/solo/in-the-wake-of-grief-meta.html'),
+        (Path(__file__).resolve().parents[1] / 'solo/in-the-wake-of-grief-meta.html'),
         'In the Wake of Grief',
         '''
       <p>This is a companion page for the article <a href="/solo/in-the-wake-of-grief.html">In the Wake of Grief</a>.</p>
@@ -197,7 +197,7 @@ def main():
 
     # Fix carnival-adventure.html - this one is more complex
     # It has lots of head content but no body
-    filepath = Path('/home/user/InTheWake/ships/carnival/carnival-adventure.html')
+    filepath = (Path(__file__).resolve().parents[1] / 'ships/carnival/carnival-adventure.html')
     content = filepath.read_text()
 
     # Find where the head content ends

--- a/scripts/fix-remaining-nav.py
+++ b/scripts/fix-remaining-nav.py
@@ -81,7 +81,7 @@ NEW_HEADER = '''  <a href="#main-content" class="skip-link">Skip to main content
 
 def fix_carnival_tropicale():
     """Fix carnival-tropicale.html"""
-    filepath = Path('/home/user/InTheWake/ships/carnival/carnival-tropicale.html')
+    filepath = (Path(__file__).resolve().parents[1] / 'ships/carnival/carnival-tropicale.html')
     content = filepath.read_text()
 
     # Replace old header
@@ -100,7 +100,7 @@ def fix_carnival_tropicale():
 
 def fix_affiliate_disclosure():
     """Fix affiliate-disclosure.html"""
-    filepath = Path('/home/user/InTheWake/affiliate-disclosure.html')
+    filepath = (Path(__file__).resolve().parents[1] / 'affiliate-disclosure.html')
     content = filepath.read_text()
 
     # Replace old header (including skip link)
@@ -119,7 +119,7 @@ def fix_affiliate_disclosure():
 
 def fix_cruise_duck():
     """Fix cruise-duck-tradition.html"""
-    filepath = Path('/home/user/InTheWake/articles/cruise-duck-tradition.html')
+    filepath = (Path(__file__).resolve().parents[1] / 'articles/cruise-duck-tradition.html')
     content = filepath.read_text()
 
     # Check if it has header

--- a/scripts/migrate-port-template-v2.py
+++ b/scripts/migrate-port-template-v2.py
@@ -123,7 +123,7 @@ def update_file(filepath):
         return f"ERROR writing: {e}"
 
 def main():
-    ports_dir = Path('/home/user/InTheWake/ports')
+    ports_dir = (Path(__file__).resolve().parents[1] / 'ports')
 
     results = {'UPDATED': 0, 'SKIP': 0, 'ERROR': 0}
 

--- a/scripts/migrate-port-template.py
+++ b/scripts/migrate-port-template.py
@@ -134,7 +134,7 @@ def update_file(filepath):
         return f"ERROR writing: {e}"
 
 def main():
-    ports_dir = Path('/home/user/InTheWake/ports')
+    ports_dir = (Path(__file__).resolve().parents[1] / 'ports')
 
     results = {'UPDATED': 0, 'SKIP': 0, 'ERROR': 0}
 

--- a/scripts/update-nav.py
+++ b/scripts/update-nav.py
@@ -122,7 +122,7 @@ def update_file(filepath):
         return f"ERROR writing: {e}"
 
 def main():
-    base_dir = Path('/home/user/InTheWake')
+    base_dir = (Path(__file__).resolve().parents[1])
 
     # Skip these files
     skip_files = {

--- a/scripts/update-simple-nav.py
+++ b/scripts/update-simple-nav.py
@@ -125,7 +125,7 @@ def update_file(filepath):
         return f"ERROR writing: {e}"
 
 def main():
-    base_dir = Path('/home/user/InTheWake')
+    base_dir = (Path(__file__).resolve().parents[1])
 
     # Skip these files
     skip_files = {


### PR DESCRIPTION
64 `admin/`/`scripts/` files hardcoded `/home/user/InTheWake` as the repo root, so `existsSync`/`Path` checks were false on every host but the original (off-host portability bug, #2489). #2483 (`repair-port.js`) was already portable.

## Fix
All offenders are at **depth-1** (`admin/X` or `scripts/X`), so `Path(__file__).resolve().parents[1]` is the correct repo root on **any** host:

| Original | Portable |
|---|---|
| `Path('/home/user/InTheWake')` | `Path(__file__).resolve().parents[1]` |
| `Path('/home/user/InTheWake/sub')` | `... .parents[1] / 'sub'` |
| bare `'/home/user/InTheWake/sub'` | `str(... .parents[1] / 'sub')` |
| f-string with `{x}` in the path | `f'{... .parents[1]}/...{x}'` |

- **63 Python files** transformed (pathlib `Path` import added where missing).
- `repair-port.js` (#2483) already portable via `path.join(__dirname, '..', ...)`.
- **Inline self-location chosen over a shared helper** — keeps each one-shot script self-contained (no cross-script import dependency).

## Verification
- All **63 changed `.py` files `py_compile` clean** (the transformer aborts the write on any compile failure — 0 aborts).
- `parents[1]` from `admin/`+`scripts/` resolves to the real repo root (`ships/` + `ports/` present).
- No active hardcoded paths remain (the 2 leftover occurrences are comments).
- Strictly an improvement: on the original host `parents[1]` also resolves to `/home/user/InTheWake`.

Worker: vivenna. Needs sibling 2nd-verify before HLS closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)