### PR TITLE
fix(_headers): cover all subdir images with long cache (#2486)

### DIFF
--- a/_headers
+++ b/_headers
@@ -39,15 +39,33 @@
 /assets/articles/thumbs/*
   Cache-Control: public, max-age=31536000, immutable
 
-# Subdirectory images (assets/ships/* incl ships/rcl,/princess,…; assets/beta/*) — itw-subdir-image-cache-gap,
-# the image half of the itw-gh-1721 Netlify mid-`*` subdir gap (33 refs, all unversioned). Unlike subdir
-# CSS/JS (which change every deploy → revalidating), these are STATIC content, so `immutable` matches the
-# site's existing image rules above. ASSUMPTION: an image is replaced by CHANGING ITS FILENAME (standard for
-# static assets); to overwrite an image in place, add a ?v=/hash cache-buster or it will serve stale.
+# Subdirectory images — itw-subdir-image-cache-gap (#2486), the image half of the itw-gh-1721 Netlify
+# mid-`*` subdir gap: /assets/*.webp does NOT match /assets/<dir>/x.webp, so these fell through to the
+# default short cache. Unlike subdir CSS/JS (which change every deploy → revalidating), these are STATIC
+# content, so `immutable` matches the site's image rules above. ASSUMPTION: an image is replaced by CHANGING
+# ITS FILENAME (standard for static assets); to overwrite in place, add a ?v=/hash cache-buster or it serves stale.
 /assets/ships/*
   Cache-Control: public, max-age=31536000, immutable
 /assets/beta/*
   Cache-Control: public, max-age=31536000, immutable
+/assets/images/*
+  Cache-Control: public, max-age=31536000, immutable
+/assets/img/*
+  Cache-Control: public, max-age=31536000, immutable
+/assets/articles/*
+  Cache-Control: public, max-age=31536000, immutable
+/assets/brand/*
+  Cache-Control: public, max-age=31536000, immutable
+/assets/restaurants/*
+  Cache-Control: public, max-age=31536000, immutable
+/assets/placeholders/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Social/OG images are regenerated at a STABLE URL (assets/social/<slug>.jpg via add-social-images.py),
+# so they must NOT be `immutable` (that would serve stale share cards after a rebuild). Long cache WITH
+# revalidation keeps them fast but fresh.
+/assets/social/*
+  Cache-Control: public, max-age=604800, must-revalidate
 
 # Data files (JSON with versioning via content updates)
 /assets/data/*.json


### PR DESCRIPTION
`itw-subdir-image-cache-gap` only covered `/assets/ships/*` and `/assets/beta/*`. The larger image subdirs fell through Netlify's mid-`*` gap to the default short cache: **social (2,559 refs)**, images (1,421), articles (875 non-thumb), brand (231), img (136), restaurants (5), placeholders (4).

- Added `immutable` rules for `images`/`img`/`articles`/`brand`/`restaurants`/`placeholders` — STATIC, filename-versioned (matches the existing ships/beta decision + comment).
- **`/assets/social/*` deliberately NOT `immutable`**: `add-social-images.py` regenerates it at a *stable* URL (`social/<slug>.jpg`), so `immutable` would serve stale share cards after a rebuild. Uses a 1-week cache **with `must-revalidate`** instead.

Verified: every referenced image subdir now has a `_headers` rule (`comm` referenced-vs-covered = empty); no duplicate rules.

Worker: vivenna; needs sibling 2nd-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)