### PR TITLE
ci(tools): enforce tool-page smoke gate + fix dead precache URL (#2419, #2421)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -280,11 +280,41 @@ jobs:
       - name: Verify index is up to date
         run: node admin/validator-spec/scripts/generate-index.cjs --check
 
+  tools-smoke:
+    name: Tools Smoke (no JS errors)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      # Zero-JS-pageerror + no-[object Object] regression gate for every tool page
+      # (itw-tools-zero-pageerrors-gate #2419 / itw-tools-object-object-404 #2421).
+      # The spec already existed but was never wired to CI, so it protected nothing.
+      # --workers=1 is REQUIRED, not a perf choice: the test web server is a single-
+      # threaded `python3 -m http.server`, and each tool page registers a service
+      # worker whose warmPrecache() fires a burst of fetches. Run fully parallel (the
+      # config default), those bursts saturate the single-threaded server and the
+      # heaviest pages (drink-calculator*) lose resource races -> flaky false-red.
+      # Serial makes the gate deterministic (verified: 2x green locally).
+      - name: Run tool-page smoke gate
+        run: npx playwright test tools-smoke.spec.js --workers=1
+
   # Summary job
   summary:
     name: Quality Summary
     runs-on: ubuntu-latest
-    needs: [link-check, placeholder-check, validate-html, meta-keywords-guard, v1beta-guard, validator-spec-lint]
+    needs: [link-check, placeholder-check, validate-html, meta-keywords-guard, v1beta-guard, validator-spec-lint, tools-smoke]
     if: always()
     steps:
       - name: Summary
@@ -299,5 +329,6 @@ jobs:
           echo "| Meta Keywords Guard | ${{ needs.meta-keywords-guard.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| V1.Beta Guard | ${{ needs.v1beta-guard.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Validator Spec Lint | ${{ needs.validator-spec-lint.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tools Smoke (no JS errors) | ${{ needs.tools-smoke.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "See individual job logs for details." >> $GITHUB_STEP_SUMMARY

--- a/precache-manifest.json
+++ b/precache-manifest.json
@@ -13,7 +13,6 @@
   "pages": [
     { "url": "/", "priority": "critical" },
     { "url": "/drink-calculator.html", "priority": "critical" },
-    { "url": "/drink-calculatorv2.html", "priority": "critical" },
     { "url": "/planning.html", "priority": "high" },
     { "url": "/restaurants.html", "priority": "high" },
     { "url": "/ports.html", "priority": "high" },

--- a/tests/playwright/tools-smoke.spec.js
+++ b/tests/playwright/tools-smoke.spec.js
@@ -39,8 +39,8 @@ const TOOLS = [
   { url: "/tools/port-tracker.html",              h1: /Port Logbook/ },
   { url: "/tools/ship-tracker.html",              h1: /Ship Logbook/ },
   { url: "/tools/ship-size-atlas.html",           h1: /Ship Size Atlas/ },
-  { url: "/drink-calculator.html",                h1: /Drink Package Calculator/ },
-  { url: "/drink-calculatorv2.html",              h1: /Drink Package Calculator/ },
+  { url: "/drink-calculator.html",                h1: /Drink Package Calculator/ }, // v2 was promoted here (9a3932f42)
+  { url: "/drink-calculator-v1.html",             h1: /Drink Package Calculator/ }, // archived v1, still served
   { url: "/stateroom-check.html",                 h1: /Stateroom Sanity Check/ }
 ];
 


### PR DESCRIPTION
## What

Two related tool-page issues:

- **#2419 (zero-pageerrors gate):** `tests/playwright/tools-smoke.spec.js` asserts *no JS pageerrors* and *no `[object Object]` requests* across 8 tool pages — but it was **never run by any CI workflow**, so it protected nothing. This adds a `tools-smoke` job to `quality.yml` (installs Playwright chromium, runs the spec) and wires it into the summary. The gate is now real.
- **#2421 (`[object Object]` 404 noise):** the root cause (sw.js `warmPrecache` coercing manifest objects to `[object Object]`) was already fixed on main (`b35236293`). Wiring the gate surfaced the *remaining* precache 404 noise: a genuine **dead URL**.

## The dead URL it caught

`9a3932f42` promoted the v2 calculator to `/drink-calculator.html` and archived v1, but left `/drink-calculatorv2.html` behind in:
- `precache-manifest.json` → SW `warmPrecache()` fetched a **404 on every install**. Removed. Manifest now has **0 dead URLs** across all categories (swept pages/assets/images/data/fonts).
- the smoke spec → repointed at the archived `/drink-calculator-v1.html`, which is still served.

## Why `--workers=1` (not a perf choice)

The test web server is a single-threaded `python3 -m http.server`. Each tool page registers a service worker whose `warmPrecache()` fires a burst of fetches. Run fully parallel (the config default), those bursts saturate the single-threaded server and the heaviest pages (`drink-calculator*`) lose resource races → **flaky false-red**. A flaky gate gets ignored or disabled, so the gate is pinned serial for determinism.

## Verification

- Gate green **2× serially** (8/8), deterministic.
- **Self-attack:** pointed the gate at a deliberately-missing page → **RED** (detects broken/missing tool pages); reverted clean.
- Sophos-verify ran `npx playwright test tools-smoke.spec.js --workers=1` itself → **exit 0** (ledger #29).
- YAML parses; `npm ci --dry-run` clean; manifest valid JSON.

Soli Deo Gloria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)