### PR TITLE
fix(validator): recognize <div class=faq-item><h3> FAQ format (#2444)

### DIFF
--- a/scripts/port-weather-validator-core.js
+++ b/scripts/port-weather-validator-core.js
@@ -364,10 +364,11 @@ class PortWeatherValidator {
     if (ok) this.log('pass', 'D_MONTHS', 'All months valid');
   }
 
-  // Extract visible FAQ question text from all three formats the repo uses:
+  // Extract visible FAQ question text from all four formats the repo uses:
   //   1) <details class="faq-item"><summary>question</summary>        (acapulco style, no Q: prefix)
   //   2) <details class="faq-item"><summary>Q: question</summary>      (college-fjord style)
   //   3) <p><strong>Q: question</strong><br>A: ...</p>                 (anchorage inline style)
+  //   4) <div class="faq-item"><h3>question</h3><p>answer</p></div>    (guam/holyhead style, #2444)
   // Returns an array of question strings with leading "Q:" stripped and
   // whitespace trimmed. Used by validateFAQ so topic checks only see what a
   // visitor would actually read, not schema / narrative / notices text.
@@ -381,6 +382,14 @@ class PortWeatherValidator {
     const inlineRe = /<strong>\s*Q:\s*([\s\S]*?)\s*<\/strong>/gi;
     while ((m = inlineRe.exec(this.content)) !== null) {
       questions.push(m[1].replace(/<[^>]+>/g, '').trim());
+    }
+    // Format 4: a <div class="faq-item"> whose question is the first heading.
+    // Mutually exclusive with format 1 (<details> vs <div> tag) and format 3
+    // (heading, not <strong>Q:), so no double-count. Blind spot that produced
+    // Page:0 false FAQ_COUNT mismatches on guam/holyhead/kiel/... (#2444).
+    const divHeadingRe = /<div[^>]*class="(?:[^"]*\s)?faq-item(?:\s[^"]*)?"[^>]*>\s*<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi;
+    while ((m = divHeadingRe.exec(this.content)) !== null) {
+      questions.push(m[1].replace(/<[^>]+>/g, '').replace(/^\s*Q:\s*/i, '').trim());
     }
     return questions;
   }
@@ -399,10 +408,19 @@ class PortWeatherValidator {
     else {
       this.log('pass', 'FAQ_SCHEMA', 'FAQPage schema present');
       const sq = this.count(/"@type":\s*"Question"/);
-      // Support multiple FAQ formats: Q: prefix (inline/collapsible) and <summary> (details accordion)
+      // Support all FAQ render formats: Q: prefix (inline/collapsible), <summary>
+      // (details accordion), and <div class="faq-item"><h3> (guam/holyhead style).
+      // The div format was a blind spot that produced Page:0 false FAQ_COUNT
+      // mismatches on ~19 pages whose FAQs matched their schema. (#2444)
+      // NOTE: this stays a per-format Math.max, NOT a sum: pages that render the
+      // SAME questions in two formats (or a curated schema subset of a larger
+      // visible set, e.g. barcelona: 5 accordion + 5 inline, schema 5) must not
+      // be double-counted into a false mismatch. The deeper "visible FAQ set vs
+      // FAQPage schema drift" question is tracked separately (see #2444 follow-up).
       const qPrefixed = this.count(/<p><strong>Q:|<strong>Q:|<summary[^>]*>Q:/);
       const summaryFAQs = this.count(/<details class="faq-item"><summary>/);
-      const vq = Math.max(qPrefixed, summaryFAQs);
+      const divFAQs = this.count(/<div[^>]*class="(?:[^"]*\s)?faq-item(?:\s[^"]*)?"[^>]*>\s*<h[1-6]/);
+      const vq = Math.max(qPrefixed, summaryFAQs, divFAQs);
       if (sq !== vq) this.log('error', 'FAQ_COUNT', `FAQ count mismatch`, `Schema: ${sq}, Page: ${vq}`);
       else this.log('pass', 'FAQ_COUNT', `FAQ count: ${sq}`);
     }

--- a/tests/unit/port-weather-faq/extract.test.mjs
+++ b/tests/unit/port-weather-faq/extract.test.mjs
@@ -1,0 +1,57 @@
+// tests/unit/port-weather-faq/extract.test.mjs
+// Locks extractVisibleFAQQuestions() against silent regression of the four FAQ
+// render formats the port fleet uses. Format 4 (<div class="faq-item"><h3>) was
+// a blind spot that produced ~28 false FAQ_COUNT / FAQ_<topic> failures (#2444).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+// port-weather-validator-core.js is CommonJS; bridge it into this ESM test.
+const require = createRequire(import.meta.url);
+const { PortWeatherValidator } = require("../../../scripts/port-weather-validator-core.js");
+
+function extract(html) {
+  const v = new PortWeatherValidator("/virtual/test.html");
+  v.content = html;
+  return v.extractVisibleFAQQuestions();
+}
+
+test("format 1: <details class=faq-item><summary> plain question", () => {
+  const q = extract(`<details class="faq-item"><summary>How far is the port?</summary><p>A.</p></details>`);
+  assert.deepEqual(q, ["How far is the port?"]);
+});
+
+test("format 2: <summary> with Q: prefix is stripped", () => {
+  const q = extract(`<details class="faq-item"><summary>Q: Is it safe?</summary><p>A.</p></details>`);
+  assert.deepEqual(q, ["Is it safe?"]);
+});
+
+test("format 3: inline <p><strong>Q: ...</strong>", () => {
+  const q = extract(`<p><strong>Q: What should I pack?</strong><br>A: Layers.</p>`);
+  assert.deepEqual(q, ["What should I pack?"]);
+});
+
+test("format 4: <div class=faq-item><h3> (the #2444 fix)", () => {
+  const q = extract(`<div class="faq-item"><h3>Is Guam a US territory?</h3><p>Yes.</p></div>`);
+  assert.deepEqual(q, ["Is Guam a US territory?"]);
+});
+
+test("format 4: div faq-item with extra classes and attrs", () => {
+  const q = extract(`<div id="x" class="card faq-item open"><h2>Where do ships dock?</h2><p>Apra.</p></div>`);
+  assert.deepEqual(q, ["Where do ships dock?"]);
+});
+
+test("false-positive guard: faq-item-wrapper / myfaq-item / heading-less div are NOT FAQs", () => {
+  assert.deepEqual(extract(`<div class="faq-item-wrapper"><h3>Not a FAQ</h3></div>`), []);
+  assert.deepEqual(extract(`<div class="myfaq-item"><h3>Not a FAQ</h3></div>`), []);
+  assert.deepEqual(extract(`<div class="faq-item"><p>no heading here</p></div>`), []);
+});
+
+test("mixed formats accumulate across all four", () => {
+  const html = `
+    <details class="faq-item"><summary>One?</summary></details>
+    <p><strong>Q: Two?</strong></p>
+    <div class="faq-item"><h3>Three?</h3></div>`;
+  const q = extract(html);
+  assert.deepEqual(q.sort(), ["One?", "Three?", "Two?"]);
+});

--- a/tests/unit/port-weather-faq/package.json
+++ b/tests/unit/port-weather-faq/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}


### PR DESCRIPTION
## What #2444 actually was

The issue was filed as *"FAQ_COUNT mismatch: add Q: prefix to original non-prefixed FAQs or adjust validator."* Investigation showed the premise was too simple — the real root cause is a **fourth FAQ render format the validator was blind to**:

```html
<div class="faq-item"><h3>question</h3><p>answer</p></div>
```

The extractor + FAQ_COUNT knew three formats (`<details><summary>`, `<summary>Q:`, inline `<strong>Q:`) but not this one. Pages that render all their FAQs as `<div class="faq-item">` (guam, holyhead, kiel, honfleur, …) reported **`Page: 0`** and failed FAQ_COUNT *and* several `FAQ_<topic>` checks — even though their visible FAQs matched their schema exactly.

## Fix (reality-anchored against the full 390-page fleet)

- `extractVisibleFAQQuestions()`: add the `<div class="faq-item"><h3>` format.
- `FAQ_COUNT`: add `divFAQs` as a third **`Math.max`** term — *not a sum*. Pages that render the same questions twice, or expose a curated schema subset of a larger visible set, must not be double-counted into a false mismatch.
- **Before/after: 747 → 719 errors. 28 false failures removed** (19 `FAQ_COUNT` + 5 `FAQ_PACKING_FOR_WEATHER` + 3 `FAQ_BEST_TIME_TO_VISIT` + 1 `FAQ_HURRICANE/STORM_SEASON`). **Zero new errors across every code.**

## Careful-not-clever notes

- My **first** attempt used `vq = visibleQuestions.length` (accurate count). The before/after diff caught that it **regressed 24 pages** — barcelona-type pages that genuinely render 10 distinct visible FAQs (5 accordion + 5 inline weather) but declare 5 in schema. That's a real content/schema-design question, not this bug — so I reverted to the regression-free `Math.max` form.
- The class-token regex is **word-bounded**: matches `faq-item`, `x faq-item`, `faq-item y`, but **not** `faq-item-wrapper` / `myfaq-item`, and requires a heading child. 7 guard cases in the new unit test.
- The validator has **no CI gate and no prior tests**, so this locks the extraction logic with `tests/unit/port-weather-faq/extract.test.mjs` (7 tests, all green).

## Follow-up (separate, tracked)

~40 port pages have a genuine **FAQPage-schema vs visible-FAQ drift** (visible > schema). Whether schema should be an exact match or a curated subset is a content decision, so those pages stay correctly flagged — filed as a follow-up rather than papered over.

## Verification

- `node --test tests/unit/port-weather-faq/extract.test.mjs` → 7/7 green (run by Sophos-verify, ledger #32).
- Full-fleet before/after diff: 28 fixed, 0 regressions.

Soli Deo Gloria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)