### PR TITLE
ci: gate fleet-wide ai-summary boilerplate (ICP-018 / #2428)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -211,6 +211,15 @@ jobs:
             echo "✓ HTML structure checks passed"
           fi
 
+      # ICP-018 anti-boilerplate gate (#2428). The ai-summary PRESENCE check above
+      # does NOT catch fleet-wide boilerplate ai-summaries (generic text that could
+      # describe any ship). validate-ship-page.js enforces ICP-018 per page but never
+      # runs in CI, so a boilerplate ai-summary could regress unseen. This reuses the
+      # SSOT phrase list from admin/validator-config.json (not a copy) and fails the
+      # build if any ship page's ai-summary is boilerplate. Currently 0 violators.
+      - name: Fail on boilerplate ai-summary (ICP-018 / #2428)
+        run: node admin/check-ai-summary-boilerplate.mjs
+
   # Dead meta keywords guard (ICP-2 anti-pattern #4) — blocks regressions like #1851
   meta-keywords-guard:
     name: Meta Keywords Guard

--- a/admin/check-ai-summary-boilerplate.mjs
+++ b/admin/check-ai-summary-boilerplate.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// check-ai-summary-boilerplate.mjs — CI gate for ICP-018 (#2428).
+//
+// validate-ship-page.js enforces "ai-summary must not be boilerplate" per page,
+// but that validator never runs in CI, so a generic/templated ai-summary (text
+// that could describe any ship) could regress unseen. The Validate HTML job only
+// checks ai-summary PRESENCE, not its content. This closes that gap with a fast,
+// dependency-free fleet scan that reuses the SAME phrase list the validator uses
+// (admin/validator-config.json — SSOT, not a copy), and fails the build if any
+// ship page's ai-summary contains a boilerplate phrase.
+//
+// Scope: ships/<line>/*.html (individual ship pages — where ICP-018 applies).
+// Exit 0 = clean, exit 1 = violations found. Soli Deo Gloria.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cfgPath = path.join(repoRoot, "admin", "validator-config.json");
+const shipsDir = path.join(repoRoot, "ships");
+
+const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+const phrases = (cfg.ai_summary_boilerplate_phrases || []).map((p) => String(p).toLowerCase());
+if (phrases.length === 0) {
+  console.log("check-ai-summary-boilerplate: no phrases configured — nothing to enforce.");
+  process.exit(0);
+}
+
+// Ship pages live one level under ships/<line>/. Skip ships/assets and non-html.
+function shipPages(dir) {
+  const out = [];
+  for (const line of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!line.isDirectory() || line.name === "assets") continue;
+    const lineDir = path.join(dir, line.name);
+    for (const f of fs.readdirSync(lineDir)) {
+      if (f.endsWith(".html")) out.push(path.join(lineDir, f));
+    }
+  }
+  return out;
+}
+
+// Extract the ai-summary meta tag's content regardless of attribute order,
+// mirroring validate-ship-page.js's cheerio $('meta[name="ai-summary"]').attr('content').
+function aiSummaryOf(html) {
+  const tag = html.match(/<meta\b[^>]*\bname\s*=\s*["']ai-summary["'][^>]*>/i);
+  if (!tag) return "";
+  const c = tag[0].match(/\bcontent\s*=\s*["']([^"']*)["']/i);
+  return c ? c[1] : "";
+}
+
+const pages = shipPages(shipsDir);
+const violators = [];
+for (const file of pages) {
+  const summary = aiSummaryOf(fs.readFileSync(file, "utf8")).toLowerCase();
+  if (!summary) continue;
+  const hit = phrases.find((p) => summary.includes(p));
+  if (hit) violators.push({ file: path.relative(repoRoot, file), phrase: hit });
+}
+
+console.log(`Scanned ${pages.length} ship pages against ${phrases.length} boilerplate phrases.`);
+if (violators.length > 0) {
+  console.error(`\n❌ ${violators.length} ship page(s) have a boilerplate ai-summary (ICP-018):`);
+  for (const v of violators) console.error(`  ${v.file}\n      matched: "${v.phrase}"`);
+  console.error(`\nFix: rewrite each with 2 ship-specific facts + 1 voice-aligned editorial line (ai-summary-rewriter skill).`);
+  process.exit(1);
+}
+console.log("✓ No boilerplate ai-summaries. Soli Deo Gloria.");


### PR DESCRIPTION
## The gap

The **Validate HTML** job checks ai-summary *presence* but not *content*. `validate-ship-page.js` enforces **ICP-018** (ai-summary must not be boilerplate — generic text that could describe any ship) per page, but that validator never runs in CI, and the full aggregator is too heavy / hangs (#2426). So a boilerplate ai-summary could regress into the fleet unseen.

## The fix

`admin/check-ai-summary-boilerplate.mjs` — a fast, dependency-free scan of `ships/<line>/*.html` that:
- reuses the **SSOT** phrase list from `admin/validator-config.json` (not a copy — can't drift from the validator),
- extracts ai-summary content regardless of meta attribute order (mirrors the validator's cheerio `attr('content')`),
- exits 1 with the offending files if any ship page's ai-summary is boilerplate.

Wired as a **blocking** step in the Validate HTML job. Runs on the default runner node — no `npm ci`, no browsers.

## Verification

- **Green today:** 306 ship pages scanned, **0 violators** (the ~6 pages ICP-018's comment mentions were already remediated).
- **Self-attack:** injecting `"offers something for everyone"` (a config phrase) into one page's ai-summary → **exit 1** with the offending file; reverted, git clean. So the gate is currently green *and* genuinely detects a regression.
- Sophos-verify ran the check itself → exit 0 (ledger #36).

Soli Deo Gloria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)