### PR TITLE
feat(index): skeleton + no-JS fallback for Recent Stories rail (#2453)

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,6 +253,24 @@
   </script>
 
   <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+  <!-- Recent Stories rail loading state (#2453): skeleton while JS fetches, muted
+       fallback color lifted off the inline style, and a no-JS path (see the noscript blocks). -->
+  <style>
+    .rail-fallback { color: var(--text-muted); }
+    .rail-skeleton { list-style: none; margin: 0; padding: 0; }
+    .rail-skeleton li { display: grid; grid-template-columns: 56px 1fr; gap: 0.6rem;
+      align-items: start; padding: 0.5rem 0; border-bottom: 1px solid #eef2f5; }
+    .rail-skeleton .sk-thumb { width: 56px; height: 56px; border-radius: 8px; }
+    .rail-skeleton .sk-lines { display: grid; gap: 0.4rem; align-content: start; }
+    .rail-skeleton .sk-line { height: 0.7rem; border-radius: 4px; }
+    .rail-skeleton .sk-line.short { width: 60%; }
+    .sk-shimmer { background: linear-gradient(90deg, #eef2f5 25%, #e2e8ec 37%, #eef2f5 63%);
+      background-size: 400% 100%; animation: railShimmer 1.4s ease infinite; }
+    @keyframes railShimmer { 0% { background-position: 100% 50%; } 100% { background-position: 0 50%; } }
+    @media (prefers-reduced-motion: reduce) { .sk-shimmer { animation: none; } }
+  </style>
+  <!-- No-JS: hide the JS-only loading skeleton so it never shimmers forever. -->
+  <noscript><style>#recent-rail-fallback { display: none; }</style></noscript>
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high"/>
   <link rel="preload" as="image" href="/assets/compass_rose.svg?v=3.010.400" fetchpriority="high"/>
@@ -718,7 +736,17 @@
         <nav id="recent-rail-nav-top" class="rail-nav" aria-label="Article pagination" style="display:none; margin-bottom: 0.5rem;"></nav>
         <div id="recent-rail" class="rail-list" aria-live="polite"></div>
         <nav id="recent-rail-nav-bottom" class="rail-nav" aria-label="Article pagination" style="display:none; margin-top: 0.75rem;"></nav>
-        <p id="recent-rail-fallback" class="tiny" style="color: #666;">Loading articles…</p>
+        <div id="recent-rail-fallback" class="tiny rail-fallback" role="status" aria-label="Loading articles">
+          <ul class="rail-skeleton" aria-hidden="true">
+            <li><span class="sk-thumb sk-shimmer"></span><span class="sk-lines"><span class="sk-line sk-shimmer"></span><span class="sk-line short sk-shimmer"></span></span></li>
+            <li><span class="sk-thumb sk-shimmer"></span><span class="sk-lines"><span class="sk-line sk-shimmer"></span><span class="sk-line short sk-shimmer"></span></span></li>
+            <li><span class="sk-thumb sk-shimmer"></span><span class="sk-lines"><span class="sk-line sk-shimmer"></span><span class="sk-line short sk-shimmer"></span></span></li>
+          </ul>
+          <span>Loading articles…</span>
+        </div>
+        <noscript>
+          <p class="tiny rail-fallback"><a href="/articles.html">Browse all articles →</a></p>
+        </noscript>
       </section>
 
       <!-- Authors rail -->

--- a/tests/unit/homepage-rail/package.json
+++ b/tests/unit/homepage-rail/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/tests/unit/homepage-rail/skeleton.test.mjs
+++ b/tests/unit/homepage-rail/skeleton.test.mjs
@@ -1,0 +1,48 @@
+// tests/unit/homepage-rail/skeleton.test.mjs
+// Text-invariant lock for the Recent Stories rail loading state (#2453). This UI
+// cannot be eyeballed in CI, so these assertions pin the served index.html markup:
+// a skeleton while JS loads, the muted color lifted off the inline style, and a
+// real no-JS fallback so the placeholder never "loads forever" without scripts.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const html = readFileSync(path.join(repoRoot, "index.html"), "utf8");
+
+// Isolate the fallback element's opening tag.
+const fallbackTag = html.match(/<[a-z]+[^>]*\bid="recent-rail-fallback"[^>]*>/i);
+
+test("JS contract intact: #recent-rail-fallback element still exists", () => {
+  assert.ok(fallbackTag, "the fallback element the rail JS drives must exist");
+});
+
+test("inline color is lifted: fallback carries .rail-fallback, no inline color", () => {
+  assert.match(fallbackTag[0], /class="[^"]*\brail-fallback\b[^"]*"/, "must use the .rail-fallback class");
+  assert.doesNotMatch(fallbackTag[0], /style="[^"]*color/i, "must not set color via inline style");
+});
+
+test(".rail-fallback rule uses the theme muted-text variable, not a hardcoded hex", () => {
+  assert.match(html, /\.rail-fallback\s*\{\s*color:\s*var\(--text-muted\)/, "muted color must come from the CSS variable");
+});
+
+test("skeleton loader markup is present with a reduced-motion guard", () => {
+  assert.match(html, /class="rail-skeleton"/, "skeleton list must be present");
+  assert.match(html, /@keyframes\s+railShimmer/, "shimmer keyframes must be defined");
+  assert.match(html, /prefers-reduced-motion:\s*reduce[^}]*\{[^}]*animation:\s*none/, "must disable shimmer under reduced-motion");
+});
+
+test("no-JS: head <noscript> hides the JS-only skeleton so it never shimmers forever", () => {
+  assert.match(html, /<noscript>\s*<style>[^<]*#recent-rail-fallback\s*\{\s*display:\s*none/i);
+});
+
+test("no-JS: a real fallback links to the full articles page", () => {
+  // A <noscript> block containing a link to /articles.html.
+  const noscripts = html.match(/<noscript>[\s\S]*?<\/noscript>/gi) || [];
+  assert.ok(
+    noscripts.some((n) => /href="\/articles\.html"/.test(n)),
+    "a <noscript> fallback must link to /articles.html"
+  );
+});


### PR DESCRIPTION
## The problem

The homepage Recent Stories rail showed a plain `<p style="color:#666">Loading articles…</p>`. Two issues:
1. **Without JS it said "Loading articles…" forever** — no graceful degradation.
2. The loading color was an inline style.

## The fix (all three of #2453's asks)

- **Skeleton:** the fallback renders 3 shimmer placeholder rows while the rail JS fetches the article index, with a `prefers-reduced-motion` guard that disables the animation.
- **No-JS / SSR fallback:** a `<head>` `<noscript>` hides the JS-only skeleton (so it never shimmers forever), and a `<body>` `<noscript>` shows a real **"Browse all articles →"** link to `/articles.html`. Scripts off → a usable path, not a spinner.
- **Inline color lifted:** `color:#666` → a `.rail-fallback` class using `var(--text-muted)` (theme-consistent with the footer). Page-level `<style>` so it ships immediately without bumping the immutable `styles.css ?v=`.

## Careful-not-clever

- **JS contract preserved:** the element keeps `id="recent-rail-fallback"`; the rail JS still hides it on success (`display:none`) and swaps in its error text (`textContent`) — the container keeps the `tiny` + muted classes so the error stays styled.
- This UI **can't be eyeballed in CI** (no browser), so it's locked with `tests/unit/homepage-rail/skeleton.test.mjs` — 6 text-invariant checks, all green.
- Structural self-attack: div balance 44/44, `<noscript>` 2/2 (a stray literal tag in an HTML comment was reworded).

## Verification

- `node --test tests/unit/homepage-rail/skeleton.test.mjs` → 6/6 (run by Sophos-verify, ledger #39).

Soli Deo Gloria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)