### PR TITLE
fix(data): correct Firenze/Venezia hull dims — Vista-class, not Spirit-class (#2433)

### DIFF
--- a/ships/carnival/carnival-firenze.html
+++ b/ships/carnival/carnival-firenze.html
@@ -515,7 +515,7 @@ Dining Venues on Carnival Firenze <a href="/restaurants/" style="font-size: 1rem
     <section class="card" aria-labelledby="stats-title">
       <h2 id="stats-title">Ship Statistics</h2>
           <div id="ship-stats" class="stats-grid" data-slug="carnival-firenze"></div>
-          <script type="application/json" id="ship-stats-fallback">{"slug":"carnival-firenze","name":"Carnival Firenze","class":"Venezia Class","entered_service":2024,"gt":"135,156 GT","guests":"4,208","crew":"1,278","length":"960 ft (293 m)","beam":"106 ft (32 m)","registry":"Panama"}</script>
+          <script type="application/json" id="ship-stats-fallback">{"slug":"carnival-firenze","name":"Carnival Firenze","class":"Venezia Class","entered_service":2024,"gt":"135,156 GT","guests":"4,208","crew":"1,278","length":"1,061 ft (323 m)","beam":"122 ft (37 m)","registry":"Panama"}</script>
 
       <div class="stats-grid">
         <div class="stat-item">

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -603,7 +603,7 @@ Dining Venues on Carnival Venezia <a href="/restaurants/" style="font-size: 1rem
           <div class="card-header">
             <h2 id="stats-title">Ship Statistics</h2>
           <div id="ship-stats" class="stats-grid" data-slug="carnival-venezia"></div>
-          <script type="application/json" id="ship-stats-fallback">{"slug":"carnival-venezia","name":"Carnival Venezia","class":"Venezia Class","entered_service":2023,"gt":"135,225 GT","guests":"4,208","crew":"1,278","length":"960 ft (293 m)","beam":"106 ft (32 m)","registry":"Panama"}</script>
+          <script type="application/json" id="ship-stats-fallback">{"slug":"carnival-venezia","name":"Carnival Venezia","class":"Venezia Class","entered_service":2023,"gt":"135,225 GT","guests":"4,208","crew":"1,278","length":"1,061 ft (323 m)","beam":"122 ft (37 m)","registry":"Bahamas"}</script>
         <script type="application/json" id="dining-data-source">{"provider":"carnival","json":"/assets/data/venues-v2.json","ship_slug":"carnival-venezia","aliases":["Carnival Venezia"]}</script>
           </div>
           <div class="card-body">
@@ -625,11 +625,11 @@ Dining Venues on Carnival Venezia <a href="/restaurants/" style="font-size: 1rem
                 <span class="stat-label">Crew</span>
               </div>
               <div class="stat-item">
-                <span class="stat-value">1,060 ft</span>
+                <span class="stat-value">1,061 ft</span>
                 <span class="stat-label">Length</span>
               </div>
               <div class="stat-item">
-                <span class="stat-value">121 ft</span>
+                <span class="stat-value">122 ft</span>
                 <span class="stat-label">Beam</span>
               </div>
               <div class="stat-item">


### PR DESCRIPTION
## The bug

The `#ship-stats-fallback` SSOT on **carnival-firenze.html** and **carnival-venezia.html** carried **Spirit-class dimensions** — length `960 ft (293 m)`, beam `106 ft (32 m)` — on ships that are actually Fincantieri **Vista-class** hulls (ex-Costa Firenze / ex-Costa Venezia), ~323.6 m long / 37.2 m abeam. Venezia's SSOT also had registry `Panama` when the ship flags **Bahamas (Nassau)**. The visible fact-blocks were mostly correct already, so only the machine-readable SSOT (used by validators + AI answer engines) was wrong.

## The fix

| | length | beam | registry |
|---|---|---|---|
| Firenze SSOT | 960 ft (293 m) → **1,061 ft (323 m)** | 106 ft (32 m) → **122 ft (37 m)** | Panama (correct, kept) |
| Venezia SSOT | 960 ft (293 m) → **1,061 ft (323 m)** | 106 ft (32 m) → **122 ft (37 m)** | Panama → **Bahamas** |

Venezia's visible stats (1,060 ft / 121 ft) were nudged to 1,061 ft / 122 ft so both identical-class hulls match and are accurate.

## Sourcing (original-research discipline — two independent sources per value)

Every corrected value was verified against sources opened this session. **The issue's claimed IMO 9787475 was wrong and not used** — shipspotting / VesselFinder / Wikipedia all give **9801691** (Firenze) and **9801689** (Venezia), matching the page.

- Firenze — IMO 9801691, 135,156 GT, **323.63 m (1,061 ft 9 in)**, beam **37.2 m (122 ft 1 in)**, Vista-class, Fincantieri Marghera, Panama. [Wikipedia](https://en.wikipedia.org/wiki/Carnival_Firenze) · [CruiseMapper](https://www.cruisemapper.com/ships/Carnival-Firenze-2120) (324 m / 37 m, Panama)
- Venezia — IMO 9801689, 135,225 GT, **323.6 m (1,061 ft 8 in)**, beam **37.2 m (122 ft 1 in)**, Fincantieri Monfalcone, **Bahamas (Nassau)**. [Wikipedia](https://en.wikipedia.org/wiki/Carnival_Venezia) · [CruiseMapper](https://www.cruisemapper.com/ships/Carnival-Venezia-1651) (324 m / 37 m, Bahamas)

## Verification

- `validate-ship-page.js` blocking errors **3 → 1 on each page** (the two resolved per page were the SSOT-vs-visible dimension inconsistencies); the remaining one each is **pre-existing and unrelated** (Firenze: too few images; Venezia: a separate 4,208-vs-4,090 guest-count drift — DATA-004, its own task) — confirmed pre-existing by validating the `HEAD` version.
- Focused verifier (correct dims + registries + valid JSON + **no Spirit-class residue**) → exit 0, run by Sophos-verify (ledger #42).

**Out of scope:** the class label (`Venezia Class` vs `Vista-class`) — a defensible marketing grouping, not a hull-data error.

Soli Deo Gloria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)