### PR TITLE
fix(data): correct double-occupancy guest counts on 3 Carnival ships (fleet DATA-004 audit)

### DIFF
--- a/ships/carnival/carnival-panorama.html
+++ b/ships/carnival/carnival-panorama.html
@@ -297,10 +297,10 @@
     <!-- ICP-Lite: Page Intro -->
     <section class="page-intro" aria-label="Carnival Panorama overview">
       
-      <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Carnival Panorama is a Vista Class cruise ship operated by Carnival Cruise Line. She entered service in 2019, measures 133,868 gross tons, and carries approximately 3,954 guests at double occupancy.</p>
+      <p class="fact-block" style="font-size: 0.95rem; color: #345; line-height: 1.6; margin: 0.5rem 0;">Carnival Panorama is a Vista Class cruise ship operated by Carnival Cruise Line. She entered service in 2019, measures 133,868 gross tons, and carries approximately 4,008 guests at double occupancy.</p>
 
       <p class="answer-line" style="margin: 0.75rem 0; padding: 0.5rem 0.75rem; border-left: 3px solid var(--rope, #d9b382); background: #f7fdff; border-radius: 8px;">
-        <strong>Quick Answer:</strong> Carnival Panorama (133,868 GT | 3,954 guests | 2019) is Carnival's first new ship on the West Coast in 20 years — a Vista Class vessel sailing from Long Beach with SkyZone trampoline park and Sky Zone. This page covers deck plans, live tracking, dining venues, and videos.
+        <strong>Quick Answer:</strong> Carnival Panorama (133,868 GT | 4,008 guests | 2019) is Carnival's first new ship on the West Coast in 20 years — a Vista Class vessel sailing from Long Beach with SkyZone trampoline park and Sky Zone. This page covers deck plans, live tracking, dining venues, and videos.
       </p>
 
       <p class="fit-guidance" style="margin: 0.75rem 0; font-size: 0.95rem; color: #134; line-height: 1.6;">
@@ -541,7 +541,7 @@ The REAL Carnival Panorama, 133,868 gross-ton cruise ship, i"
     <section class="card" aria-labelledby="stats-title" id="stats-card">
       <h2 id="stats-title">Ship Statistics</h2>
           <div id="ship-stats" class="stats-grid" data-slug="carnival-panorama"></div>
-          <script type="application/json" id="ship-stats-fallback">{"slug":"carnival-panorama","name":"Carnival Panorama","class":"Vista Class","entered_service":2019,"gt":"133,868 GT","guests":"3,954","crew":"1,450","length":"1,055 ft (322 m)","beam":"122 ft (37 m)","registry":"Panama"}</script>
+          <script type="application/json" id="ship-stats-fallback">{"slug":"carnival-panorama","name":"Carnival Panorama","class":"Vista Class","entered_service":2019,"gt":"133,868 GT","guests":"4,008","crew":"1,450","length":"1,055 ft (322 m)","beam":"122 ft (37 m)","registry":"Panama"}</script>
         <script type="application/json" id="dining-data-source">{"provider":"carnival","json":"/assets/data/venues-v2.json","ship_slug":"carnival-panorama","aliases":["Carnival Panorama"]}</script>
       <div class="stats-grid">
         <div class="stat-item">

--- a/ships/carnival/carnival-sunshine.html
+++ b/ships/carnival/carnival-sunshine.html
@@ -596,7 +596,7 @@ Dining Venues on Carnival Sunshine <a href="/restaurants/" style="font-size: 1re
                 <span class="stat-label">Gross Tons</span>
               </div>
               <div class="stat-item">
-                <span class="stat-value">2,984</span>
+                <span class="stat-value">2,974</span>
                 <span class="stat-label">Guests (Double)</span>
               </div>
               <div class="stat-item">

--- a/ships/carnival/carnival-venezia.html
+++ b/ships/carnival/carnival-venezia.html
@@ -226,7 +226,7 @@
         "name": "How big is Carnival Venezia?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Carnival Venezia is 135,225 gross tons, 323 meters (1,060 feet) long, and carries 4,090 guests at double occupancy (up to 5,145 maximum). She features 2,116 staterooms and has 1,424 crew members."
+          "text": "Carnival Venezia is 135,225 gross tons, 323 meters (1,060 feet) long, and carries 4,208 guests at double occupancy (up to 5,145 maximum). She features 2,116 staterooms and has 1,424 crew members."
         }
       }
     ]
@@ -613,7 +613,7 @@ Dining Venues on Carnival Venezia <a href="/restaurants/" style="font-size: 1rem
                 <span class="stat-label">Gross Tons</span>
               </div>
               <div class="stat-item">
-                <span class="stat-value">4,090</span>
+                <span class="stat-value">4,208</span>
                 <span class="stat-label">Guests (Double)</span>
               </div>
               <div class="stat-item">
@@ -799,7 +799,7 @@ Dining Venues on Carnival Venezia <a href="/restaurants/" style="font-size: 1rem
 
             <details class="faq-item">
               <summary>How big is Carnival Venezia?</summary>
-              <p>Carnival Venezia is 135,225 gross tons, 323 meters (1,060 feet) long, and carries 4,090 guests at double occupancy (up to 5,145 maximum). She features 2,116 staterooms across 18 guest decks and has a crew of 1,424.</p>
+              <p>Carnival Venezia is 135,225 gross tons, 323 meters (1,060 feet) long, and carries 4,208 guests at double occupancy (up to 5,145 maximum). She features 2,116 staterooms across 18 guest decks and has a crew of 1,424.</p>
             </details>
           </div>
         </section>


### PR DESCRIPTION
## Fleet audit

Ran `validate-ship-page.js --all-ships` (306 ships) and triaged the `data_consistency` (DATA-004) findings. Only **4 ships** contradicted themselves on guest count; **3 were genuine errors**, one was a validator false-positive.

| Ship | Fix | Why |
|---|---|---|
| carnival-venezia | 4,090 → **4,208** ×3 | contradicted the page's own SSOT + fact-block (already 4,208) |
| carnival-panorama | 3,954 → **4,008** ×3 | prose already labeled "4,008 (double occupancy)" |
| carnival-sunshine | 2,984 → **2,974** ×1 | lone visible stat vs SSOT + Carnival official |

**Sources — two per value, canonical = double-occupancy (Policy 0.2):**
- Venezia **4,208** — [Wikipedia](https://en.wikipedia.org/wiki/Carnival_Venezia) + CruiseMapper (+ page SSOT)
- Panorama **4,008** — [Wikipedia](https://en.wikipedia.org/wiki/Carnival_Panorama) (4,008 double / 5,146 max) + US News/Costco
- Sunshine **2,974** — page SSOT + Carnival official. ⚠️ Wikipedia gives **3,002** (post-2013-refit) — a genuine source discrepancy; I reconciled the page's internal 2,984-vs-2,974 conflict to the SSOT/Carnival value and **flag** the 3,002 rather than pick a side (fail-closed).

## Withheld (careful-not-clever)

**oceania/vista.html** — DATA-004 flags "1,200 vs 1,250", but that's a legitimate **comparison** ("1,200 guests **vs** 1,250 on Marina/Riviera"), not a contradictory count for Vista (verified 1,200: Oceania + NCLH + US News). Editing it would have **corrupted correct content**. Left as-is; the validator's comparison-context false-positive is a separate follow-up.

## Scope caveat (Sophos honesty)

DATA-004 only catches pages that contradict *themselves*. A ship whose SSOT and prose are **both** wrong (internally consistent, factually false) passes silently — a full factual re-verification of all 306 ships is a separate, much larger effort.

## Verification
- DATA-004 errors **1 → 0** on all 3 fixed pages; SSOTs valid JSON; stale values fully gone.
- Count-asserting fix script (aborts if occurrence count ≠ expected 3/3/1).
- Sophos-verify ran the focused verifier → exit 0 (ledger #46).

Soli Deo Gloria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)