### PR TITLE
reasoning log: install four-layer runtime-independent kit

### DIFF
--- a/.claude/hooks/reasoning-log-inject.sh
+++ b/.claude/hooks/reasoning-log-inject.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Soli Deo Gloria.
+# reasoning-log-inject — the reasoning-log obligation loads itself, every
+# session AND every prompt, regardless of which model or runtime is driving.
+#
+# Operator directive (Ken, 2026-07-30, strengthened same day): the reasoning
+# log must fire EVERY time, be MODEL-INDEPENDENT, and capture reasoning from
+# ANY agent — Claude, Grok, Codex, Hermes, the household pipeline.
+#
+# Why a hook and not a skill: a skill loads only when something invokes it, and
+# `/model` re-rolls the runtime mid-session. The harness runs this hook itself.
+#
+# TWO MODES (argv[1], default "session"):
+#   session — SessionStart: full obligation + log status. Once per session.
+#   prompt  — UserPromptSubmit: ONE terse line. Fires on EVERY request so the
+#             obligation cannot drift out of attention in a long session, but
+#             stays cheap enough to repeat every turn.
+#
+# HONEST LIMIT — read before trusting it: this hook GUARANTEES the obligation
+# is present in context. It CANNOT guarantee an entry is written; only the
+# agent can do that. The mechanical halves are injection (here), persistence
+# (reasoning-log-persist.sh), the commit-time guard (.githooks/
+# reasoning-log-guard.sh — which DOES block, and covers every runtime that
+# commits), and pipeline capture (atlas/server/reasoning-log-capture.mjs —
+# which needs no compliance at all). Do not mistake a hook for proof the log
+# is current: read the log.
+#
+# Fail-open: always exits 0. Kill-switch: REASONING_LOG_INJECT=0
+set +e
+
+[ "${REASONING_LOG_INJECT:-1}" = "0" ] && exit 0
+
+MODE="${1:-session}"
+PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+LOG="$PROJ/REASONING-LOG.md"
+TODAY="$(date -u +%Y-%m-%d)"
+
+# Dated entries only — the file's own prose sections are also '## ' headers.
+entry_count() { grep -cE '^## [0-9]{4}-[0-9]{2}-[0-9]{2}' "$LOG" 2>/dev/null || echo 0; }
+has_today()   { grep -qE "^## ${TODAY}" "$LOG" 2>/dev/null; }
+
+if [ "$MODE" = "prompt" ]; then
+    # Per-request: one line, and it names the current state so an unwritten log
+    # is visible on every single turn rather than once at session start.
+    if [ ! -f "$LOG" ]; then
+        echo "[reasoning log] REASONING-LOG.md does not exist yet — create it for this request (Asked/Weighed/Decided/Unsure). Standing operator directive; applies to every runtime."
+    elif has_today; then
+        echo "[reasoning log] REASONING-LOG.md has an entry for ${TODAY}. Append another for this request if it carries real reasoning (Asked/Weighed/Decided/Unsure)."
+    else
+        echo "[reasoning log] REASONING-LOG.md has NO entry for ${TODAY} ($(entry_count) total). Write one for this request before you finish (Asked/Weighed/Decided/Unsure)."
+    fi
+    exit 0
+fi
+
+echo "── reasoning log: session-start obligation injection (automated) ──"
+
+if [ -f "$LOG" ]; then
+    LAST=$(grep -m1 -E '^## [0-9]{4}-[0-9]{2}-[0-9]{2}' "$LOG" 2>/dev/null | sed 's/^## //')
+    echo "Log: REASONING-LOG.md ($(entry_count) entr(ies); most recent: ${LAST:-none})"
+    has_today || echo "NOTE: no entry yet for ${TODAY}."
+else
+    echo "Log: REASONING-LOG.md does NOT yet exist in this repo — create it on the"
+    echo "first substantive request, using the format below."
+fi
+
+cat <<'DIRECTIVE'
+
+STANDING OBLIGATION — every runtime (Claude, Grok, Codex, Hermes, the Sophos/
+HELM pipeline), every session, no invocation needed:
+
+  For each substantive request, append an entry to REASONING-LOG.md in this
+  repo explaining HOW you reached your conclusion and WHY you made the calls
+  you made. Newest entry at the TOP, under the header.
+
+  Format (four parts, kept so the log stays skimmable):
+    ## YYYY-MM-DD — <short title>
+    **Asked.**    What was requested, and how you read it.
+    **Weighed.**  Options and considerations; what you ruled in/out and why.
+    **Decided.**  The call you made, and the reasoning behind it.
+    **Unsure.**   Anything uncertain, guessed at, or worth revisiting.
+
+  Optionally close with `_Runtime: <name>_` so a reader can tell which agent
+  wrote the entry. The pipeline stamps this automatically.
+
+  Substantive = anything with real reasoning behind it. Trivial one-liners are
+  skipped deliberately, to keep the log signal rather than noise.
+
+  This is a faithful RECONSTRUCTION of reasoning, not a raw token stream, and
+  it must be honest: if you guessed, write that you guessed; if you were
+  uncertain, leave the uncertainty on the page. A polished log that hides the
+  doubt is the clever shortcut this household forbids. Integrity is doxology.
+
+  ENFORCED, not merely requested: .githooks/reasoning-log-guard.sh BLOCKS a
+  substantive commit when the log has no entry for today — from ANY runtime,
+  including ones that never read this text. Entries are committed+pushed at
+  session stop by .claude/hooks/reasoning-log-persist.sh.
+DIRECTIVE
+
+echo "── (Soli Deo Gloria) ──"
+exit 0

--- a/.claude/hooks/reasoning-log-persist.sh
+++ b/.claude/hooks/reasoning-log-persist.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Soli Deo Gloria.
+# reasoning-log-persist — Stop hook: a reasoning entry must never die with an
+# ephemeral container. If REASONING-LOG.md has uncommitted changes at session
+# stop, commit it (ONLY that path — nothing else is swept up) and push.
+#
+# Deliberately mirrors memory-autopersist.sh: same fail-open contract, same
+# narrow add-only-what-was-detected discipline. The reasoning log is the
+# human-readable half of continuity, as cognitive memory is the machine half;
+# both must survive the container, and neither may sweep up unrelated work.
+#
+# The commit message carries [no-reasoning] on purpose: this commit contains
+# ONLY the log, so requiring the log-guard to pass on it would be circular
+# (the guard already exempts log-only commits; the tag is belt and suspenders
+# for repos where the guard is installed but the exemption list drifts).
+#
+# Fail-open contract: ALWAYS exits 0 — a broken push must never block session
+# teardown. Failures are loud: logged to /tmp/reasoning-log-persist.err and
+# echoed so the transcript shows them.
+#
+# Kill-switch: REASONING_LOG_PERSIST=0
+set +e
+
+[ "${REASONING_LOG_PERSIST:-1}" = "0" ] && exit 0
+
+PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJ" || exit 0
+[ -f "REASONING-LOG.md" ] || exit 0
+
+# Only the reasoning log — never sweep unrelated working-tree changes.
+CHANGES=$(git status --porcelain -- REASONING-LOG.md 2>/dev/null)
+[ -z "$CHANGES" ] && exit 0
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+git add -- REASONING-LOG.md 2>>/tmp/reasoning-log-persist.err
+git commit -m "docs(reasoning): persist reasoning-log entr(ies) at session stop [no-reasoning]
+
+Automated by .claude/hooks/reasoning-log-persist.sh — the reasoning log is
+git-persisted; an entry left uncommitted dies with an ephemeral container.
+Only REASONING-LOG.md is included.
+
+Soli Deo Gloria." >>/tmp/reasoning-log-persist.err 2>&1
+
+if git push origin "$BRANCH" >>/tmp/reasoning-log-persist.err 2>&1; then
+    echo "[reasoning-log-persist] committed+pushed REASONING-LOG.md on ${BRANCH}"
+else
+    echo "[reasoning-log-persist] WARNING: committed REASONING-LOG.md on ${BRANCH} but PUSH FAILED — see /tmp/reasoning-log-persist.err; the entry is safe in the local commit only"
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,15 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/reasoning-log-inject.sh session",
+            "timeout": 30
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -48,6 +57,15 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-guardrail.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/reasoning-log-inject.sh prompt",
+            "timeout": 15
           }
         ]
       }
@@ -144,6 +162,15 @@
           {
             "type": "command",
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/memory-autopersist.sh",
+            "timeout": 60
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/reasoning-log-persist.sh",
             "timeout": 60
           }
         ]

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -174,4 +174,11 @@ if [ "${#PRODUCTION_FILES[@]}" -gt 0 ]; then
     fi
 fi
 
+
+# Reasoning log — the RUNTIME-INDEPENDENT half. Injection hooks only reach agents
+# whose harness runs Claude Code hooks; every runtime commits. Blocks a substantive
+# commit with no reasoning entry dated today. Opt out per-commit with [no-reasoning].
+if [ -x "$REPO_ROOT/.githooks/reasoning-log-guard.sh" ]; then
+  "$REPO_ROOT/.githooks/reasoning-log-guard.sh" || exit 1
+fi
 exit 0

--- a/.githooks/reasoning-log-guard.sh
+++ b/.githooks/reasoning-log-guard.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# ============================================================================
+# reasoning-log-guard.sh — the RUNTIME-INDEPENDENT half of the reasoning log.
+#
+# Injection hooks (.claude/hooks/reasoning-log-inject.sh) only reach agents
+# whose harness runs Claude Code hooks. Grok, Codex, Hermes, a shell script, a
+# human — none of them see that text. But every one of them lands work the same
+# way: `git commit`. So the obligation is enforced HERE, where all runtimes
+# converge.
+#
+# RULE: a substantive commit requires a REASONING-LOG.md entry dated today.
+#
+# Substantive = the commit stages something that is not itself bookkeeping.
+# Exempt (never require an entry):
+#   • commits that touch ONLY REASONING-LOG.md      (the log's own persistence)
+#   • commits that touch ONLY .memory/ or .household-library/  (machine state)
+#   • merge commits                                  (no new reasoning authored)
+#   • commit message contains [no-reasoning]         (explicit, reviewable opt-out)
+#   • REASONING_LOG_GUARD=0                          (operator debugging)
+#
+# Satisfied by EITHER: REASONING-LOG.md staged in this commit, OR an entry
+# already dated today (one session's entry covers its several commits).
+#
+# Exit 0 = allowed. Exit 1 = blocked with instructions.
+# Soli Deo Gloria
+# ============================================================================
+set -u
+
+[ "${REASONING_LOG_GUARD:-1}" = "0" ] && exit 0
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+LOG="$REPO_ROOT/REASONING-LOG.md"
+TODAY="$(date -u +%Y-%m-%d)"
+
+# A merge in progress authors no new reasoning of its own.
+[ -f "$REPO_ROOT/.git/MERGE_HEAD" ] && exit 0
+
+# Explicit opt-out recorded in the commit message itself (reviewable in history).
+for mf in "$REPO_ROOT/.git/COMMIT_EDITMSG" "$REPO_ROOT/.git/MERGE_MSG"; do
+  [ -f "$mf" ] && grep -qiF '[no-reasoning]' "$mf" && exit 0
+done
+
+STAGED="$(git diff --cached --name-only 2>/dev/null)"
+[ -z "$STAGED" ] && exit 0
+
+# Is anything staged that is NOT pure bookkeeping?
+SUBSTANTIVE=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    REASONING-LOG.md|.memory/*|.household-library/*) continue ;;
+    *) SUBSTANTIVE=1; break ;;
+  esac
+done <<< "$STAGED"
+
+[ "$SUBSTANTIVE" -eq 0 ] && exit 0
+
+# Satisfied if the log is part of this commit.
+echo "$STAGED" | grep -qxF 'REASONING-LOG.md' && exit 0
+
+# Or if today's entry already exists (one entry covers a session's commits).
+if [ -f "$LOG" ] && grep -qE "^## ${TODAY}" "$LOG" 2>/dev/null; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+ERROR [reasoning-log]: this commit changes work but REASONING-LOG.md has no
+entry dated ${TODAY}.
+
+  Operator directive (2026-07-30): every runtime — Claude, Grok, Codex, Hermes,
+  the household pipeline — records HOW it reached its conclusions and WHY it
+  made the calls it made. The log is kept for the operator's own reading.
+
+  Append to ${LOG#$REPO_ROOT/}, newest at the top:
+
+    ## ${TODAY} — <short title>
+    **Asked.**    What was requested, and how you read it.
+    **Weighed.**  Options considered; what you ruled in/out and why.
+    **Decided.**  The call you made, and the reasoning behind it.
+    **Unsure.**   Anything uncertain, guessed at, or worth revisiting.
+
+  Be honest: if you guessed, say so. Uncertainty stays on the page.
+
+  Genuinely trivial change? Add [no-reasoning] to the commit message — an
+  explicit, reviewable record of that judgment. Operator debugging override:
+  REASONING_LOG_GUARD=0.
+EOF
+exit 1

--- a/AGENT.md
+++ b/AGENT.md
@@ -42,3 +42,16 @@ Doctrine: `/Users/kenbaker/atlas-serve/skills/destructive-command-safety/SKILL.m
 6. `/Users/kenbaker/atlas-serve/skills/household-library/SKILL.md`
 
 **Do not skip 5–6 without 1–4.** **Runtime:** [`CLAUDE.md`](./CLAUDE.md)
+
+## Reasoning log — required for this runtime too
+
+This repo keeps `REASONING-LOG.md`: for each substantive request, append an
+entry — newest at top — in four parts: **Asked / Weighed / Decided / Unsure**.
+Explain HOW you reached the conclusion and WHY you made the calls you made, and
+leave your uncertainty on the page rather than polishing it away.
+
+This applies to every runtime, not only Claude Code: a pre-commit guard
+(`.githooks/reasoning-log-guard.sh`) BLOCKS a substantive commit when the log
+has no entry dated today. Close your entry with `_Runtime: <name>_`.
+
+**Soli Deo Gloria.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,38 @@ Enforcement:
   bypass; kill-switches are for operator debugging only.
 
 **Soli Deo Gloria.**
+
+## 📓 Reasoning log — required, runtime-independent (operator directive 2026-07-30)
+
+**Every agent that works in this repo — Claude, Grok, Codex, Hermes, the
+Sophos/HELM pipeline — records the reasoning behind its calls.** Ken reads this
+to see *how* a conclusion was reached and *why* the calls were made, not just
+what changed.
+
+For each substantive request, append an entry to **`REASONING-LOG.md`** at the
+repo root, newest at the top, in four parts: **Asked / Weighed / Decided /
+Unsure**. Trivial one-liners are skipped deliberately, to keep the log signal
+rather than noise. Be honest — if you guessed, say you guessed; uncertainty
+stays on the page.
+
+Four layers, because no single one reaches every runtime:
+
+| Layer | Mechanism | Covers |
+|---|---|---|
+| Inject | `.claude/hooks/reasoning-log-inject.sh` — SessionStart **and UserPromptSubmit** | Claude Code, any model, every turn |
+| Persist | `.claude/hooks/reasoning-log-persist.sh` — Stop; commits+pushes the log only | anything the harness runs |
+| **Guard** | `.githooks/reasoning-log-guard.sh` — pre-commit **BLOCK** | **every runtime that commits** — Grok, Codex, scripts, humans |
+| Capture | `atlas/server/reasoning-log-capture.mjs` | the pipeline itself — mechanical, needs no compliance |
+
+Kill-switches (operator debugging only): `REASONING_LOG_INJECT=0`,
+`REASONING_LOG_PERSIST=0`, `REASONING_LOG_GUARD=0`, `REASONING_LOG_CAPTURE=off`.
+Per-commit opt-out for a genuinely trivial change: put `[no-reasoning]` in the
+commit message — an explicit, reviewable record of that judgment.
+
+**Honest limit.** Injection guarantees the obligation is *present*; persistence
+guarantees what was written *survives*; the guard makes omission *block a
+commit*; capture is the only layer that is *self-executing*. None of them can
+make a model write a truthful entry. Read the log; do not trust the machinery
+as proof it is current.
+
+**Soli Deo Gloria.**

--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -1,0 +1,55 @@
+<!-- Soli Deo Gloria. A reasoning log kept for Ken — how we got there, and why. -->
+
+# Reasoning Log
+
+**For Ken. A running record of *how* and *why* — not just *what*.**
+
+Every agent that works in this repo — Claude, Grok, Codex, Hermes, the Sophos/HELM
+pipeline — records the reasoning behind its calls here. Newest entries at the top.
+
+## What this is (and an honest note on what it isn't)
+
+No agent can pipe its raw internal tokens into a file; dressing a polished summary up as
+"the raw stream" would be a clever fake rather than honest work. So this is the honest
+version: a genuine reconstruction — what was understood, the options weighed, what was
+ruled in or out and why, where the uncertainty was, and how it landed. When something was
+guessed, the entry says it was guessed.
+
+Pipeline entries are different in kind: they are generated mechanically from the run
+record (plan, retrieval, governance findings, publish decision), so they need no
+compliance from anyone — if the run happened, the entry is true.
+
+## How to read an entry
+
+- **Asked** — what was requested, and how it was read.
+- **Weighed** — the options and considerations in play.
+- **Decided** — the call made, and the *why* behind it.
+- **Unsure** — anything uncertain, or worth revisiting.
+
+---
+
+## 2026-07-30 — Reasoning log installed here (four layers, every runtime)
+
+**Asked.** Ken asked for the reasoning log to be stronger and to cover all 16 household
+repositories, capturing reasoning from any agent — Claude, Grok, Codex, the pipeline.
+
+**Weighed.** The earlier version reached only Claude Code (SessionStart + Stop hooks), and
+injected once per session, so it could drift. The gap that mattered: every other runtime —
+Grok, Codex, a script, a person — was uncovered. What they all share is `git commit`, so
+enforcement belongs there.
+
+**Decided.** Installed from the household canonical kit (`open-claw-stuff`,
+`admin/install-reasoning-log.mjs`): per-turn injection (`UserPromptSubmit`, not just
+session start), Stop-time persistence of this file, and a pre-commit guard that BLOCKS a
+substantive commit with no entry dated today. The installer also ran
+`git config core.hooksPath .githooks` — without it every `.githooks` guard here was
+silently inert. `[no-reasoning]` in a commit message opts a trivial change out, reviewably.
+
+**Unsure.** The hooks guarantee the obligation is present and that what was written
+survives; the guard makes omission block a commit. None of them can make an agent write a
+*truthful* entry — read the log rather than trusting the machinery. Pipeline auto-capture
+exists only in `open-claw-stuff`, where Atlas lives; this repo has the other three layers.
+
+_Runtime: claude-opus-5 (Claude Code)_
+
+


### PR DESCRIPTION
Propagated from the household canonical kit (open-claw-stuff admin/install-reasoning-log.mjs) per operator directive 2026-07-30: reasoning from ANY agent — Claude, Grok, Codex, Hermes, the pipeline — must reach these logs.

  inject  — SessionStart AND UserPromptSubmit, so the obligation survives a
            /model swap and cannot drift over a long session
  persist — Stop hook commits+pushes REASONING-LOG.md only
  guard   — .githooks/reasoning-log-guard.sh BLOCKS a substantive commit with
            no entry dated today; the layer that reaches every runtime that
            commits, not just Claude Code. [no-reasoning] opts out.

Also sets core.hooksPath=.githooks, without which every .githooks guard in this repo is silently inert.


Claude-Session: https://claude.ai/code/session_01BPGiQ2FTo3gg4TyjLtQLX4