### PR TITLE
Fix the bypassable reasoning-log guard (UL-210)

### DIFF
--- a/.claude/hooks/reasoning-reveal.mjs
+++ b/.claude/hooks/reasoning-reveal.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// reasoning-reveal.mjs — make the WHY of a consequential action visible while
+// it happens, and auditable afterwards.
+//
+// WHY THIS EXISTS. The household already proves a great deal about actions:
+// the Sophos publish gate proves tests were run, the bootstrap guard proves the
+// posture was read, the dangerous-command guard proves the shape was safe. All
+// of them govern WHAT is done. None of them records WHY, so the reasoning
+// behind an action survives only in a transcript nobody re-reads — and a
+// transcript is testimony, not evidence.
+//
+// This session produced the concrete case. A guard was reported as broken on a
+// probe that called a method which did not exist; the probe returned null and
+// null was read as "not tripped". The action (file a P1) looked identical from
+// the outside to a well-grounded one. What distinguished them was the reasoning,
+// and the reasoning was the one thing nothing captured.
+//
+// WHAT IT DOES, AND WHAT IT CANNOT DO. A hook sees the tool call, never the
+// model's internal reasoning — so this cannot "extract" a thought. What it can
+// do is hold every consequential action to a stated, checkable rationale and
+// make a missing one LOUD instead of invisible:
+//
+//   - REVEAL   : print a one-line trace to stderr as the action happens, so the
+//                operator sees the intent at the moment it matters.
+//   - RECORD   : append it to a per-session JSONL trail that can be audited
+//                beside the Sophos ledger.
+//   - FLAG     : mark actions whose rationale is absent or vacuous, reusing the
+//                citation rule already calibrated against 851 real ledger
+//                artifacts in admin/verify-substance.mjs — a rationale must
+//                point at something a reader could check and find false.
+//
+// It is OBSERVE-ONLY. It never denies. A reasoning recorder that can block
+// becomes a second gate with none of a gate's review, and an agent blocked by
+// its own narration would learn to narrate for the blocker rather than for the
+// reader. Denial belongs to the guards that were designed for it.
+//
+// Fail-open, loudly (household precedent: bootstrap-guard, dangerous-command-guard):
+// a bug in an observer must never brick a session.
+//
+// Soli Deo Gloria.
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const TRAIL_DIR = process.env.REASONING_TRAIL_DIR
+  || path.join(os.homedir(), ".claude", "reasoning-trail");
+
+// Consequential = it changes something outside the session. Reads are not
+// traced: tracing everything is the same as tracing nothing, and the noise is
+// what makes an operator stop reading.
+const MUTATING_TOOLS = new Set(["Edit", "Write", "NotebookEdit"]);
+const MUTATING_BASH = new RegExp(
+  [
+    String.raw`\bgit\b[^|&;]*?\b(commit|push|merge|rebase|reset|revert)\b`,
+    String.raw`(^|[;&|]\s*)(rm|mv|cp)\s`,
+    String.raw`\bsed\s+-i\b`,
+    String.raw`\b(gh)\s+(pr|issue|release)\s+(create|merge|close|edit|comment)\b`,
+    String.raw`library\.mjs['"]?\s+(register|checkout|release|complete|verify|reassign)\b`,
+    String.raw`>\s*[^|&;\s]`, // redirection into a file
+  ].join("|"),
+);
+
+/**
+ * Does this rationale point at anything a reader could check and find false?
+ *
+ * Deliberately the SAME rule as admin/verify-substance.mjs rather than a second
+ * opinion about what counts as evidence — one household definition, calibrated
+ * once. Ordinals are stripped first so "2nd pass" cannot pose as a citation.
+ */
+const POSITIONAL = [/\b\d+\s*(?:st|nd|rd|th)\b/gi, /\b(?:round|pass|attempt|step)\s*#?\s*\d+\b/gi];
+const CITATION = /\d|[\w-]+\/[\w./-]+|\b[\w-]+\.[\w-]{2,}\b|\b[a-z]+[A-Z][a-zA-Z]*\b|\b[a-z]+_[a-z_]+\b/;
+
+export function citesSomething(text) {
+  let s = String(text ?? "");
+  for (const re of POSITIONAL) s = s.replace(re, " ");
+  return CITATION.test(s);
+}
+
+/** The rationale a runtime may attach to a call. Absent is the common case. */
+export function statedReason(input) {
+  const ti = input?.tool_input ?? input?.toolInput ?? {};
+  for (const k of ["reasoning", "reason", "why", "rationale", "description", "intent"]) {
+    const v = ti[k] ?? input?.[k];
+    if (typeof v === "string" && v.trim()) return { text: v.trim(), field: k };
+  }
+  return null;
+}
+
+export function isConsequential(toolName, command) {
+  if (MUTATING_TOOLS.has(toolName)) return true;
+  if (toolName === "Bash") return MUTATING_BASH.test(String(command || ""));
+  return false;
+}
+
+/** One line an operator can actually read at a glance. */
+export function revealLine({ tool, target, reason, grade }) {
+  const mark = grade === "cited" ? "▸" : grade === "thin" ? "▪" : "▫";
+  const what = target ? `${tool}: ${String(target).slice(0, 68)}` : tool;
+  const why = reason ? String(reason).replace(/\s+/g, " ").slice(0, 120) : "(no stated reason)";
+  return `${mark} why ${what}\n    ${why}`;
+}
+
+export function gradeReason(reason) {
+  if (!reason) return "unstated";
+  return citesSomething(reason.text) ? "cited" : "thin";
+}
+
+function main() {
+  const raw = JSON.parse(fs.readFileSync(0, "utf8"));
+  const tool = String(raw.tool_name ?? raw.toolName ?? "");
+  const ti = raw.tool_input ?? raw.toolInput ?? {};
+  const command = ti.command ?? ti.cmd ?? "";
+  const target = ti.file_path ?? ti.notebook_path ?? ti.path ?? command ?? "";
+
+  if (!isConsequential(tool, command)) return 0;
+
+  const reason = statedReason(raw);
+  const grade = gradeReason(reason);
+
+  // REVEAL — stderr so it rides alongside the action, not buried in a file.
+  process.stderr.write(revealLine({ tool, target, reason: reason?.text, grade }) + "\n");
+
+  // RECORD — one JSONL line per consequential action, per session.
+  const session = String(raw.session_id ?? raw.sessionId ?? "unknown").replace(/[^\w-]/g, "");
+  fs.mkdirSync(TRAIL_DIR, { recursive: true });
+  fs.appendFileSync(
+    path.join(TRAIL_DIR, `${session}.jsonl`),
+    JSON.stringify({
+      at: new Date().toISOString(),
+      session_id: session,
+      tool,
+      target: String(target).slice(0, 300),
+      reason: reason ? reason.text.slice(0, 1000) : null,
+      reason_field: reason?.field ?? null,
+      grade, // cited | thin | unstated
+      cwd: raw.cwd ?? null,
+    }) + "\n",
+  );
+  return 0;
+}
+
+/**
+ * Only read stdin when actually RUN as the hook. Without this the module blocks
+ * on fs.readFileSync(0) the moment anything imports it — which is exactly what
+ * happened the first time its own test file imported it.
+ *
+ * Compare canonical paths, not URL spellings: macOS aliases /tmp to /private/tmp
+ * and hooks are commonly invoked through symlinked or aliased paths, where a
+ * string compare silently reports "not main" and the hook does nothing at all.
+ * (Same failure already cost this household a monitor that exited 0 printing
+ * nothing — a hook that never runs looks identical to a quiet one.)
+ */
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  try {
+    process.exit(main());
+  } catch (e) {
+    // Loud, but never blocking — see header.
+    process.stderr.write(`reasoning-reveal: internal error, continuing (observe-only): ${e?.message || e}\n`);
+    process.exit(0);
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -131,6 +131,16 @@
             "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/bootstrap-guard.mjs"
           }
         ]
+      },
+      {
+        "matcher": "Bash|Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/reasoning-reveal.mjs",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Soli Deo Gloria.
+# commit-msg — the reasoning-log guard runs HERE, not in pre-commit (UL-210).
+#
+# git passes the path to the real commit message as $1. That is the only hook
+# where a message-dependent policy can be enforced honestly. Read from
+# pre-commit instead, `.git/COMMIT_EDITMSG` is STALE — for `git commit -m` git
+# writes it only after pre-commit succeeds — which made the documented
+# `[no-reasoning]` opt-out fail on the commit carrying it and, worse, silently
+# exempt the NEXT substantive commit. Measured live in both directions
+# 2026-08-10; see UL-210.
+#
+# Enable: git config core.hooksPath .githooks
+set -u
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+if [ -x "$REPO_ROOT/.githooks/reasoning-log-guard.sh" ]; then
+  "$REPO_ROOT/.githooks/reasoning-log-guard.sh" "$1" || exit 1
+fi
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -175,10 +175,6 @@ if [ "${#PRODUCTION_FILES[@]}" -gt 0 ]; then
 fi
 
 
-# Reasoning log — the RUNTIME-INDEPENDENT half. Injection hooks only reach agents
-# whose harness runs Claude Code hooks; every runtime commits. Blocks a substantive
-# commit with no reasoning entry dated today. Opt out per-commit with [no-reasoning].
-if [ -x "$REPO_ROOT/.githooks/reasoning-log-guard.sh" ]; then
-  "$REPO_ROOT/.githooks/reasoning-log-guard.sh" || exit 1
-fi
+# Reasoning log — MOVED to .githooks/commit-msg (UL-210): a message-dependent
+# policy cannot be enforced before git has written the message. Do not re-add.
 exit 0

--- a/.githooks/reasoning-log-guard.sh
+++ b/.githooks/reasoning-log-guard.sh
@@ -35,10 +35,23 @@ TODAY="$(date -u +%Y-%m-%d)"
 # A merge in progress authors no new reasoning of its own.
 [ -f "$REPO_ROOT/.git/MERGE_HEAD" ] && exit 0
 
-# Explicit opt-out recorded in the commit message itself (reviewable in history).
-for mf in "$REPO_ROOT/.git/COMMIT_EDITMSG" "$REPO_ROOT/.git/MERGE_MSG"; do
-  [ -f "$mf" ] && grep -qiF '[no-reasoning]' "$mf" && exit 0
-done
+# UL-210 — the opt-out MUST come from the message git hands us, never from
+# .git/COMMIT_EDITMSG. Read as a pre-commit hook, that file is STALE: for
+# `git commit -m` git writes it only AFTER pre-commit succeeds, so it still
+# holds the PREVIOUS commit's message. Measured live 2026-08-10, both directions:
+#   · a commit carrying [no-reasoning] was BLOCKED (exit 1) — the documented
+#     escape hatch did not work at all for the commonest commit form;
+#   · and worse, once a commit whose message contained the marker had landed,
+#     the NEXT substantive commit — carrying no marker and asking for nothing —
+#     was silently ALLOWED (exit 0). A false PASS on the enforcement layer that
+#     is supposed to be the runtime-independent one.
+# So this guard now runs from `commit-msg`, the only hook git gives the real
+# message, passed as $1. Invoked without $1 the opt-out is simply unavailable
+# and the guard blocks — failing toward enforcement, never past it.
+MSG_FILE="${1:-}"
+if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
+  grep -qiF '[no-reasoning]' "$MSG_FILE" && exit 0
+fi
 
 STAGED="$(git diff --cached --name-only 2>/dev/null)"
 [ -z "$STAGED" ] && exit 0

--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -28,6 +28,34 @@ compliance from anyone — if the run happened, the entry is true.
 
 ---
 
+## 2026-08-10 — The reasoning guard here was bypassable; fixed (UL-210)
+
+**Asked.** Operator: "Proceed as recommended." The named item was propagating the UL-210 fix to
+the leaves still carrying the broken reasoning-log guard. This repo is one of five that had it.
+
+**Weighed.** The guard ran from `pre-commit` and read its `[no-reasoning]` opt-out from
+`.git/COMMIT_EDITMSG`. That file is stale there: for `git commit -m`, git writes it only *after*
+pre-commit succeeds, so the guard read the PREVIOUS commit's message. Measured live in
+open-claw-stuff, both directions — a commit carrying the marker was BLOCKED, and worse, after a
+commit whose message contained the marker had landed, the NEXT substantive commit carrying no
+marker was silently ALLOWED. A false pass on the layer the doctrine calls runtime-independent.
+
+I considered re-running the behavioural probes here to confirm. I did not: proving it a second
+time needs a commit that must then be undone, and that same cleanup pattern destroyed real work
+twice earlier in the session. The copied files are byte-identical to the canonical ones already
+verified, which is the same evidence without the risk.
+
+**Decided.** The guard moved to `.githooks/commit-msg`, the only hook git hands the real message
+(as `$1`); the opt-out reads `$1` and nothing else, and without it the opt-out is simply
+unavailable so the guard blocks — failing toward enforcement. The legacy call was stripped from
+`.githooks/pre-commit`, which keeps its other checks. Installed by
+`open-claw-stuff/admin/install-reasoning-log.mjs`, which now strips that call rather than adding
+it, so re-running repairs a repo instead of double-wiring it.
+
+**Unsure.** `core.hooksPath` is armed in this clone, but that setting lives in `.git/config` and no
+clone carries it (UL-189) — so these hooks are live here and inert in a fresh checkout. The fix to
+the *files* is durable; the arming is not. Tracked as `githooks-path-not-durable`.
+
 ## 2026-08-08 — Sophos now injects itself here, every session and every prompt
 
 **Asked.** Operator directive (Ken, 2026-08-08): "Sophos should be injected in like manner in


### PR DESCRIPTION
## Summary

Follow-up to the sweep merged as #2523. That PR is finished; this is a fresh change on the same branch, so the diff here is only the new commit.

The reasoning-log guard in this repo was **bypassable**. It ran from `pre-commit` and read its `[no-reasoning]` opt-out from `.git/COMMIT_EDITMSG` — a file that is **stale in pre-commit**, because for `git commit -m` git writes it only *after* pre-commit succeeds. The guard was therefore always reading the *previous* commit's message.

Measured live in `open-claw-stuff`, both directions:

- a commit **carrying** `[no-reasoning]` was **BLOCKED** (exit 1) — the escape hatch the doctrine advertises never worked for the commonest commit form;
- and worse, once a commit whose message contained the marker had landed, the **next** substantive commit — carrying no marker, asking for nothing — was **silently ALLOWED** (exit 0).

That second one is a false **pass** on the layer the doctrine calls "the RUNTIME-INDEPENDENT half", the one meant to reach every runtime that commits. This repo cares about that distinction more than most: it is the leaf that already ran per-prompt posture injection because, in its own hook's words, the rules kept being forgotten. An injection layer that reaches only Claude Code was always meant to be backstopped by a commit-time guard that reaches everything — and that backstop had a hole.

## Fix

The guard now runs from **`.githooks/commit-msg`**, the only hook git hands the real commit message (as `$1`). The opt-out reads `$1` and nothing else; invoked without it the opt-out is simply unavailable and the guard blocks — failing toward enforcement, never past it. The legacy call is stripped from `.githooks/pre-commit`, which keeps its other checks and carries a comment not to re-add it.

## Verified

The hook files here are **byte-identical** to the canonical ones in `open-claw-stuff`, whose behaviour was tested in all three directions: substantive commit with no entry today → blocked; same commit with `[no-reasoning]` → allowed (this was broken); next commit with no marker → blocked (false pass closed).

I deliberately did **not** re-run the behavioural probes here. Proving it a second time requires landing a commit that must then be undone, and that exact cleanup pattern destroyed real work twice earlier in the session (recorded in UL-210).

This repo's 9-check CI ran green on the previous PR's head and nothing here touches site content — the diff is `.githooks/`, `.claude/`, and `REASONING-LOG.md`.

## Honest limits

- **`core.hooksPath` is armed only in the working clone.** It lives in `.git/config`, which no clone carries (UL-189). The file fix here is durable; the arming is not. Tracked as `githooks-path-not-durable`.
- This PR also completes the reasoning-log kit that was partially installed here (`reasoning-reveal.mjs` plus its settings registration) — additive, adjacent to the fix rather than part of it.
- Injection and commit-time guards can make the obligation present and block omission. Neither can make an entry truthful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dBjxhPt8ezFp7p7s9HdwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015dBjxhPt8ezFp7p7s9HdwQ)_