### PR TITLE
chore(skills): sync soli-deo-gloria — a link that resolved in only one repo

### DIFF
--- a/.claude/skills/soli-deo-gloria/SKILL.md
+++ b/.claude/skills/soli-deo-gloria/SKILL.md
@@ -69,7 +69,7 @@ decoration. It is the posture every task is done in.
   or home, disk wipe, force-push over shared history, `curl … | sh`), and never a live destructive
   payload to "prove a point" — demonstrate with an inert one. Preserving what is entrusted is part of
   the worship. (Enforced mechanically by the destructive-command guard; doctrine in
-  [`skills/destructive-command-safety`](../destructive-command-safety/SKILL.md) and Sophos's
+  `open-claw-stuff/skills/destructive-command-safety/SKILL.md` (household path — this skill is synced into every repo, and a sibling-relative link resolves only in `open-claw-stuff`) and Sophos's
   `destructive_execution` gate.)
 
 ## One dedication, lived in layers

--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -28,6 +28,31 @@ compliance from anyone — if the run happened, the entry is true.
 
 ---
 
+## 2026-08-11 — rysn: household sync of soli-deo-gloria (a link that resolved in only one repo)
+
+**Asked.** Propagate the canonical `soli-deo-gloria` change made in the household SSOT. This repo's
+copy was one of sixteen behind it.
+
+**Weighed.** The change is one line: a sibling-relative link, `../destructive-command-safety/SKILL.md`,
+replaced with the household-qualified path `open-claw-stuff/skills/destructive-command-safety/SKILL.md`.
+That matters precisely because this skill is synced byte-identical into every repo — a relative link
+resolves in `open-claw-stuff` and is dead everywhere else, including here. So the copy that read
+correctly in one place was silently broken in fifteen others, on a P0 posture skill pointing at the
+destructive-command doctrine.
+
+I did not author this fix; a sibling did, and I verified it before propagating rather than trusting
+it: the target exists, and the failure it describes is the same one I had just committed myself in
+`careful-not-clever` (repo-relative `docs/...` paths that resolve only in the SSOT). Their reasoning
+is right and mine had been wrong in the same way.
+
+**Decided.** Sync it here, byte-identical to canonical, and commit — a sync written into a working
+tree and never committed is how the household's manifest came to assert "in sync" for four months
+about files that never existed on any main branch.
+
+**Unsure.** Nothing about this change. The uncertainty is upstream and recorded there: whether
+household-qualified paths should be the standing convention for every synced skill, or whether
+synced skills should stop citing cross-repo paths at all.
+
 ## 2026-08-10 — The reasoning guard here was bypassable; fixed (UL-210)
 
 **Asked.** Operator: "Proceed as recommended." The named item was propagating the UL-210 fix to

--- a/grok/skills/soli-deo-gloria/SKILL.md
+++ b/grok/skills/soli-deo-gloria/SKILL.md
@@ -69,7 +69,7 @@ decoration. It is the posture every task is done in.
   or home, disk wipe, force-push over shared history, `curl … | sh`), and never a live destructive
   payload to "prove a point" — demonstrate with an inert one. Preserving what is entrusted is part of
   the worship. (Enforced mechanically by the destructive-command guard; doctrine in
-  [`skills/destructive-command-safety`](../destructive-command-safety/SKILL.md) and Sophos's
+  `open-claw-stuff/skills/destructive-command-safety/SKILL.md` (household path — this skill is synced into every repo, and a sibling-relative link resolves only in `open-claw-stuff`) and Sophos's
   `destructive_execution` gate.)
 
 ## One dedication, lived in layers


### PR DESCRIPTION
Household skill sync, propagated from the SSOT (`open-claw-stuff`, merged as #2928). Both copies here — `.claude/skills` and `grok/skills`.

Canonical `soli-deo-gloria` replaced a sibling-relative link, `../destructive-command-safety/SKILL.md`, with the household-qualified path `open-claw-stuff/skills/destructive-command-safety/SKILL.md`.

That matters because this skill is synced **byte-identical into sixteen copies**: a relative link resolves in `open-claw-stuff` and is dead everywhere else — including here. So the copy that read correctly in one place was silently broken in fifteen others, on a P0 posture skill pointing at the destructive-command doctrine.

I did not author this fix; a sibling did, and I verified it before propagating rather than trusting it — the target exists, and the failure it describes is one I had just committed myself in `careful-not-clever`.

## Unrelated finding in this repo, filed not fixed

While sweeping skill packages, `.claude/skills/voice-audit/SKILL.md:310` instructs the reader to run the framework against `examples/falsification-test.md`. That package ships **only `SKILL.md`** — no `examples/` directory, and the `good-voice.md` / `bad-voice.md` its own text calls "the existing examples in the skill" are absent too. An agent following that instruction gets silence.

I did not touch it: whether to write those files or drop the pointer is a call for whoever owns the voice framework. Registered as `skill-resource-check-examples-stopword` (p2) in the household library, together with the reason the SSOT's own checker reports this package clean — `examples` sits on its placeholder stopword list.

## Verified

`skill-sync doctor` exit 0 across all sixteen copies after propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dBjxhPt8ezFp7p7s9HdwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015dBjxhPt8ezFp7p7s9HdwQ)_