### PR TITLE
Sync Layer 0 skills from canonical (soli-deo-gloria; sophos where pre…

### DIFF
--- a/.claude/skills/soli-deo-gloria/SKILL.md
+++ b/.claude/skills/soli-deo-gloria/SKILL.md
@@ -69,7 +69,7 @@ decoration. It is the posture every task is done in.
   or home, disk wipe, force-push over shared history, `curl … | sh`), and never a live destructive
   payload to "prove a point" — demonstrate with an inert one. Preserving what is entrusted is part of
   the worship. (Enforced mechanically by the destructive-command guard; doctrine in
-  [`skills/destructive-command-safety`](../destructive-command-safety/SKILL.md) and Sophos's
+  `open-claw-stuff/skills/destructive-command-safety/SKILL.md` (household path — this skill is synced into every repo, and a sibling-relative link resolves only in `open-claw-stuff`) and Sophos's
   `destructive_execution` gate.)
 
 ## One dedication, lived in layers

--- a/grok/skills/soli-deo-gloria/SKILL.md
+++ b/grok/skills/soli-deo-gloria/SKILL.md
@@ -69,7 +69,7 @@ decoration. It is the posture every task is done in.
   or home, disk wipe, force-push over shared history, `curl … | sh`), and never a live destructive
   payload to "prove a point" — demonstrate with an inert one. Preserving what is entrusted is part of
   the worship. (Enforced mechanically by the destructive-command guard; doctrine in
-  [`skills/destructive-command-safety`](../destructive-command-safety/SKILL.md) and Sophos's
+  `open-claw-stuff/skills/destructive-command-safety/SKILL.md` (household path — this skill is synced into every repo, and a sibling-relative link resolves only in `open-claw-stuff`) and Sophos's
   `destructive_execution` gate.)
 
 ## One dedication, lived in layers


### PR DESCRIPTION
…sent)

Mechanical propagation via tools/skill-sync/skill-sync.py --apply from open-claw-stuff canonical. soli-deo-gloria: one line — a sibling-relative link that resolves only inside open-claw-stuff replaced by the explicit household path. Project-Sophos also takes the sophos front door (4b2f340f70be -> ead5f8b72e66, 144L -> 214L), which had drifted three minor versions and was missing Layer 3 (hard safety) entirely.

Transient .bak backups written by the tool were removed, not committed.

[no-reasoning]


Claude-Session: https://claude.ai/code/session_017zVTnRNrDNauFg6X62JRZm