### PR TITLE
Getaway Day 1 logbook + three pre-trip articles (shore power, GSC, cabin types)

### DIFF
--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -28,6 +28,36 @@ compliance from anyone — if the run happened, the entry is true.
 
 ---
 
+## 2026-08-22 — Three articles in one pass: shore power, GSC changes, cabin types (syl)
+
+**Asked.** Ken approved all three proposed articles for today and asked that they be run
+"through all of our voice skills."
+
+**Weighed.** Sourcing per piece: shore power rests on Miami-Dade County's own program page
+(terminals, $125M cost, grants, 98%-while-connected, 3-ships, ~35 seaports) with the
+Getaway test-night purpose attributed to cruise media; GSC rests on NCL's own May-2026
+booklet (SSOT text held in admin/sources/) for everything waterpark, with the pier
+reopening deliberately marked UNVERIFIED because current reports conflict — stated as a
+conflict rather than picked; the cabin guide quotes no prices or square footage at all
+(they churn faster than an article should track) and anchors the balcony case in Ken's
+published Quantum logbook moments rather than invented experience. Voice pipeline applied
+per article: like-a-human during drafting, six-axis voice-audit self-scan and
+emotional-hook-test (5/5 each) attested in the sidecars. One flagged token — "unpack" in
+the shore-power piece — kept deliberately: it's the literal luggage verb, and contorting
+an honest sentence to dodge a tell-list is validator-gaming in mirror form.
+
+**Decided.** Three articles + three factcheck sidecars with voice/emotional attestations,
+three index entries, and bidirectional cross-links (Getaway hub → shore power + GSC; GSC
+port page → GSC article; seasickness + deck-plans → cabin guide). All three articles
+carry a forward commitment the sailing week can keep: Monday night verifies shore power,
+Thursday verifies the pier and lagoon pricing.
+
+**Unsure.** Whether the GSC pier has actually reopened (the article says so plainly), and
+whether the Great Life Lagoon is truly included — the booklet's silence is a signal, not
+a promise; both are on the Thursday checklist.
+
+---
+
 ## 2026-08-22 — Getaway article: booked-on-it confirmed + cross-link pass (syl)
 
 **Asked.** Ken confirmed he is booked on the Aug 24 Getaway sailing and "will write about

--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -28,6 +28,33 @@ compliance from anyone — if the run happened, the entry is true.
 
 ---
 
+## 2026-08-24 — Day 1 dispatch: logbook created, dirty-cabin report published as sent (syl)
+
+**Asked.** Ken, aboard, sent Day 1: embarkation smooth; rooms dirty and deteriorated —
+toenails on the floor, detritus from previous guests; "We're giving them an opportunity to
+fix it."
+
+**Weighed.** Structure (deferred until now): one running logbook page over per-day
+articles — one URL for the week, day anchors, matches the Quantum logbook precedent; no
+placeholder sections for future days (coming-soon content is banned). Fidelity: the entry
+carries ONLY the dispatched facts; nothing invented — no cabin numbers, times, staff
+interactions, meals, or sailaway color, and no shore-power observations since he hasn't
+sent any (the entry defers them to Day 2 explicitly rather than pretending). Tone: the
+never-chipper rule governs — the failure is stated plainly ("toenails-on-the-floor dirty"),
+and the fairness posture is his own words elevated to the entry's spine: the verdict is
+deferred to how the ship responds.
+
+**Decided.** New page norwegian-getaway-aug-2026-logbook (Trip Logbooks) with Day 1 only;
+hub updated so "the logbook is next" now links the live logbook; index entry added.
+Because the logbook links the shore-power and GSC research pieces, the whole branch goes
+to main in this pass — daily-dispatch publishing implies live publication, per the
+operator's standing "make it live on main" pattern and his "stay tuned" to readers.
+
+**Unsure.** Whether the cabin gets made right, and how fast — deliberately so; that is
+Day 2's entry, not this one's speculation.
+
+---
+
 ## 2026-08-22 — Three articles in one pass: shore power, GSC changes, cabin types (syl)
 
 **Asked.** Ken approved all three proposed articles for today and asked that they be run

--- a/admin/UNFINISHED_TASKS.md
+++ b/admin/UNFINISHED_TASKS.md
@@ -816,3 +816,12 @@ node admin/library.mjs mirrors --repo InTheWake
 
 <!-- library register 2026-08-22T03:17:24.747Z -->
 | inthewake-ship-page-js-validator-nav-gold-standard-expects-depre | 2 | InTheWake ship-page JS validator: nav gold standard expects deprecated flat paths (/ports.html, /cruise-lines.html) — modern hub-path ship pages falsely REGRESS and the regression guard blocks all commits to them; update gold standard + refresh audit-reports/ship-validation-dashboard.json, then add the deferred Getaway article link to ships/norwegian/norwegian-getaway.html Plan Your Cruise |
+
+<!-- library register 2026-08-22T21:52:13.724Z -->
+| article-shore-power-at-portmiami-why-getaway-overnights-in-miami | 2 | Article: shore power at PortMiami — why Getaway overnights in Miami (explainer) |
+
+<!-- library register 2026-08-22T21:52:14.331Z -->
+| article-great-stirrup-cay-is-about-to-change-pier-great-tides-wa | 2 | Article: Great Stirrup Cay is about to change — pier + Great Tides waterpark (news/explainer) |
+
+<!-- library register 2026-08-22T21:52:14.700Z -->
+| article-interior-vs-balcony-vs-oceanview-cabin-decision-guide-ev | 2 | Article: interior vs balcony vs oceanview — cabin decision guide (evergreen) |

--- a/articles/anthem-of-the-seas-deck-plans.html
+++ b/articles/anthem-of-the-seas-deck-plans.html
@@ -376,6 +376,7 @@ All work on this project is offered as a gift to God.
       <h2 id="related">Related Guides &amp; Tools</h2>
       <ul>
         <li><a href="/ships/rcl/anthem-of-the-seas.html">Anthem of the Seas — full ship guide, live tracker &amp; dining</a></li>
+        <li><a href="/articles/interior-vs-balcony-vs-oceanview.html">Interior vs. Balcony vs. Oceanview — deciding the cabin type first</a></li>
         <li><a href="/ships/rcl/quantum-of-the-seas.html">Quantum of the Seas — ship guide</a></li>
         <li><a href="/articles/quantum-of-the-seas-pacific-coastal.html">Ten Days on Quantum of the Seas — a Pacific Coastal logbook</a></li>
         <li><a href="/stateroom-check.html">Stateroom Check — cabin-noise sanity check</a></li>

--- a/articles/cruise-seasickness-what-works.html
+++ b/articles/cruise-seasickness-what-works.html
@@ -344,6 +344,7 @@ All work on this project is offered as a gift to God.
       <!-- RELATED -->
       <h2 id="related">Related Guides &amp; Tools</h2>
       <ul>
+        <li><a href="/articles/interior-vs-balcony-vs-oceanview.html">Interior vs. Balcony vs. Oceanview — which cabin type to book</a></li>
         <li><a href="/articles/anthem-of-the-seas-deck-plans.html">Anthem of the Seas Deck Plans — the midship cabin strategy</a></li>
         <li><a href="/stateroom-check.html">Stateroom Check — cabin noise &amp; location flags</a></li>
         <li><a href="/articles/cruise-travel-insurance-2026.html">Cruise Travel Insurance in 2026</a></li>

--- a/articles/cruise-shore-power-explained.factcheck.json
+++ b/articles/cruise-shore-power-explained.factcheck.json
@@ -1,0 +1,96 @@
+{
+  "_doctrine": ".claude/skills/original-research/SKILL.md",
+  "article_filename": "cruise-shore-power-explained.html",
+  "last_factcheck_date": "2026-08-22",
+  "verified_by": "Claude (patron syl, operator-supervised)",
+  "hls_task": "article-shore-power-at-portmiami-why-getaway-overnights",
+  "affiliate_posture": {"links_present": false, "rationale": "Explainer; nothing to sell."},
+  "claims": {
+    "five_terminals_lines": {
+      "claim": "Shore power at five PortMiami terminals: AA=MSC, A=Royal Caribbean, B=Norwegian, F=Carnival, V=Virgin Voyages",
+      "source": "https://www.miamidade.gov/portmiami/shore-power.page (WebFetch 2026-08-22, verbatim terminal list) — PRIMARY (county program page)",
+      "verified": "2026-08-22"
+    },
+    "cost_and_grants": {
+      "claim": "$125 million program (~$25M/terminal); $21.7M in grants ($19.7M FDOT, $2M EPA)",
+      "source": "miamidade.gov shore-power page (verbatim)",
+      "verified": "2026-08-22"
+    },
+    "emissions_98": {
+      "claim": "Plugging in cuts a docked ship's emissions by up to 98% while connected; one terminal's annual reduction ≈ removing 7,500 cars",
+      "source": "miamidade.gov (verbatim: 'reducing emissions by up to 98%'; 7,500-cars equivalence). Attributed in-article to the county program ('the program's own numbers') with the honest caveat that it applies only while docked/connected.",
+      "verified": "2026-08-22"
+    },
+    "three_ships_simultaneous": {
+      "claim": "PortMiami can plug in three ships safely and simultaneously",
+      "source": "miamidade.gov (verbatim)",
+      "verified": "2026-08-22"
+    },
+    "21_ships_350_calls": {
+      "claim": "21 ships expected to connect across 350+ calls in the coming year",
+      "source": "miamidade.gov / program materials via WebSearch summary 2026-08-22; phrased as the port's expectation",
+      "verified": "2026-08-22"
+    },
+    "35_seaports": {
+      "claim": "PortMiami is one of ~35 seaports worldwide with at least one shore-power cruise berth",
+      "source": "miamidade.gov (verbatim: 'one of 35 seaports around the world')",
+      "verified": "2026-08-22"
+    },
+    "small_city_load": {
+      "claim": "A docked cruise ship uses about as much electricity as a small city",
+      "source": "miamidade.gov program description (attributed in-article as 'PortMiami's own description')",
+      "verified": "2026-08-22"
+    },
+    "getaway_overnight_purpose": {
+      "claim": "Getaway's Aug 24 Miami overnight (3:00 am Tue departure) supports shore power system testing; NCL's berth is Terminal B; unrelated to Nassau propulsion repairs",
+      "source": "https://www.cruisehive.com/propulsion-problem-keeps-norwegian-cruise-ship-in-port-until-midnight/214347 (WebFetch, verbatim) + NCL letter for the times — attributed as 'cruise media report'",
+      "verified": "2026-08-22"
+    },
+    "fpl_partner": {
+      "claim": "The landside utility is Florida Power & Light; cruise-line partners are Carnival Corp, MSC, NCLH, Royal Caribbean Group, Virgin Voyages",
+      "source": "miamidade.gov (verbatim partner list)",
+      "verified": "2026-08-22"
+    },
+    "passenger_perceptions": {
+      "claim": "What passengers notice is framed as absence (no hum/vibration/exhaust) and hedged ('possibly nothing'); author will verify aboard Monday",
+      "source": "Framed as expectation, not fact; Monday dispatch is the committed verification path",
+      "verified": "2026-08-22",
+      "disposition": "hedged forward-looking"
+    }
+  },
+  "voice_audit": {
+    "audited_against": "voice-audit v2.3.0",
+    "audit_date": "2026-08-22",
+    "audited_by": "Claude (patron syl)",
+    "audit_scope": "full article body",
+    "authorship_mode": "Explainer with a booked-and-will-verify lived stake (operator confirmed booking in-session 2026-08-22). All aboard-ship perception claims future-tense/hedged.",
+    "machine_tells": {
+      "banned_cruise_vocab_count": 0,
+      "generic_ai_tells_count": 1,
+      "generic_ai_tells_locations": ["'unpack' appears once in the literal luggage sense ('board, unpack, have dinner, sleep at the pier') — the ban targets the rhetorical AI-tell usage; literal sense retained deliberately rather than contorting an honest sentence"],
+      "promotional_verbs_count": 0,
+      "stat_grid_opening": false,
+      "announcement_before_move_count": 0,
+      "filler_transitions_count": 0
+    },
+    "must_be_present": {
+      "honest_limitation": "Yes — 98% figure bounded ('while connected, at that pier... says nothing about emissions at sea'); 'a port promoting its investment' sourcing caveat; per-passenger cost admitted unknowable; 'possibly nothing' on perceptibility.",
+      "real_numbers": "$125M, $25M/terminal, $21.7M/$19.7M/$2M grants, 98%, 7,500 cars, 3 ships, 21 ships/350 calls, 35 seaports, 5 terminals, 3:00 a.m.",
+      "lived_anchor": "Booked on the test-night sailing; Monday-night verification committed and linked to the dispatch hub.",
+      "plain_copulas_dominant": true
+    },
+    "cadence_check": "pass — varied sentence length; short declaratives at confidence points ('The ship's lights stay on; the source changes.')",
+    "promotional_drift_check": "pass — marketing framing explicitly flagged twice (port promoting investment; 'marketing tends to quote only the first')",
+    "cluster_detection_verdict": "likely_human — Layer 3 counter-signals (bounded claims, named dollar figures with sources, admitted unknowables, committed future verification) with no Layer 1 strong signals found on self-scan",
+    "risk_rating": "Low"
+  },
+  "emotional_hook_test": {
+    "audited_against": "emotional-hook-test v2.0.0 (Article target: authenticity + learning)",
+    "clarity_0_5s": "PASS — title + answer line state what shore power is and why the ship sleeps over",
+    "calm_5_10s": "PASS — the odd 3 a.m. schedule is explained, not dramatized",
+    "seen_10_15s": "PASS — written to the passenger who got the odd itinerary email",
+    "confidence_15_20s": "PASS — reader knows what to expect and what's on/off their bill",
+    "guided_20_30s": "PASS — table + FAQ structure; no jargon left undefined (cold ironing defined at first use)",
+    "score": "5/5 — ship"
+  }
+}

--- a/articles/cruise-shore-power-explained.html
+++ b/articles/cruise-shore-power-explained.html
@@ -1,0 +1,358 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+  <meta charset="utf-8"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- ======================================================
+       In the Wake — Article
+       Page: Shore Power, Explained — Why Your Cruise Ship Sleeps Over in Miami
+       Version: 3.010.400  |  Standards baseline: 3.010.x
+       Content Protocol: ICP-2
+       ====================================================== -->
+
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="strict-origin-when-cross-origin"/>
+  <meta name="ai-summary" content="Shore power lets a docked cruise ship shut down its engines and plug into the city grid. PortMiami built it at five terminals for $125 million, cutting a plugged-in ship's emissions by up to 98 percent. It's why Norwegian Getaway stays overnight in Miami on August 24, 2026 — the port is testing the system. What plugging in means for passengers: quieter decks, less soot, and the occasional odd schedule."/>
+  <meta name="last-reviewed" content="2026-08-22"/>
+  <meta name="content-protocol" content="ICP-2"/>
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light dark"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
+  <meta name="author" content="Ken Baker"/>
+
+  <!-- SEO -->
+  <title>Shore Power, Explained: Why Your Cruise Ship Sleeps Over in Miami — In the Wake</title>
+  <meta name="description" content="What shore power is, why PortMiami spent $125 million to let cruise ships plug in at five terminals, and what it means for passengers — including the Norwegian Getaway overnight on August 24, 2026."/>
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://cruisinginthewake.com/articles/cruise-shore-power-explained.html"/>
+
+  <!-- Social -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Shore Power, Explained: Why Your Cruise Ship Sleeps Over in Miami"/>
+  <meta property="og:description" content="A docked ship uses as much electricity as a small town. Shore power lets it shut the engines down and plug into the grid — and it's why one ship is sleeping over in Miami this Monday."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles/cruise-shore-power-explained.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="article:section" content="Cruise Tips"/>
+  <meta property="article:published_time" content="2026-08-22"/>
+  <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Shore Power, Explained: Why Your Cruise Ship Sleeps Over in Miami"/>
+  <meta name="twitter:description" content="A docked ship uses as much electricity as a small town. Shore power lets it shut the engines down and plug into the grid."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Structured data: Article -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Shore Power, Explained: Why Your Cruise Ship Sleeps Over in Miami",
+    "description":"What shore power is, why PortMiami built it at five terminals, and what plugging in means for passengers.",
+    "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
+    "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
+    "datePublished":"2026-08-22",
+    "dateModified":"2026-08-22",
+    "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
+    "mainEntityOfPage":"https://cruisinginthewake.com/articles/cruise-shore-power-explained.html",
+    "articleSection":"Cruise Tips",
+    "about":[
+      {"@type":"Thing","name":"Shore power"},
+      {"@type":"Thing","name":"PortMiami"},
+      {"@type":"Thing","name":"Cruise ship emissions"}
+    ],
+    "citation":"https://www.miamidade.gov/portmiami/shore-power.page"
+  }
+  </script>
+
+  <!-- Structured data: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"What is shore power on a cruise ship?","acceptedAnswer":{"@type":"Answer","text":"Shore power — also called cold ironing or plugging in — lets a docked cruise ship shut down its diesel generators and draw electricity from the landside grid instead. The hotel side of the ship (lights, air conditioning, galleys, elevators) runs on city power while the engines rest. Per PortMiami, plugging in can cut a docked ship's emissions by up to 98 percent."}},
+      {"@type":"Question","name":"Which PortMiami terminals have shore power?","acceptedAnswer":{"@type":"Answer","text":"Five cruise terminals: AA (MSC Cruises), A (Royal Caribbean), B (Norwegian Cruise Line), F (Carnival Cruise Line), and V (Virgin Voyages). The county's program cost about $125 million — roughly $25 million per terminal — and the port says it can plug in three ships safely at the same time."}},
+      {"@type":"Question","name":"Why is Norwegian Getaway staying overnight in Miami on August 24, 2026?","acceptedAnswer":{"@type":"Answer","text":"Cruise media report the ship remains docked overnight to help PortMiami test its shore power systems, departing at 3:00 a.m. Tuesday. For guests it works like a hotel night aboard — board Monday, sleep at the pier, wake up at sea. It is unrelated to the ship's separate propulsion repairs in Nassau."}},
+      {"@type":"Question","name":"Can passengers tell when a ship is on shore power?","acceptedAnswer":{"@type":"Answer","text":"Sometimes. The most noticeable differences are the absence of engine hum and vibration at the pier and no exhaust haze over the aft decks. Onboard life is otherwise unchanged — the power arrives from a different source, and the lights don't flicker for it."}},
+      {"@type":"Question","name":"Does shore power cost passengers anything?","acceptedAnswer":{"@type":"Answer","text":"No fee appears on your bill for it. The infrastructure was funded by Miami-Dade County with about $21.7 million in grants — $19.7 million from the Florida Department of Transportation and $2 million from the EPA — and the cruise lines partner in the program. Whether energy costs eventually flow into fares isn't something any line itemizes."}},
+      {"@type":"Question","name":"How common is cruise shore power?","acceptedAnswer":{"@type":"Answer","text":"Still uncommon but growing. PortMiami counts itself among roughly 35 seaports worldwide offering at least one shore-power cruise berth, and it expects 21 ships to plug in across more than 350 calls in the coming year. Newer ships are typically built shore-power ready; older ones need retrofits before they can connect."}}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ken Baker",
+    "url":"https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle":"Pastor, Cruise Writer",
+    "description":"Reformed Baptist pastor and cruise writer specializing in accessible travel, grief support, and compassionate cruise guidance.",
+    "worksFor":{"@type":"Organization","name":"In the Wake"},
+    "knowsAbout":["Shore power","PortMiami","Cruise ships","Norwegian Cruise Line"]
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <!-- ================= HEADER ================= -->
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships/">Ships</a>
+            <a href="/cruise-lines/">Cruise Lines</a>
+            <a href="/ports/">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Tools Dropdown -->
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/cruise-tipping-calculator.html">Tipping Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+
+        <!-- Onboard Dropdown -->
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants/">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="Shore power for cruise ships, explained">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">Shore Power, Explained</div>
+    </div>
+  </header>
+
+  <!-- ================= MAIN ================= -->
+  <main id="main-content" class="wrap page-grid" role="main" aria-label="Main content">
+    <article class="card solo-article" itemscope itemtype="https://schema.org/Article">
+      <header style="max-width:min(860px,92%);margin-inline:auto">
+        <h1 itemprop="headline">Shore Power, Explained: Why Your Cruise Ship Sleeps Over in Miami</h1>
+        <p class="dek" itemprop="description">A docked cruise ship burns fuel all day just to keep the lights on — unless it can plug into the city instead. Miami spent $125 million so ships could do exactly that, and on Monday night I'll be aboard a ship that's staying at the pier to help test it.</p>
+        <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-08-22">August 22, 2026</time></p>
+      </header>
+
+      <div itemprop="articleBody" style="max-width:min(860px,92%);margin-inline:auto">
+
+      <!-- ICP-2 answer line -->
+      <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
+        <strong>Answer first:</strong> Shore power — the industry also calls it cold ironing — lets a docked cruise ship shut down its diesel generators and run everything from the landside electrical grid. PortMiami built it at five cruise terminals for about $125 million, says a plugged-in ship cuts its dockside emissions by up to 98 percent, and can connect three ships at once. It's the reason <a href="/ships/norwegian/norwegian-getaway.html">Norwegian Getaway</a> stays docked overnight in <a href="/ports/miami.html">Miami</a> on August 24, 2026, sailing at 3:00 a.m. — the port is testing the system. For passengers, plugging in mostly means a quieter, cleaner ship at the pier, and occasionally a schedule shaped around the plug.
+      </p>
+
+      <!-- Who this is for -->
+      <section class="fit-guidance" aria-labelledby="who-this-is-for" style="background:#f8f9fa;border-left:3px solid #0e6e8e;padding:1rem 1.25rem;border-radius:4px;margin:1rem 0 1.5rem">
+        <h2 id="who-this-is-for" style="margin-top:0;font-size:1.15rem">Who This Is For</h2>
+        <p style="margin:0.5rem 0">Anyone whose cruise schedule just did something odd — an overnight at the embarkation pier, a 3 a.m. departure — and wants to know why. Anyone curious what that thick cable between the hull and the dock actually does. And anyone weighing the honest environmental picture of cruising, which is neither as clean as the brochures say nor as hopeless as the critics say.</p>
+        <p style="margin:0.5rem 0">My own stake: I'm booked on the Getaway sailing that sleeps over in Miami Monday night for these tests. Monday evening I'll be aboard a ship at a pier, and I'll be paying attention to the things this article says you can notice — the hum, the haze, the quiet. The <a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">daily dispatches</a> will say whether the theory held.</p>
+      </section>
+
+      <!-- WHAT IT IS -->
+      <h2 id="what-it-is">The Problem Shore Power Solves</h2>
+
+      <p>A big cruise ship at a dock is still, in one sense, running hard. The propulsion is off, but the hotel is not: thousands of cabins of air conditioning in a Florida summer, a dozen galleys, elevators, freezers, lights, water treatment. All of that electricity has historically come from the ship's own diesel generators — engines idling at the pier for eight or ten hours, in the middle of a city, on turnaround days when the ship never moves an inch. PortMiami's own description is blunt about the scale: a docked cruise ship uses about as much electricity as a small city.</p>
+
+      <p>Shore power moves that load ashore. A heavy connection joins the ship to the local grid — at PortMiami, that's Florida Power &amp; Light — and the generators shut down. The ship's lights stay on; the source changes. When the ship is ready to sail, it transfers back to its own power and unplugs.</p>
+
+      <p>The payoff is local and immediate. Per <a href="https://www.miamidade.gov/portmiami/shore-power.page" rel="nofollow noopener" target="_blank">Miami-Dade County</a>, switching a docked ship's engines off cuts its emissions by up to 98 percent while connected, and the county estimates the annual reduction at a single terminal equals taking 7,500 cars off the road. Those are the program's own numbers — a port promoting its investment — but the mechanism behind them is simple physics: an engine that isn't running doesn't emit.</p>
+
+      <!-- MIAMI SPECIFICS -->
+      <h2 id="miami">What Miami Built</h2>
+
+      <p>PortMiami calls itself the Cruise Capital of the World, which makes it the natural proving ground. The county's Shore Power Program wired five cruise terminals, each matched to a resident line:</p>
+
+      <div style="overflow-x:auto;margin:1rem 0 1.5rem">
+      <table style="width:100%;border-collapse:collapse;font-size:0.97rem">
+        <caption class="sr-only">PortMiami shore power terminals and their cruise lines</caption>
+        <thead>
+          <tr style="background:#0e6e8e;color:#fff;text-align:left">
+            <th scope="col" style="padding:0.5rem 0.6rem">Terminal</th>
+            <th scope="col" style="padding:0.5rem 0.6rem">Cruise line</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr style="border-bottom:1px solid #d0e4f0"><th scope="row" style="padding:0.5rem 0.6rem">AA</th><td style="padding:0.5rem 0.6rem">MSC Cruises</td></tr>
+          <tr style="border-bottom:1px solid #d0e4f0;background:#f8fbfc"><th scope="row" style="padding:0.5rem 0.6rem">A</th><td style="padding:0.5rem 0.6rem">Royal Caribbean International</td></tr>
+          <tr style="border-bottom:1px solid #d0e4f0"><th scope="row" style="padding:0.5rem 0.6rem">B</th><td style="padding:0.5rem 0.6rem">Norwegian Cruise Line</td></tr>
+          <tr style="border-bottom:1px solid #d0e4f0;background:#f8fbfc"><th scope="row" style="padding:0.5rem 0.6rem">F</th><td style="padding:0.5rem 0.6rem">Carnival Cruise Line</td></tr>
+          <tr><th scope="row" style="padding:0.5rem 0.6rem">V</th><td style="padding:0.5rem 0.6rem">Virgin Voyages</td></tr>
+        </tbody>
+      </table>
+      </div>
+
+      <p>The cost was about $125 million — roughly $25 million per terminal — with $21.7 million of it covered by grants ($19.7 million from the Florida Department of Transportation, $2 million from the EPA). The port says it can plug in three ships safely at the same time, and that in the coming year it expects 21 different ships to connect across more than 350 calls. For scale on how early-days this still is: PortMiami counts itself among roughly 35 seaports worldwide with even one shore-power cruise berth.</p>
+
+      <p>That last number is the honest context. Shore power is real, funded, and operating — and it is nowhere near universal. A ship that plugs in at Miami runs its generators at the next port that has no plug. Newer ships are generally built ready to connect; older ships need retrofits, which is part of why the port's 21-ship figure isn't the whole fleet that calls there.</p>
+
+      <!-- THE GETAWAY OVERNIGHT -->
+      <h2 id="getaway">Why a Ship Sleeps Over: the Getaway Test</h2>
+
+      <p>Which brings us to the odd schedule that started this article. Norwegian Getaway's August 24, 2026 sailing boards on Monday, stays at the pier overnight, and departs at 3:00 a.m. Tuesday. Cruise media report the reason plainly: the ship remains docked to help PortMiami test its shore power systems — Norwegian's home is Terminal B, one of the five wired berths. (This is a separate matter from the same sailing's <a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">propulsion repairs in Nassau</a>, which have their own article.)</p>
+
+      <p>Commissioning a system like this takes exactly this kind of time: a real ship, connected for real hours, under real hotel load, while engineers on both sides of the cable watch what happens. A ship that would normally cast off at 5 p.m. instead becomes the test bench for the evening. For the passengers aboard, the practical shape is a hotel night on a ship — board, unpack, have dinner, sleep at the pier, wake up somewhere in the Florida Straits.</p>
+
+      <p>What might you notice from a cabin during a shore-power hookup? The honest answer is: possibly nothing, and that's the point. The differences passengers do report at plugged-in ports are the absence of things — no faint engine hum through the hull, no vibration at the stern, no exhaust shimmer over the aft rail. I'll be aboard for this one, and the Monday dispatch will say what an ordinary passenger can actually perceive, rather than what the theory predicts.</p>
+
+      <!-- WHAT IT MEANS FOR YOU -->
+      <h2 id="for-you">What Shore Power Means for Passengers</h2>
+
+      <ul style="line-height:1.7">
+        <li><strong>Nothing on your bill.</strong> There's no shore-power line item. The infrastructure was county-funded with state and federal grants; the lines are program partners. Whether energy costs eventually find their way into fares is not something any line itemizes, so no one can honestly tell you the per-passenger cost.</li>
+        <li><strong>A quieter ship at the pier — sometimes noticeably.</strong> If you've ever eaten breakfast on an aft deck over the low rumble of generators, the plugged-in version of that morning is stiller. Light sleepers in aft cabins have the most to gain.</li>
+        <li><strong>Cleaner air where the ship sits.</strong> The 98-percent figure applies while connected, at that pier. It's a genuinely large local improvement, and it says nothing about the ship's emissions at sea. Both halves of that sentence are true; marketing tends to quote only the first.</li>
+        <li><strong>Occasionally, a schedule shaped by the plug.</strong> Testing windows, connection time, and port electrical work can nudge departure times — the Getaway's 3 a.m. sailing being the live example. Read your itinerary emails; the reason is usually in the fine print or, failing that, in the cruise press.</li>
+      </ul>
+
+      <!-- FAQ -->
+      <h2 id="faq">Frequently Asked Questions</h2>
+
+      <h3>What is shore power on a cruise ship?</h3>
+      <p>It lets a docked ship shut down its diesel generators and draw power from the landside grid — the hotel functions run on city electricity while the engines rest. PortMiami puts the emissions cut at up to 98 percent while connected.</p>
+
+      <h3>Which PortMiami terminals have it?</h3>
+      <p>Five: AA (MSC), A (Royal Caribbean), B (Norwegian), F (Carnival), and V (Virgin Voyages) — about $125 million of infrastructure, three ships connectable at once.</p>
+
+      <h3>Why is Norwegian Getaway overnighting in Miami on August 24?</h3>
+      <p>To help the port test shore power systems, per cruise media — departing 3:00 a.m. Tuesday. It works like a hotel night aboard, and it's unrelated to the ship's Nassau propulsion repairs.</p>
+
+      <h3>Can passengers tell when a ship is plugged in?</h3>
+      <p>Sometimes — mostly by absence: no engine hum, no vibration, no exhaust haze aft. Onboard life is otherwise unchanged.</p>
+
+      <h3>Does it cost passengers anything?</h3>
+      <p>No fee appears anywhere on your account. The build was grant-supported county infrastructure; any indirect cost in fares isn't itemized by the lines.</p>
+
+      <h3>How common is this?</h3>
+      <p>Roughly 35 seaports worldwide offer at least one shore-power cruise berth, per PortMiami — real momentum, far from universal. Ships still run generators at unwired ports.</p>
+
+      <hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+      <!-- RELATED -->
+      <h2 id="related">Related Guides &amp; Coverage</h2>
+      <ul>
+        <li><a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">Norwegian Getaway's Overnight in Nassau — the same sailing's other schedule change</a></li>
+        <li><a href="/articles/cruise-embarkation-day-what-to-expect.html">Cruise Embarkation Day: What to Expect</a></li>
+        <li><a href="/ports/miami.html">Miami — port guide</a></li>
+        <li><a href="/ships/norwegian/norwegian-getaway.html">Norwegian Getaway — ship guide</a></li>
+        <li><a href="/articles/cruise-ship-size-explained.html">Cruise Ship Size, Explained</a></li>
+      </ul>
+
+      <p class="tiny muted" style="margin-top:1.5rem">Sources: <a href="https://www.miamidade.gov/portmiami/shore-power.page" rel="nofollow noopener" target="_blank">Miami-Dade County — PortMiami Shore Power Program</a> (terminals, cost, grants, emissions and capacity figures); <a href="https://www.cruisehive.com/propulsion-problem-keeps-norwegian-cruise-ship-in-port-until-midnight/214347" rel="nofollow noopener" target="_blank">Cruise Hive</a> (the Getaway overnight's shore-power-testing purpose). Reviewed August 22, 2026. This page carries no affiliate links.</p>
+
+      </div>
+    </article>
+  </main>
+
+  <!-- ================= FOOTER ================= -->
+  <footer class="wrap footer" role="contentinfo">
+    <p>&copy; 2026 In the Wake. All rights reserved.</p>
+    <p class="trust-badge">✓ No ads. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+    <nav aria-label="Footer navigation">
+      <ul style="list-style:none;padding:0;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
+        <li><a href="/about-us.html">About</a></li>
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/reaching-someone-at-sea.html">Reach Family at Sea</a></li>
+        <li><a href="/affiliate-disclosure.html">Affiliate Disclosure</a></li>
+      </ul>
+    </nav>
+    <p class="tiny center" style="margin-top:.5rem;opacity:0.7">
+      Soli Deo Gloria — Every pixel and part of this project is offered as worship to God.
+    </p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+</body>
+</html>

--- a/articles/great-stirrup-cay-changes-2026.factcheck.json
+++ b/articles/great-stirrup-cay-changes-2026.factcheck.json
@@ -1,0 +1,79 @@
+{
+  "_doctrine": ".claude/skills/original-research/SKILL.md",
+  "article_filename": "great-stirrup-cay-changes-2026.html",
+  "last_factcheck_date": "2026-08-22",
+  "verified_by": "Claude (patron syl, operator-supervised)",
+  "hls_task": "article-great-stirrup-cay-is-about-to-change-pier-great",
+  "affiliate_posture": {"links_present": false, "rationale": "News/explainer; venue names are not commission links (stated on-page)."},
+  "claims": {
+    "waterpark_booklet_facts": {
+      "claim": "Great Tides Waterpark: 19 slides, Tidal Tower, Wandering River, Cliffside Cove, Splash Cay, Grotto Bar; 'Starting this September, sailings to Great Stirrup Cay include access to book Great Tides Waterpark. Check the app for pricing' (quoted verbatim in-article); renderings/venue names subject to change",
+      "source": "NCL guest booklet (May 2026), full extracted text SSOT: admin/sources/ncl-gsc-great-tides-waterpark/gsc-booklet-extracted-text.txt — PRIMARY (NCL's own publication)",
+      "verified": "2026-08-22"
+    },
+    "access_to_book_not_included": {
+      "claim": "Waterpark is bookable-access upcharge, not included in fare; pricing published only in NCL app (no price repeated in-article)",
+      "source": "Booklet verbatim + derived-facts section of the SSOT; article explicitly refuses to repeat third-party price guesses",
+      "verified": "2026-08-22"
+    },
+    "upcharge_vs_included": {
+      "claim": "Marked '$' by NCL: Great Tides, Splash Cay, Cliffside Cove, Flighthouse zipline, Kayak Tour, Silver Cove Lagoon Villa, Silver Cove Spa. Great Life Lagoon (28,000 sq ft pool, swim-up bars) carries no upcharge marker",
+      "source": "Booklet's own '$' markings (SSOT). Article states the honest limit: 'no upcharge marker' is the booklet's silence, not a printed 'free' — flagged for Thursday on-the-ground check",
+      "verified": "2026-08-22"
+    },
+    "new_map_items": {
+      "claim": "Island map marks new: Great Life Lagoon, Pier, Welcome Plaza, Panoramic Bridge, Vibe Shore Club, Splash Harbor; Great Tides marked NEW - NOW OPEN on map",
+      "source": "Booklet map legend (SSOT)",
+      "verified": "2026-08-22"
+    },
+    "pier_timeline": {
+      "claim": "First pier opened Dec 28, 2025; closed April 1, 2026 for two-ship expansion; tenders expected in the interim",
+      "source": "Cruise guide/trade reporting via WebSearch 2026-08-22 (deeparrival.com summer-2026 report; travelperks 2026 guide; CruiseMapper port page) — SECONDARY, attributed",
+      "verified": "2026-08-22"
+    },
+    "pier_reopening_uncertain": {
+      "claim": "Reopening date treated as UNVERIFIED: early-August reports of reopening conflict with current guides still describing tendering",
+      "source": "Conflicting secondary reports (Aug-4 reopening reports noted in the household's Getaway voyage-pack sidecar vs. current guides via WebSearch). Article states the conflict outright ('Those can't both be right, and I won't pretend to know which is') and commits to Thursday in-person resolution",
+      "verified": "2026-08-22",
+      "disposition": "UNVERIFIED — stated as such per three-states doctrine (REPORT/EMPTY/UNAVAILABLE)"
+    },
+    "cococay_competitive_frame": {
+      "claim": "GSC buildout is NCL's direct answer to Royal Caribbean's Perfect Day at CocoCay; same free-pool/paid-waterpark model",
+      "source": "Household memory b4e7d905 (competitive posture) + structural comparison of published models; framed as analysis",
+      "verified": "2026-08-22"
+    }
+  },
+  "voice_audit": {
+    "audited_against": "voice-audit v2.3.0",
+    "audit_date": "2026-08-22",
+    "audited_by": "Claude (patron syl)",
+    "audit_scope": "full article body",
+    "authorship_mode": "News/explainer organized around honest epistemic sorting (confirmed / upcharge / unverified) with a committed Thursday in-person verification (operator confirmed aboard the Aug 27 call).",
+    "machine_tells": {
+      "banned_cruise_vocab_count": 0,
+      "generic_ai_tells_count": 0,
+      "promotional_verbs_count": 0,
+      "stat_grid_opening": false,
+      "notes": "NCL's 'private island paradise' line NOT quoted; 'surprises at every turn' quoted once with immediate deflation ('which is marketing for a lazy river with features') — quoted marketing analyzed, not adopted."
+    },
+    "must_be_present": {
+      "honest_limitation": "Yes — the pier reopening conflict stated as unresolvable from the desk; 'no upcharge marker is the booklet's silence, not a printed promise'; NCL's own renderings caveat passed through to readers.",
+      "real_numbers": "Dec 28 2025, April 1 2026, 19 slides, 28,000 sq ft, September 2026, two-ship pier.",
+      "lived_anchor": "Thursday island visit committed; specific checkable list named (pier state, lagoon pricing, construction line).",
+      "plain_copulas_dominant": true
+    },
+    "cadence_check": "pass",
+    "promotional_drift_check": "pass — upcharge model stated plainly ('Your fare buys the right to purchase entry')",
+    "cluster_detection_verdict": "likely_human — the article's spine is friction (conflicting reports, unpublished pricing, booklet silence) rather than smooth persuasion; no Layer 1 signals on self-scan",
+    "risk_rating": "Low"
+  },
+  "emotional_hook_test": {
+    "audited_against": "emotional-hook-test v2.0.0 (Article target: authenticity + learning)",
+    "clarity_0_5s": "PASS — title + answer line say what changed and what's uncertain",
+    "calm_5_10s": "PASS — the confusing pier situation is organized, not amplified; 'check your ship' is actionable",
+    "seen_10_15s": "PASS — opens on the reader who 'keeps finding contradictory answers'; mobility/tender note serves disabled readers specifically",
+    "confidence_15_20s": "PASS — included-vs-extra table gives a budgeting handle; September rule is unambiguous",
+    "guided_20_30s": "PASS — per-date guidance (before Sept / after Sept / any date)",
+    "score": "5/5 — ship"
+  }
+}

--- a/articles/great-stirrup-cay-changes-2026.html
+++ b/articles/great-stirrup-cay-changes-2026.html
@@ -1,0 +1,371 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+  <meta charset="utf-8"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- ======================================================
+       In the Wake — Article
+       Page: Great Stirrup Cay Is About to Change — Pier, Waterpark, and What's True Right Now
+       Version: 3.010.400  |  Standards baseline: 3.010.x
+       Content Protocol: ICP-2
+       ====================================================== -->
+
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="strict-origin-when-cross-origin"/>
+  <meta name="ai-summary" content="NCL's Great Stirrup Cay is mid-transformation: the island's first pier opened December 28, 2025, closed April 1, 2026 for a two-ship expansion, and its reopening date is genuinely unclear — while the 19-slide Great Tides Waterpark opens for booked access starting September 2026, alongside the complimentary 28,000-square-foot Great Life Lagoon pool. What NCL's own booklet confirms, what's an upcharge, and what remains unverified. The author visits Thursday and will report."/>
+  <meta name="last-reviewed" content="2026-08-22"/>
+  <meta name="content-protocol" content="ICP-2"/>
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light dark"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
+  <meta name="author" content="Ken Baker"/>
+
+  <!-- SEO -->
+  <title>Great Stirrup Cay Is About to Change: Pier, Waterpark, and What's True Right Now — In the Wake</title>
+  <meta name="description" content="NCL's private island is mid-transformation — a two-ship pier under construction, the Great Tides Waterpark opening for booking in September 2026, and a new free lagoon pool. What's confirmed, what costs extra, and what's still uncertain."/>
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://cruisinginthewake.com/articles/great-stirrup-cay-changes-2026.html"/>
+
+  <!-- Social -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Great Stirrup Cay Is About to Change: Pier, Waterpark, and What's True Right Now"/>
+  <meta property="og:description" content="A two-ship pier under construction, a 19-slide waterpark opening in September, a new free lagoon pool — and one big open question about how you'll get ashore. Sorted into confirmed, upcharge, and unverified."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles/great-stirrup-cay-changes-2026.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="article:section" content="Cruise News"/>
+  <meta property="article:published_time" content="2026-08-22"/>
+  <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Great Stirrup Cay Is About to Change"/>
+  <meta name="twitter:description" content="A two-ship pier under construction, a 19-slide waterpark opening in September, a new free lagoon pool — and one big open question about how you'll get ashore."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Structured data: Article -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Great Stirrup Cay Is About to Change: Pier, Waterpark, and What's True Right Now",
+    "description":"NCL's private island mid-transformation — the pier project, Great Tides Waterpark, the free Great Life Lagoon, and what remains unverified.",
+    "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
+    "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
+    "datePublished":"2026-08-22",
+    "dateModified":"2026-08-22",
+    "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
+    "mainEntityOfPage":"https://cruisinginthewake.com/articles/great-stirrup-cay-changes-2026.html",
+    "articleSection":"Cruise News",
+    "about":[
+      {"@type":"Thing","name":"Great Stirrup Cay"},
+      {"@type":"Thing","name":"Norwegian Cruise Line"},
+      {"@type":"Thing","name":"Great Tides Waterpark"}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Does Great Stirrup Cay have a pier, or do ships tender?","acceptedAnswer":{"@type":"Answer","text":"Both answers have been true in 2026, which is why guests are confused. The island's first pier opened December 28, 2025, then closed April 1, 2026 so NCL could enlarge it into a two-ship pier. During the expansion, tendering has been the expected way ashore. Reports differ on whether the expanded pier has reopened, so verify with your ship — your cruise line app and your cabin's daily program will say whether your call is docked or tendered."}},
+      {"@type":"Question","name":"When does Great Tides Waterpark open?","acceptedAnswer":{"@type":"Answer","text":"Per NCL's own guest booklet, starting in September 2026 sailings to Great Stirrup Cay include access to book Great Tides Waterpark through the NCL app. It is booked access, not included in the fare, and NCL had not published pricing as of the booklet — the app is the source of truth. The park is described as 19 slides, the Tidal Tower, a Wandering River, and Cliffside Cove cliff jumping."}},
+      {"@type":"Question","name":"What's free at Great Stirrup Cay and what costs extra?","acceptedAnswer":{"@type":"Answer","text":"The 28,000-square-foot Great Life Lagoon pool with swim-up bars carries no upcharge marker in NCL's booklet, and the beaches remain included. Marked as extra-charge in NCL's own materials: Great Tides Waterpark, Splash Cay, Cliffside Cove, the Flighthouse zipline, the Kayak Tour, Silver Cove Lagoon Villas, and the Silver Cove Spa."}},
+      {"@type":"Question","name":"What else is new on the island?","acceptedAnswer":{"@type":"Answer","text":"NCL's island map marks several additions beyond the waterpark: a Welcome Plaza, a Panoramic Bridge, the Vibe Shore Club, Splash Harbor, and the Great Life Lagoon, alongside the pier itself. NCL's own materials caution that renderings and venue names are subject to change."}},
+      {"@type":"Question","name":"Is the waterpark open for August 2026 visits?","acceptedAnswer":{"@type":"Answer","text":"No. NCL's booklet ties bookable access to sailings starting in September 2026. An August visit gets the island's existing beaches and any completed new spaces, not the slides."}}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ken Baker",
+    "url":"https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle":"Pastor, Cruise Writer",
+    "description":"Reformed Baptist pastor and cruise writer specializing in accessible travel, grief support, and compassionate cruise guidance.",
+    "worksFor":{"@type":"Organization","name":"In the Wake"},
+    "knowsAbout":["Great Stirrup Cay","Norwegian Cruise Line","Private cruise islands","Bahamas cruising"]
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <!-- ================= HEADER ================= -->
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships/">Ships</a>
+            <a href="/cruise-lines/">Cruise Lines</a>
+            <a href="/ports/">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Tools Dropdown -->
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/cruise-tipping-calculator.html">Tipping Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+
+        <!-- Onboard Dropdown -->
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants/">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="Great Stirrup Cay changes in 2026">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">Great Stirrup Cay, Changing</div>
+    </div>
+  </header>
+
+  <!-- ================= MAIN ================= -->
+  <main id="main-content" class="wrap page-grid" role="main" aria-label="Main content">
+    <article class="card solo-article" itemscope itemtype="https://schema.org/Article">
+      <header style="max-width:min(860px,92%);margin-inline:auto">
+        <h1 itemprop="headline">Great Stirrup Cay Is About to Change: Pier, Waterpark, and What's True Right Now</h1>
+        <p class="dek" itemprop="description">NCL's private island is mid-transformation — a two-ship pier half-built, a 19-slide waterpark opening in September, a new free lagoon pool — and the guest-facing facts are scattered across marketing, news reports, and rumor. Here's the sorted version: confirmed, upcharge, and honestly unknown. I'm on the island Thursday, and I'll close the gaps in person.</p>
+        <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-08-22">August 22, 2026</time></p>
+      </header>
+
+      <div itemprop="articleBody" style="max-width:min(860px,92%);margin-inline:auto">
+
+      <!-- ICP-2 answer line -->
+      <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
+        <strong>Answer first:</strong> <a href="/ports/great-stirrup-cay.html">Great Stirrup Cay</a> got its first pier on December 28, 2025, then closed it on April 1, 2026 to rebuild it bigger — a two-ship pier — with tenders carrying guests ashore in the meantime, and its reopening date genuinely unclear as of this writing. Meanwhile, per NCL's own guest booklet, the 19-slide <strong>Great Tides Waterpark</strong> opens for bookable access on sailings starting September 2026 (an upcharge, priced only in the NCL app), while the 28,000-square-foot <strong>Great Life Lagoon</strong> pool carries no upcharge marker. If you're sailing there before September: you get beaches and whatever new spaces are finished — not the slides — and you should check your ship's app on the day to learn whether you dock or tender.</p>
+
+      <!-- Who this is for -->
+      <section class="fit-guidance" aria-labelledby="who-this-is-for" style="background:#f8f9fa;border-left:3px solid #0e6e8e;padding:1rem 1.25rem;border-radius:4px;margin:1rem 0 1.5rem">
+        <h2 id="who-this-is-for" style="margin-top:0;font-size:1.15rem">Who This Is For</h2>
+        <p style="margin:0.5rem 0">Anyone with a Great Stirrup Cay call on an upcoming itinerary who keeps finding contradictory answers — "there's a pier now" versus "we tendered last week" — and anyone deciding whether the September waterpark opening should shape which sailing they book. This island is NCL's direct answer to Royal Caribbean's Perfect Day at CocoCay, and the next few months are when the comparison becomes real.</p>
+        <p style="margin:0.5rem 0">The reason this page can improve fast: I'm standing on the island <strong>Thursday</strong>, on the Getaway call that <a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">runs 8 a.m. to 8 p.m.</a> I'll see the pier state, the construction line, and what's actually open with my own eyes, and this article will be updated from that visit. Until then, every claim below names its source.</p>
+      </section>
+
+      <!-- THE PIER -->
+      <h2 id="pier">The Pier: One Honest Timeline, One Open Question</h2>
+
+      <p>For most of its history, Great Stirrup Cay was a tender island — ships anchored off and ferried guests in by boat, which meant rough-weather days sometimes canceled the island entirely. The pier changes that math, which is why its timeline matters:</p>
+
+      <ul style="line-height:1.7">
+        <li><strong>December 28, 2025</strong> — the island's first pier opens and begins receiving ships, ending the tender-only era.</li>
+        <li><strong>April 1, 2026</strong> — NCL closes that pier to enlarge it into a <strong>two-ship pier</strong>, so a pair of vessels can dock at once. During the work, tendering is again the way ashore.</li>
+        <li><strong>Now</strong> — the reopening date is the genuinely murky part. Some early-August reports said the expanded pier had reopened; other current guides still describe tendering as the expected arrival until the work completes. Those can't both be right, and I won't pretend to know which is.</li>
+      </ul>
+
+      <p>So here is the honest guidance: <strong>assume nothing; check your ship.</strong> Whether your call docks or tenders will be in the cruise line app and the daily program aboard, and it can differ ship to ship while construction winds down. If you have mobility considerations, this is worth confirming before your cruise — tendering and docking are very different propositions with a wheelchair or scooter, and our <a href="/accessibility.html">accessibility guide</a> covers the tender question in more depth. Thursday, I'll report which one the Getaway actually did.</p>
+
+      <!-- THE WATERPARK -->
+      <h2 id="waterpark">Great Tides Waterpark: What NCL's Own Booklet Commits To</h2>
+
+      <p>The centerpiece of the transformation is Great Tides Waterpark, and the most reliable public source on it is NCL's own guest booklet (dated May 2026). Its operative sentence is precise in a way worth quoting: <em>"Starting this September, sailings to Great Stirrup Cay include access to book Great Tides Waterpark. Check the app for pricing and reserve your spot today."</em></p>
+
+      <p>Read that carefully, because two facts hide in it:</p>
+
+      <ul style="line-height:1.7">
+        <li><strong>"Access to book" — not access.</strong> The waterpark is an upcharge, reserved through the NCL app. Your fare buys the right to purchase entry, the same model Royal Caribbean uses for the Thrill Waterpark at CocoCay.</li>
+        <li><strong>No price has been published.</strong> The booklet points to the app and nothing else. Any dollar figure you see elsewhere before NCL's app shows one is a guess, and this page won't repeat guesses.</li>
+      </ul>
+
+      <p>What the booklet says the park contains: <strong>19 slides</strong>, racing runs at the <strong>Tidal Tower</strong>, a <strong>Wandering River</strong> ("with surprises at every turn," which is marketing for a lazy river with features), cliff jumping at <strong>Cliffside Cove</strong>, the <strong>Splash Cay</strong> splash pad for young kids, and the <strong>Grotto Bar</strong> for the adults watching them. NCL's fine print adds its own honest hedge, which deserves passing on: renderings are illustrative, and venue names are subject to change.</p>
+
+      <!-- FREE VS PAID -->
+      <h2 id="free-vs-paid">What's Included and What Costs Extra</h2>
+
+      <p>NCL's booklet marks its upcharge venues explicitly, which makes this sorting unusually solid — it's the line's own labeling, not my inference:</p>
+
+      <div style="overflow-x:auto;margin:1rem 0 1.5rem">
+      <table style="width:100%;border-collapse:collapse;font-size:0.97rem">
+        <caption class="sr-only">Great Stirrup Cay venues — included versus extra charge, per NCL's 2026 booklet</caption>
+        <thead>
+          <tr style="background:#0e6e8e;color:#fff;text-align:left">
+            <th scope="col" style="padding:0.5rem 0.6rem">Included in your fare</th>
+            <th scope="col" style="padding:0.5rem 0.6rem">Extra charge (marked "$" by NCL)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="padding:0.5rem 0.6rem;vertical-align:top">
+              The beaches, as ever<br/>
+              <strong>Great Life Lagoon</strong> — the new 28,000&nbsp;sq&nbsp;ft pool with swim-up bars (no upcharge marker in the booklet)
+            </td>
+            <td style="padding:0.5rem 0.6rem;vertical-align:top">
+              Great Tides Waterpark<br/>
+              Splash Cay<br/>
+              Cliffside Cove<br/>
+              Flighthouse zipline<br/>
+              Kayak Tour<br/>
+              Silver Cove Lagoon Villas<br/>
+              Silver Cove Spa
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      </div>
+
+      <p>One caution on the left column: "no upcharge marker" is the booklet's silence, not a printed promise of "free." It's a strong signal — NCL marked everything else — but if the Great Life Lagoon turns out to carry a charge, that's the kind of thing a day on the island settles. It's on my Thursday list.</p>
+
+      <p>The island map in the same booklet marks more new construction beyond the waterpark: a <strong>Welcome Plaza</strong>, a <strong>Panoramic Bridge</strong>, the <strong>Vibe Shore Club</strong>, and <strong>Splash Harbor</strong>, alongside the pier. How many of those are finished versus fenced is exactly the ground truth an August visit can capture and a booklet can't.</p>
+
+      <!-- WHAT IT MEANS -->
+      <h2 id="what-it-means">What This Means for Your Sailing</h2>
+
+      <ul style="line-height:1.7">
+        <li><strong>Before September 2026:</strong> beaches, the existing island, and whatever new spaces have quietly opened. No slides. If the waterpark is the reason you're choosing an itinerary, book September or later — and even then, treat opening-month dates gently; new venues slip.</li>
+        <li><strong>September onward:</strong> budget for the waterpark as an add-on if you want it, and check the NCL app for pricing the moment your sailing's booking window opens — popular time slots on private-island attractions sell through.</li>
+        <li><strong>Any date:</strong> confirm dock-versus-tender in the app on the day. And pack for a real beach day either way — our <a href="/articles/cruise-gear-worth-packing.html">gear guide</a> covers the short list, starting with reef-safe sunscreen.</li>
+        <li><strong>Comparing private islands:</strong> the shape of NCL's buildout — free signature pool, paid waterpark, paid cabana tiers — mirrors Perfect Day at CocoCay closely enough that the fair question is execution, not concept. After Thursday I'll have walked both, and a comparison piece is the natural follow-up.</li>
+      </ul>
+
+      <!-- FAQ -->
+      <h2 id="faq">Frequently Asked Questions</h2>
+
+      <h3>Does Great Stirrup Cay have a pier, or do ships tender?</h3>
+      <p>Both have been true this year: first pier opened December 28, 2025; closed April 1, 2026 for a two-ship expansion; tendering in the interim, with the reopening date unclear from conflicting reports. Check your ship's app on the day.</p>
+
+      <h3>When does Great Tides Waterpark open?</h3>
+      <p>Bookable access begins with September 2026 sailings, per NCL's booklet — an upcharge reserved in the NCL app, with pricing published only there.</p>
+
+      <h3>What's free and what costs extra?</h3>
+      <p>Beaches and — per the booklet's markings — the Great Life Lagoon pool are included; the waterpark, Splash Cay, Cliffside Cove, zipline, kayak tour, villas, and spa are marked as extra charge.</p>
+
+      <h3>What else is new?</h3>
+      <p>The map marks a Welcome Plaza, Panoramic Bridge, Vibe Shore Club, and Splash Harbor alongside the pier — with NCL's own caveat that names and renderings can change.</p>
+
+      <h3>Is the waterpark open in August 2026?</h3>
+      <p>No — access starts with September sailings. An August day on the island is a beach day.</p>
+
+      <hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+      <!-- RELATED -->
+      <h2 id="related">Related Guides &amp; Coverage</h2>
+      <ul>
+        <li><a href="/ports/great-stirrup-cay.html">Great Stirrup Cay — port guide</a></li>
+        <li><a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">The Getaway Sailing That Gets 12 Hours on the Cay</a></li>
+        <li><a href="/articles/royal-beach-club-collection-2026.html">Royal's Beach Club Collection — the competing buildout</a></li>
+        <li><a href="/articles/cruise-gear-worth-packing.html">Cruise Gear Worth Packing</a></li>
+        <li><a href="/articles/cruise-embarkation-day-what-to-expect.html">Cruise Embarkation Day: What to Expect</a></li>
+      </ul>
+
+      <p class="tiny muted" style="margin-top:1.5rem">Sources: NCL's "Great Tides Waterpark" guest booklet, May 2026 (waterpark contents, September booking access, upcharge markings, island map — full extracted text held in this site's records); pier timeline per cruise trade and guide reporting including <a href="https://www.cruisemapper.com/ports/great-stirrup-cay-port-1023" rel="nofollow noopener" target="_blank">CruiseMapper</a>, with the reopening date treated as unverified where reports conflict. Reviewed August 22, 2026. This page carries no affiliate links; the waterpark and island venues named are not commission links.</p>
+
+      </div>
+    </article>
+  </main>
+
+  <!-- ================= FOOTER ================= -->
+  <footer class="wrap footer" role="contentinfo">
+    <p>&copy; 2026 In the Wake. All rights reserved.</p>
+    <p class="trust-badge">✓ No ads. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+    <nav aria-label="Footer navigation">
+      <ul style="list-style:none;padding:0;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
+        <li><a href="/about-us.html">About</a></li>
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/reaching-someone-at-sea.html">Reach Family at Sea</a></li>
+        <li><a href="/affiliate-disclosure.html">Affiliate Disclosure</a></li>
+      </ul>
+    </nav>
+    <p class="tiny center" style="margin-top:.5rem;opacity:0.7">
+      Soli Deo Gloria — Every pixel and part of this project is offered as worship to God.
+    </p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+</body>
+</html>

--- a/articles/interior-vs-balcony-vs-oceanview.factcheck.json
+++ b/articles/interior-vs-balcony-vs-oceanview.factcheck.json
@@ -1,0 +1,70 @@
+{
+  "_doctrine": ".claude/skills/original-research/SKILL.md",
+  "article_filename": "interior-vs-balcony-vs-oceanview.html",
+  "last_factcheck_date": "2026-08-22",
+  "verified_by": "Claude (patron syl, operator-supervised)",
+  "hls_task": "article-interior-vs-balcony-vs-oceanview-cabin-decision",
+  "affiliate_posture": {"links_present": false, "rationale": "Decision guide; deliberately no product or booking links."},
+  "claims": {
+    "no_prices_no_sizes": {
+      "claim": "The article deliberately quotes NO cabin prices and NO square footage; the closing note explains why (they vary faster than an article should pretend to track)",
+      "source": "Editorial decision per original-research discipline — unverifiable-at-scale numbers omitted rather than invented",
+      "verified": "2026-08-22",
+      "disposition": "structural honesty choice"
+    },
+    "cdc_motion_guidance": {
+      "claim": "CDC motion-sickness guidance favors midship/low positioning and a horizon view",
+      "source": "CDC Yellow Book — Motion Sickness, verified in-session 2026-06-18 and recorded verbatim in articles/cruise-seasickness-what-works.factcheck.json; article links that guide as the source carrier",
+      "verified": "2026-08-22"
+    },
+    "quantum_virtual_balconies": {
+      "claim": "Royal Caribbean Quantum-class interiors carry virtual balconies (real-time sea screens); Anthem Deck 3 oceanviews have portholes; some balcony/oceanview categories are lifeboat-obstructed",
+      "source": "This site's RC-primary deck-plan research (articles/anthem-of-the-seas-deck-plans.factcheck.json: Deck 3 virtual-balcony inside + porthole oceanview categories; Deck 6 obstructed categories 1E/2E/2F) — verified 2026-06-17/18",
+      "verified": "2026-08-22"
+    },
+    "interior_darkness": {
+      "claim": "Interiors are completely dark and are the lowest-priced category; disorientation is the trade-off",
+      "source": "Category definition + universal pricing structure across lines (interior < oceanview < balcony is the standard order); no specific prices asserted",
+      "verified": "2026-08-22"
+    },
+    "lived_balcony_anchor": {
+      "claim": "First-person balcony experiences: sunrise coffee/journaling, whale-scanning off Baja, reading over the wake, embarkation-day nap",
+      "source": "Ken's published, attested Quantum of the Seas Pacific Coastal logbook (articles/quantum-of-the-seas-pacific-coastal.html) — each named moment appears in that logbook; linked in-article",
+      "verified": "2026-08-22",
+      "disposition": "lived-grade anchor, published attested content"
+    }
+  },
+  "voice_audit": {
+    "audited_against": "voice-audit v2.3.0",
+    "audit_date": "2026-08-22",
+    "audited_by": "Claude (patron syl)",
+    "audit_scope": "full article body",
+    "authorship_mode": "Evergreen decision guide in the walk-a-friend-through-it register; lived-grade balcony anchor from published logbook; pastoral case (caregivers, hard seasons) included per audience-profiles.",
+    "machine_tells": {
+      "banned_cruise_vocab_count": 0,
+      "generic_ai_tells_count": 0,
+      "promotional_verbs_count": 0,
+      "stat_grid_opening": false,
+      "notes": "Anti-sales-pitch stance is explicit ('most advice about it is a sales pitch in disguise'); 'Booking the interior isn't settling. It's arithmetic.' carries the permission-giving pastoral note."
+    },
+    "must_be_present": {
+      "honest_limitation": "Yes — prices/sizes refused with stated reason; 'none of that may matter... for two adults and a child it will' situational bounding; balcony for-case conditioned on 'if you're the person who uses it.'",
+      "lived_anchor": "Yes — four specific published-logbook moments, linked.",
+      "pastoral_honesty": "Yes — the retreat case names caregivers and people 'processing a hard season' without performance; interior framed with dignity, not as the poverty option.",
+      "plain_copulas_dominant": true
+    },
+    "cadence_check": "pass — short sentence at the confidence moment ('It's arithmetic.')",
+    "promotional_drift_check": "pass — no CTAs, no 'perfect for', category premium challenged rather than sold",
+    "cluster_detection_verdict": "likely_human — lived-grade Layer 3 anchors with named published source; decision logic carries friction (when the balcony is money poorly spent) rather than a persuasion arc",
+    "risk_rating": "Low"
+  },
+  "emotional_hook_test": {
+    "audited_against": "emotional-hook-test v2.0.0 (Article target: authenticity + learning)",
+    "clarity_0_5s": "PASS — title is the exact decision; answer line gives the three questions",
+    "calm_5_10s": "PASS — reduces a pressured upsell decision to three answerable questions",
+    "seen_10_15s": "PASS — budget-constrained reader addressed directly and with dignity ('without apology'); caregiver/grief retreat case present",
+    "confidence_15_20s": "PASS — compressed decision table; reader can pick a row and act",
+    "guided_20_30s": "PASS — next step named (check the specific cabin number; two site tools linked)",
+    "score": "5/5 — ship"
+  }
+}

--- a/articles/interior-vs-balcony-vs-oceanview.html
+++ b/articles/interior-vs-balcony-vs-oceanview.html
@@ -1,0 +1,359 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+  <meta charset="utf-8"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- ======================================================
+       In the Wake — Article
+       Page: Interior vs. Balcony vs. Oceanview — Which Cruise Cabin Should You Book?
+       Version: 3.010.400  |  Standards baseline: 3.010.x
+       Content Protocol: ICP-2
+       ====================================================== -->
+
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="strict-origin-when-cross-origin"/>
+  <meta name="ai-summary" content="Interior, oceanview, or balcony comes down to three questions: how much time you'll actually spend in the cabin, whether darkness helps or disorients you, and what the itinerary shows out the window. Interiors are the best sleep and the best price; oceanviews buy daylight without the balcony premium; balconies earn their cost on scenic itineraries, for seasickness-prone travelers, and for anyone who needs a private retreat. A decision guide, not a sales pitch."/>
+  <meta name="last-reviewed" content="2026-08-22"/>
+  <meta name="content-protocol" content="ICP-2"/>
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light dark"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
+  <meta name="author" content="Ken Baker"/>
+
+  <!-- SEO -->
+  <title>Interior vs. Balcony vs. Oceanview: Which Cruise Cabin Should You Book? — In the Wake</title>
+  <meta name="description" content="An honest decision guide to cruise cabin types — when an interior is genuinely the right call, when an oceanview is the quiet bargain, and when a balcony earns its premium. No sales pitch."/>
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://cruisinginthewake.com/articles/interior-vs-balcony-vs-oceanview.html"/>
+
+  <!-- Social -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Interior vs. Balcony vs. Oceanview: Which Cruise Cabin Should You Book?"/>
+  <meta property="og:description" content="Three questions decide it: how much you'll be in the cabin, whether darkness helps or disorients you, and what's out the window on your route. An honest decision guide."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles/interior-vs-balcony-vs-oceanview.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="article:section" content="Cruise Tips"/>
+  <meta property="article:published_time" content="2026-08-22"/>
+  <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Interior vs. Balcony vs. Oceanview: Which Cruise Cabin Should You Book?"/>
+  <meta name="twitter:description" content="Three questions decide it: how much you'll be in the cabin, whether darkness helps or disorients you, and what's out the window on your route."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Structured data: Article -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Interior vs. Balcony vs. Oceanview: Which Cruise Cabin Should You Book?",
+    "description":"An honest decision guide to cruise cabin types — when each one is genuinely the right call.",
+    "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
+    "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
+    "datePublished":"2026-08-22",
+    "dateModified":"2026-08-22",
+    "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
+    "mainEntityOfPage":"https://cruisinginthewake.com/articles/interior-vs-balcony-vs-oceanview.html",
+    "articleSection":"Cruise Tips",
+    "about":[
+      {"@type":"Thing","name":"Cruise cabins"},
+      {"@type":"Thing","name":"Balcony stateroom"},
+      {"@type":"Thing","name":"Interior stateroom"},
+      {"@type":"Thing","name":"Oceanview stateroom"}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"FAQPage",
+    "mainEntity":[
+      {"@type":"Question","name":"Is a balcony cabin worth the extra money?","acceptedAnswer":{"@type":"Answer","text":"It depends on three things: your itinerary, your habits, and your body. A balcony earns its premium on scenic routes (Alaska, fjords, repositioning days at sea), for travelers prone to seasickness who benefit from immediate fresh air and a horizon view, and for anyone who genuinely uses a private outdoor retreat — early coffee, reading, watching the wake. It is money poorly spent if your cruise is port-intensive and the cabin is only where you sleep and shower."}},
+      {"@type":"Question","name":"Are interior cruise cabins bad?","acceptedAnswer":{"@type":"Answer","text":"No — they're the best-priced rooms on the ship and, for many people, the best sleep afloat: perfectly dark and often among the quieter locations. The honest trade-offs are total darkness (you lose all sense of time and weather without an alarm and a routine) and less space on most ships. Some ships soften the darkness — Royal Caribbean's Quantum-class interiors carry virtual balconies, real-time screens showing the sea."}},
+      {"@type":"Question","name":"What is an oceanview cabin, and who should pick it?","acceptedAnswer":{"@type":"Answer","text":"An oceanview (outside) cabin has a sealed window or porthole — daylight and a view, no outdoor space. It suits travelers who want to know whether it's morning and what the sea is doing without paying the balcony premium — and in rough or cold-weather itineraries a sealed window arguably beats an unusable balcony. Check the deck plan before booking: some oceanview categories, like Anthem of the Seas' Deck 3 rooms, have portholes rather than picture windows, and some are partially obstructed."}},
+      {"@type":"Question","name":"Which cabin type is best for seasickness?","acceptedAnswer":{"@type":"Answer","text":"Location beats category. CDC guidance for motion sickness favors midship and low, with a horizon view when symptoms threaten — so the steadiest choice is a midship cabin on a lower deck. A balcony adds the ability to get fresh air and a horizon instantly without leaving your cabin, which many seasickness-prone cruisers value; an interior gives neither, so if you book one for the price, know where your nearest open deck is."}},
+      {"@type":"Question","name":"Which cabin should a first-time cruiser book?","acceptedAnswer":{"@type":"Answer","text":"If the budget covers it comfortably, a midship balcony one deck-search away from being noise-checked is the forgiving default — you learn what you value and can economize next time. If the budget is the difference between cruising and not cruising, book the interior without apology: you get the same ship, food, ports, and shows as everyone else. The cabin is the smallest part of the trip for most people."}}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ken Baker",
+    "url":"https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle":"Pastor, Cruise Writer",
+    "description":"Reformed Baptist pastor and cruise writer specializing in accessible travel, grief support, and compassionate cruise guidance.",
+    "worksFor":{"@type":"Organization","name":"In the Wake"},
+    "knowsAbout":["Cruise cabins","Balcony staterooms","Cruise planning","Stateroom selection"]
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <!-- ================= HEADER ================= -->
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships/">Ships</a>
+            <a href="/cruise-lines/">Cruise Lines</a>
+            <a href="/ports/">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Tools Dropdown -->
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/cruise-tipping-calculator.html">Tipping Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+
+        <!-- Onboard Dropdown -->
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants/">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="Choosing between interior, oceanview, and balcony cruise cabins">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">Which Cabin Should You Book?</div>
+    </div>
+  </header>
+
+  <!-- ================= MAIN ================= -->
+  <main id="main-content" class="wrap page-grid" role="main" aria-label="Main content">
+    <article class="card solo-article" itemscope itemtype="https://schema.org/Article">
+      <header style="max-width:min(860px,92%);margin-inline:auto">
+        <h1 itemprop="headline">Interior vs. Balcony vs. Oceanview: Which Cruise Cabin Should You Book?</h1>
+        <p class="dek" itemprop="description">The cabin decision is where cruise budgets get made or broken, and most advice about it is a sales pitch in disguise. Here's the decision the way I'd walk a friend through it: three questions, honest trade-offs, and permission to book the cheap room without apology.</p>
+        <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-08-22">August 22, 2026</time></p>
+      </header>
+
+      <div itemprop="articleBody" style="max-width:min(860px,92%);margin-inline:auto">
+
+      <!-- ICP-2 answer line -->
+      <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
+        <strong>Answer first:</strong> Three questions decide it. <em>How many waking hours will you actually spend in the cabin?</em> If the honest answer is "almost none," the interior is the smart money. <em>Does total darkness help you or unmoor you?</em> Interiors are the best sleep on the ship and the easiest place to lose all sense of time. <em>What's outside the window on this route?</em> Glaciers and fjords argue for the balcony; a wall of terminal buildings on a port-a-day Caribbean run does not. Oceanview sits in the middle for a reason — daylight without the balcony premium. And location matters as much as category: midship and low rides steadiest, whatever you book.
+      </p>
+
+      <!-- Who this is for -->
+      <section class="fit-guidance" aria-labelledby="who-this-is-for" style="background:#f8f9fa;border-left:3px solid #0e6e8e;padding:1rem 1.25rem;border-radius:4px;margin:1rem 0 1.5rem">
+        <h2 id="who-this-is-for" style="margin-top:0;font-size:1.15rem">Who This Is For</h2>
+        <p style="margin:0.5rem 0">First-timers staring at a booking screen with three prices and no idea what the difference feels like at sea; returning cruisers wondering whether the balcony they always book is a habit or a preference; and anyone budgeting hard, who deserves a straight answer about what the cheap room actually costs you in experience. (Short version: less than the industry wants you to think.)</p>
+      </section>
+
+      <!-- INTERIOR -->
+      <h2 id="interior">The Interior: Best Price, Best Sleep, One Real Cost</h2>
+
+      <p>An interior cabin has no window. That single fact does all the work in both directions.</p>
+
+      <p>In its favor: interiors are the least expensive rooms on the ship, and the money you don't spend on the cabin is money for the things the cabin can't give you — a specialty dinner, a shore excursion, or simply cruising at all. They are also, and this gets undersold, the best sleep afloat. A cruise-ship interior at night is perfectly, completely dark in a way few bedrooms on land ever manage. Night-shift workers and light-sensitive sleepers sometimes book interiors on purpose.</p>
+
+      <p>The real cost is disorientation. With no window, you wake with no idea whether it's 6 a.m. or noon, sunny or storming. It sounds trivial; over a week it isn't. The mitigation is a routine — an alarm, and a habit of checking the deck above with your own eyes before dressing for the day. Some ships also soften the trade: Royal Caribbean's Quantum-class ships fit interior cabins with <em>virtual balconies</em> — floor-to-ceiling screens showing the sea in real time — which our <a href="/articles/anthem-of-the-seas-deck-plans.html">Anthem of the Seas deck-plan guide</a> maps by deck and category. A screen is not a window, but it does tell you it's morning.</p>
+
+      <p>Space varies by ship, but interiors run smaller than balcony cabins on most of them, and there's no retreating outside when a cabin-mate is napping. For a solo traveler out all day, none of that may matter. For two adults and a child on a sea-day-heavy week, it will. Our <a href="/articles/stateroom-sanity-check.html">Stateroom Sanity Check</a> covers the cabin mistakes that hurt regardless of category.</p>
+
+      <!-- OCEANVIEW -->
+      <h2 id="oceanview">The Oceanview: The Quiet Middle Option</h2>
+
+      <p>An oceanview — some lines say "outside" — has a sealed window or porthole: daylight, weather, and a view, with no outdoor space. It's the unglamorous middle child of cabin categories, and it's underrated.</p>
+
+      <p>What it buys over the interior is exactly one thing, and it's the thing the interior costs you: orientation. You wake knowing it's morning and what the sea is doing. For a fraction of the balcony premium, that's a real quality-of-life purchase — especially on itineraries where a balcony would go unused anyway. On a cold-weather or rough-water route, a sealed picture window arguably beats a balcony you can't comfortably sit on.</p>
+
+      <p>Two checks before you book one. First, look at the deck plan for what "window" means in that category — on <a href="/articles/anthem-of-the-seas-deck-plans.html">Anthem of the Seas</a>, for instance, the Deck 3 oceanviews carry portholes rather than picture windows, which is charming or disappointing depending on what you pictured. Second, check for obstruction: some oceanview and balcony categories look at the top of a lifeboat, and the deck plan (or our <a href="/stateroom-check.html">Stateroom Check</a>) will say which cabins.</p>
+
+      <!-- BALCONY -->
+      <h2 id="balcony">The Balcony: When the Premium Earns Itself</h2>
+
+      <p>I'll say the for-case personally, because it's the cabin I know best. On my <a href="/articles/quantum-of-the-seas-pacific-coastal.html">ten days on Quantum of the Seas</a>, the balcony was where the trip happened: coffee and journaling at sunrise, scanning for whales off the Baja coast, reading while the wake unspooled behind us, the restorative embarkation-day nap with the door cracked. None of that shows up on a deck plan. All of it is what the premium is for — <em>if you're the person who uses it.</em></p>
+
+      <p>The balcony earns its cost when at least one of these is true:</p>
+
+      <ul style="line-height:1.7">
+        <li><strong>The route is the show.</strong> Alaska, Norwegian fjords, canal transits, long scenic sea days. When the view changes hourly, a private front-row seat is the difference between watching and glimpsing.</li>
+        <li><strong>Your body votes for it.</strong> CDC guidance for motion sickness favors a horizon view and fresh air when queasiness threatens — a balcony puts both one step from your bed, no elevator required. Our <a href="/articles/cruise-seasickness-what-works.html">seasickness guide</a> covers the rest (midship and low still matters more than category).</li>
+        <li><strong>You need a retreat.</strong> Caregivers traveling with someone who naps; introverts who recharge alone; anyone processing a hard season who needs ten quiet minutes that don't happen in a windowless room or a crowded lounge. This is the pastoral case for the balcony, and for some readers of this site it's the deciding one.</li>
+        <li><strong>You're aboard-heavy by temperament.</strong> If sea days are your favorite days and the cabin is somewhere you linger, the balcony multiplies the hours you enjoy most.</li>
+      </ul>
+
+      <p>And the balcony is money poorly spent when none of those hold: a port-intensive week where you're ashore by eight and back for dinner, a traveler who uses the cabin to sleep and shower and nothing else, a budget where the premium crowds out the experiences you'd actually remember. Booking the interior in that case isn't settling. It's arithmetic.</p>
+
+      <!-- DECISION TABLE -->
+      <h2 id="decision">The Decision, Compressed</h2>
+
+      <div style="overflow-x:auto;margin:1rem 0 1.5rem">
+      <table style="width:100%;border-collapse:collapse;font-size:0.97rem">
+        <caption class="sr-only">Which cruise cabin type fits which traveler</caption>
+        <thead>
+          <tr style="background:#0e6e8e;color:#fff;text-align:left">
+            <th scope="col" style="padding:0.5rem 0.6rem">If this is you</th>
+            <th scope="col" style="padding:0.5rem 0.6rem">Book</th>
+            <th scope="col" style="padding:0.5rem 0.6rem">Why</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr style="border-bottom:1px solid #d0e4f0"><td style="padding:0.5rem 0.6rem">Ashore every port, cabin is for sleeping, budget matters</td><td style="padding:0.5rem 0.6rem">Interior</td><td style="padding:0.5rem 0.6rem">Same ship, ports, food, shows — lowest price, darkest sleep</td></tr>
+          <tr style="border-bottom:1px solid #d0e4f0;background:#f8fbfc"><td style="padding:0.5rem 0.6rem">Want daylight and orientation without the premium</td><td style="padding:0.5rem 0.6rem">Oceanview</td><td style="padding:0.5rem 0.6rem">The window solves the interior's one real cost</td></tr>
+          <tr style="border-bottom:1px solid #d0e4f0"><td style="padding:0.5rem 0.6rem">Scenic route, seasickness-prone, or need a private retreat</td><td style="padding:0.5rem 0.6rem">Balcony</td><td style="padding:0.5rem 0.6rem">The premium buys hours you'll actually use</td></tr>
+          <tr style="border-bottom:1px solid #d0e4f0;background:#f8fbfc"><td style="padding:0.5rem 0.6rem">First cruise, budget comfortable, preferences unknown</td><td style="padding:0.5rem 0.6rem">Midship balcony</td><td style="padding:0.5rem 0.6rem">The forgiving default — learn what you value, economize next time</td></tr>
+          <tr><td style="padding:0.5rem 0.6rem">Any of the above</td><td style="padding:0.5rem 0.6rem">Midship, mid-to-low deck</td><td style="padding:0.5rem 0.6rem">Location steadies the ride more than category changes it</td></tr>
+        </tbody>
+      </table>
+      </div>
+
+      <p>Whatever you choose, spend five minutes on the specific cabin number before paying: what's directly above and below, obstruction, distance to elevators. The <a href="/articles/anthem-of-the-seas-deck-plans.html">deck-plan guide</a> shows how to read a plan for exactly this, and the <a href="/stateroom-check.html">Stateroom Check</a> flags known problem cabins. A well-placed interior beats a badly placed balcony more often than the price difference suggests.</p>
+
+      <!-- FAQ -->
+      <h2 id="faq">Frequently Asked Questions</h2>
+
+      <h3>Is a balcony cabin worth the extra money?</h3>
+      <p>On scenic routes, for seasickness-prone travelers, and for people who genuinely use private outdoor space — yes. On port-intensive weeks where the cabin is a bed with a shower — usually not. The honest test is hours: how many will you spend out there?</p>
+
+      <h3>Are interior cabins bad?</h3>
+      <p>No. They're the best-priced rooms and the darkest, often quietest sleep on the ship. The one real cost is losing your sense of time and weather; an alarm and a morning routine — or a Quantum-class virtual balcony — cover most of it.</p>
+
+      <h3>What exactly is an oceanview cabin?</h3>
+      <p>A sealed window or porthole — daylight and a view, no outdoor space. The quiet bargain for travelers who want orientation without the balcony premium. Check the deck plan for porthole-versus-window and for obstruction.</p>
+
+      <h3>Which cabin is best for seasickness?</h3>
+      <p>Location first: midship and low, per CDC motion-sickness guidance. A balcony adds instant fresh air and horizon; if you book an interior for the price, learn the fastest route to an open deck on day one.</p>
+
+      <h3>Which should a first-timer book?</h3>
+      <p>Budget comfortable: a midship balcony, then adjust next cruise once you know your habits. Budget deciding whether you cruise at all: the interior, without apology.</p>
+
+      <hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+      <!-- RELATED -->
+      <h2 id="related">Related Guides &amp; Tools</h2>
+      <ul>
+        <li><a href="/articles/stateroom-sanity-check.html">Stateroom Sanity Check — the cabin mistakes nobody warns you about</a></li>
+        <li><a href="/articles/anthem-of-the-seas-deck-plans.html">Anthem of the Seas Deck Plans — reading a deck plan for cabin strategy</a></li>
+        <li><a href="/articles/cruise-seasickness-what-works.html">Cruise Seasickness: What Actually Works</a></li>
+        <li><a href="/stateroom-check.html">Stateroom Check — flag a specific cabin before you book</a></li>
+        <li><a href="/articles/what-cruise-actually-costs-2026.html">What a Cruise Actually Costs in 2026</a></li>
+        <li><a href="/first-cruise.html">Your First Cruise</a></li>
+      </ul>
+
+      <p class="tiny muted" style="margin-top:1.5rem">This guide deliberately avoids quoting cabin prices and square footage — both vary by ship, sailing, and season faster than an article should pretend to track. The decision logic is the durable part. Seasickness positioning per CDC traveler guidance (see the <a href="/articles/cruise-seasickness-what-works.html">seasickness guide</a> for sources); ship-specific cabin facts per this site's verified deck-plan research. Reviewed August 22, 2026. No affiliate links.</p>
+
+      </div>
+    </article>
+  </main>
+
+  <!-- ================= FOOTER ================= -->
+  <footer class="wrap footer" role="contentinfo">
+    <p>&copy; 2026 In the Wake. All rights reserved.</p>
+    <p class="trust-badge">✓ No ads. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+    <nav aria-label="Footer navigation">
+      <ul style="list-style:none;padding:0;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
+        <li><a href="/about-us.html">About</a></li>
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/reaching-someone-at-sea.html">Reach Family at Sea</a></li>
+        <li><a href="/affiliate-disclosure.html">Affiliate Disclosure</a></li>
+      </ul>
+    </nav>
+    <p class="tiny center" style="margin-top:.5rem;opacity:0.7">
+      Soli Deo Gloria — Every pixel and part of this project is offered as worship to God.
+    </p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+</body>
+</html>

--- a/articles/norwegian-getaway-aug-2026-logbook.factcheck.json
+++ b/articles/norwegian-getaway-aug-2026-logbook.factcheck.json
@@ -1,0 +1,42 @@
+{
+  "_doctrine": ".claude/skills/original-research/SKILL.md",
+  "article_filename": "norwegian-getaway-aug-2026-logbook.html",
+  "last_factcheck_date": "2026-08-24",
+  "verified_by": "Claude (patron syl); source is the operator aboard",
+  "hls_task": "getaway-aug-24-28-daily-logbook-publish-ken-s-dispatches-dai",
+  "format_decision": "Single running logbook page, day entries appended as dispatches arrive (the structure question deferred at hub-creation is now decided — matches the Quantum Pacific Coastal logbook precedent, one URL for the week). No placeholder sections for future days (site rule: no coming-soon content).",
+  "affiliate_posture": {"links_present": false},
+  "entries": {
+    "day_1": {
+      "date": "2026-08-24",
+      "source": "Ken's in-session dispatch from aboard, verbatim basis: 'embarkation was smooth, rooms are dirty and deteriorated. Toenails on the floor, detritus from previous guests. We're giving them an opportunity to fix it.'",
+      "fidelity_notes": "Entry contains ONLY the dispatched facts: smooth embarkation; rooms (plural, as dispatched) dirty and deteriorated; toenails on the floor; detritus from previous guests; opportunity-to-fix posture. Deliberately NOT invented: cabin numbers, deck, times, staff interactions, meals, sailaway, shore-power observations (owed but not yet dispatched — entry defers them to Day 2 explicitly). The 'turnaround day is a hard day for housekeeping' line is general fairness framing, not a claim about this crew.",
+      "pastoral_handling": "Failure stated plainly per PASTORAL_GUARDRAILS/never-chipper rule ('There's no soft way to write that sentence, and I'm not going to try'); fairness posture is the operator's own ('the same standard I'd ask readers to hold us to'); no outrage amplification; verdict explicitly deferred to the ship's response."
+    }
+  },
+  "voice_audit": {
+    "audited_against": "voice-audit v2.3.0",
+    "audit_date": "2026-08-24",
+    "audited_by": "Claude (patron syl)",
+    "audit_scope": "Day 1 entry + standing intro",
+    "authorship_mode": "First-person lived dispatch — the operator's own report from aboard, expanded only with framing, zero invented sensory or narrative detail.",
+    "machine_tells": {"banned_cruise_vocab_count": 0, "generic_ai_tells_count": 0, "promotional_verbs_count": 0, "stat_grid_opening": false},
+    "must_be_present": {
+      "first_person_attestation_with_date": "Yes — Day 1, Monday August 24, from aboard.",
+      "honest_limitation": "Yes — 'doesn't yet tell you whether you're looking at a bad hour or a bad operation'; verdict deferred; 'unpolished on purpose.'",
+      "friction": "The entry IS friction — a lived-grade Layer 3 anchor (toenails on the floor) that no brochure or model would volunteer.",
+      "plain_copulas_dominant": true
+    },
+    "cluster_detection_verdict": "likely_human — operator-dispatched lived content with named ugly specifics and a withheld verdict",
+    "risk_rating": "Low"
+  },
+  "emotional_hook_test": {
+    "audited_against": "emotional-hook-test v2.0.0 (Article/Logbook target: authenticity + learning)",
+    "clarity_0_5s": "PASS — standing intro says exactly what the page is and how it updates",
+    "calm_5_10s": "PASS — the bad news is delivered measured, with the fix-first posture modeled",
+    "seen_10_15s": "PASS — readers who've walked into a dirty cabin see their experience named without minimization",
+    "confidence_15_20s": "PASS — the opportunity-to-fix standard gives readers a usable script for their own bad cabin",
+    "guided_20_30s": "PASS — what tomorrow's entry will cover is named",
+    "score": "5/5 — ship"
+  }
+}

--- a/articles/norwegian-getaway-aug-2026-logbook.html
+++ b/articles/norwegian-getaway-aug-2026-logbook.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<!--
+Soli Deo Gloria
+All work on this project is offered as a gift to God.
+"Trust in the LORD with all your heart..." — Proverbs 3:5
+"Whatever you do, work heartily..." — Colossians 3:23
+-->
+
+<html lang="en" class="no-js">
+<head>
+  <meta charset="utf-8"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/in_the_wake_icon_32x32.png"/>
+  <!-- ======================================================
+       In the Wake — Article (Trip Logbook, updated daily during the sailing)
+       Page: Norwegian Getaway, Day by Day — Logbook of a Repair Sailing (Aug 24–28, 2026)
+       Version: 3.010.400  |  Standards baseline: 3.010.x
+       Content Protocol: ICP-2
+       ====================================================== -->
+
+  <script>document.documentElement.classList.remove('no-js');</script>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta name="referrer" content="strict-origin-when-cross-origin"/>
+  <meta name="ai-summary" content="A daily logbook from aboard Norwegian Getaway's August 24-28, 2026 sailing — the cruise rearranged for propulsion repairs, with an overnight in Nassau and 12 hours at Great Stirrup Cay. Day 1: embarkation was smooth; the cabins arrived dirty and deteriorated, with debris from previous guests, and the family is giving the ship the opportunity to make it right. Updated each day of the sailing."/>
+  <meta name="last-reviewed" content="2026-08-24"/>
+  <meta name="content-protocol" content="ICP-2"/>
+  <meta name="robots" content="index,follow,max-image-preview:large"/>
+  <meta name="color-scheme" content="light dark"/>
+  <meta name="theme-color" content="#0e6e8e"/>
+  <meta name="version" content="3.010.400"/>
+  <meta name="page:version" content="3.010.400"/>
+  <meta name="author" content="Ken Baker"/>
+
+  <!-- SEO -->
+  <title>Norwegian Getaway, Day by Day: Logbook of a Repair Sailing (Aug 24–28, 2026) — In the Wake</title>
+  <meta name="description" content="Daily dispatches from aboard Norwegian Getaway's rearranged August 2026 sailing — the Nassau repair overnight, 12 hours at Great Stirrup Cay, and an honest record of how the week actually goes, starting with a smooth embarkation and a cabin that wasn't ready to be lived in."/>
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://cruisinginthewake.com/articles/norwegian-getaway-aug-2026-logbook.html"/>
+
+  <!-- Social -->
+  <meta property="og:type" content="article"/>
+  <meta property="og:site_name" content="In the Wake"/>
+  <meta property="og:title" content="Norwegian Getaway, Day by Day: Logbook of a Repair Sailing"/>
+  <meta property="og:description" content="Daily dispatches from aboard the rearranged August 2026 sailing — starting with a smooth embarkation and a cabin that wasn't ready to be lived in."/>
+  <meta property="og:url" content="https://cruisinginthewake.com/articles/norwegian-getaway-aug-2026-logbook.html"/>
+  <meta property="og:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta property="article:section" content="Trip Logbooks"/>
+  <meta property="article:published_time" content="2026-08-24"/>
+  <meta property="article:author" content="https://cruisinginthewake.com/authors/ken-baker.html"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Norwegian Getaway, Day by Day: Logbook of a Repair Sailing"/>
+  <meta name="twitter:description" content="Daily dispatches from aboard the rearranged August 2026 sailing."/>
+  <meta name="twitter:image" content="https://cruisinginthewake.com/assets/social/articles-hero.jpg"/>
+
+  <!-- Structured data: Article -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline":"Norwegian Getaway, Day by Day: Logbook of a Repair Sailing (Aug 24–28, 2026)",
+    "description":"Daily dispatches from aboard Norwegian Getaway's rearranged August 2026 sailing — an honest running record, updated each day.",
+    "author":{"@type":"Person","name":"Ken Baker","url":"https://cruisinginthewake.com/authors/ken-baker.html"},
+    "publisher":{"@type":"Organization","name":"In the Wake","logo":{"@type":"ImageObject","url":"https://cruisinginthewake.com/assets/logo_wake.png"}},
+    "datePublished":"2026-08-24",
+    "dateModified":"2026-08-24",
+    "image":"https://cruisinginthewake.com/assets/social/articles-hero.jpg",
+    "mainEntityOfPage":"https://cruisinginthewake.com/articles/norwegian-getaway-aug-2026-logbook.html",
+    "articleSection":"Trip Logbooks",
+    "about":[
+      {"@type":"Thing","name":"Norwegian Getaway"},
+      {"@type":"Thing","name":"Norwegian Cruise Line"},
+      {"@type":"Thing","name":"Cruise logbook"}
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Person",
+    "name":"Ken Baker",
+    "url":"https://cruisinginthewake.com/authors/ken-baker.html",
+    "jobTitle":"Pastor, Cruise Writer",
+    "description":"Reformed Baptist pastor and cruise writer specializing in accessible travel, grief support, and compassionate cruise guidance.",
+    "worksFor":{"@type":"Organization","name":"In the Wake"},
+    "knowsAbout":["Norwegian Getaway","Norwegian Cruise Line","Cruise travel","Trip logbooks"]
+  }
+  </script>
+
+  <link rel="stylesheet" href="/assets/styles.css?v=3.010.400"/>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
+
+  <script>
+  if('serviceWorker' in navigator){
+    window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
+  }
+  </script>
+</head>
+<body class="page">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div id="a11y-status" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+  <div id="a11y-alerts" role="alert" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+
+  <!-- ================= HEADER ================= -->
+  <header class="hero-header" role="banner">
+    <div class="navbar">
+      <div class="brand">
+        <img src="/assets/logo_wake_256.png" srcset="/assets/logo_wake_256.png 1x, /assets/logo_wake_512.png 2x" width="256" height="259" alt="In the Wake wordmark" decoding="async"/>
+
+      </div>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle-icon"><span></span><span></span><span></span></span>
+      </button>
+      <nav class="site-nav" id="site-nav" aria-label="Main site navigation">
+        <a class="nav-pill" href="/">Home</a>
+
+        <!-- Planning Dropdown -->
+        <div class="nav-dropdown" id="nav-planning">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Planning <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/first-cruise.html">Your First Cruise</a>
+            <a href="/ships/">Ships</a>
+            <a href="/cruise-lines/">Cruise Lines</a>
+            <a href="/ports/">Ports</a>
+            <a href="/packing-lists.html">Packing Lists</a>
+            <a href="/accessibility.html">Accessibility</a>
+          </div>
+        </div>
+
+        <!-- Tools Dropdown -->
+        <div class="nav-dropdown" id="nav-tools">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Tools <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/ships/quiz.html">Ship Quiz</a>
+            <a href="/cruise-lines/quiz.html">Cruise Line Quiz</a>
+            <a href="/drink-calculator.html">Drink Calculator</a>
+            <a href="/stateroom-check.html">Stateroom Check</a>
+            <a href="/tools/port-tracker.html">Port Logbook</a>
+            <a href="/tools/ship-tracker.html">Ship Logbook</a>
+            <a href="/tools/cruise-budget-calculator.html">Budget Calculator</a>
+            <a href="/tools/cruise-tipping-calculator.html">Tipping Calculator</a>
+            <a href="/tools/port-day-planner.html">Port Day Planner</a>
+            <a href="/tools/ship-size-atlas.html">Ship Size Atlas</a>
+          </div>
+        </div>
+
+        <!-- Onboard Dropdown -->
+        <div class="nav-dropdown" id="nav-onboard">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Onboard <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/restaurants/">Restaurants &amp; Menus</a>
+            <a href="/drink-packages.html">Drink Packages</a>
+            <a href="/internet-at-sea.html">Internet at Sea</a>
+            <a href="/articles.html">Articles</a>
+          </div>
+        </div>
+
+        <!-- Travel Dropdown -->
+        <div class="nav-dropdown" id="nav-travel">
+          <button class="nav-pill" type="button" aria-expanded="false" aria-haspopup="true">
+            Travel <span class="caret">&#9662;</span>
+          </button>
+          <div class="dropdown-menu" role="menu">
+            <a href="/travel.html">Travel (overview)</a>
+            <a href="/solo.html">Solo</a>
+          </div>
+        </div>
+
+        <a class="nav-pill" href="/search.html">Search</a>
+        <a class="nav-pill" href="/about-us.html">About</a>
+      </nav>
+    </div>
+    <div class="hero" role="img" aria-label="Norwegian Getaway daily logbook, August 2026">
+      <img class="hero-compass" src="/assets/compass_rose.svg?v=3.010.400" width="180" height="180" alt="" aria-hidden="true" decoding="async"/>
+      <div class="hero-title">
+        <img class="logo" src="/assets/logo_wake_560.png" srcset="/assets/logo_wake_560.png 1x, /assets/logo_wake_1120.png 2x" alt="In the Wake" decoding="async" fetchpriority="high" width="560" height="567"/>
+      </div>
+      <div class="tagline" aria-hidden="true">Getaway, Day by Day</div>
+    </div>
+  </header>
+
+  <!-- ================= MAIN ================= -->
+  <main id="main-content" class="wrap page-grid" role="main" aria-label="Main content">
+    <article class="card solo-article" itemscope itemtype="https://schema.org/Article">
+      <header style="max-width:min(860px,92%);margin-inline:auto">
+        <h1 itemprop="headline">Norwegian Getaway, Day by Day: Logbook of a Repair Sailing (Aug 24–28, 2026)</h1>
+        <p class="dek" itemprop="description">Dispatches from aboard the sailing NCL rearranged around propulsion repairs — the overnight in Nassau, the 12-hour island day, and whatever else the week actually delivers. Written from the ship, one day at a time, the good and the bad both.</p>
+        <p class="byline">by <a href="/authors/ken-baker.html"><span itemprop="author">Ken Baker</span></a> | <time datetime="2026-08-24">August 24, 2026</time> — updated daily during the sailing</p>
+      </header>
+
+      <div itemprop="articleBody" style="max-width:min(860px,92%);margin-inline:auto">
+
+      <!-- Standing intro -->
+      <p class="answer-line" style="font-size:1.05rem;border-left:3px solid #0e6e8e;padding:0.75rem 1rem;background:#f8fbfc;border-radius:4px;margin:1rem 0 1.5rem">
+        <strong>What this page is:</strong> the daily logbook of the August 24–28, 2026 Norwegian Getaway sailing from Miami — the cruise that was <a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">rearranged before departure</a> so the ship can overnight in Nassau for propulsion repairs, with <a href="/articles/great-stirrup-cay-changes-2026.html">Great Stirrup Cay</a> extended to a 12-hour day (8 a.m. to 8 p.m.). I wrote the research before boarding; this page is what actually happens. New entries are added each day of the sailing, newest at the bottom, unpolished on purpose — a logbook, not a brochure.
+      </p>
+
+      <!-- ================= DAY 1 ================= -->
+      <h2 id="day-1">Day 1 — Monday, August 24: Boarding Smooth, Cabins Not Ready to Be Lived In</h2>
+
+      <p>Embarkation was smooth. After writing a whole <a href="/articles/cruise-embarkation-day-what-to-expect.html">guide to embarkation day</a> from research, I have nothing to correct from the lived version of this one: the terminal did its job and we walked aboard without drama.</p>
+
+      <p>The cabins are another story. Our rooms came to us dirty and deteriorated — not tired-around-the-edges dirty, but toenails-on-the-floor dirty, with detritus from the previous guests still in the room. There's no soft way to write that sentence, and I'm not going to try. A cabin is the one space on a ship a family has to itself, and this one had not been made ready for us.</p>
+
+      <p>Here is where we've landed, and it's the same standard I'd ask readers to hold us to: <strong>we've given the ship the opportunity to fix it.</strong> A turnaround day is a hard day for a housekeeping team, and a failure on one cabin — or several — doesn't yet tell you whether you're looking at a bad hour or a bad operation. What happens next is the actual information: how fast, how thoroughly, and with what attitude the ship makes this right. That's tomorrow's entry.</p>
+
+      <p>More from the ship tomorrow — including the night we spend plugged in at the pier before the 3 a.m. departure, which the <a href="/articles/cruise-shore-power-explained.html">shore power piece</a> promised I'd report on honestly.</p>
+
+      <hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
+
+      <!-- RELATED -->
+      <h2 id="related">The Pre-Trip Research This Logbook Is Testing</h2>
+      <ul>
+        <li><a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">The itinerary change, explained — why this sailing overnights in Nassau</a></li>
+        <li><a href="/articles/cruise-shore-power-explained.html">Shore Power, Explained — the Monday-night test at the pier</a></li>
+        <li><a href="/articles/great-stirrup-cay-changes-2026.html">Great Stirrup Cay Is About to Change — the pier question Thursday should answer</a></li>
+        <li><a href="/articles/cruise-embarkation-day-what-to-expect.html">Cruise Embarkation Day: What to Expect</a></li>
+        <li><a href="/ships/norwegian/norwegian-getaway.html">Norwegian Getaway — ship guide</a></li>
+      </ul>
+
+      <p class="tiny muted" style="margin-top:1.5rem">Source for every entry on this page: the author, aboard, that day. Entries are dispatches, not reconstructions — short when the day was short on words. Reviewed August 24, 2026. No affiliate links.</p>
+
+      </div>
+    </article>
+  </main>
+
+  <!-- ================= FOOTER ================= -->
+  <footer class="wrap footer" role="contentinfo">
+    <p>&copy; 2026 In the Wake. All rights reserved.</p>
+    <p class="trust-badge">✓ No ads. Independent of cruise lines. <a href="/affiliate-disclosure.html">Affiliate Disclosure</a></p>
+    <nav aria-label="Footer navigation">
+      <ul style="list-style:none;padding:0;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
+        <li><a href="/about-us.html">About</a></li>
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/reaching-someone-at-sea.html">Reach Family at Sea</a></li>
+        <li><a href="/affiliate-disclosure.html">Affiliate Disclosure</a></li>
+      </ul>
+    </nav>
+    <p class="tiny center" style="margin-top:.5rem;opacity:0.7">
+      Soli Deo Gloria — Every pixel and part of this project is offered as worship to God.
+    </p>
+  </footer>
+
+  <script src="/assets/js/dropdown.js"></script>
+</body>
+</html>

--- a/articles/norwegian-getaway-nassau-repairs-overnight-2026.html
+++ b/articles/norwegian-getaway-nassau-repairs-overnight-2026.html
@@ -236,7 +236,7 @@ All work on this project is offered as a gift to God.
       <section class="fit-guidance" aria-labelledby="who-this-is-for" style="background:#f8f9fa;border-left:3px solid #0e6e8e;padding:1rem 1.25rem;border-radius:4px;margin:1rem 0 1.5rem">
         <h2 id="who-this-is-for" style="margin-top:0;font-size:1.15rem">Who This Is For</h2>
         <p style="margin:0.5rem 0">Anyone booked on this sailing and wondering what the letter means in practice; anyone following how cruise lines handle mechanical problems mid-season; and anyone who wants a calm read on itinerary changes generally — because the pattern here repeats across every line, and knowing it takes most of the sting out of the next email like this one.</p>
-        <p style="margin:0.5rem 0"><strong>And a note on what's coming:</strong> I'm booked on this cruise. I board Monday, and I'll write from the ship every day — how the repairs look from a deck chair, how an overnight in Nassau actually plays, whether the 8 p.m. island departure is as good on the ground as it reads on paper. Those daily dispatches will be published here as the week unfolds. This page is the before; the logbook is next.</p>
+        <p style="margin:0.5rem 0"><strong>And a note on what's coming:</strong> I'm booked on this cruise. I board Monday, and I'll write from the ship every day — how the repairs look from a deck chair, how an overnight in Nassau actually plays, whether the 8 p.m. island departure is as good on the ground as it reads on paper. Those dispatches are now live in the <a href="/articles/norwegian-getaway-aug-2026-logbook.html">day-by-day logbook</a>, updated from the ship. This page is the before; the logbook is what actually happened.</p>
       </section>
 
       <!-- WHAT CHANGED -->
@@ -333,6 +333,7 @@ All work on this project is offered as a gift to God.
       <!-- RELATED -->
       <h2 id="related">Related Guides &amp; Coverage</h2>
       <ul>
+        <li><a href="/articles/norwegian-getaway-aug-2026-logbook.html">The Day-by-Day Logbook — live dispatches from this sailing</a></li>
         <li><a href="/ships/norwegian/norwegian-getaway.html">Norwegian Getaway — full ship guide</a></li>
         <li><a href="/articles/cruise-shore-power-explained.html">Shore Power, Explained — why this sailing sleeps over in Miami</a></li>
         <li><a href="/articles/great-stirrup-cay-changes-2026.html">Great Stirrup Cay Is About to Change — what's waiting on the island</a></li>

--- a/articles/norwegian-getaway-nassau-repairs-overnight-2026.html
+++ b/articles/norwegian-getaway-nassau-repairs-overnight-2026.html
@@ -334,6 +334,8 @@ All work on this project is offered as a gift to God.
       <h2 id="related">Related Guides &amp; Coverage</h2>
       <ul>
         <li><a href="/ships/norwegian/norwegian-getaway.html">Norwegian Getaway — full ship guide</a></li>
+        <li><a href="/articles/cruise-shore-power-explained.html">Shore Power, Explained — why this sailing sleeps over in Miami</a></li>
+        <li><a href="/articles/great-stirrup-cay-changes-2026.html">Great Stirrup Cay Is About to Change — what's waiting on the island</a></li>
         <li><a href="/articles/cruise-embarkation-day-what-to-expect.html">Cruise Embarkation Day: What to Expect, Hour by Hour</a> — for the Monday boarding</li>
         <li><a href="/articles/cruise-itinerary-changes-what-to-do.html">Cruise Itinerary Changes: What You Can Actually Do</a></li>
         <li><a href="/articles/nassau-brawls-cruise-passenger-arrests-2026.html">What Actually Happens When Cruise Passengers Get Arrested in the Bahamas</a></li>

--- a/assets/data/articles/index.json
+++ b/assets/data/articles/index.json
@@ -2,6 +2,20 @@
   "version": "v3.010.400",
   "articles": [
     {
+      "id": "norwegian-getaway-aug-2026-logbook",
+      "slug": "norwegian-getaway-aug-2026-logbook",
+      "title": "Norwegian Getaway, Day by Day: Logbook of a Repair Sailing (Aug 24–28, 2026)",
+      "url": "/articles/norwegian-getaway-aug-2026-logbook.html",
+      "date": "2026-08-24",
+      "published": "2026-08-24",
+      "status": "published",
+      "excerpt": "Daily dispatches from aboard the sailing NCL rearranged around propulsion repairs — the Nassau overnight, the 12-hour Great Stirrup Cay day, and an honest running record of how the week actually goes. Day 1: embarkation was smooth; the cabins arrived dirty and deteriorated — toenails on the floor, debris from previous guests — and the family is giving the ship the opportunity to make it right before any verdict. Updated each day of the sailing, written from the ship.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {"name": "Ken Baker", "url": "/authors/ken-baker.html", "image": "/assets/articles/ken1.png"},
+      "keywords": ["norwegian getaway logbook", "norwegian getaway august 2026", "ncl getaway review", "dirty cruise cabin", "norwegian getaway daily blog", "getaway repair sailing"]
+    },
+    {
       "id": "cruise-shore-power-explained",
       "slug": "cruise-shore-power-explained",
       "title": "Shore Power, Explained: Why Your Cruise Ship Sleeps Over in Miami",

--- a/assets/data/articles/index.json
+++ b/assets/data/articles/index.json
@@ -2,6 +2,48 @@
   "version": "v3.010.400",
   "articles": [
     {
+      "id": "cruise-shore-power-explained",
+      "slug": "cruise-shore-power-explained",
+      "title": "Shore Power, Explained: Why Your Cruise Ship Sleeps Over in Miami",
+      "url": "/articles/cruise-shore-power-explained.html",
+      "date": "2026-08-22",
+      "published": "2026-08-22",
+      "status": "published",
+      "excerpt": "A docked cruise ship burns fuel all day just to keep the hotel running — unless it can plug into the city grid instead. PortMiami wired five cruise terminals for about $125 million, says a connected ship cuts its dockside emissions by up to 98 percent, and can plug in three ships at once. It's why Norwegian Getaway sleeps over in Miami on August 24, 2026, sailing at 3 a.m. after shore power tests. What cold ironing is, what it means for passengers, and what you can actually notice from a cabin — which the author, booked on that sailing, will verify Monday night.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {"name": "Ken Baker", "url": "/authors/ken-baker.html", "image": "/assets/articles/ken1.png"},
+      "keywords": ["cruise shore power", "cold ironing cruise ship", "portmiami shore power", "why is my cruise leaving at 3am", "cruise ship plug in", "cruise ship emissions in port"]
+    },
+    {
+      "id": "great-stirrup-cay-changes-2026",
+      "slug": "great-stirrup-cay-changes-2026",
+      "title": "Great Stirrup Cay Is About to Change: Pier, Waterpark, and What's True Right Now",
+      "url": "/articles/great-stirrup-cay-changes-2026.html",
+      "date": "2026-08-22",
+      "published": "2026-08-22",
+      "status": "published",
+      "excerpt": "NCL's private island is mid-transformation: the first pier opened December 28, 2025, closed April 1, 2026 for a two-ship expansion, and its reopening date is genuinely unclear — while the 19-slide Great Tides Waterpark opens for bookable (upcharge) access on September 2026 sailings, alongside the 28,000-square-foot Great Life Lagoon pool, which carries no upcharge marker in NCL's own booklet. Sorted honestly into confirmed, extra-charge, and unverified — with the pier question flagged for the author's Thursday visit to settle in person.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {"name": "Ken Baker", "url": "/authors/ken-baker.html", "image": "/assets/articles/ken1.png"},
+      "keywords": ["great stirrup cay pier", "great tides waterpark", "great stirrup cay 2026", "great stirrup cay tender or dock", "ncl private island", "great stirrup cay what's free"]
+    },
+    {
+      "id": "interior-vs-balcony-vs-oceanview",
+      "slug": "interior-vs-balcony-vs-oceanview",
+      "title": "Interior vs. Balcony vs. Oceanview: Which Cruise Cabin Should You Book?",
+      "url": "/articles/interior-vs-balcony-vs-oceanview.html",
+      "date": "2026-08-22",
+      "published": "2026-08-22",
+      "status": "published",
+      "excerpt": "The cabin decision, the way you'd walk a friend through it: three questions — how many waking hours you'll actually spend in the cabin, whether total darkness helps or unmoors you, and what's outside the window on your route. When the interior is the smart money (and the best sleep afloat), when the oceanview is the quiet bargain, and when the balcony premium genuinely earns itself — scenic routes, seasickness, and the caregiver who needs a private retreat. No prices quoted, no sales pitch, and permission to book the cheap room without apology.",
+      "thumbnail": "/assets/social/articles-hero.jpg",
+      "image": "/assets/social/articles-hero.jpg",
+      "author": {"name": "Ken Baker", "url": "/authors/ken-baker.html", "image": "/assets/articles/ken1.png"},
+      "keywords": ["interior vs balcony cruise", "is a balcony cabin worth it", "oceanview vs balcony", "which cruise cabin should I book", "cruise cabin types", "best cruise cabin for seasickness"]
+    },
+    {
       "id": "norwegian-getaway-nassau-repairs-overnight-2026",
       "slug": "norwegian-getaway-nassau-repairs-overnight-2026",
       "title": "Norwegian Getaway's August 24 Itinerary Change: an Overnight in Nassau, Explained",

--- a/ports/great-stirrup-cay.html
+++ b/ports/great-stirrup-cay.html
@@ -642,6 +642,7 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
         <summary>Plan Your Visit</summary>
         <div class="card-content">
           <ul class="plan-visit-list">
+            <li><a href="/articles/great-stirrup-cay-changes-2026.html">Great Stirrup Cay Is About to Change</a> — pier, waterpark, and what's confirmed vs. unverified in 2026.</li>
             <li><a href="/articles/norwegian-getaway-nassau-repairs-overnight-2026.html">A 12-Hour Day on the Cay (Aug 2026)</a> — the Getaway itinerary change that runs this island call from 8 a.m. to 8 p.m.</li>
             <li><a href="/packing-lists.html">Cruise Packing Lists</a> — beach-day essentials and reef-safe sun care.</li>
             <li><a href="/articles/cruise-tech-photography-guide.html">Photography &amp; Tech Guide</a> — waterproof cases and charging at sea.</li>


### PR DESCRIPTION
Live publication for the sailing week:

- **Day-by-day logbook** (`norwegian-getaway-aug-2026-logbook`) — Ken's Day 1 dispatch from aboard, published with strict fidelity to his words: embarkation smooth; cabins dirty and deteriorated (toenails on the floor, detritus from previous guests); the family is giving the ship the opportunity to fix it before any verdict. Shore-power observations explicitly deferred to Day 2. Days append to this page all week.
- **Three articles from the pre-trip batch**, all through the full voice pipeline (like-a-human, six-axis voice-audit, emotional-hook 5/5, attestations in sidecars): Shore Power Explained (Miami-Dade primary-sourced), Great Stirrup Cay Is About to Change (NCL booklet-sourced; pier reopening honestly marked unverified pending Thursday's visit), Interior vs. Balcony vs. Oceanview (evergreen decision guide, no invented prices).
- Bidirectional cross-links throughout; hub now links the live logbook; index at 59 articles.
- Excluded on purpose: `admin/UNFINISHED_TASKS.md` working-tree change — the no-getbets pre-commit guard correctly flagged pre-existing banned-string content in HLS-mirrored task rows there; registered in HLS for a catalog-level fix rather than bypassed.

All touched articles PASS the page validator; JSON valid; JSON-LD parses; no affiliate links in any of the four new pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV)_