### PR TITLE
Sidecar: voice-audit attestation for Day 1 evening addendum

### DIFF
--- a/articles/norwegian-getaway-aug-2026-logbook.factcheck.json
+++ b/articles/norwegian-getaway-aug-2026-logbook.factcheck.json
@@ -28,7 +28,14 @@
     "audited_against": "voice-audit v2.3.0",
     "audit_date": "2026-08-24",
     "audited_by": "Claude (patron syl)",
-    "audit_scope": "Day 1 entry + standing intro",
+    "audit_scope": "Day 1 entry + standing intro; evening addendum audited separately 2026-08-24 (see addendum_audit)",
+    "addendum_audit": {
+      "banned_vocab_scan": "0 hits (mechanical grep over the addendum section, full banned list)",
+      "layer_1_signals": "None found. No semantic placeholders (every abstraction traces to a photographed referent); no unanchored authority claims; the closing item-list ('the garment bag, the wristband, the tag scrap, the debris') is an inventory of photographed objects, not decorative triplet rhythm; friction present — policy logic explicitly unknown, verdict withheld.",
+      "layer_3_lived_grade": "The photos themselves; the 'REMOVE THIS PORTION ONLY' tag scrap (idiosyncratic micro-observation); alcohol/soda/unsweet-tea enforcement specificity from the operator's own afternoon.",
+      "honest_flags": "'Strikingly uneven' is slightly writerly; the 'drinks nobody profits from' aphorism is editorial analysis (mine, not the operator's words) — kept because the text flags it as a reading to test, not a fact. Named here so the judgment is reviewable.",
+      "verdict": "Low risk — ship. Attested by Claude (patron syl), 2026-08-24."
+    },
     "authorship_mode": "First-person lived dispatch — the operator's own report from aboard, expanded only with framing, zero invented sensory or narrative detail.",
     "machine_tells": {"banned_cruise_vocab_count": 0, "generic_ai_tells_count": 0, "promotional_verbs_count": 0, "stat_grid_opening": false},
     "must_be_present": {


### PR DESCRIPTION
Records the formal voice-audit pass (banned-vocab scan, cluster detection, lived-grade counter-signals, honest flags) for the already-published Day 1 evening addendum in the logbook's factcheck sidecar. Sidecar-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV)_