### PR TITLE
Logbook Day 1: O'Sheehan's dining verdicts + evening engine runs

### DIFF
--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -28,6 +28,31 @@ compliance from anyone — if the run happened, the entry is true.
 
 ---
 
+## 2026-08-24 — Day 1 dining + engine runs (syl)
+
+**Asked.** Fourth Day 1 dispatch: O'Sheehan's lunch (fish and chips good — crunchy
+outside, moist inside; Irish Reuben unbalanced, too much acid), dinner NY strip + two
+lobster tails with verdict promised later, and engines being started and run off and on
+all evening.
+
+**Weighed.** Venue name: dispatch says "o Sheehans (oceans)" — used O'Sheehan's (the
+operator's own name for it, and our venue page exists at restaurants/ncl/osheehans.html);
+left "(oceans)" out rather than guess what it meant. Dinner venue wasn't named, so the
+entry doesn't name one. Engines: the observation sits right next to the shore-power
+question, and the temptation is to conclude the ship isn't plugged in — resisted, because
+engine runs at a pier have innocent explanations (pre-departure checks among them) and
+the shore-power report is Ken's to make with more than a sound. Wrote it as an observed
+detail plus the open question.
+
+**Decided.** Two short h3s appended to Day 1 (dining, engines) with the venue cross-link;
+sidecar records dispatch-vs-framing including normalized typos and the not-claimed list.
+Published live per the daily pattern.
+
+**Unsure.** What "(oceans)" meant in the dispatch — flagged in the sidecar instead of
+guessed. What the engine runs actually were — deliberately left open in print.
+
+---
+
 ## 2026-08-24 — Day 1 heat note: no breeze on a stationary ship (syl)
 
 **Asked.** Third Day 1 dispatch: "No breeze on a cruise ship that's not moving. It's hot

--- a/articles/norwegian-getaway-aug-2026-logbook.factcheck.json
+++ b/articles/norwegian-getaway-aug-2026-logbook.factcheck.json
@@ -23,6 +23,11 @@
       },
       "fidelity_notes": "Dirty-vs-deteriorated distinction (steward-fixable vs deferred maintenance) is editorial framing grounded in the photos, not a new factual claim. Hot-tub entry states ONLY the observed pattern (alcohol undisturbed; soda flagged; unsweet tea flagged) and explicitly disclaims knowledge of the policy logic; 'nobody profits from' line is analysis flagged as a reading to be tested during the week, not asserted fact. NOT claimed: who enforced, how many instances, whether cabins were fixed yet (still tomorrow's entry)."
     },
+    "day_1_dining_and_engines": {
+      "date": "2026-08-24",
+      "source": "Ken's fourth in-session dispatch: O'Sheehan's lunch (fish and chips crunchy outside/moist inside; Irish Reuben lacked balance, too much acid); dinner NY strip + pair of lobster tails, verdict pending ('Will update you'); engines started and run off and on all evening.",
+      "fidelity_notes": "Venue name as the operator gave it (O'Sheehan's), linked to the existing venue page restaurants/ncl/osheehans.html. Dispatch typos normalized (nee york -> New York, lonster -> lobster, Ruben -> Reuben); '(oceans)' in the dispatch left out as unclear rather than guessed at. Dinner venue NOT named (not dispatched); dinner verdict explicitly deferred. Engine entry states only the observation; both candidate explanations (pre-departure checks, ordinary hotel-load rhythm) offered as unknowns, no claim about whether shore power is connected. NOT claimed: times, which engines, exhaust, noise level in cabins."
+    },
     "day_1_heat_note": {
       "date": "2026-08-24",
       "source": "Ken's third in-session dispatch, verbatim basis: 'No breeze on a cruise ship that's not moving. It's hot in South Florida today.'",

--- a/articles/norwegian-getaway-aug-2026-logbook.html
+++ b/articles/norwegian-getaway-aug-2026-logbook.html
@@ -265,6 +265,14 @@ All work on this project is offered as a gift to God.
 
       <p>There is no breeze on a cruise ship that isn't moving. It's hot in South Florida today, and this sailing doesn't leave the pier until the small hours — so the open decks spend the evening learning what every ship's brochure photo quietly assumes: the wind up there is usually the ship's own speed, made by moving. Tied up alongside, you get whatever the Miami afternoon feels like giving you, which today is not much. File it with the things an itinerary built around staying in port trades away — the overnights in this rearranged week buy repair time and a longer island day, and they pay for it in evenings like this one.</p>
 
+      <h3 id="day-1-dining">Day 1 dining: O'Sheehan's does the simple thing right</h3>
+
+      <p>Lunch was <a href="/restaurants/ncl/osheehans.html">O'Sheehan's</a> — fish and chips and an Irish Reuben. The fish and chips earned its keep: crunchy outside, moist inside, which is the entire job description of fish and chips and one plenty of kitchens still fail. The Irish Reuben didn't find its balance — too much acid, the kind of sandwich where one element is shouting over the rest. Dinner was a New York strip and a pair of lobster tails; verdict to come.</p>
+
+      <h3 id="day-1-engines">And one sound from the pier</h3>
+
+      <p>Off and on all evening, they've been starting the engines and letting them run. I don't know what tonight's runs are — could be checks before the 3 a.m. departure, could be the ordinary rhythm of a ship keeping herself alive at the pier — but it's exactly the kind of detail the <a href="/articles/cruise-shore-power-explained.html">shore power piece</a> taught me to listen for, and it goes in the notebook next to the question that article promised this sailing would answer.</p>
+
       <hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
 
       <!-- RELATED -->


### PR DESCRIPTION
Appends the fourth Day 1 dispatch: O'Sheehan's lunch verdicts (fish and chips right; Irish Reuben over-acidic) with a cross-link to the existing venue page, dinner noted with verdict deferred, and the off-and-on engine runs at the pier written as observation + open question next to the shore-power report still owed. Sidecar and reasoning log updated. Validator: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV)_