### PR TITLE
Logbook Day 1 close: same-night fixes + the sushi-dinner prediction

### DIFF
--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -28,6 +28,30 @@ compliance from anyone — if the run happened, the entry is true.
 
 ---
 
+## 2026-08-24 — Day 1 closes: the ship answered, and a prediction goes on the record (syl)
+
+**Asked.** Eighth and final Day 1 dispatch: vacuum sent, door handle repaired, TV fixed —
+same night; the sushi-dinner-for-mom request "noted in the report"; Ken's read that
+comping it is cheap goodwill that sells a second meal, that it would be appreciated, and
+that he doubts it happens.
+
+**Weighed.** The page had just printed skepticism ("'apparently,' which is the word you
+reach for…"), so honesty required walking that back explicitly when the ship delivered
+same-night — "'apparently' turned out to be unfair" — rather than quietly absorbing the
+good news. Scope discipline: only a vacuum was dispatched, so the entry does not claim
+the toenails-and-detritus cleaning is resolved; that stays a morning question. The
+sushi-dinner doubt is framed as an explicit, scoreable prediction — the logbook's own
+device: it committed to judging the ship by its response, so it should also commit its
+author's predictions to the record where they can be wrong in public.
+
+**Decided.** Two paragraphs closing the cabin thread (the answer + the open thread with
+prediction), sidecar updated, published live.
+
+**Unsure.** Whether "I'd write about it" reads as soliciting a comp — judged no, since
+the whole page already declares everything gets written about, good and bad alike.
+
+---
+
 ## 2026-08-24 — Day 1: early departure, scuttlebutt handled as scuttlebutt, cabin list grows (syl)
 
 **Asked.** Seventh Day 1 dispatch: Facebook-group screenshot showing the ship left port

--- a/articles/norwegian-getaway-aug-2026-logbook.factcheck.json
+++ b/articles/norwegian-getaway-aug-2026-logbook.factcheck.json
@@ -37,6 +37,11 @@
       "photos": "day1-getaway-model.webp (model in glass case, hull art, abstract artwork behind — caption describes only what is visible); day1-bremerhaven-plaque.webp (rotated upright; plate legibly reads SEESTADT BREMERHAVEN; caption describes the relief and notes the ship was built in Germany — Getaway was built at Meyer Werft, already stated on our ship page — without claiming what the plaque commemorates).",
       "cabin_additions": "TV broken, door lock broken, maintenance promised — 'apparently' kept as the operator's own skeptical word. Folded into the fix-it scorecard alongside cleaning."
     },
+    "day_1_ship_answered": {
+      "date": "2026-08-24",
+      "source": "Ken's eighth in-session dispatch: someone sent to vacuum; inside of the exterior door knob repaired; TV fixed; crew would 'note it in the report that the customer requested a dinner at the sushi restaurant for his mom' (quote as dispatched); Ken's analysis — low-hanging fruit, comped dinner guarantees a second purchased meal, gesture would be appreciated, 'But I doubt that will happen.'",
+      "fidelity_notes": "Same-night fixes stated as dispatched (vacuum, door handle, TV); 'apparently turned out to be unfair' is the honest walk-back of the earlier skepticism about response speed. Deeper-clean status NOT claimed — only a vacuum pass was dispatched, so the entry defers that to morning. Sushi venue NOT named (dispatch said 'the sushi restaurant'). The comp-economics analysis is Ken's own, printed in his framing; the doubt is printed as an explicit scored prediction the week can settle. 'I'd write about it' is inherent to the page's premise, not a new claim."
+    },
     "day_1_heat_note": {
       "date": "2026-08-24",
       "source": "Ken's third in-session dispatch, verbatim basis: 'No breeze on a cruise ship that's not moving. It's hot in South Florida today.'",

--- a/articles/norwegian-getaway-aug-2026-logbook.html
+++ b/articles/norwegian-getaway-aug-2026-logbook.html
@@ -297,6 +297,10 @@ All work on this project is offered as a gift to God.
 
       <p>The TV and the door lock are both broken. Maintenance is coming — "apparently," which is the word you reach for after the day we've had with this room. Add it to tomorrow's scorecard: the cleaning, the fixtures, and now the electronics, all waiting on the same question of how this ship responds when something's wrong.</p>
 
+      <p><strong>And then the ship answered.</strong> "Apparently" turned out to be unfair: someone came to vacuum, the inside of the exterior door handle got repaired, and the TV got fixed — same night, all of it. Credit where due: the answer to <em>how fast</em> started arriving before Day 1 ended. Whether the deeper cleaning matches the vacuum pass is a morning question.</p>
+
+      <p>One thread left open, with a prediction attached. When we raised the day's troubles, the answer was that they'd "note it in the report that the customer requested a dinner at the sushi restaurant for his mom." Here's the honest math on that gesture: it's low-hanging fruit. Comp one dinner and they all but guarantee I buy a second seat at the same table — the goodwill costs them almost nothing and probably nets a sale. My mother would appreciate it, and I'd write about it. On the record: I doubt it will happen. The rest of the week gets to score that prediction.</p>
+
       <hr style="border:0;border-top:2px solid var(--foam);margin:2rem 0">
 
       <!-- RELATED -->


### PR DESCRIPTION
Closes Day 1: the ship answered same-night (vacuum, door handle, TV) with an explicit walk-back of the page's earlier "apparently" skepticism; deeper-clean verdict deferred to morning since only a vacuum was dispatched. The sushi-dinner-for-mom thread stays open with the operator's comp-economics analysis and his doubt printed as a scoreable prediction. Sidecar and reasoning log updated. Validator: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV)_