### PR TITLE
Logbook: steak-doneness claim carries its derivation

### DIFF
--- a/articles/norwegian-getaway-aug-2026-logbook.html
+++ b/articles/norwegian-getaway-aug-2026-logbook.html
@@ -336,7 +336,7 @@ All work on this project is offered as a gift to God.
 
       <p>We ordered lunch from room service: flank steak, a Cobb salad, and a BLT. The BLT tasted excellent — but order two, it's small. The Cobb salad was a 6 out of 10: the chicken was dry, and they didn't put the balsamic vinaigrette on it that I asked for — though the blue cheese they chose was fantastic. The flank steak was an 8 out of 10: overcooked but still tender and moist, and the chimichurri was fantastic too.</p>
 
-      <p>Two days in, the kitchen pattern is holding steady: the flavors keep landing — chimichurri, that blue cheese, yesterday's buttery lobster — while the misses stay in the same two columns, doneness (two overcooked steaks in two days) and order accuracy (a missing vinaigrette after yesterday's wandering bruschetta). Good kitchen, loose execution. It's a fixable kind of flaw, which is exactly why it's worth writing down.</p>
+      <p>Two days in, the kitchen pattern is holding steady: the flavors keep landing — chimichurri, that blue cheese, yesterday's buttery lobster — while the misses stay in the same two columns, doneness (Monday's New York strip came overcooked, and now Tuesday's flank did too — two overcooked steaks in two days) and order accuracy (a missing vinaigrette after yesterday's wandering bruschetta). Good kitchen, loose execution. It's a fixable kind of flaw, which is exactly why it's worth writing down.</p>
 
       <p>After lunch we went up to <a href="/restaurants/ncl/spice-h2o.html">Spice H2O</a> and grabbed a table. The hot tubs and pool were full, but we found a shady spot — which, on a hot afternoon with the ship underway, is all the real estate you actually need.</p>
 


### PR DESCRIPTION
Sophos duration standard: "two overcooked steaks in two days" now names its sources inline (Monday's New York strip, Tuesday's flank) so the count carries its own evidence. One-line change. Validator: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV)_