### PR TITLE
Reader-support CTA on every article

### DIFF
--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -28,6 +28,48 @@ compliance from anyone — if the run happened, the entry is true.
 
 ---
 
+## 2026-08-28 — Reader-support CTA on every article and voyage pack (syl)
+
+**Asked.** Ken: put https://buymeacoffee.com/inthewake with a CTA in every article and
+voyage pack — "Was this helpful? Buymeacoffee. However you think is best. Unobtrusive,
+but visible."
+
+**Weighed.** Checked for prior art before inventing: support.html and voyage-packs.html
+already use BMC with a house pattern (brand #0e6e8e, rel="noopener", pill/inline links),
+so the block matches that rather than introducing a new style. Placement: a bordered
+aside immediately before </article> — outside itemprop="articleBody", so a donation ask
+is not folded into Article schema content. Anchor verified unique in all 52 article
+files before any bulk edit. Link hygiene: articles use the site-relative /support.html;
+packs use ABSOLUTE cruisinginthewake.com URLs because packs ship as PDF and offline HTML
+where relative links break. Wording keeps the site's actual differentiator ("takes no
+money from cruise lines or travel agents") so the ask reinforces the independence claim
+instead of undercutting it — this is reader funding, not industry funding, and it is not
+an affiliate link (so no rel="sponsored", which is reserved for the gear links).
+
+**Decided.** SHIPPED: 52 articles. DEFERRED to an operator decision: all voyage packs.
+The pack edits were written, their 25 PDFs regenerated (pandoc + weasyprint installed to
+do it properly rather than ship sources newer than deliverables), and then BACKED OUT —
+because the original-research factcheck gate blocks any pack .md commit whose
+.factcheck.json is older than the source. That gate is mtime-based, and a boilerplate
+support footer carries no factual claim, so its prescribed remedy ("re-verify the claims
+that changed") has nothing to verify. The two ways past it are both operator calls, not
+mine: bump last_factcheck_date (which would assert a verification that did not happen —
+an unearned stamp, refused) or --no-verify (an operator switch). Deliberately EXCLUDED
+from the pack set regardless, when it does ship: the six *handoff-card* packs
+(wallet/emergency contact cards — a tip jar on an emergency card is the wrong instrument
+in the wrong moment) and v0.1-v0.1.2-FACT-CHECK.md (internal QA doc).
+
+**Unsure.** Whether the handoff-card exclusion matches Ken's intent — he said "every
+voyage pack" and I read emergency cards as out of that spirit; one word from him
+reverses it. Open question for Ken: the cleanest long-term fix is teaching the factcheck
+gate to compare claim-bearing content rather than mtime, so boilerplate never trips it —
+but that is a harness change and needs its own review, not a same-breath edit. Also surfaced and fixed a PRE-EXISTING defect while sweeping:
+articles/cruise-tech-photography-guide.html was missing both analytics blocks (absent in
+the committed version too, verified via git show) and was the only article failing the
+validator; it now carries the same block as its 51 siblings and passes.
+
+---
+
 ## 2026-08-26 — Day 3 photos: the plaque becomes the source (syl)
 
 **Asked.** Third Day 3 dispatch: five Nassau photos — staircase gorge, steps with

--- a/articles/america-250-at-sea-2026.html
+++ b/articles/america-250-at-sea-2026.html
@@ -299,6 +299,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/anthem-of-the-seas-deck-plans.html
+++ b/articles/anthem-of-the-seas-deck-plans.html
@@ -385,6 +385,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/bahamas-election-day-cruise-decisions-2026.html
+++ b/articles/bahamas-election-day-cruise-decisions-2026.html
@@ -430,6 +430,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/caribbean-cruise-trends-2026.html
+++ b/articles/caribbean-cruise-trends-2026.html
@@ -554,6 +554,11 @@ All work on this project is offered as a gift to God.
       </section>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/caribbean-princess-power-loss-2026.html
+++ b/articles/caribbean-princess-power-loss-2026.html
@@ -424,6 +424,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/costa-maya-mesoamerican-reef-diving.html
+++ b/articles/costa-maya-mesoamerican-reef-diving.html
@@ -458,6 +458,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-cabin-organization.html
+++ b/articles/cruise-cabin-organization.html
@@ -333,6 +333,11 @@ All work on this project is offered as a gift to God.
 </section>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-duck-tradition.html
+++ b/articles/cruise-duck-tradition.html
@@ -275,6 +275,11 @@ All work on this project is offered as a gift to God.
           <li><a href="/planning.html">Cruise Planning Guide</a></li>
         </ul>
       </section>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-embarkation-day-what-to-expect.html
+++ b/articles/cruise-embarkation-day-what-to-expect.html
@@ -327,6 +327,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-gear-worth-packing.html
+++ b/articles/cruise-gear-worth-packing.html
@@ -324,6 +324,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-itinerary-changes-what-to-do.html
+++ b/articles/cruise-itinerary-changes-what-to-do.html
@@ -481,6 +481,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-seasickness-what-works.html
+++ b/articles/cruise-seasickness-what-works.html
@@ -355,6 +355,11 @@ All work on this project is offered as a gift to God.
       <p class="tiny muted" style="margin-top:1.5rem">Source for the medical guidance on this page: U.S. Centers for Disease Control and Prevention, <a href="https://www.cdc.gov/yellow-book/hcp/travel-air-sea/motion-sickness.html" rel="noopener" target="_blank">CDC Yellow Book — Motion Sickness</a>. Reviewed June 18, 2026. This page carries no advertising and no affiliate links.</p>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-ship-size-explained.html
+++ b/articles/cruise-ship-size-explained.html
@@ -496,6 +496,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-shore-power-explained.html
+++ b/articles/cruise-shore-power-explained.html
@@ -331,6 +331,11 @@ All work on this project is offered as a gift to God.
       <p class="tiny muted" style="margin-top:1.5rem">Sources: <a href="https://www.miamidade.gov/portmiami/shore-power.page" rel="nofollow noopener" target="_blank">Miami-Dade County — PortMiami Shore Power Program</a> (terminals, cost, grants, emissions and capacity figures); <a href="https://www.cruisehive.com/propulsion-problem-keeps-norwegian-cruise-ship-in-port-until-midnight/214347" rel="nofollow noopener" target="_blank">Cruise Hive</a> (the Getaway overnight's shore-power-testing purpose). Reviewed August 22, 2026. This page carries no affiliate links.</p>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-tech-photography-guide.html
+++ b/articles/cruise-tech-photography-guide.html
@@ -118,6 +118,17 @@ All work on this project is offered as a gift to God.
     window.addEventListener('load',()=>navigator.serviceWorker.register('/sw.js').catch(()=>{}));
   }
   </script>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WZP891PZXJ"></script>
+  <script>
+    window.dataLayer=window.dataLayer||[];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js',new Date());
+    gtag('config','G-WZP891PZXJ',{anonymize_ip:true});
+  </script>
+
+  <!-- Umami (secondary analytics) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="9661a449-3ba9-49ea-88e8-4493363578d2"></script>
 </head>
 <body class="page">
   <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -331,6 +342,11 @@ All work on this project is offered as a gift to God.
 </section>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-tipping-2026.html
+++ b/articles/cruise-tipping-2026.html
@@ -359,6 +359,11 @@ All work on this project is offered as a gift to God.
       <p style="font-size:0.95rem;color:#444">Last reviewed: <time datetime="2026-05-08">May 8, 2026</time>. Rate verification window: 60 days. Source registry: <code>admin/CRUISE_TIPPING_RESEARCH_2026.md</code> in the site repo. Every dollar figure and percent in this article traces to the cruise line's official policy page or to a corroborating trade source (Cruise Critic, Cruise Hive, Cruzely, Cruise Industry News). Subject to change without notice.</p>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-travel-insurance-2026.html
+++ b/articles/cruise-travel-insurance-2026.html
@@ -534,6 +534,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cruise-travel-safety-shore-side-net.html
+++ b/articles/cruise-travel-safety-shore-side-net.html
@@ -435,6 +435,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/cuba-earthquake-cruise-ships-2026.html
+++ b/articles/cuba-earthquake-cruise-ships-2026.html
@@ -323,6 +323,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/great-stirrup-cay-changes-2026.html
+++ b/articles/great-stirrup-cay-changes-2026.html
@@ -344,6 +344,11 @@ All work on this project is offered as a gift to God.
       <p class="tiny muted" style="margin-top:1.5rem">Sources: NCL's "Great Tides Waterpark" guest booklet, May 2026 (waterpark contents, September booking access, upcharge markings, island map — full extracted text held in this site's records); pier timeline per cruise trade and guide reporting including <a href="https://www.cruisemapper.com/ports/great-stirrup-cay-port-1023" rel="nofollow noopener" target="_blank">CruiseMapper</a>, with the reopening date treated as unverified where reports conflict. Reviewed August 22, 2026. This page carries no affiliate links; the waterpark and island venues named are not commission links.</p>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/hantavirus-cruise-ships-2026.html
+++ b/articles/hantavirus-cruise-ships-2026.html
@@ -471,6 +471,11 @@ All work on this project is offered as a gift to God.
       <p style="font-size:0.95rem;color:#444">Last reviewed: <time datetime="2026-05-14">May 14, 2026</time>. This is an active outbreak; numbers above are accurate as of the review date and will move. Primary sources: <a href="https://www.who.int/emergencies/disease-outbreak-news/item/2026-DON600" rel="noopener">WHO Disease Outbreak News (DON600)</a>, <a href="https://www.ecdc.europa.eu/en/infectious-disease-topics/hantavirus-infection/surveillance-and-updates/andes-hantavirus-outbreak" rel="noopener">ECDC outbreak surveillance update</a>, <a href="https://www.cdc.gov/han/php/notices/han00528.html" rel="noopener">CDC HAN Notice 528</a>. Historical hantavirus background draws on CDC Hantavirus pages and the published literature on the 1996 Bariloche and 2018–2019 Epuyen outbreaks. For the freshest case totals, the WHO and ECDC pages are updated faster than this article will be.</p>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/hurricane-season-2026-cruisers.html
+++ b/articles/hurricane-season-2026-cruisers.html
@@ -538,6 +538,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/hurricane-season-opens-june-1-2026.html
+++ b/articles/hurricane-season-opens-june-1-2026.html
@@ -455,6 +455,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/interior-vs-balcony-vs-oceanview.html
+++ b/articles/interior-vs-balcony-vs-oceanview.html
@@ -332,6 +332,11 @@ All work on this project is offered as a gift to God.
       <p class="tiny muted" style="margin-top:1.5rem">This guide deliberately avoids quoting cabin prices and square footage — both vary by ship, sailing, and season faster than an article should pretend to track. The decision logic is the durable part. Seasickness positioning per CDC traveler guidance (see the <a href="/articles/cruise-seasickness-what-works.html">seasickness guide</a> for sources); ship-specific cabin facts per this site's verified deck-plan research. Reviewed August 22, 2026. No affiliate links.</p>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/is-drink-package-worth-it.html
+++ b/articles/is-drink-package-worth-it.html
@@ -488,6 +488,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/jewel-of-the-seas-mobility-scooter-lawsuit-2026.html
+++ b/articles/jewel-of-the-seas-mobility-scooter-lawsuit-2026.html
@@ -392,6 +392,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/legend-of-the-seas-maiden-voyage-2026.html
+++ b/articles/legend-of-the-seas-maiden-voyage-2026.html
@@ -311,6 +311,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/liberty-of-the-seas-royal-amplification-2026.html
+++ b/articles/liberty-of-the-seas-royal-amplification-2026.html
@@ -403,6 +403,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/msc-seaside-service-review.html
+++ b/articles/msc-seaside-service-review.html
@@ -396,6 +396,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/msc-voyagers-club-status-match-from-rcl-diamond.html
+++ b/articles/msc-voyagers-club-status-match-from-rcl-diamond.html
@@ -393,6 +393,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/nassau-brawls-cruise-passenger-arrests-2026.html
+++ b/articles/nassau-brawls-cruise-passenger-arrests-2026.html
@@ -439,6 +439,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/norwegian-dawn-cdc-inspection-2026.html
+++ b/articles/norwegian-dawn-cdc-inspection-2026.html
@@ -408,6 +408,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/norwegian-getaway-aug-2026-logbook.html
+++ b/articles/norwegian-getaway-aug-2026-logbook.html
@@ -421,6 +421,11 @@ All work on this project is offered as a gift to God.
       <p class="tiny muted" style="margin-top:1.5rem">Source for every entry on this page: the author, aboard, that day. Entries are dispatches, not reconstructions — short when the day was short on words. Reviewed August 26, 2026. No affiliate links.</p>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/norwegian-getaway-nassau-repairs-overnight-2026.html
+++ b/articles/norwegian-getaway-nassau-repairs-overnight-2026.html
@@ -349,6 +349,11 @@ All work on this project is offered as a gift to God.
       <p class="tiny muted" style="margin-top:1.5rem">Sources: NCL guest notification for the August 24, 2026 Norwegian Getaway sailing (received directly, August 2026); <a href="https://www.cruisehive.com/propulsion-problem-keeps-norwegian-cruise-ship-in-port-until-midnight/214347" rel="nofollow noopener" target="_blank">Cruise Hive</a> reporting on the propulsion repairs and the July 31 sailing; NCL's published Great Stirrup Cay development materials for the waterpark opening window. Reviewed August 22, 2026.</p>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/oversold-cruise-volunteer-offers-2026.html
+++ b/articles/oversold-cruise-volunteer-offers-2026.html
@@ -309,6 +309,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/perfect-day-mexico-rejected-2026.html
+++ b/articles/perfect-day-mexico-rejected-2026.html
@@ -368,6 +368,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/port-day-that-doesnt-go-sideways.html
+++ b/articles/port-day-that-doesnt-go-sideways.html
@@ -452,6 +452,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/quantum-of-the-seas-pacific-coastal.html
+++ b/articles/quantum-of-the-seas-pacific-coastal.html
@@ -590,6 +590,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/quiet-hurricane-season-july-check-in-2026.html
+++ b/articles/quiet-hurricane-season-july-check-in-2026.html
@@ -304,6 +304,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/radiance-of-the-seas-5-night-bahamas.html
+++ b/articles/radiance-of-the-seas-5-night-bahamas.html
@@ -381,6 +381,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/rocket-launch-from-cruise-ship-2026.html
+++ b/articles/rocket-launch-from-cruise-ship-2026.html
@@ -391,6 +391,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/royal-beach-club-collection-2026.html
+++ b/articles/royal-beach-club-collection-2026.html
@@ -474,6 +474,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/royal-caribbean-vs-msc.html
+++ b/articles/royal-caribbean-vs-msc.html
@@ -544,6 +544,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/ruby-princess-norovirus-outbreak-2026.html
+++ b/articles/ruby-princess-norovirus-outbreak-2026.html
@@ -321,6 +321,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/seward-terminal-delay-alaska-2026.html
+++ b/articles/seward-terminal-delay-alaska-2026.html
@@ -414,6 +414,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/silver-whisper-pacific-rescue-2026.html
+++ b/articles/silver-whisper-pacific-rescue-2026.html
@@ -388,6 +388,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/south-pacific-cruise-primer-2026.html
+++ b/articles/south-pacific-cruise-primer-2026.html
@@ -516,6 +516,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/stateroom-sanity-check.html
+++ b/articles/stateroom-sanity-check.html
@@ -507,6 +507,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/tropical-storm-arthur-watch-2026.html
+++ b/articles/tropical-storm-arthur-watch-2026.html
@@ -391,6 +391,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/watching-usmnt-loss-at-sea-2026.html
+++ b/articles/watching-usmnt-loss-at-sea-2026.html
@@ -318,6 +318,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/what-cruise-actually-costs-2026.html
+++ b/articles/what-cruise-actually-costs-2026.html
@@ -526,6 +526,11 @@ All work on this project is offered as a gift to God.
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 

--- a/articles/world-cup-cruise-watch-parties-2026.html
+++ b/articles/world-cup-cruise-watch-parties-2026.html
@@ -310,6 +310,11 @@ Soli Deo Gloria
       </ul>
 
       </div>
+      <!-- READER SUPPORT — site-wide CTA -->
+      <aside class="support-cta" style="max-width:min(860px,92%);margin:2rem auto 0;padding:1rem 1.25rem;border:1px solid #d0e4f0;border-left:3px solid #0e6e8e;border-radius:6px;background:#f8fbfc">
+        <p style="margin:0 0 .4rem"><strong>Was this helpful?</strong> In the Wake takes no money from cruise lines or travel agents. Readers are what keep it independent.</p>
+        <p style="margin:0"><a href="https://buymeacoffee.com/inthewake" rel="noopener" style="color:#0e6e8e;font-weight:600">Buy me a coffee</a> <span class="tiny muted">— or see <a href="/support.html">other ways to support</a>.</span></p>
+      </aside>
     </article>
   </main>
 


### PR DESCRIPTION
Adds an unobtrusive Buy Me a Coffee CTA to all 52 articles, placed as a bordered aside immediately before `</article>` — outside `itemprop="articleBody"`, so a donation ask is not folded into Article schema content. Matches the existing support.html house pattern (brand `#0e6e8e`, `rel="noopener"`) rather than introducing a new style; links to the BMC page with a secondary link to `/support.html`. Wording keeps the site's independence claim ("takes no money from cruise lines or travel agents") so the ask reinforces it. Not an affiliate link, so no `rel="sponsored"`.

Voyage packs are deliberately **not** in this PR: the edits were written and their 25 PDFs regenerated, then backed out because the original-research factcheck gate blocks pack `.md` commits whose sidecar is older than the source. A boilerplate footer changes no factual claim, so the gate's remedy has nothing to verify — and both routes past it (bumping `last_factcheck_date`, or `--no-verify`) are operator decisions. Awaiting Ken.

Also fixes a pre-existing defect surfaced by the sweep: `articles/cruise-tech-photography-guide.html` was missing both analytics blocks (absent in the committed version too) and was the only article failing the validator. Validator now 52/52 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct4V1GGTFAHNfMVeFy5xJV)_