### PR TITLE
Fix FAQ_COUNT mismatches (#2444)

### DIFF
--- a/REASONING-LOG.md
+++ b/REASONING-LOG.md
@@ -28,6 +28,18 @@ compliance from anyone — if the run happened, the entry is true.
 
 ---
 
+## 2026-09-03 — FAQ_COUNT: validator whitespace + schema sync (grok1)
+
+**Asked.** Keep looping until tasks are complete. I had stopped after the Icon store listing; FAQ_COUNT (`itw-faq-count-prefix`, #2444) was still checked out.
+
+**Weighed.** Format-4 extract was already landed. Live FAQ_COUNT still failed 40/399 ports: 39 schema-short of visible questions, 1 Petersburg Page:0 (`<details style>` without `faq-item`, so the old single-line regex saw nothing). Expanding extract to every `#faq` `<details>` would have created 120 false mismatches (weather/packing details). Dual-format pages (Barcelona 5+5) must keep Math.max, not a sum.
+
+**Decided.** Loosen FAQ_COUNT to `<details class="faq-item"[^>]*>\s*<summary`. Tag Petersburg FAQ details with `faq-item`. Sync FAQPage `mainEntity` from visible Q&A (copied from the page, not invented) on the other 39. Fleet FAQ_COUNT mismatches: 40 → 0. Mutation: drop one Holyhead schema Question → FAQ_COUNT errors; restored.
+
+**Unsure.** beijing/falmouth/kyoto have schema 0 and no FAQ_COUNT page items — they never failed this check. Schema-vs-visible *unique extract* drift on dual-format pages remains a follow-up, not this task's FAQ_COUNT regex.
+
+---
+
 ## 2026-08-26 — Day 3 photos: the plaque becomes the source (syl)
 
 **Asked.** Third Day 3 dispatch: five Nassau photos — staircase gorge, steps with

--- a/admin/scripts/sync-faq-count.mjs
+++ b/admin/scripts/sync-faq-count.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// Sync FAQPage JSON-LD mainEntity to the visible FAQ questions the FAQ_COUNT
+// regex actually sees. Answers are copied from the page — never invented.
+// Also tags Petersburg-style <details> inside #faq with class="faq-item".
+// Usage: node admin/scripts/sync-faq-count.mjs [--apply]
+import fs from "node:fs";
+import path from "node:path";
+
+const APPLY = process.argv.includes("--apply");
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../..");
+const PORTS = path.join(ROOT, "ports");
+
+function strip(s) {
+  return String(s || "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/^\s*Q:\s*/i, "")
+    .replace(/^\s*A:\s*/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractPairs(html) {
+  const pairs = [];
+  const push = (q, a) => {
+    q = strip(q);
+    a = strip(a);
+    if (q && a) pairs.push({ q, a });
+  };
+  let m;
+  const qRe = /<p><strong>\s*Q:\s*([\s\S]*?)\s*<\/strong>\s*(?:<br\s*\/?>)?\s*([\s\S]*?)<\/p>/gi;
+  while ((m = qRe.exec(html))) push(m[1], m[2]);
+  const dRe = /<details class="faq-item"[^>]*>\s*<summary[^>]*>([\s\S]*?)<\/summary>\s*<p[^>]*>([\s\S]*?)<\/p>/gi;
+  while ((m = dRe.exec(html))) push(m[1], m[2]);
+  const vRe = /<div[^>]*class="(?:[^"]*\s)?faq-item(?:\s[^"]*)?"[^>]*>\s*<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>\s*<p[^>]*>([\s\S]*?)<\/p>/gi;
+  while ((m = vRe.exec(html))) push(m[1], m[2]);
+  const seen = new Set();
+  const uniq = [];
+  for (const p of pairs) {
+    const k = p.q.toLowerCase();
+    if (seen.has(k)) continue;
+    seen.add(k);
+    uniq.push(p);
+  }
+  return uniq;
+}
+
+function pageCount(html) {
+  const qPrefixed = (html.match(/<p><strong>Q:|<strong>Q:|<summary[^>]*>Q:/g) || []).length;
+  const summaryFAQs = (html.match(/<details class="faq-item"[^>]*>\s*<summary/g) || []).length;
+  const divFAQs = (html.match(/<div[^>]*class="(?:[^"]*\s)?faq-item(?:\s[^"]*)?"[^>]*>\s*<h[1-6]/gi) || []).length;
+  return Math.max(qPrefixed, summaryFAQs, divFAQs);
+}
+
+function schemaCount(html) {
+  return (html.match(/"@type":\s*"Question"/g) || []).length;
+}
+
+function findFaqPageScript(html) {
+  const re = /<script type="application\/ld\+json">/gi;
+  let m;
+  while ((m = re.exec(html))) {
+    const tagEnd = m.index + m[0].length;
+    let i = tagEnd;
+    while (i < html.length && html[i] !== "{") i++;
+    if (html[i] !== "{") continue;
+    let depth = 0;
+    let j = i;
+    for (; j < html.length; j++) {
+      if (html[j] === "{") depth++;
+      else if (html[j] === "}") {
+        depth--;
+        if (depth === 0) {
+          j++;
+          break;
+        }
+      }
+    }
+    const raw = html.slice(i, j);
+    let obj;
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (obj && obj["@type"] === "FAQPage") {
+      const close = html.indexOf("</script>", j);
+      return { start: m.index, end: close + "</script>".length, obj, raw };
+    }
+  }
+  return null;
+}
+
+function tagPetersburgDetails(html) {
+  return html.replace(/(<section[^>]*id="faq"[^>]*>)([\s\S]*?)(<\/section>)/i, (all, open, body, close) => {
+    const tagged = body.replace(
+      /<details(?![^>]*\bfaq-item\b)(?![^>]*\bsection-collapse\b)([^>]*)>/gi,
+      '<details class="faq-item"$1>'
+    );
+    return open + tagged + close;
+  });
+}
+
+function buildEntity(p) {
+  return {
+    "@type": "Question",
+    name: p.q,
+    acceptedAnswer: { "@type": "Answer", text: p.a },
+  };
+}
+
+const files = fs.readdirSync(PORTS).filter((f) => f.endsWith(".html")).sort();
+let changed = 0;
+let skipped = 0;
+const report = [];
+
+for (const f of files) {
+  const fp = path.join(PORTS, f);
+  let html = fs.readFileSync(fp, "utf8");
+  const before = { sq: schemaCount(html), vq: pageCount(html) };
+  let next = html;
+  if (pageCount(html) === 0 && schemaCount(html) > 0) {
+    next = tagPetersburgDetails(html);
+  }
+  const pairs = extractPairs(next);
+  const vq = pageCount(next);
+  const sq = schemaCount(next);
+  if (sq === vq && vq > 0) {
+    if (next !== html && APPLY) {
+      fs.writeFileSync(fp, next);
+      changed++;
+      report.push(`${f}: tagged faq-item only`);
+    } else if (next !== html) {
+      report.push(`${f}: would tag faq-item`);
+    } else skipped++;
+    continue;
+  }
+  if (vq === 0) {
+    report.push(`${f}: SKIP no visible FAQ_COUNT page items (schema ${sq})`);
+    skipped++;
+    continue;
+  }
+  const script = findFaqPageScript(next);
+  if (!script) {
+    report.push(`${f}: SKIP no FAQPage JSON-LD (page ${vq} schema ${sq})`);
+    skipped++;
+    continue;
+  }
+  if (pairs.length < vq) {
+    report.push(`${f}: SKIP extracted ${pairs.length} pairs < page ${vq} (schema ${sq})`);
+    skipped++;
+    continue;
+  }
+  const use = pairs.slice(0, vq);
+  script.obj.mainEntity = use.map(buildEntity);
+  const pretty = JSON.stringify(script.obj, null, 2);
+  const replacement = `<script type="application/ld+json">\n${pretty}\n  </script>`;
+  next = next.slice(0, script.start) + replacement + next.slice(script.end);
+  const after = { sq: schemaCount(next), vq: pageCount(next) };
+  if (after.sq !== after.vq) {
+    report.push(`${f}: FAIL after sync schema=${after.sq} page=${after.vq}`);
+    skipped++;
+    continue;
+  }
+  report.push(`${f}: ${before.sq}->${after.sq} schema, page ${after.vq}`);
+  if (APPLY) {
+    fs.writeFileSync(fp, next);
+    changed++;
+  }
+}
+
+console.log(report.join("\n"));
+console.log(APPLY ? `applied ${changed}, skipped ${skipped}` : `dry-run ${report.length} rows, skipped ${skipped}. Pass --apply to write.`);

--- a/ports/cagliari.html
+++ b/ports/cagliari.html
@@ -54,16 +54,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {"@type": "Question", "name": "Is Cagliari worth visiting on a cruise?", "acceptedAnswer": {"@type": "Answer", "text": "Absolutely. Cagliari offers Sardinian authenticity without tourist crowds — medieval Castello quarter, Roman ruins, pink flamingos in lagoons, and Poetto Beach just 800 meters from the cruise port."}},
-      {"@type": "Question", "name": "Can you walk to the beach from the cruise port?", "acceptedAnswer": {"@type": "Answer", "text": "Yes. Poetto Beach is only 800 meters from the cruise terminal — a 10-minute walk. This 8km stretch of white sand and turquoise water is one of the Mediterranean's finest urban beaches."}},
-      {"@type": "Question", "name": "What are the must-see attractions in Cagliari?", "acceptedAnswer": {"@type": "Answer", "text": "Bastione di Saint Remy for panoramic views, medieval Castello quarter with its towers, Roman Amphitheatre, Cathedral of Santa Maria, and Molentargius lagoon for pink flamingos."}},
-      {"@type": "Question", "name": "How much time do you need in Cagliari?", "acceptedAnswer": {"@type": "Answer", "text": "A full port day (6-8 hours) covers the Castello quarter, Bastione views, Roman sites, and Poetto Beach. The compact center is walkable."}}
-    ]
-  }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Cagliari worth visiting on a cruise stop?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Cagliari offers Sardinian authenticity without tourist crowds — medieval Castello quarter, Roman ruins, flamingos in urban lagoons, and excellent beach just steps from the port. It's one of the Mediterranean's underrated gems."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can you walk to Poetto Beach from the cruise port?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The beach is only 800 meters from the terminal — about a 10-minute walk. Eight kilometers of white sand and turquoise water await."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the best thing to do in Cagliari?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Start at Bastione di Saint Remy for panoramic views, then explore the medieval Castello quarter. Save beach time for afternoon when the morning sightseeing is done."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Should I book excursions through the ship?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For Cagliari itself, go independent — everything is walkable from the port. Ship excursions make sense for Nora archaeological site or wine country where transportation is complicated and guaranteed return matters."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are the flamingos really there?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Thousands of wild pink flamingos live year-round in the Molentargius lagoon near Poetto Beach. One of Cagliari's most unexpected attractions."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the climb to Castello quarter difficult?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The hills are real. Allow 20-30 minutes from the port with rest stops. An elevator at Bastione di Saint Remy helps. Those with mobility issues should consider taxis or the tourist train."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Google Analytics -->

--- a/ports/corinto.html
+++ b/ports/corinto.html
@@ -54,52 +54,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Corinto, Nicaragua?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock directly at the Corinto pier, Nicaragua's principal Pacific Ocean port facility. The terminal is basic with limited amenities — a working cargo port that handles cruise ships. León, the primary tourist destination, is 20 miles inland, requiring a 40-minute drive. Most cruise lines offer organized shore excursions; independent travel is possible but requires planning."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is it safe to visit León and Corinto, Nicaragua?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, with standard precautions. Nicaragua experienced political unrest in 2018, but León and tourist areas remain generally safe for visitors. Stick to main tourist sites, travel with reputable tour operators, avoid political demonstrations, and don't wander into unfamiliar neighborhoods alone. The Nicaraguan people are notably warm and welcoming to tourists."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is volcano boarding at Cerro Negro?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Cerro Negro is Central America's youngest and most active volcano. Volcano boarding involves hiking up the black cinder cone (about 45 minutes) then sliding down the steep volcanic gravel slopes on a wooden board, reaching speeds up to 50 mph. It's thrilling, dusty, and utterly unique to Nicaragua. Tours provide protective suits, goggles, gloves, and boards. Requires moderate fitness for the hike up."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What makes León's cathedral UNESCO-worthy?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "León Cathedral (Basílica Catedral de la Asunción) is the largest cathedral in Central America and a UNESCO World Heritage Site. Construction began in 1747 and took 100 years to complete. Its massive Baroque-Neoclassical facade, fortress-like appearance, and underground crypts holding national poets (including Rubén Darío) make it architecturally and culturally significant. You can walk on the white-domed roof for panoramic city views."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What currency should I bring to Nicaragua?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Nicaragua's currency is the Córdoba (NIO), but US Dollars are widely accepted throughout the country, especially in tourist areas. Bring small denomination US bills ($1, $5, $10, $20) as change can be difficult. ATMs in León dispense both Córdobas and US Dollars. Credit cards are accepted at larger establishments but cash is essential for local restaurants and street vendors."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Corinto, Nicaragua?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships dock directly at the Corinto pier, Nicaragua's principal Pacific Ocean port facility. The terminal is basic with limited amenities — a working cargo port that handles cruise ships. León, the primary tourist destination, is 20 miles inland, requiring a 40-minute drive. Most cruise lines offer organized shore excursions; independent travel is possible but requires planning ahead to ensure a smooth experience."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is it safe to visit León and Corinto, Nicaragua?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, with standard precautions. Nicaragua experienced political unrest in 2018, but León and tourist areas remain generally safe for visitors. Stick to main tourist sites, travel with reputable tour operators, avoid political demonstrations, and don't wander into unfamiliar neighborhoods alone. The Nicaraguan people are notably warm and welcoming to tourists."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is volcano boarding at Cerro Negro?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Cerro Negro is Central America's youngest and most active volcano. Volcano boarding involves hiking up the black cinder cone (about 45 minutes) then sliding down the steep volcanic gravel slopes on a wooden board, reaching speeds up to 50 mph. It's thrilling, dusty, and utterly unique to Nicaragua. Tours provide protective suits, goggles, gloves, and boards. Requires moderate fitness for the hike up. Cost ranges from $30 to $90 depending on whether you book independent or through the ship."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What makes León's cathedral UNESCO-worthy?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "León Cathedral (Basílica Catedral de la Asunción) is the largest cathedral in Central America and a UNESCO World Heritage Site. Construction began in 1747 and took 100 years to complete. Its massive Baroque-Neoclassical facade, fortress-like appearance, and underground crypts holding the remains of Rubén Darío make it architecturally and culturally significant. You can walk on the white-domed roof for panoramic city views."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What currency should I bring to Nicaragua?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nicaragua's currency is the Córdoba (NIO), but US Dollars are widely accepted throughout the country, especially in tourist areas. Bring small denomination US bills ($1, $5, $10, $20) as change can be difficult. ATMs in León dispense both Córdobas and US Dollars. Credit cards are accepted at larger establishments but cash is essential for local restaurants and street vendors."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Corinto accessible for travelers with mobility challenges?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The pier area is generally flat and accessible for wheelchair users. León's central plaza and cathedral ground floor are accessible, though the rooftop walk requires stairs. Some colonial sidewalks are uneven. Beach areas and volcano hikes are not wheelchair accessible. Organized tours can accommodate many mobility needs with advance notice — discuss requirements when booking."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/doha.html
+++ b/ports/doha.html
@@ -54,44 +54,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Doha?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at the Grand Cruise Terminal at Doha Port, located on the Corniche waterfront. The dual terminals can handle up to 12,000 passengers daily at two berths. The terminal is close to major attractions, with Souq Waqif about 10 minutes by taxi."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What should I see first in Doha on a short visit?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "For a half-day visit, prioritize the Museum of Islamic Art (world-class collection in stunning I.M. Pei building) and Souq Waqif (traditional market with spices, handicrafts, and authentic atmosphere). Both offer quintessential Doha experiences combining culture, architecture, and local life."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is falconry in Qatar?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Falconry is an ancient Qatari tradition and cultural heritage practice passed down through generations. It was essential for desert survival when hunting required partnership with birds. The Falcon Souq at Souq Waqif displays this heritage, where falcons are examined and traded with ceremonial respect."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "When is the best time to visit Doha?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "October through April offers pleasant weather (20-30 C). May through September is extremely hot with temperatures regularly exceeding 40 C. Most cruise ships visit during the cooler winter months when outdoor exploration is comfortable."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Doha?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships dock at the Grand Cruise Terminal at Doha Port on the Corniche waterfront. The modern dual terminals have excellent facilities and can handle up to 12,000 passengers daily. The terminal is close to major attractions — Souq Waqif is about 10 minutes by taxi at a cost of $5-8."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I see first on a short visit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prioritize the Museum of Islamic Art (free admission, architectural masterpiece with world-class collection) and Souq Waqif (the restored Arabian souq with spices, handicrafts, and authentic atmosphere). Both are within 10 minutes of the cruise terminal and offer quintessential Doha experiences combining culture, architecture, and local life."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Doha safe for tourists?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Extremely safe. Qatar has very low crime rates and is one of the safest destinations in the Middle East. Standard precautions apply, but violent crime against tourists is virtually unheard of. The infrastructure is modern and well-maintained."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the dress code?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Modest dress is recommended out of respect — cover shoulders and knees. Women should bring a light scarf for mosques and cultural sites. This is not strictly enforced in hotels and malls, but is appreciated in the souq, at Katara, and at religious or cultural sites."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is it very hot?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "October through April is pleasant (20-30 C) and ideal for outdoor exploration. May through September is extremely hot, frequently exceeding 40 C. Nearly all cruise ships visit during the cooler winter months. Stay hydrated, wear sunscreen, and take advantage of the air-conditioned metro and museum."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How accessible is Doha for visitors with mobility challenges?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The cruise terminal, Doha Metro, Museum of Islamic Art, and most major attractions are wheelchair accessible with ramps and elevators. Souq Waqif has uneven surfaces in some alleys but the main pathways are manageable. Taxis can accommodate most mobility needs. Qatar invested heavily in accessible infrastructure for the 2022 FIFA World Cup, and the benefits remain."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/easter-island.html
+++ b/ports/easter-island.html
@@ -702,17 +702,60 @@ Soli Deo Gloria
     });
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {"@type": "Question", "name": "How do ships access Easter Island?", "acceptedAnswer": {"@type": "Answer", "text": "All ships anchor offshore and tender to Hanga Roa harbor. No cruise pier exists. Tender operations depend on sea conditions."}},
-      {"@type": "Question", "name": "Which moai site is most important?", "acceptedAnswer": {"@type": "Answer", "text": "Rano Raraku quarry (nearly 400 moai in progress) and Ahu Tongariki (15 restored moai) are essential. Most tours combine both."}},
-      {"@type": "Question", "name": "What is the National Park fee?", "acceptedAnswer": {"@type": "Answer", "text": "$100 USD for foreigners. Required for Rano Raraku, Ahu Tongariki, Orongo. Buy at airport or Hanga Roa before touring."}},
-      {"@type": "Question", "name": "Is one day enough?", "acceptedAnswer": {"@type": "Answer", "text": "Full-island tour takes 6-8 hours. One day provides meaningful experience but cannot cover everything. Prioritize Rano Raraku and Tongariki."}},
-      {"@type": "Question", "name": "What should I budget?", "acceptedAnswer": {"@type": "Answer", "text": "National Park $100, tour $100-150, lunch $15-25. Total approximately $220-295 for complete experience."}}
-    ]
-  }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do cruise ships access Easter Island?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "All ships anchor offshore and tender passengers to Hanga Roa harbor (about 20 minutes). There is no cruise pier. Tender operations depend on sea conditions – swells can delay or cancel access. Ship excursions typically receive tender priority."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which moai site should I prioritize?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Rano Raraku quarry (nearly 400 moai in various completion stages) and Ahu Tongariki (15 restored moai in a row) are essential. Most tours combine both sites. If choosing only one, Rano Raraku reveals how moai were created – an unforgettable experience."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the National Park fee?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "$100 USD for foreign visitors. Required for major sites including Rano Raraku, Ahu Tongariki, and Orongo. Buy at airport or Hanga Roa park office before touring. Valid 10 days. Some tours include; others require separate purchase."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is one day enough for Easter Island?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A comprehensive tour (Rano Raraku, Ahu Tongariki, Orongo) takes 6-8 hours. Most cruise calls allow 8-12 hours. One day provides meaningful experience but cannot cover everything. Prioritize Rano Raraku and Tongariki. Everyone wishes for more time – but one day among the moai leaves lasting impressions."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Should I book ship excursions or go independent?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ship excursions are strongly recommended for Easter Island. They guarantee tender priority, coordinated return timing, and experienced local guides. Independent exploration works but requires rental vehicle confidence and careful tender schedule monitoring. The stakes are high when your ship anchors offshore."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I budget?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "National Park $100. Full-island tour $100-150. Lunch $15-25. Souvenirs variable. Total approximately $220-295 for complete experience. ATMs exist in Hanga Roa but bring Chilean pesos or USD for efficiency."
+      }
+    }
+  ]
+}
   </script>
   <!-- Port Weather Widget -->
   <script type="module" src="/assets/js/port-weather.js"></script>

--- a/ports/fremantle.html
+++ b/ports/fremantle.html
@@ -714,16 +714,60 @@ Soli Deo Gloria
     }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {"@type": "Question", "name": "Is the cruise terminal walkable to Fremantle's attractions?", "acceptedAnswer": {"@type": "Answer", "text": "Yes – the heritage terminal is right in Fremantle. Everything is within 15-20 minutes walking."}},
-      {"@type": "Question", "name": "Should I visit Perth or stay in Fremantle?", "acceptedAnswer": {"@type": "Answer", "text": "With limited time, Fremantle alone is rewarding. Many find its heritage more interesting than Perth's modern cityscape."}},
-      {"@type": "Question", "name": "Are the Fremantle Markets open every day?", "acceptedAnswer": {"@type": "Answer", "text": "No – Friday 9am-8pm, Saturday 9am-6pm, Sunday 10am-5pm only."}},
-      {"@type": "Question", "name": "Can I see quokkas without going to Rottnest Island?", "acceptedAnswer": {"@type": "Answer", "text": "Not really – quokkas live almost exclusively on Rottnest. Plan at least 4-5 hours for the trip."}}
-    ]
-  }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is the cruise terminal walkable to Fremantle's attractions?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Victoria Quay terminal sits in the center of town. The prison, markets, Maritime Museum, Cappuccino Strip, and Fishing Boat Harbour are all within a 15-minute walk on flat, paved paths. No shuttle or taxi is needed for Fremantle itself."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Should I visit Perth or stay in Fremantle?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "If your port time is eight hours or less, Fremantle alone fills the day richly. With a full day, you can add a Perth trip via the 30-minute train. Many cruisers find Fremantle's heritage character more memorable than Perth's modern cityscape."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are the Fremantle Markets open every day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. The markets open Friday 9am-8pm, Saturday 9am-6pm, and Sunday 10am-5pm only. They are closed Monday through Thursday. Check your port day carefully before planning around them."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Rottnest Island on a port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, but budget at least four to five hours for the ferry crossing and island time. Book ahead in peak season. If your port call is under eight hours, you may need to choose between Rottnest and exploring Fremantle properly."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What currency does Fremantle use?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Australian dollars (AUD). Tap-and-go card payments work virtually everywhere, including market stalls and public transport. You do not need to carry cash or exchange currency in advance."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Fremantle accessible for visitors with mobility challenges?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The central streets are flat with curb cuts. The free CAT bus has wheelchair ramps. Fremantle Prison offers adapted ground-level tours. The train to Perth has step-free boarding. Rottnest Island is more difficult, with unsealed paths beyond the main settlement."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Recent Articles Rail Script -->

--- a/ports/guayaquil.html
+++ b/ports/guayaquil.html
@@ -592,53 +592,69 @@ Soli Deo Gloria
 
     <!-- JSON-LD: FAQPage -->
     <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
     {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      "mainEntity": [
-        {
-          "@type": "Question",
-          "name": "Is Guayaquil safe for cruise passengers visiting independently?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Yes, tourist areas like Malecón 2000, Las Peñas, and Parque Seminario are safe during daylight hours. Guayaquil underwent major urban renewal in the 2000s, improving security significantly."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "Can I visit the Galápagos Islands from Guayaquil during a cruise port call?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "No, not during a typical port call. The Galápagos Islands are 600 miles offshore and require flights (1.5-2 hours) or multi-day cruises. Guayaquil is the main gateway for Galápagos travel, but you'd need several days minimum."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "What currency is used in Ecuador, and can I use US dollars?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Ecuador officially uses the US Dollar (USD) as its currency since 2000. You can use US cash everywhere. Bring small bills as change can be limited."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "How many steps are there to the top of Cerro Santa Ana, and is the climb difficult?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "There are exactly 444 numbered steps from the base to the summit. The climb is moderately strenuous, especially in Guayaquil's heat and humidity. Take your time and climb in early morning or late afternoon."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "Are the iguanas in Parque Seminario dangerous?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "No, the land iguanas at Parque Seminario are harmless and completely accustomed to human presence. They're docile and largely ignore visitors."
-          }
-        }
-      ]
+      "@type": "Question",
+      "name": "Is Guayaquil safe for cruise passengers visiting independently?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, tourist areas like Malecón 2000, Las Peñas, and Parque Seminario are safe during daylight hours. Guayaquil underwent major urban renewal in the 2000s, improving security significantly. Stick to main tourist zones, use Uber or official taxis, and avoid isolated areas after dark. The city has worked hard to shed its former reputation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit the Galápagos Islands from Guayaquil during a cruise port call?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No, not during a typical port call. The Galápagos Islands are 600 miles offshore and require flights (1.5-2 hours) or multi-day cruises. Guayaquil is the main gateway for Galápagos travel, but you would need several days minimum. Focus on the city's own attractions during your port day."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What currency is used in Ecuador, and can I use US dollars?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ecuador officially uses the US Dollar (USD) as its currency since 2000, when it dollarized its economy. You can use US cash everywhere. Bring small bills ($1, $5, $10) as change can be limited. Credit cards are accepted in tourist areas, hotels, and larger restaurants."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How many steps are there to the top of Cerro Santa Ana, and is the climb difficult?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "There are exactly 444 numbered steps from the base to the summit. The climb is moderately strenuous, especially in the heat and humidity. Take your time, stop at cafés or viewpoints along the way, and climb in early morning or late afternoon to avoid peak sun. The panoramic view from the top is worth the effort. Not recommended for visitors with mobility limitations."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are the iguanas in Parque Seminario dangerous?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No, the land iguanas at Parque Seminario are harmless and completely accustomed to human presence. They are docile, sunbathe on walkways and benches, and largely ignore visitors. While locals sometimes feed them, it is best not to touch or disturb them."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best time of year to visit Guayaquil?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The dry season from June to September offers cooler temperatures and lower humidity, making it the most comfortable time for sightseeing. The wet season (December-May) brings higher temperatures and occasional heavy rain but fewer crowds. Check the weather section above for details."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for a day in Guayaquil?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Lightweight, breathable clothing is essential. Bring sunscreen, a hat, sunglasses, comfortable walking shoes, and a water bottle. A light rain jacket is wise during the wet season. Download a Spanish translation app before going ashore."
+      }
     }
-    </script>
+  ]
+}
+  </script>
 
     <!-- Planning Resources -->
     

--- a/ports/ha-long-bay.html
+++ b/ports/ha-long-bay.html
@@ -55,44 +55,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Ha Long Bay?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at Ha Long International Cruise Port. Most visitors explore the bay via day cruise on junk boats, which depart from various piers. Your cruise line will arrange transfers to the appropriate embarkation point for bay tours."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is the best way to experience Ha Long Bay?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "A day cruise on a wooden junk boat is the essential Ha Long Bay experience. These tours navigate between limestone karsts, include stops at Sung Sot Cave and Ti Top Island, and often provide kayaking opportunities. October through April offers the best weather with calm seas and clear skies."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I kayak in Ha Long Bay?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes — kayaking is a highlight. Waters are calm, currents gentle, and most day cruises include 1-2 hours of kayaking with sit-on-top kayaks and life jackets provided. Luon Cave kayaking takes you through a narrow tunnel to a hidden lagoon ringed by limestone cliffs."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "When is the best time to visit Ha Long Bay?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "October through April during the dry season offers calm seas, clear skies, and comfortable temperatures. Avoid June-August typhoon season. March-April can be misty but creates hauntingly beautiful photographs of karsts emerging from fog."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ha Long International Cruise Port. Most bay exploration happens via day cruises on junk boats, which depart from various piers. Transfers are arranged by your cruise line."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best way to see Ha Long Bay?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A day cruise on a junk boat. These tours navigate between karsts, include lunch, cave visits (Sung Sot Cave), island stops (Ti Top), and kayaking. Six to eight hours is typical. This is the essential Ha Long Bay experience."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is kayaking difficult?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Waters are calm, currents gentle, and sit-on-top kayaks are stable. Life jackets are provided. Minimal experience needed. Guides accompany groups. Most visitors find it accessible and rewarding."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I swim in Ha Long Bay?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Ti Top Island and several other beaches offer swimming. Water is warm year-round and clear. Most day cruises include a swimming stop."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "When is the best time to visit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "October through April (dry season) offers calm seas, clear skies, and comfortable temperatures. Avoid June through August typhoon season. March and April can be misty but hauntingly beautiful. December through February is coolest at approximately 15-20 degrees Celsius."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are the caves accessible for visitors with limited mobility?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sung Sot Cave requires climbing 100+ steps that are uneven and can be slippery. Inside paths involve more stairs. Moderate fitness required. Luon Cave is accessed by kayak only. These sites are not wheelchair accessible. Visitors with walking difficulty should discuss options with their tour operator before booking."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/hiroshima.html
+++ b/ports/hiroshima.html
@@ -56,44 +56,76 @@ Soli Deo Gloria
   </script>
 
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Hiroshima?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Most ships dock at Ujina Foreign Trade Wharf (280m berth), about 3 km from the city center. Larger vessels use Itsukaichi Wharf (430m berth). Both offer shuttle services or taxis to Peace Memorial Park and downtown."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I visit both Peace Memorial Park and Miyajima in one day?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. Start early at Peace Memorial Park (opens 8:30 AM), spend 2-3 hours, then take the World Heritage Sea Route ferry (45 minutes) to Miyajima for the afternoon. This covers both UNESCO World Heritage sites in a full day."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is the best time to visit the floating torii gate at Miyajima?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Check tide times before visiting. At high tide, the famous vermilion torii gate appears to float on water, creating the iconic view. At low tide, you can walk across the sand to touch the ancient pillars. Both experiences are beautiful but very different. Tide tables are posted at ferry terminals."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How long should I spend at the Peace Memorial Museum?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Allow 2-3 hours minimum for a contemplative experience. The museum opens at 8:30 AM — arrive early to avoid crowds and experience the exhibits with quiet reflection. The museum chronicles the atomic bombing of August 6, 1945 with dignity and profound honesty, presenting personal artifacts and testimonies that require time to absorb."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most ships dock at Ujina Foreign Trade Wharf (3 km from Peace Park). Larger ships use Itsukaichi Wharf. Shuttles or taxis connect to city center (10-15 min). Cost is about $10-15 by taxi."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Peace Park and Miyajima in one day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, if you start early. Peace Park from 8:30 AM to noon, then World Heritage Sea Route ferry to Miyajima (45 min) for the afternoon. Full-day ship excursions often combine both sites."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the Peace Memorial Museum emotionally difficult?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. It is unflinching but presented with dignity and respect. Allow yourself to feel what you feel. Benches and rest areas are available throughout. The experience is powerful, important, and ultimately hopeful."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "When is the best time to see the floating torii gate?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Check tide tables (posted at ferry terminals and available online). High tide means the gate appears to float. Low tide means you can walk beneath it. Both views are stunning. High tide is more photogenic; low tide is more interactive."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What currency should I bring?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Japanese Yen (JPY). Credit cards are accepted at major sites but cash is preferred at smaller establishments. ATMs at 7-Eleven accept foreign cards. Bring cash for streetcars, small restaurants, and temples."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to speak Japanese?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Major sites have English signage and some English-speaking staff. Google Translate is invaluable for menus and signs. Learn basic phrases (thank you is arigatou gozaimasu). Hiroshima is accustomed to international visitors."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the best time of year to visit Hiroshima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Spring (March-May) for cherry blossoms and autumn (October-November) for foliage are peak seasons. Avoid late July through August due to extreme heat and humidity. The cruise season generally offers the most reliable weather."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will rain ruin my port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Brief showers are common but rarely last long enough to ruin a day. The Peace Memorial Museum is entirely indoors, and Miyajima's shrine has covered walkways. Carry a compact umbrella and have a flexible plan."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/holyhead.html
+++ b/ports/holyhead.html
@@ -64,44 +64,60 @@ Soli Deo Gloria
   </script>
 
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Is Holyhead worth visiting on a cruise?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Holyhead itself is a working port town, but it serves as the gateway to Snowdonia National Park, Caernarfon Castle (UNESCO World Heritage), and the village with the longest name in Europe. The surrounding Anglesey Island and Welsh mountains are spectacular."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can you visit Caernarfon Castle from Holyhead?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes — Caernarfon Castle is about 30 minutes by car from Holyhead. This massive fortress was built by Edward I starting in 1283 and is a UNESCO World Heritage Site and one of Wales' most iconic landmarks."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How far is Snowdonia from Holyhead?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Snowdonia National Park's eastern edge is about 30-45 minutes from Holyhead. Mount Snowdon (Wales' highest peak at 1,085m) is about 1 hour away. Scenic drives through the park offer dramatic mountain landscapes, glacial valleys, and historic Welsh villages."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is the longest village name and can I visit it?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch (58 letters) is about 20 minutes from Holyhead on Anglesey. The name roughly translates to 'St Mary's Church in the hollow of white hazel near a rapid whirlpool and the Church of St. Tysilio near the red cave.' The railway station sign makes a great photo!"
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Holyhead worth visiting on a cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Holyhead itself is a modest working port, but it serves as the gateway to Caernarfon Castle, Snowdonia National Park, Beaumaris Castle, and the village with the longest name in Europe. The real value is the surrounding region — castles, mountains, and Welsh heritage within easy reach."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Caernarfon Castle from Holyhead?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Caernarfon is about 30 minutes by taxi (£35–45 each way). Ship excursions run £65–85 per person and typically combine the castle with other stops. Allow 4–5 hours for a round trip including time inside the castle."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I get from the port to town?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Holyhead town centre is a fifteen-minute walk or five-minute taxi ride (about £5) from the port gate. Some cruise lines provide a shuttle bus. The railway station is also walkable from the port."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the weather like in Holyhead?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Maritime and changeable. Summer temperatures range 12–18 °C. Rain can arrive any day of the year, and the exposed coastal position means wind is constant. Bring waterproof layers and warm clothing even in July and August."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the Snowdon Mountain Railway worth booking?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The railway climbs to 1,085 metres and offers spectacular views when the weather cooperates. Tickets cost £30 return and should be booked in advance during summer. However, the train only runs in fair weather — fog or high winds cancel services, so have a backup plan ready."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What can I do if I stay near the port?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Walk to St Cybi's Church inside its Roman fort, visit the Maritime Museum (£3), and stroll the 1.7-mile Holyhead Breakwater — the longest in Europe. These are all free or low-cost and within walking distance, making them suitable for a relaxed low-energy port day."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- LCP Optimization: Preload critical hero images -->

--- a/ports/honfleur.html
+++ b/ports/honfleur.html
@@ -64,44 +64,60 @@ Soli Deo Gloria
   </script>
 
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Is Honfleur worth visiting on a cruise?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Absolutely — Honfleur is one of Normandy's most picturesque ports. The colorful Vieux Bassin (old harbor), Sainte-Catherine wooden church, cobblestone streets, and art galleries create a postcard-perfect French experience. It's where Impressionism was born, with Boudin mentoring Monet here."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can you walk from the cruise port to Honfleur?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Most cruise ships dock at Le Havre, about 20km from Honfleur. Shuttle services or organized excursions are needed. Some smaller ships can dock closer to Honfleur or tender passengers directly into the old harbor. Check your cruise line's port information."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is Sainte-Catherine Church known for?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Sainte-Catherine is the largest wooden church in France, built by shipwrights between 1460-1496. Its unique twin-nave structure resembles an upturned ship's hull. The separate bell tower stands across the square to reduce fire risk."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is Honfleur's connection to Impressionism?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Honfleur is the birthplace of Impressionism. Artist Eugene Boudin set up his easel at the harbor and convinced young Claude Monet to paint outdoors, revolutionizing art. The Boudin Museum displays works by both artists."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock for Honfleur?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most ships dock at Le Havre, about 20 km away. Shuttle transfers cross the Pont de Normandie in 30-40 minutes. Smaller ships sometimes anchor in the estuary and tender directly into the Vieux Bassin harbour."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I explore Honfleur independently from Le Havre?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Local bus line 20 runs between Le Havre and Honfleur for about 2 EUR, and taxis cost 50-70 EUR one way. Many visitors share a taxi to split costs. Independent exploration is straightforward once you arrive."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much time do I need in Honfleur?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Four to five hours is enough to walk the harbour, visit Sainte-Catherine's Church, see the Boudin Museum, and enjoy lunch. The town is compact and most sights are within a five-minute walk of each other."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is Sainte-Catherine's Church?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "France's largest wooden church, built by shipwrights between 1460 and 1496. Its twin-nave interior resembles an upturned ship hull. Free to enter, with flat access through the main door for wheelchair users."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I eat in Honfleur?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Moules-frites (mussels and chips) in cream sauce, galettes with Camembert, and fresh Normandy cider are the local specialities. Harbour restaurants serve lunch for 15-20 EUR. Calvados apple brandy tastings are available at many shops."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Honfleur accessible for wheelchair users?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The quayside and main streets around the Vieux Bassin are mostly flat and manageable. Cobblestones can be uneven in places. Sainte-Catherine's Church has flat access. The hillside Cote de Grace is steep and not wheelchair accessible."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- LCP Optimization: Preload critical hero images -->

--- a/ports/ibiza.html
+++ b/ports/ibiza.html
@@ -70,44 +70,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "What's the ancient history of Ibiza?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ibiza has over 2,600 years of documented history. The Phoenicians founded the settlement of Ibossim around 654 BCE, making it one of the oldest continuously inhabited sites in the Mediterranean. The Puig des Molins necropolis (10-minute walk from the cruise terminal) contains thousands of Phoenician and Carthaginian tombs and is the best-preserved ancient cemetery in the entire Mediterranean. In 1999, UNESCO designated the island as 'Ibiza, Biodiversity and Culture' in recognition of its extraordinary historical and natural heritage."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Formentera worth the ferry?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Absolutely — it has some of the clearest water in the Mediterranean. The ferry is 30 minutes and runs frequently from the cruise terminal. Rent a scooter on Formentera to explore the pristine beaches and relaxed atmosphere."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Do I need to party to enjoy Ibiza?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Not at all. The UNESCO-listed Dalt Vila old town, ancient Puig des Molins necropolis, pristine beaches, hippy markets, and dramatic sunset spots offer rich experiences without ever entering a club. Ibiza's 2,600 years of history provide endless quiet exploration."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Where's the best sunset?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Café del Mar in San Antonio is famous, but Cala Conta with views of Es Vedrà (the dramatic 400-meter rocky island shrouded in myths) is more dramatic and less crowded. The sight of the sun dropping behind Es Vedrà is unforgettable."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Ibiza?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most large ships anchor in the harbor and tender passengers to the marina in Ibiza Town. The tender ride takes 5-10 minutes and offers scenic views of Dalt Vila. Some smaller ships dock directly at Botafoc pier. The tender dock area is accessible for wheelchair users with level boarding ramps."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Ibiza worth visiting beyond the beaches?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely. The UNESCO-listed Dalt Vila fortified old town has over 2,600 years of history, the Puig des Molins necropolis is the best-preserved Phoenician burial ground in the Mediterranean, and the island's artisan markets, traditional cuisine, and natural landscapes offer rich experiences far beyond the coastline."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Formentera on a port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — the ferry from Ibiza port to Formentera takes about 30 minutes and costs €20-30 round-trip. Ferries run frequently. However, plan your time carefully: you need to be back at the tender dock well before all-aboard. Confirm the last ferry departure time when you buy your ticket, and give yourself a generous buffer."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Ibiza accessible for visitors with limited mobility?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The marina promenade and lower town are flat and accessible. However, Dalt Vila involves steep cobblestone climbs that are challenging for wheelchair users or those with walking difficulty. The Puig des Molins museum level is accessible, though the outdoor tomb areas are uneven. Taxis and buses can reach most beach destinations without extended walking."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best time of year to visit Ibiza?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Peak cruise season (May-September) offers the best weather and calmest seas. Spring and early autumn have fewer crowds and pleasant temperatures. Check the weather section above for specific month recommendations based on your planned activities."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Ibiza?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Essentials include sunscreen, comfortable walking shoes for cobblestones, a hat, swimwear, and layers for cool evenings. A light rain jacket is wise in spring and autumn. Bring cash for markets and small vendors."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- LCP Optimization: Preload critical hero images -->

--- a/ports/invergordon.html
+++ b/ports/invergordon.html
@@ -62,44 +62,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Is Invergordon worth it?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Invergordon is the best cruise port access to Loch Ness and the Scottish Highlands. The port itself is a small town, but it serves as the gateway to dramatic Highland scenery, Urquhart Castle on Loch Ness shores, Cawdor Castle, and the historic Invergordon Mutiny site from 1931."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is the best thing to do at Invergordon?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The Loch Ness cruise combined with Urquhart Castle is the most popular excursion. The Jacobite boat tour takes you across the loch's dark waters with sonar searching the 230-meter depths for Nessie, while Urquhart Castle's dramatic ruins overlook the shore. It's the quintessential Scottish Highlands experience."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How long does it take to visit Loch Ness from Invergordon?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "A full port day is ideal for Loch Ness. Most tours depart at 8 AM and return by late afternoon. The drive to Loch Ness takes about 90 minutes each way through beautiful Highland scenery, with several hours at the loch for boat cruises and castle visits."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can you walk from the cruise port in Invergordon?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, you can walk to Invergordon village from the cruise dock. However, the main attractions (Loch Ness, Highland castles, distilleries) require transportation. Ship excursions or private coach tours are the best options for exploring the Highlands from this port."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Invergordon worth visiting on a cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Invergordon is the gateway to Loch Ness, Urquhart Castle, and the Scottish Highlands. The town itself is small, but the excursions available from here rank among the most dramatic in northern European cruising."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I walk from the cruise pier to town?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Invergordon town centre is a five-minute flat walk from the pier. The route is paved and wheelchair accessible. However, major attractions like Loch Ness and Inverness require coach or taxi transport."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How long does it take to reach Loch Ness from Invergordon?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "About 90 minutes each way by coach through Highland scenery. A full port day is needed. Most tours depart at eight in the morning and return by late afternoon."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I wear for a day in the Scottish Highlands?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Waterproof jacket, warm layers, and sturdy shoes with grip. Even in summer, temperatures stay around 12–17 °C and rain can arrive without warning. Wind at castle ruins makes it feel colder."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are midges really that bad in Scotland?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From June through September, Highland midges can be fierce near lochs and glens, especially on still, damp evenings. Carry insect repellent — the local Smidge brand (about £6) works well."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need British Pounds in Invergordon?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Card payments work at most shops and attractions. Carry some cash for small purchases, tips, and market stalls. ATMs are available in the town centre, a short walk from the pier."
+      }
+    }
+  ]
+}
   </script>
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high">

--- a/ports/jacksonville.html
+++ b/ports/jacksonville.html
@@ -58,44 +58,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "What cruise lines sail from Jacksonville?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Carnival Cruise Line offers sailings from Jacksonville (JAXPORT) to the Bahamas and Eastern Caribbean destinations."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How far is the cruise port from Jacksonville Airport?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Jacksonville International Airport (JAX) is approximately 20 miles from the JAXPORT cruise terminal, about 30-40 minutes by car depending on traffic."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is there parking at the Jacksonville cruise terminal?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, JAXPORT offers on-site parking at the cruise terminal for approximately $15-17 per day. The lot is within walking distance of the terminal."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What beaches are near the Jacksonville cruise port?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Jacksonville Beach, Neptune Beach, and Atlantic Beach are all about 20-25 minutes from the cruise terminal."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What cruise lines sail from Jacksonville?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Carnival Cruise Line offers sailings from Jacksonville (JAXPORT) to the Bahamas and Eastern Caribbean destinations. The port serves as a homeport for embarkation."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "How far is the cruise port from Jacksonville Airport?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jacksonville International Airport (JAX) is approximately 20 miles from the JAXPORT cruise terminal, about 30-40 minutes by car depending on traffic. Rideshare costs $30-45; taxis run $45-55."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there parking at the Jacksonville cruise terminal?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, JAXPORT offers on-site parking adjacent to the cruise terminal for approximately $15-17 per day. The lot accepts cash and credit cards and is within easy walking distance of the terminal."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What beaches are near the Jacksonville cruise port?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jacksonville Beach, Neptune Beach, and Atlantic Beach are all about 20-25 minutes from the cruise terminal by car. These beach communities have restaurants, shops, and free public beach access."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit St. Augustine from Jacksonville before my cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, St. Augustine is about 40 minutes south by car. If you arrive the day before your cruise, it makes a memorable day trip. On embarkation day, only attempt it if you have 6+ hours before boarding."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the weather like in Jacksonville for cruise season?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jacksonville has a humid subtropical climate with temperatures ranging from 7-33 C (45-91 F). Cruise season typically falls in the cooler, drier months. Hurricane season runs June through November."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/jeju.html
+++ b/ports/jeju.html
@@ -55,44 +55,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Jeju?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Jeju has two cruise ports: Jeju Port on the north coast (2km from downtown, handles ships under 140,000 GT) and Seogwipo Gangjeong Port on the south coast (handles mega-ships up to 220,000 GT). Most cruise ships use Jeju Port for convenient downtown access."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What makes Jeju a UNESCO triple crown site?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Jeju earned UNESCO recognition three times: as a Biosphere Reserve (2002), World Natural Heritage Site (2007), and Global Geopark (2010). The volcanic island's unique geology, lava tubes, tuff cones, and biodiversity earned this rare triple designation."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I hike Hallasan Mountain summit on a cruise day?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Summit requires 8-9 hours round trip—too long for most cruise calls. Choose shorter Eorimok Trail (2-3 hours) for mountain experience, or focus on lava tubes and Sunrise Peak instead for cruise day time constraints."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What's the best single UNESCO site if I only have time for one?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Manjanggul Lava Tube for geological drama (4.6 miles of underground tunnel with 75-foot ceilings), or Seongsan Ilchulbong for panoramic views and moderate 30-minute hike. Both deliver the 'wow' factor that explains UNESCO's attention."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Jeju?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jeju Port on the north coast (most ships, 2 km from downtown) or Seogwipo Gangjeong Port on the south coast (mega-ships over 140,000 GT). Both are dock-side, no tendering."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the best single UNESCO site if I only have time for one?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Manjanggul Lava Tube for geological drama or Seongsan Ilchulbong for panoramic views. Both are about 35-40 minutes from Jeju Port by taxi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I hike Hallasan summit on a cruise day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No — the summit requires 8-9 hours round trip. The Eorimok Trail (2-3 hours) gives a good mountain experience within cruise day constraints."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to speak Korean?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "English signage exists at major sites but is limited elsewhere. Google Translate's camera function helps with menus. Having destinations written in Korean on your phone helps with taxi drivers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Jeju good for wheelchair users?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The natural attractions are challenging — most involve stairs and uneven volcanic terrain. Jeju City's downtown is flatter and more accessible. The Haenyeo Museum and Dongmun Market are manageable options."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I eat?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Heukdwaeji (black pork) grilled at your table is the signature dish (~15,000 won/$11). Fresh hallabong tangerine juice and Dongmun Market street food are worth seeking out."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/kiel.html
+++ b/ports/kiel.html
@@ -64,44 +64,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Is Kiel worth visiting on a cruise?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Kiel is the most authentic German maritime port, offering a unique combination of naval history, the legendary Kiel Canal, and sailing heritage that you won't find elsewhere."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is the best thing to see in Kiel?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The Kiel Canal transit experience combined with the Laboe U-boat museum. The canal is one of the world's busiest artificial waterways, and U-995 is one of the last surviving Type VII U-boats from WWII."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How long does it take to visit Laboe?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Allow 3 hours round-trip from Kiel cruise terminal to properly see both the Naval Memorial tower and U-995 submarine museum."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can you walk from the cruise port in Kiel?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes — the Ostseekai cruise terminal is right in the heart of the city, with a ten-minute walk putting you in the center and directly into sailing central."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Kiel worth visiting on a cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kiel offers a genuine German maritime experience. The Laboe U-boat memorial, Kiel Canal, and waterfront promenade provide a rewarding port day that feels distinctly different from more touristy Baltic stops."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can you walk from the cruise port to the city centre?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Ostseekai terminal is in the heart of Kiel. The harbour promenade is a five-minute walk, and Holstenstrasse pedestrian shopping street is about ten minutes on foot. The terrain is flat and wheelchair accessible."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I get to Laboe from the cruise terminal?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Bus 100 or 102 runs from near Kiel Hauptbahnhof to Laboe in about twenty minutes. Tickets cost approximately 3.50 euros. A taxi costs 25-30 euros one way."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best thing to see in Kiel?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The Laboe Naval Memorial and U-995 submarine together offer the most moving and educational experience. The Kiel Canal observation is also remarkable and completely free."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Hamburg from Kiel on a cruise day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Hamburg is one hour by train. If your ship gives you ten or more hours in port, a day trip is feasible. Return tickets cost about 30 euros. Ship excursions cost 90-130 euros and guarantee your return."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is Kieler Woche?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kieler Woche (Kiel Week) is the world's largest sailing regatta, held in late June. Over three million visitors attend ten days of racing, concerts, and waterfront celebrations. If your cruise visits during this period, expect crowds and excitement."
+      }
+    }
+  ]
+}
   </script>
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high">

--- a/ports/koper.html
+++ b/ports/koper.html
@@ -62,44 +62,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Is Koper worth visiting on a cruise?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, Koper is the sleeper hit of the Adriatic — a miniature Venice with Slovenian prices. You get authentic Venetian-Gothic architecture, 500 years of maritime history, and access to Slovenia's stunning Istrian coast, all without the crowds and expense of Venice itself."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is the best thing to do in Koper?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The combination of exploring the old town's Venetian architecture (Praetorian Palace, Tito Square, bell tower) and biking the Parenzana trail into Istrian wine and truffle country. The old railway path offers stunning coastal and countryside views with stops at local konobas for authentic cuisine."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How long does the Parenzana bike trail take?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "A round-trip ride on the Parenzana trail takes 3-4 hours depending on how far you go and how many stops you make. The trail passes through old railway tunnels and over stone viaducts, with opportunities to stop at olive groves and truffle-focused restaurants along the way."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can you walk to Koper old town from the cruise port?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, the walk from the cruise port to Tito Square in the heart of Koper's old town takes about 15-20 minutes. The route is straightforward and brings you directly into the historic Venetian quarter with its Gothic palaces and maritime heritage."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can I walk from the cruise port to Koper old town?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The walk from the passenger terminal to Tito Square takes about fifteen minutes along a flat, paved waterfront path that is wheelchair accessible. No shuttle bus is needed."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Koper worth visiting on a cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Koper offers authentic Venetian-Gothic architecture, genuine Slovenian culture, and access to Piran, Ljubljana, and Postojna Cave — all at prices well below neighbouring Italy or Croatia. It is an underrated stop that rewards curious travellers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What currency does Koper use?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Slovenia uses the euro. Credit cards are accepted at most restaurants and shops. Carry small cash for market vendors, bus fares, and countryside konobas. ATMs are available in the old town."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Ljubljana from Koper in a day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, but it requires planning. Ljubljana is about one hour by road. Ship excursions cost 55–80 EUR and guarantee timely return. Independent visitors can hire a driver for 120–150 EUR round trip or take the bus at about 12 EUR each way."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How long does the Parenzana bike trail take?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A round trip to the first tunnels and viaducts takes three to four hours at a relaxed pace. Bike rental runs about 15 EUR for a half day. The trail is flat to gently rolling and suitable for moderate fitness."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I eat in Koper?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Try grilled branzino (sea bass) with local olive oil, fuzi pasta with Istrian truffles, and Malvazija white wine. A full meal with wine costs 18–25 EUR at a waterfront restaurant — exceptional value for Adriatic dining."
+      }
+    }
+  ]
+}
   </script>
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high">

--- a/ports/kota-kinabalu.html
+++ b/ports/kota-kinabalu.html
@@ -74,45 +74,77 @@ Soli Deo Gloria
     }
     </script>
     <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
     {
-        "@context": "https://schema.org",
-        "@type": "FAQPage",
-        "mainEntity": [
-            {
-                "@type": "Question",
-                "name": "Where do cruise ships dock in Kota Kinabalu?",
-                "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "Most cruise ships dock at Kota Kinabalu Port (Sapangar Bay) or at Jesselton Point Ferry Terminal. Sapangar Bay is about 25km from the city center, requiring a shuttle or taxi. Jesselton Point is centrally located, walking distance to attractions."
-                }
-            },
-            {
-                "@type": "Question",
-                "name": "Can you see Mount Kinabalu from Kota Kinabalu?",
-                "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "On clear mornings, Mount Kinabalu is visible from Kota Kinabalu city, rising majestically about 90km away. Signal Hill Observatory offers the best views. The mountain is often cloud-covered by afternoon, so morning visits are recommended."
-                }
-            },
-            {
-                "@type": "Question",
-                "name": "Is Tunku Abdul Rahman Marine Park worth visiting on a cruise day?",
-                "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "Yes, the five islands of Tunku Abdul Rahman Marine Park are easily accessible from Jesselton Point by speedboat (15-20 minutes). Snorkeling, clear waters, and beaches make it a natural fit for short cruise visits. Manukan and Sapi islands are most popular."
-                }
-            },
-            {
-                "@type": "Question",
-                "name": "What currency is used in Kota Kinabalu?",
-                "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "Malaysian Ringgit (MYR or RM) is the official currency. Credit cards are widely accepted in shopping centers and restaurants, but cash is preferred at markets and small vendors. ATMs are readily available throughout the city."
-                }
-            }
-        ]
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Kota Kinabalu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most cruise ships dock at Sapangar Bay, about 25km north of the city center, requiring a 30-40 minute shuttle or taxi (fare approximately RM 60-80 / $13-17). Some smaller ships dock at Jesselton Point Ferry Terminal, which is centrally located and walking distance to waterfront attractions."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can you see Mount Kinabalu from Kota Kinabalu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "On clear mornings, Mount Kinabalu is visible from the city, rising majestically about 90km away. Signal Hill Observatory offers the best views. The mountain is often cloud-covered by afternoon, so early morning visits are recommended for the best chance of clear sightings."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Tunku Abdul Rahman Marine Park worth visiting on a cruise day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely. The five islands are easily accessible from Jesselton Point by speedboat (15-20 minutes). Snorkeling, clear waters, and coral shores make it a natural fit for a half-day visit. Manukan and Sapi islands are most popular. Budget RM 80-120 ($17-26) per person."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What currency is used in Kota Kinabalu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Malaysian Ringgit (MYR or RM). Exchange rate approximately RM 4.5 = $1 USD. Credit cards are accepted at larger shops and restaurants. Cash is essential at waterfront stalls and small vendors. ATMs are readily available throughout the city center."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the best time of year to visit Kota Kinabalu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "March through August offers the driest weather and calmest seas, suited to island visits and outdoor activities. The monsoon season (November-January) brings heavier rainfall and rougher seas that may disrupt island boat services. However, Kota Kinabalu is south of the typhoon belt, so severe storms are rare year-round."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Kota Kinabalu safe for cruise visitors?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, very safe. Standard travel awareness applies, but violent crime against tourists is rare. The main risks are sun exposure, dehydration, and occasional afternoon thunderstorms rather than security concerns."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much should I budget for a port day in Kota Kinabalu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "KK is remarkably affordable. A full day including island boat trip ($10-15), lunch at waterfront stalls ($3-5), taxi rides ($5-10), and souvenirs could cost as little as $30-50 per person. This makes it one of the most budget-friendly cruise ports in Southeast Asia."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will rain ruin my port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Brief afternoon showers are common but rarely last more than an hour. Mornings are typically clear. Carry a light rain jacket and plan outdoor activities for the morning. The Sabah State Museum and indoor attractions make excellent rain alternatives."
+      }
     }
-    </script>
+  ]
+}
+  </script>
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">

--- a/ports/luanda.html
+++ b/ports/luanda.html
@@ -79,45 +79,53 @@ Soli Deo Gloria
     </script>
 
     <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
     {
-        "@context": "https://schema.org",
-        "@type": "FAQPage",
-        "mainEntity": [
-            {
-                "@type": "Question",
-                "name": "What is the best way to get around Luanda?",
-                "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "Taxis are the most practical option for visitors. Blue-and-white taxis are metered and more reliable. Always agree on the fare beforehand or ensure the meter is running. The candongueiro minibuses are adventurous but require local knowledge."
-                }
-            },
-            {
-                "@type": "Question",
-                "name": "Is Luanda safe for cruise passengers?",
-                "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "Stick to well-traveled areas like the Marginal, Ilha de Luanda, and major tourist sites. Keep valuables out of sight, avoid walking alone after dark, and use reputable taxis. The city has improved significantly since the civil war ended in 2002."
-                }
-            },
-            {
-                "@type": "Question",
-                "name": "What currency should I bring to Luanda?",
-                "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "The official currency is the Angolan Kwanza (AOA). US dollars are sometimes accepted at larger establishments, but you'll get better value exchanging for kwanzas. ATMs are available in the city center, though they can be unreliable."
-                }
-            },
-            {
-                "@type": "Question",
-                "name": "What should I try for local food in Luanda?",
-                "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "Don't miss muamba de galinha (chicken stew with palm oil and okra), calulu (dried fish stew), and fresh seafood grilled at Ilha de Luanda. Funge, a cassava porridge, accompanies most meals. Wash it down with Cuca, the local beer."
-                }
-            }
-        ]
+      "@type": "Question",
+      "name": "What's the best time of year to visit Luanda, Angola: A Maritime Guide to Africa's Oil Capital | In The Wake?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Peak cruise season offers the most reliable weather and best conditions for sightseeing. Check the weather section above for specific month recommendations based on your planned activities."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Luanda, Angola: A Maritime Guide to Africa's Oil Capital | In The Wake have extreme weather to worry about?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Like most destinations, weather conditions vary by season. Check the weather hazards section above for specific concerns and the best time to visit. Cruise lines monitor conditions and will adjust itineraries if needed for passenger safety."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Luanda, Angola: A Maritime Guide to Africa's Oil Capital | In The Wake's weather?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Essentials include sunscreen, comfortable walking shoes, and layers for variable conditions. Check the packing tips section in our weather section for destination-specific recommendations."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will rain ruin my port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Brief showers are common in many destinations but rarely last long enough to significantly impact your day. Have a backup plan for indoor attractions, and remember that many activities continue in light rain. Check the weather forecast before your visit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Luanda, Angola: A Maritime have a hurricane or storm season?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Weather patterns vary by region and season. Check the weather hazards section above for specific storm season concerns and timing. Cruise lines closely monitor weather conditions and will adjust itineraries if needed for passenger safety. Travel insurance is recommended for cruises during peak storm season months."
+      }
     }
-    </script>
+  ]
+}
+  </script>
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">

--- a/ports/maui.html
+++ b/ports/maui.html
@@ -63,44 +63,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Is Maui (Kahului) worth visiting on a cruise?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Absolutely. Maui offers Haleakala volcano, the legendary Road to Hana, Iao Valley's green needle peak, and Upcountry lavender farms. Kahului port provides access to the entire Valley Isle — it's far bigger than one town."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What's the best thing to do on Maui in one day?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "For cruise passengers, combine Iao Valley State Park with Upcountry (Kula lavender farms, Ali'i Kula Lavender Farm). Or do a partial Road to Hana — the first 20-30 miles to waterfalls and Keanae Peninsula shows you why this road is legendary without the full 10-12 hour commitment."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I do Haleakala sunrise on a cruise day?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Very difficult. The summit is 38 miles from Kahului port, requiring 3am departure plus advance recreation.gov reservation. Consider sunset or midday visits instead — the summit is stunning any time of day, and you'll actually have time to enjoy it."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Lahaina open after the 2023 fire?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Lahaina is rebuilding after the devastating August 2023 fire. Some areas are accessible, and the community welcomes respectful visitors supporting recovery. Check current status before visiting and approach with sensitivity to this ongoing healing process."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Maui (Kahului) worth visiting on a cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely. Maui offers Haleakala volcano, the legendary Road to Hana, Iao Valley's green needle peak, and Upcountry lavender farms. Kahului port provides access to the entire Valley Isle — the island offers far more than any single town. A rental car at $50-$80 per day unlocks the best of what this island has to offer."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best thing to do on Maui in one day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For cruise passengers, combine Iao Valley State Park with Upcountry Kula lavender farms for a relaxed half-day. Or do a partial Road to Hana covering the first 20-30 miles to waterfalls and Keanae Peninsula, which shows you why this road is legendary without the full 10-12 hour commitment that would risk missing your ship."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I do Haleakala sunrise on a cruise day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It is very difficult independently. The summit is 38 miles from Kahului port, requiring a 3am departure plus an advance recreation.gov reservation. A ship excursion is the safer choice for sunrise since it offers guaranteed return. Alternatively, consider a sunset or midday visit — the summit is stunning at any time of day, and you will actually have time to enjoy the drive through Upcountry on the way back."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How long does the full Road to Hana take?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The full round trip takes 10-12 hours minimum, making it impractical for most cruise port days. Most cruise passengers do the first third of the route (3-4 hours round trip) and still see waterfalls, bamboo forests, and dramatic coastline."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I walk from the port to attractions?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Only to Costco and a few stores about one mile away. For all sightseeing, a rental car is essential. The port sits in an industrial zone with minimal walking difficulty to nearby shops but nothing scenic within foot range."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Lahaina open after the 2023 fire?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Lahaina is rebuilding after the devastating August 2023 wildfire. Some areas are accessible, and the community welcomes respectful visitors who support local recovery businesses. Check current access status before visiting and approach with sensitivity to the ongoing healing process."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/norfolk.html
+++ b/ports/norfolk.html
@@ -49,16 +49,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {"@type": "Question", "name": "What cruise lines sail from Norfolk?", "acceptedAnswer": {"@type": "Answer", "text": "Royal Caribbean offers seasonal sailings from Norfolk on Vision of the Seas to Bermuda, Bahamas, and Caribbean destinations. Carnival has also offered sailings in the past."}},
-      {"@type": "Question", "name": "How far is Norfolk Airport from the cruise terminal?", "acceptedAnswer": {"@type": "Answer", "text": "Norfolk International Airport (ORF) is approximately 8 miles from Half Moone Cruise Terminal. Rideshare or taxi takes 15-20 minutes and costs $20-35."}},
-      {"@type": "Question", "name": "Should I arrive a day early for a Norfolk cruise?", "acceptedAnswer": {"@type": "Answer", "text": "Yes, arriving a day early is recommended to avoid missing your cruise due to travel delays. Norfolk offers Nauticus museum, USS Wisconsin, Naval Station tours, and Virginia Beach is just 30 minutes away."}},
-      {"@type": "Question", "name": "How much does parking cost at the cruise terminal?", "acceptedAnswer": {"@type": "Answer", "text": "Parking at Half Moone Cruise Terminal costs approximately $15-18 per day. Reservations recommended during peak season. The garage is attached to the terminal for convenience."}}
-    ]
-  }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What ships sail from Norfolk?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Royal Caribbean deploys Vision of the Seas seasonally from Norfolk, typically offering Bermuda, Bahamas, and Caribbean itineraries spring through fall. Carnival has offered sailings in the past. Check current schedules as deployment changes annually."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there Uber/Lyft at Norfolk Airport?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, both operate at ORF. Pickup is at the terminal's ground transportation area. Expect $20-35 to reach downtown Norfolk and the cruise terminal, with the trip taking 15-20 minutes depending on traffic."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Naval Station Norfolk?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, through official tours booked via Nauticus. Tours run several times daily and last about 45 minutes. You'll ride a bus through the base viewing carriers, submarines, and support ships. ID required; book in advance as tours fill up."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How far is Virginia Beach from the cruise terminal?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "About 18 miles, or 25-35 minutes by car depending on traffic. The beach resort area has its own hotels if you want to split your pre-cruise time between Norfolk attractions and beach relaxation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Norfolk worth arriving a day early?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, if you're interested in naval history. The USS Wisconsin and Nauticus provide a solid half-day of exploration. Combined with a nice dinner downtown, it makes for a pleasant pre-cruise experience. If military history doesn't appeal to you, you might prefer arriving same-day."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where should I stay near the cruise terminal?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The Norfolk Waterside Marriott and Sheraton Norfolk Waterside are both downtown within walking distance of attractions and the terminal. For budget options, there are hotels near the airport or along I-64, though you'll need to drive or rideshare to embarkation."
+      }
+    }
+  ]
+}
   </script>
 
   <meta name="twitter:card" content="summary_large_image">

--- a/ports/norwegian-fjords.html
+++ b/ports/norwegian-fjords.html
@@ -70,44 +70,68 @@ Soli Deo Gloria
 
   <!-- JSON-LD: FAQPage -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Which Norwegian fjord port is best?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Geiranger for scenery (UNESCO World Heritage waterfalls), Flåm for the railway (world's most beautiful train ride), Olden for glacier access (Briksdal), and Ålesund for Art Nouveau architecture. All score 5/5 for natural beauty."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is the Flåm Railway worth it?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes — consistently rated one of the world's most beautiful train rides. The 20km journey climbs 863 meters through 20 tunnels with spectacular views, including the Kjosfossen waterfall stop with huldra dancer performance. Book independently at vy.no for better prices than ship excursions."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I hike to Briksdal Glacier in Olden?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes — the hike is 2.8km each way with moderate difficulty. 'Troll cars' (electric buggies) are available for those who prefer not to hike. The glacier has retreated significantly due to climate change but remains spectacular."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What's the best time to visit Norwegian fjords?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "May–September is cruise season. Waterfalls are most powerful in spring/early summer from snowmelt. June–July offers nearly 24-hour daylight. September has autumn colors but fewer cruise ships. All fjord ports score perfect 5.0 for scenery regardless of season."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Which Norwegian fjord port is best?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Geiranger for sheer scenic impact (UNESCO World Heritage fjord with thundering waterfalls), Flam for the railway (one of the world's most beautiful train rides), Olden for glacier access (Briksdal Glacier arm), and Alesund for Art Nouveau architecture. All fjord ports score perfect 5.0 for natural beauty."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the Flam Railway worth it?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — consistently rated one of the world's most beautiful train rides. The twenty-kilometre journey climbs 863 metres through twenty tunnels with spectacular views, including the Kjosfossen waterfall stop with the huldra dancer performance. Book independently at vy.no for approximately €55 return, often cheaper than the ship excursion price of €80 or more."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I hike to Briksdal Glacier in Olden?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — the hike is 2.8 km each way with moderate difficulty along a river valley. Electric troll cars are available for visitors with wheelchair access needs or those who prefer not to hike the full distance. The glacier has retreated significantly due to climate change but remains spectacular."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best time to visit Norwegian fjords?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "May through September is cruise season. Waterfalls are most powerful in spring and early summer from snowmelt. June and July offer nearly twenty-four-hour daylight. September has autumn colours but fewer cruise ships. All fjord ports offer perfect scenery regardless of the specific month within season."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Norwegian fjords?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Essentials include a waterproof jacket, layers for variable temperatures (it can be warm at sea level and cold at altitude on the same day), comfortable walking shoes with grip for wet paths, sunscreen, and a camera. A hat and gloves are wise for Dalsnibba and glacier excursions even in summer."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there wheelchair accessibility in the fjord ports?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Accessibility varies by port. Flam and Alesund have pier-side docking with level access to town. Geiranger and Olden require tender boats which may present challenges for wheelchair users. At Briksdal Glacier, electric troll cars provide an accessible alternative to the hiking trail. Many ship excursions can accommodate mobility needs with advance notice."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will rain ruin my port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Brief showers are common in the fjords but rarely last long enough to significantly impact your day. Rain can actually enhance the scenery by creating additional waterfalls on the cliff faces. A good waterproof jacket is essential. Have a backup plan for indoor attractions in Alesund (Jugendstil Centre, aquarium) if weather is severe."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/penang.html
+++ b/ports/penang.html
@@ -54,44 +54,52 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Penang?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at Swettenham Pier Cruise Terminal in Georgetown, within walking distance of the Clan Jetties and about 15 minutes by taxi from the UNESCO heritage core."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Why is Georgetown a UNESCO World Heritage Site?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Georgetown (along with Melaka) was inscribed in 2008 for its unique architectural and cultural townscape blending colonial, Chinese, Indian Muslim, and Malay influences. The heritage zone preserves centuries of multicultural history still actively lived by residents today."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Where can I find Ernest Zacharevic's famous murals?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "His iconic Children on a Bicycle is on Armenian Street (Lebuh Armenian). Boy on a Motorbike is nearby. The iron caricature installations are scattered throughout the heritage zone."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is the best way to explore Georgetown?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The Clan Jetties are walking distance from the port. The main heritage zone (street art, temples, Khoo Kongsi) is best reached by taxi or Grab (15 min, very affordable). Once there, everything is walkable. Kek Lok Si Temple and Penang Hill require transportation."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the best time to visit Penang?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Spring and early autumn tend to offer the most comfortable conditions for sightseeing — mild temperatures, manageable crowds, and pleasant light for photography. Summer brings the warmest weather but also peak cruise traffic and higher prices. Winter visits can be rewarding for those who prefer quiet streets and authentic atmosphere, though some attractions may have reduced hours."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Penang suitable for passengers with mobility challenges?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Accessibility varies by area. The port vicinity and main commercial streets are generally manageable, but older historic districts may feature cobblestones, stairs, and uneven surfaces. Consider booking an accessible ship excursion if you have concerns. The ship's shore excursion desk can advise on specific accessibility options for this port."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to exchange currency before arriving?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The local currency is MYR. Most tourist-facing businesses accept major credit cards. ATMs near the port offer competitive exchange rates. Carry some local cash for small purchases, markets, and tips. Avoid exchanging money on the ship — the rates are typically unfavorable compared to local bank ATMs."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I explore independently or should I book a ship excursion?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both options work well. Ship excursions guarantee return to the vessel and handle logistics, making them ideal for first-time visitors. Independent exploration costs less and allows more flexibility — just keep track of time and allow a 30-minute buffer before all-aboard. Many passengers combine approaches: an organized morning tour followed by free afternoon exploration."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I bring on a port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Comfortable walking shoes are essential — you will walk more than you expect. Sunscreen, a hat, and a refillable water bottle help in warm weather. Carry your ship card (or a photo of it), a small amount of local cash, and one credit card. Leave jewelry and unnecessary valuables on the ship. A lightweight daypack beats a purse or tote for all-day comfort."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/petersburg.html
+++ b/ports/petersburg.html
@@ -87,44 +87,52 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "What is Petersburg Alaska known for?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Petersburg is known as 'Little Norway' — a working fishing village settled by Norwegian fishermen in 1897. It's one of Alaska's most productive fishing ports, featuring authentic Norwegian heritage, rosemaling (decorative painting) on buildings throughout town, and access to LeConte Glacier, the nearest tidewater glacier to a town in North America."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Why don't large cruise ships visit Petersburg?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Petersburg's Wrangell Narrows channel is too shallow and narrow for mega-cruise ships. Only small expedition-style ships from lines like UnCruise, Lindblad, and select Holland America vessels can navigate the passage. This keeps Petersburg authentically uncrowded and off the mega-ship tourist circuit."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can you visit LeConte Glacier from Petersburg?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes — LeConte Glacier is accessible by boat from Petersburg and is the nearest tidewater glacier to a town in North America. Boat tours typically take 4-6 hours and offer views of calving ice and marine wildlife including harbor seals on icebergs."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Petersburg worth visiting on an Alaska cruise?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Absolutely — Petersburg offers one of the most authentic Alaska experiences available. With about 3,000 residents and virtually no mega-ship tourism, you'll find a genuine working fishing village with Norwegian heritage, exceptional birding, and LeConte Glacier access without the crowds found at larger ports."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is Petersburg Alaska known for?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Petersburg is known as \"Little Norway\" — a working fishing village settled by Norwegian fishermen in 1897. It is one of Alaska's most productive fishing ports, famous for its authentic Norwegian heritage, rosemaling (decorative painting) on buildings throughout town, the Sons of Norway Hall, the Clausen Memorial Museum, and access to LeConte Glacier — the nearest tidewater glacier to a town in North America."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Why don't large cruise ships visit Petersburg?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The Wrangell Narrows — the 22-mile channel leading to Petersburg — is too shallow and narrow for mega-cruise ships. Draft restrictions and tight navigation limit access to smaller vessels. Only small expedition-style ships from lines like UnCruise Adventures, Lindblad Expeditions, and select smaller Holland America vessels can make the transit. This keeps Petersburg authentically uncrowded."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can you visit LeConte Glacier from Petersburg?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — LeConte Glacier is accessible by boat from Petersburg, typically a 4-6 hour round trip. It is the southernmost tidewater glacier in North America and the nearest tidewater glacier to any town on the continent. Tours offer close-up views of calving ice and harbor seals resting on icebergs. Book well in advance as capacity is limited."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Petersburg worth visiting on an Alaska cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely — if your itinerary includes it. Petersburg offers one of the most authentic Alaska experiences available to any visitor. With about 3,000 residents, virtually no mega-ship tourism, genuine Norwegian heritage, exceptional birding, and LeConte Glacier access, it provides something larger ports cannot: an unfiltered look at real small-town Alaska life."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I do if I only have a few hours in Petersburg?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Walk the harbor and Sing Lee Alley boardwalk. Visit the Clausen Memorial Museum and the Sons of Norway Hall. Look for the rosemaling on buildings throughout town. Watch the fishing boats come and go. Try to buy fresh shrimp at the harbor. If you have 5+ hours, prioritize the LeConte Glacier boat tour — it is the signature experience and unlike anything available at larger ports."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- LCP Optimization -->
@@ -597,27 +605,27 @@ STANDARDS: Every Page v3.010.300 · Production Template · Unified Nav v3.010.30
           <details class="section-collapse" open="">
             <summary><h2>Frequently Asked Questions</h2></summary>
 
-      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+      <details class="faq-item" style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600;">What is Petersburg Alaska known for?</summary>
         <p class="list-indent">Petersburg is known as "Little Norway" — a working fishing village settled by Norwegian fishermen in 1897. It is one of Alaska's most productive fishing ports, famous for its authentic Norwegian heritage, rosemaling (decorative painting) on buildings throughout town, the Sons of Norway Hall, the Clausen Memorial Museum, and access to LeConte Glacier — the nearest tidewater glacier to a town in North America.</p>
       </details>
 
-      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+      <details class="faq-item" style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600;">Why don't large cruise ships visit Petersburg?</summary>
         <p class="list-indent">The Wrangell Narrows — the 22-mile channel leading to Petersburg — is too shallow and narrow for mega-cruise ships. Draft restrictions and tight navigation limit access to smaller vessels. Only small expedition-style ships from lines like UnCruise Adventures, Lindblad Expeditions, and select smaller Holland America vessels can make the transit. This keeps Petersburg authentically uncrowded.</p>
       </details>
 
-      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+      <details class="faq-item" style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600;">Can you visit LeConte Glacier from Petersburg?</summary>
         <p class="list-indent">Yes — LeConte Glacier is accessible by boat from Petersburg, typically a 4-6 hour round trip. It is the southernmost tidewater glacier in North America and the nearest tidewater glacier to any town on the continent. Tours offer close-up views of calving ice and harbor seals resting on icebergs. Book well in advance as capacity is limited.</p>
       </details>
 
-      <details style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
+      <details class="faq-item" style="margin: 0.75rem 0; padding: 0.5rem 0; border-bottom: 1px solid #e0e8f0;">
         <summary style="cursor: pointer; font-weight: 600;">Is Petersburg worth visiting on an Alaska cruise?</summary>
         <p class="list-indent">Absolutely — if your itinerary includes it. Petersburg offers one of the most authentic Alaska experiences available to any visitor. With about 3,000 residents, virtually no mega-ship tourism, genuine Norwegian heritage, exceptional birding, and LeConte Glacier access, it provides something larger ports cannot: an unfiltered look at real small-town Alaska life.</p>
       </details>
 
-      <details style="margin: 0.75rem 0; padding: 0.5rem 0;">
+      <details class="faq-item" style="margin: 0.75rem 0; padding: 0.5rem 0;">
         <summary style="cursor: pointer; font-weight: 600;">What should I do if I only have a few hours in Petersburg?</summary>
         <p class="list-indent">Walk the harbor and Sing Lee Alley boardwalk. Visit the Clausen Memorial Museum and the Sons of Norway Hall. Look for the rosemaling on buildings throughout town. Watch the fishing boats come and go. Try to buy fresh shrimp at the harbor. If you have 5+ hours, prioritize the LeConte Glacier boat tour — it is the signature experience and unlike anything available at larger ports.</p>
       </details>

--- a/ports/picton.html
+++ b/ports/picton.html
@@ -54,52 +54,76 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Picton?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at Picton Town Wharf, right in the heart of town. You can walk off the ship directly into the town center within minutes."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I visit Marlborough wineries from Picton on a port day?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, the Marlborough wine region is about 30 minutes away by taxi or organized tour. Book ahead for tastings at Cloudy Bay, Brancott, or other renowned Sauvignon Blanc producers."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is the Queen Charlotte Track accessible on a cruise stop?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, via water taxi to trail sections. The 70-kilometer (44-mile) track runs from Ship Cove to Anakiwa and is a multi-day journey for hikers, but you can tackle scenic sections in 2-3 hours with arranged water taxi pickup. Book your water taxi in advance and confirm times carefully to match your ship's schedule."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is special about the Edwin Fox ship?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The Edwin Fox is the world's ninth-oldest surviving ship and the only remaining East Indiaman. Built in 1853, it served as a troop ship, convict transport, and immigrant vessel before arriving in Picton in 1897."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Do I need to book Queen Charlotte Sound cruises in advance?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Highly recommended, especially during cruise ship days. The scenic mail boat run and kayak tours fill up quickly. Book online before your ship arrives to secure your spot."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Picton?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships dock directly at Picton Town Wharf, right in the heart of town. You walk off the gangway into the town center within two minutes. No tender is required."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Marlborough wineries on a port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely. The wine region near Blenheim is 30 minutes away by taxi or organized tour. Tasting fees run NZ$10-20 per flight, often redeemable with bottle purchase. Book organized tours ahead to guarantee your spot and ensure a guaranteed return to the ship before sailing."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the Queen Charlotte Track accessible on a cruise stop?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, via water taxi to trail sections. The 70-kilometer track runs from Ship Cove to Anakiwa and is a multi-day journey for hikers, but you can tackle scenic sections in 2-3 hours with arranged water taxi pickup. Book your water taxi in advance and confirm pickup times carefully to match your ship's schedule. The track involves moderate to strenuous walking on uneven terrain."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is special about the Edwin Fox ship?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It is the world's ninth-oldest surviving ship and the only remaining East Indiaman. Built in 1853, it served as a troop ship in the Crimean War, transported convicts to Australia, and brought immigrants to New Zealand. Admission is NZ$15."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to book Queen Charlotte Sound cruises in advance?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Highly recommended, especially during cruise ship days. The scenic mail boat run and kayak tours fill up quickly. Book online before your ship arrives to secure your spot and confirm timing against your ship's schedule."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best time of year to visit Picton?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The New Zealand cruise season runs from November to March (Southern Hemisphere summer). December through February offers the warmest weather (20-25 degrees Celsius) and longest daylight. March and April bring stunning autumn colors and fewer crowds. Check the weather section above for specific month recommendations."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Picton accessible for wheelchair users?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The waterfront area and main town streets are generally wheelchair accessible with flat paths. The Edwin Fox Museum has an accessible ground floor. However, the Queen Charlotte Track and hillside walks are not wheelchair friendly. Water taxis can accommodate mobility needs with advance notice — contact operators directly when booking."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Picton's weather?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Essentials include sunscreen, comfortable walking shoes with good grip, and layers for variable conditions. A light rain jacket is wise even in summer. If planning boat trips on the Sounds, bring a windproof layer as it can be significantly cooler on the water."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/portofino.html
+++ b/ports/portofino.html
@@ -35,36 +35,68 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "How do cruise ships access Portofino?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Portofino is a tender port — ships anchor offshore and ferry passengers to the harbor by tender boat. Some ships anchor at nearby Santa Margherita Ligure and bus passengers to Portofino. Allow 45-60 minutes round-trip for tendering. Weather can cancel tender operations; ships may divert to Genoa in rough seas."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How long does a port day in Portofino allow?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Typical port calls are 6-8 hours, but with 45-60 minutes of tender time, you have approximately 5-6 hours for actual exploration. The village is compact and walkable — this is enough time to visit Castello Brown, walk to San Giorgio church, explore the Piazzetta, and enjoy lunch."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What are the new rules against overtourism?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Portofino has strict regulations to manage crowds: no stopping in certain zones (275 euro fine), no alcohol consumption outside restaurants/bars, waiting limits in specific areas, and fines ranging from 25-500 euros. These rules protect the village from overcrowding. Be respectful, keep moving through busy areas, and enjoy refreshments seated at cafes."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do cruise ships access Portofino?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Portofino is a tender port — ships anchor offshore and ferry passengers by tender boat (20-30 min each way). Some ships dock at Santa Margherita Ligure and bus passengers to Portofino (15 min). Total tender time: 45-60 minutes round-trip."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can tenders be cancelled?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Portofino's exposed anchorage means rough weather can cancel tender operations. Ships may divert to Genoa (approximately 1.5 hours away) if seas are too rough. This happens occasionally, especially in winter months."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much time do I actually have in Portofino?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From a typical 8-hour port call, subtract 45-60 minutes for round-trip tendering. You have approximately 5-6 hours of actual village time. The village is tiny — this is plenty to see highlights."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the new overtourism rules?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Portofino now prohibits stopping in certain zones (€275 fine), bans alcohol consumption outside restaurants and bars, and limits waiting in specific areas. Fines range €25-500. Keep moving through busy zones, enjoy drinks seated at cafes, be respectful of this small community."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Portofino worth the high prices?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "That is personal. The village is genuinely beautiful — a postcard come to life. If you accept the prices as admission to a living museum of Italian elegance, it is worth experiencing once. Budget €50-100 per person for lunch and drinks. Or visit briefly, take photos, then ferry to Santa Margherita for more affordable dining."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I prioritize with limited time?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Walk the Piazzetta (free), climb to Castello Brown (€8, 1.5 hours), have lunch with harbor views (€30-50), explore the lanes and boutiques. That is a perfect half-day. Add San Giorgio church or lighthouse walk if you have extra time and energy."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Portofino accessible for visitors with limited mobility?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The harbor-level Piazzetta and waterfront are relatively flat and accessible. However, Castello Brown, San Giorgio church, and the lighthouse trail all require steep uphill climbs on uneven cobblestones. Wheelchair access to hilltop attractions is very limited. The tender boats themselves may also present challenges for those with mobility concerns — check with your cruise line about accessible tender arrangements."
+      }
+    }
+  ]
+}
   </script>
   <script type="application/ld+json">
   {

--- a/ports/puerto-caldera.html
+++ b/ports/puerto-caldera.html
@@ -53,52 +53,76 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "What's the difference between Puerto Caldera and Puntarenas?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Puerto Caldera is Costa Rica's modern cruise terminal, built specifically for large ships with direct docking capabilities. Located 10 miles south of historic Puntarenas town, it offers closer access to San José (90 minutes versus 2+ hours) and sits adjacent to Carara National Park. While Puntarenas is the older port town, Puerto Caldera handles most cruise operations."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I see crocodiles at Tárcoles River bridge?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. The Tárcoles River bridge on Highway 34 is famous for massive American crocodiles sunning on muddy banks below. You can view them from the roadside bridge (free) or take a boat safari for closer encounters. Crocodiles here reach 12-15 feet long. Best viewing is morning hours when they bask in sunlight. The bridge is 10 minutes from Puerto Caldera terminal."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How close is Puerto Caldera to Carara National Park?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Carara National Park is only 15-20 minutes from Puerto Caldera, making it the closest major rainforest attraction to any Pacific cruise port. This proximity allows half-day tours with ample time to explore trails, spot scarlet macaws at dawn or dusk, and experience transitional rainforest biodiversity without lengthy bus rides."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Puerto Caldera safe for independent exploration?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Puerto Caldera is primarily a commercial cargo port with limited tourist infrastructure. While Costa Rica has excellent safety records, the terminal itself offers few walking destinations. Organized tours or hired transportation are strongly recommended. For independent travelers, taxis to nearby beaches or the Tárcoles bridge are safe options."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What's the best shore excursion from Puerto Caldera for wildlife?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Carara National Park combined with Tárcoles River crocodile viewing offers the most wildlife in the shortest time. Morning tours catch scarlet macaws at their most active, then proceed to the river for crocodiles, roseate spoonbills, and herons. Half-day excursions return by early afternoon. For guaranteed close encounters, add a sloth sanctuary visit."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What's the difference between Puerto Caldera and Puntarenas?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Puerto Caldera is Costa Rica's modern cruise terminal, built specifically for large ships with direct docking capabilities. Located 10 miles south of historic Puntarenas town, it offers closer access to San José (90 minutes versus 2+ hours) and sits adjacent to Carara National Park. While Puntarenas is the older port town, Puerto Caldera handles most cruise operations."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I see crocodiles at Tárcoles River bridge?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The Tárcoles River bridge on Highway 34 is famous for massive American crocodiles sunning on muddy banks below. You can view them from the roadside bridge (free) or take a boat safari for closer encounters. Crocodiles here reach 12-15 feet long. Best viewing is morning hours when they bask in sunlight. The bridge is 10 minutes from Puerto Caldera terminal."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How close is Puerto Caldera to Carara National Park?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Carara National Park is only 15-20 minutes from Puerto Caldera, making it the closest major rainforest attraction to any Pacific cruise port. This proximity allows half-day tours with ample time to explore trails, spot scarlet macaws at dawn or dusk, and experience rainforest biodiversity without lengthy bus rides."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Puerto Caldera safe for independent exploration?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Puerto Caldera is primarily a commercial cargo port with limited tourist infrastructure. While Costa Rica has excellent safety records, the terminal itself offers few walking destinations. Organized tours or hired transportation are strongly recommended. For independent travelers, taxis to nearby beaches or the Tárcoles bridge are safe options."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the best shore excursion from Puerto Caldera for wildlife?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Carara National Park combined with Tárcoles River crocodile viewing offers the most wildlife in the shortest time. Morning tours catch scarlet macaws at their most active, then proceed to the river for crocodiles, roseate spoonbills, and herons. Half-day excursions return by early afternoon. For close encounters, add a sloth sanctuary visit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the best time of year to visit Puerto Caldera?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "December through April is dry season with sunny weather and the best conditions for outdoor activities. May through November brings afternoon rain showers but lusher forests and fewer crowds. Wildlife is active year-round. Peak cruise season aligns with dry season months."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Puerto Caldera excursions?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Closed-toe shoes with ankle support for rainforest trails, DEET insect repellent, reef-safe sunscreen, light rain jacket, binoculars for wildlife viewing, waterproof bag for electronics, and breathable moisture-wicking clothing. A camera with good zoom helps capture canopy wildlife."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will rain ruin my port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Brief afternoon showers are common but rarely last long enough to significantly impact your day. Morning excursions typically enjoy clear weather. Rainforest activities continue in light rain — and many wildlife species become more active after showers. Have a backup plan for indoor attractions like coffee plantation tours or the San José museums."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/punta-del-este.html
+++ b/ports/punta-del-este.html
@@ -447,45 +447,69 @@ ITW-Lite v3.010 | ICP-Lite v1.4
 
       <!-- JSON-LD: FAQPage -->
       <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "FAQPage",
-        "mainEntity": [
-          {
-            "@type": "Question",
-            "name": "Is Punta del Este expensive?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Yes, by South American standards — comparable to European resorts in peak season. Off-season is more reasonable. Port area shops and restaurants are priciest. Budget $30-$80 per person for a comfortable day ashore."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "Can I walk to the main attractions?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Yes. La Mano is 15-20 minutes from port. Beaches and Gorlero shopping are walkable. Casapueblo requires a taxi (15km, about $25 each way)."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "What is the best time to visit Punta del Este?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Spring and early autumn offer the most comfortable conditions — mild temperatures and manageable crowds. Summer brings warmth but also peak cruise traffic and higher prices."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "Do I need to exchange currency before arriving?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "The local currency is UYU but USD is widely accepted. Most tourist businesses take credit cards. ATMs near the port offer competitive rates. Carry some local cash for markets and tips."
-            }
-          }
-        ]
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Punta del Este expensive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, by South American standards — comparable to European resorts in peak season. Off-season is more reasonable. Port area shops and restaurants are priciest. Budget $30-$80 per person for a comfortable day ashore."
       }
-      </script>
+    },
+    {
+      "@type": "Question",
+      "name": "Can I walk to the main attractions?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. La Mano is 15-20 minutes from port. Beaches and Gorlero shopping are walkable. Casapueblo requires a taxi (15km, about $25 each way)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is José Ignacio?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A smaller, bohemian-chic beach town 30km east. Famous for fire-grilled restaurant Parador La Huella. Worth a day trip if you have 4+ hours in port."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best time to visit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Spring and early autumn offer the most comfortable conditions — mild temperatures and manageable crowds. Summer brings warmth but also peak cruise traffic and higher prices."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Punta del Este accessible for passengers with mobility challenges?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Accessibility varies. The port vicinity and main streets are generally manageable. Some areas feature uneven surfaces. Consider an accessible ship excursion if you have concerns."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to exchange currency before arriving?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The local currency is UYU but USD is widely accepted. Most tourist businesses take credit cards. ATMs near the port offer competitive rates. Carry some local cash for markets and tips."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I explore independently or should I book a ship excursion?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both work well. Ship excursions guarantee return to the vessel. Independent exploration costs less and allows flexibility — just allow a 30-minute buffer before all-aboard time."
+      }
+    }
+  ]
+}
+  </script>
 
           <section class="disclaimers">
             <p class="disclaimer"><strong>Author's Note:</strong> Punta del Este rewards strolling. Walk the beaches, photograph La Mano, and visit Casapueblo for sunset if time permits.</p>

--- a/ports/quebec-city.html
+++ b/ports/quebec-city.html
@@ -60,36 +60,68 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Quebec City?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Cruise ships typically dock at the main cruise terminal in Quebec City. Check with your cruise line for specific terminal information and available transportation options to the city center."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is the best way to explore Quebec City on a cruise stop?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "You can explore Quebec City independently on foot, by taxi, or through organized shore excursions. Walking tours are popular for city centers, while excursions are recommended for attractions farther from port."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What currency is used in Quebec City?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Canada uses the Canadian dollar (CAD). Cards dominante for most restaurants and hotels in Quebec City; keep some cash for small shops and markets. U.S. dollars are occasionally accepted at tourist spots at poor rates—use CAD ATMs instead of ship exchange when possible."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Quebec City?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships dock at the Ross Gaudreault Cruise Terminal (Pointe-a-Carcy) at the base of the old walled city. The terminal is wheelchair accessible. Upper Town is a 10-minute steep walk or a 2-minute funicular ride ($4 CAD) from the pier."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Quebec City worth visiting on a cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely. It is the crown jewel of Canada and New England itineraries — the only walled city in North America north of Mexico, a UNESCO World Heritage Site since 1985, and the closest you will get to Europe without crossing the Atlantic."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How long do you need in Old Quebec?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Five to six hours covers the highlights — Chateau Frontenac, Petit Champlain, the fortifications, and a food stop. However, you will wish you had overnight to see it all."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best time of year to visit Quebec City?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Peak cruise season (May through October) offers the most reliable weather. September and October bring spectacular fall foliage. Check the weather section above for specific month recommendations based on your planned activities."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Montmorency Falls worth the trip?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The falls are taller than Niagara, only 15 minutes from the pier, and the cable car ride ($16 CAD round trip) and suspension bridge are memorable experiences."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Quebec City?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sturdy walking shoes with good grip are essential for the cobblestones. Bring layers for variable temperatures, sunscreen, and a camera. A rain jacket is wise in any season."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will rain ruin my port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Brief showers are common but rarely last long enough to significantly impact your day. Have a backup plan for indoor attractions like the Chateau Frontenac lobby, Notre-Dame-des-Victoires church, or the Musee de la Civilisation."
+      }
+    }
+  ]
+}
   </script>
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high">

--- a/ports/reykjavik.html
+++ b/ports/reykjavik.html
@@ -60,52 +60,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Reykjavik?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Cruise ships dock at Skarfabakki terminal, about 3 km from the city center. A free shuttle runs to downtown in roughly 10 minutes. Some smaller vessels may use the old harbor, which is within walking distance of Laugavegur and Hallgrimskirkja."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is the Golden Circle worth it from Reykjavik cruise port?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. The 190-mile Golden Circle loop connects three of Iceland's greatest natural wonders in a single day tour. Most ship excursions run 6 to 8 hours and are timed to guarantee return to the vessel before departure."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What currency is used in Reykjavik?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Iceland uses the Icelandic krona (ISK). Credit and debit cards are accepted almost everywhere, even for small purchases. Having local currency is helpful for small vendors, but most visitors get by entirely with cards."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I visit the Blue Lagoon on a cruise port day?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, but you must book ahead. The Blue Lagoon is about 45 minutes from Reykjavik. Comfort entry starts around $75 per person. Book the earliest slot possible to ensure you return to port on time."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Reykjavik accessible for wheelchair users?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Downtown Reykjavik is mostly flat and wheelchair accessible. The free shuttle from Skarfabakki accommodates mobility devices. Harpa Concert Hall and many restaurants are fully accessible. The Golden Circle tour coaches vary in accessibility, so confirm with your operator."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Reykjavik?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most cruise ships dock at Skarfabakki terminal, about 3 km east of downtown. A free shuttle runs every 10-15 minutes to the city center. Smaller expedition vessels sometimes use the old harbor, which is right in the heart of town."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the Golden Circle worth it from the cruise port?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely. This 190-mile loop connects Thingvellir (tectonic plates), Strokkur geyser, and Gullfoss waterfall in a single day. Ship excursions typically cost $150-200 and include guaranteed return. Independent tours run about $80 per person."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit the Blue Lagoon on a port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, but you must book ahead. Comfort entry costs around $75 per person. The lagoon is 45 minutes from the city, so plan your timing carefully to ensure you return to the ship before departure."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What currency does Iceland use?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Iceland uses the Icelandic krona (ISK). Credit and debit cards are accepted nearly everywhere, even for purchases as small as a cup of coffee. You rarely need cash."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Reykjavik accessible for guests with mobility challenges?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Downtown Reykjavik is mostly flat and wheelchair accessible. The free shuttle from Skarfabakki accommodates mobility devices. Harpa Concert Hall and most restaurants have full accessibility. Golden Circle tours involve uneven natural terrain; confirm accessibility options with your tour operator before booking."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Reykjavik weather?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Layers are essential. Even in summer, temperatures hover around 50-57 F with wind. Bring a windproof, waterproof outer layer, comfortable walking shoes, and a warm hat. Rain can appear with little warning, though it is usually light."
+      }
+    }
+  ]
+}
   </script>
   <!-- LCP Optimization: Preload critical hero images -->
   <link rel="preload" as="image" href="/assets/logo_wake_560.png" fetchpriority="high">

--- a/ports/royal-beach-club-cozumel.html
+++ b/ports/royal-beach-club-cozumel.html
@@ -57,52 +57,76 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "When will Royal Beach Club Cozumel open?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Royal Caribbean announced Royal Beach Club Cozumel for 2026, though specific opening dates have not been confirmed. Check Royal Caribbean's official announcements for the latest updates on opening timeline."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How is Royal Beach Club different from regular Cozumel port calls?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Royal Beach Club will be an exclusive beach destination accessible only to Royal Caribbean guests, similar to Royal Beach Club Paradise Island in Nassau. It will offer controlled crowds, premium amenities, and dedicated transportation — distinct from the regular Cozumel cruise port experience."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Will Royal Beach Club Cozumel cost extra?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Based on the Royal Beach Club Paradise Island model, admission will likely be a separate shore excursion fee ranging from $99-$149 per person depending on season. Food and alcoholic beverages will likely be additional charges beyond base admission."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I still visit regular Cozumel if Royal Beach Club opens?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. Royal Beach Club will be an optional shore excursion. Guests can choose between the beach club experience or exploring Cozumel independently — visiting beach clubs like Paradise Beach or Mr. Sanchos, snorkeling the reefs, touring San Gervasio ruins, or exploring downtown San Miguel."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What amenities will Royal Beach Club Cozumel have?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "While final details are pending, based on the Nassau Beach Club model, expect premium beach areas, freshwater pools, swim-up bars, cabana rentals, water sports, dining options, and cultural programming. The Mexican location may feature local cuisine and entertainment reflecting Yucatan heritage."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "When will Royal Beach Club Cozumel open?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Royal Caribbean announced the destination for 2026, but specific opening dates have not been confirmed. Check Royal Caribbean's official announcements for the latest timeline updates as the opening approaches."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "How much will Royal Beach Club Cozumel cost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pricing has not been announced. Based on Royal Beach Club Paradise Island, expect base admission around $99-149 per person depending on season, with food and alcoholic beverages as additional charges. Cabana rentals will likely add $249-599 depending on type."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will I still be able to visit regular Cozumel?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Royal Beach Club will be one shore excursion option among many. You can choose between the beach club experience or exploring Cozumel independently — visiting existing beach clubs, snorkeling the reefs, touring ruins, or exploring San Miguel. The beach club doesn't replace other options."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How is Royal Beach Club different from CocoCay?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "CocoCay is Royal Caribbean's private island where entire ships disembark. Royal Beach Club is a premium beach club with limited capacity and separate admission — more like an upscale shore excursion than a private island. Both offer exclusive experiences but with different scales and pricing models."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Royal Beach Club if I'm not on a Royal Caribbean cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Royal Beach Club destinations are exclusively for Royal Caribbean cruise guests who book through the ship's shore excursion system. They are not open to independent visitors or guests from other cruise lines."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will there be snorkeling at Royal Beach Club Cozumel?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Likely yes, though details are unconfirmed. Cozumel's position on the Mesoamerican Barrier Reef makes snorkeling a natural fit. Whether it will match the quality of dedicated boat snorkel trips to sites like Palancar Reef remains to be seen."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Royal Beach Club Cozumel wheelchair accessible?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Based on the Paradise Island model, the main facilities should be wheelchair accessible with beach wheelchairs available. Premium features like overwater cabanas typically require stair access. Confirm specific accommodations when booking becomes available."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Should I book Royal Beach Club or explore Cozumel independently?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It depends on your priorities. The beach club will offer guaranteed quality, zero logistics, and controlled crowds — ideal for families, first-timers, and those wanting hassle-free relaxation. Independent exploration offers world-class reef snorkeling, Mayan ruins, authentic Mexican food, and lower costs. See my comparison above for a detailed breakdown."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/salvador.html
+++ b/ports/salvador.html
@@ -53,44 +53,68 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Salvador?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at the cruise terminal in the Comércio district (Lower City/Cidade Baixa). The UNESCO World Heritage Pelourinho historic center is about 1 km away, reachable by taxi (10 min) or the iconic Elevador Lacerda. Mercado Modelo is walking distance from the pier."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What should I see in Pelourinho?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Pelourinho is a UNESCO World Heritage site featuring colorful colonial Portuguese architecture, cobblestone streets, baroque churches (especially São Francisco with its gold leaf interior), live music, and capoeira performances. Plan 3-4 hours to explore the triangular squares, museums, and vibrant street life."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Salvador safe for cruise visitors?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Tourist areas (Pelourinho, Barra, Mercado Modelo) are generally safe with police presence. Use normal city caution — keep valuables secure, don't display expensive items unnecessarily, stay in well-traveled areas. Organized tours add security comfort."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I see capoeira performances in Salvador?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes! Free performances happen in Pelourinho plazas throughout the day, especially Largo do Pelourinho. Tuesday evenings feature street parties with capoeira, drums, and dancing. Some schools offer quick intro lessons for visitors (~R$50)."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Salvador?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships dock at the cruise terminal in the Comercio district (Lower City). Pelourinho is approximately 1 km away, reachable by taxi (10 min, cost R$20-30) or the Elevador Lacerda elevator. Mercado Modelo is walking distance from the pier."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I see in Pelourinho?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The UNESCO historic center offers colorful colonial architecture, the Church of Sao Francisco (gold leaf baroque interior), capoeira performances, live music, and triangular plazas. Plan 3-4 hours minimum to explore properly."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Salvador safe for cruise visitors?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tourist areas (Pelourinho, Barra, Mercado Modelo) are generally safe with police presence. Use normal city caution — keep valuables secure, avoid displaying expensive items, and stay in well-traveled areas. Organized tours and ship excursion groups provide additional security and comfort."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is acaraje and how much does it cost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Iconic Bahian street food — black-eyed pea fritters fried in palm oil, split and filled with shrimp paste, dried shrimp, and okra. Sold by Baianas (women in white dress). Typically $2-4 each. Spicy and delicious — an essential Salvador experience."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I see capoeira performances?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes! Free performances happen in Pelourinho plazas throughout the day, especially Largo do Pelourinho. Tuesday evenings feature street parties with capoeira, drums, and dancing. Some schools offer quick intro lessons for visitors (~R$50 / $10)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to speak Portuguese?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Helpful but not essential. English is limited outside major tourist sites. Spanish is sometimes understood since it is similar to Portuguese. Key phrases and patience go far. Guides on ship excursion tours speak English."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the port accessible for wheelchair users?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The cruise terminal itself has accessible ramps. However, Pelourinho's cobblestone streets and steep hills present significant challenges for wheelchair users and those with mobility difficulties. The Elevador Lacerda is accessible and provides transport between cities. Taxi access to specific accessible viewpoints is recommended for those with walking difficulty."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/san-francisco.html
+++ b/ports/san-francisco.html
@@ -60,44 +60,68 @@ Soli Deo Gloria
 
   <!-- JSON-LD: FAQPage -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in San Francisco?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at the James R. Herman Cruise Terminal at Pier 27 on The Embarcadero, along the northern waterfront. The terminal is about 20 minutes walk to the Embarcadero BART/Muni station, and you can walk to Fisherman's Wharf in 15 minutes."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Do I need to book Alcatraz tickets in advance?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, absolutely. Alcatraz tickets sell out 2-4 weeks in advance, especially during summer. Book through the official Alcatraz Cruises website as soon as you know your cruise dates. Ferry departs from Pier 33."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I walk across the Golden Gate Bridge?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes! The pedestrian walkway is free and open during daylight hours. It's about 1.7 miles one way. You can take a bus or Uber to the bridge and walk across, or rent a bike for the full experience."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What's the best way to get around San Francisco from the cruise terminal?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The F-Market historic streetcar runs along the Embarcadero from near the terminal to Fisherman's Wharf for $3. Cable cars cost $8 per ride. Uber/Lyft work well, and walking the waterfront to Fisherman's Wharf takes about 15 minutes."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in San Francisco?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "James R. Herman Cruise Terminal at Pier 27 on The Embarcadero. Modern facility on northern waterfront, walkable to Fisherman's Wharf (15 min) and downtown. The terminal is fully accessible for wheelchair users and passengers with mobility challenges."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to book Alcatraz tickets in advance?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "YES. Book 2-4 weeks ahead through official Alcatraz Cruises website. Tickets cost $41 per adult and sell out, especially in summer. Ferry departs Pier 33 (5 min walk from cruise terminal)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I walk to the Golden Gate Bridge from the cruise terminal?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It is 3.5 miles from cruise terminal to bridge — doable but a long walk (1 hour+). Better: take bus, Uber ($20-25), or bike rental ($8/hour). Once there, pedestrian walkway is free and spectacular."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best way to see the city on a cruise day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "If you have Alcatraz tickets, that is your priority (3 hours total). Without Alcatraz: walk waterfront to Fisherman's Wharf, ride cable car ($8), explore North Beach or Chinatown, visit Coit Tower ($10 elevator). City is walkable but hilly."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will the weather be foggy?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Likely! Summer (June-August) is foggiest. September-October warmest and clearest. Bring layers regardless — fog can roll in any time. That is part of the charm."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best time of year to visit San Francisco?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Peak cruise season runs May through October. September and October offer the warmest, clearest weather. Check the weather section above for specific month recommendations based on your planned activities."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for San Francisco?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Layers are essential — a warm jacket, comfortable walking shoes with good grip for hills, and sunscreen. Even in summer, fog can drop temperatures quickly. Check the packing tips section in our weather section for more recommendations."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/sharm-el-sheikh.html
+++ b/ports/sharm-el-sheikh.html
@@ -61,44 +61,60 @@ Soli Deo Gloria
   }
   </script>
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Sharm el-Sheikh?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Cruise ships anchor offshore in Sharm el-Sheikh Bay and tender passengers to the marina in Sharm el Maya, the older part of town. The tender ride takes about 15-20 minutes and offers beautiful views of the Sinai mountains."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Sharm el-Sheikh good for diving and snorkeling?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Sharm el-Sheikh is one of the world's premier diving destinations. The nearby Ras Mohammed National Park and Tiran Island offer spectacular coral reefs, diverse marine life, and excellent visibility year-round. Even beginners can enjoy outstanding snorkeling from many beaches."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What currency do I need in Sharm el-Sheikh?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The Egyptian Pound (EGP) is the official currency, but US dollars and euros are widely accepted in tourist areas. ATMs are available, and credit cards work in larger establishments. Bring small bills for tips and market purchases."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Sharm el-Sheikh safe for tourists?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, the resort areas are very safe with visible security. Tourism is Egypt's economic lifeline, and authorities prioritize visitor safety. Follow normal precautions and respect local customs."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Sharm el-Sheikh?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships anchor offshore in Sharm el-Sheikh Bay and tender passengers to the marina at Sharm el Maya. The tender ride takes 15-20 minutes and offers beautiful views of the Sinai mountains. Tender tickets are distributed onboard — arrive early on busy days to avoid long waits."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Sharm el-Sheikh good for diving and snorkeling?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely — it is one of the world's premier diving destinations. Ras Mohammed National Park and Tiran Island offer spectacular coral reefs, diverse marine life, and excellent year-round visibility. Even beginners can enjoy outstanding snorkeling from many of the protected bays."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What currency do I need in Sharm el-Sheikh?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The Egyptian Pound (EGP) is official, but US dollars and euros are widely accepted in tourist areas. Bring small bills ($1, $5, $10) for tips and purchases. ATMs are available but often have queues on port days."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Sharm el-Sheikh safe for tourists?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, the resort areas are very safe with visible security. Tourism is Egypt's economic lifeline, and authorities prioritize visitor safety. Follow normal precautions and respect local customs."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need a visa for Egypt?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most nationalities need a visa. Many cruise lines arrange shore passes for day visits. If exploring independently, check current visa requirements for your nationality. Single-entry tourist visas are often available on arrival ($25 USD)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can beginners snorkel safely in Sharm el-Sheikh?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Many shores have gentle, shallow entry points ideal for beginners. Organized snorkel tours provide flotation devices and guides. Start at protected bays before venturing to reef walls. Always snorkel with a buddy and wear reef-safe sunscreen."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/sihanoukville.html
+++ b/ports/sihanoukville.html
@@ -73,40 +73,61 @@ Soli Deo Gloria
   </script>
 
     <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
     {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      "mainEntity": [{
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Sihanoukville?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at Sihanoukville Autonomous Port, Cambodia's only deep-water port. The port is approximately 3-4 km from the main beach areas. Taxis and tuk-tuks are readily available at the terminal."
-        }
-      },{
-        "@type": "Question",
-        "name": "Which island is best for a day trip from Sihanoukville?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Koh Rong Samloem offers the most pristine, tranquil experience with crystal-clear waters and white sand beaches. It's less developed than Koh Rong and ideal for swimming and snorkeling. The ferry takes about 40 minutes from Serendipity Beach pier."
-        }
-      },{
-        "@type": "Question",
-        "name": "What currency should I bring to Sihanoukville?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "US Dollars are widely accepted throughout Sihanoukville, often preferred over the Cambodian Riel. Bring small bills ($1, $5, $10) as change can be limited. ATMs dispense USD and are available near the beaches."
-        }
-      },{
-        "@type": "Question",
-        "name": "Is Sihanoukville safe for cruise visitors?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Sihanoukville is generally safe for tourists, though rapid development has brought some growing pains. Stick to main beach areas and established tourist zones during the day. Avoid walking alone at night and keep valuables secure. The island day trips are very safe."
-        }
-      }]
+      "@type": "Question",
+      "name": "What's the best time of year to visit Sihanoukville, Cambodia?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Peak cruise season offers the most reliable weather and best conditions for sightseeing. Check the weather section above for specific month recommendations based on your planned activities."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Sihanoukville, Cambodia have extreme weather to worry about?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Like most destinations, weather conditions vary by season. Check the weather hazards section above for specific concerns and the best time to visit. Cruise lines monitor conditions and will adjust itineraries if needed for passenger safety."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Sihanoukville, Cambodia's weather?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Essentials include sunscreen, comfortable walking shoes, and layers for variable conditions. Check the packing tips section in our weather section for destination-specific recommendations."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will rain ruin my port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Brief showers are common in many destinations but rarely last long enough to significantly impact your day. Have a backup plan for indoor attractions, and remember that many activities continue in light rain. Check the weather forecast before your visit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Sihanoukville, Cambodia have a hurricane or storm season?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Weather patterns vary by region and season. Check the weather hazards section above for specific storm season concerns and timing. Cruise lines closely monitor weather conditions and will adjust itineraries if needed for passenger safety. Travel insurance is recommended for cruises during peak storm season months."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Sihanoukville?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships dock at Sihanoukville Autonomous Port, Cambodia's only deep-water port. The port is approximately 3-4 km from the main beach areas. Taxis and tuk-tuks are readily available at the terminal, charging around $5-7 for the ride to Ochheuteal or Serendipity beaches."
+      }
     }
-    </script>
+  ]
+}
+  </script>
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">

--- a/ports/south-shetland-islands.html
+++ b/ports/south-shetland-islands.html
@@ -76,29 +76,53 @@ ITW-Lite v3.010 | ICP-Lite v1.4
 
     <!-- Structured Data: FAQPage -->
     <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "FAQPage",
-        "mainEntity": [
-          {
-            "@type": "Question",
-            "name": "What is Deception Island?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Deception Island is an active volcanic caldera in the South Shetland Islands. Ships sail through Neptune's Bellows into the flooded caldera. Hot springs warm the black sand beaches. Abandoned whaling station remains at Whalers Bay."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "Which research stations can you visit in the South Shetlands?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "King George Island has multiple research stations from different countries. Visits depend on prior arrangement and weather. Stations occasionally welcome cruise passengers for brief tours."
-            }
-          }
-        ]
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How much does an Antarctic expedition cruise cost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Expedition cruises to the South Shetland Islands and Antarctic Peninsula typically range from $5,000 to $15,000 per person for 10 to 21-day voyages departing from Ushuaia. All landing fees, Zodiac operations, expedition gear loans, lectures, and meals are included. Budget an additional $50 to $100 for waterproof gear rental if your ship charges separately, plus $15 to $20 per day for crew gratuities."
       }
-    </script>
+    },
+    {
+      "@type": "Question",
+      "name": "Is the South Shetland Islands suitable for passengers with mobility challenges?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Antarctic landings require stepping from a moving Zodiac onto wet, uneven terrain. Passengers need reasonable mobility, balance, and the ability to climb a short gangway ladder. Some expedition ships offer scenic Zodiac cruising as an alternative to landings for passengers who cannot manage wet beach terrain. Discuss your needs with the expedition company before booking."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Antarctic landings?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Thermal base layers, fleece mid-layers, waterproof outer shell, insulated waterproof boots (many ships provide these), warm hat, waterproof gloves, neck gaiter, and sunglasses with UV protection. Bring SPF 50+ sunscreen — the ozone is thin. A dry bag protects camera gear during Zodiac transfers. Leave cotton clothing at home; it retains moisture and loses insulation when wet."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I explore independently in Antarctica?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. All landings are guided by expedition staff following strict IAATO protocols. You must stay on designated paths, maintain wildlife distances, and return to the Zodiac when instructed. There is no independent transport, no infrastructure, and no services on shore. This structure protects both visitors and the Antarctic environment."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "When is the best time to visit the South Shetland Islands?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The Antarctic cruise season runs November through March. Early season (November to December) brings pristine snow, penguin courtship, and long daylight hours. Mid-season (January) offers the warmest temperatures and penguin chicks. Late season (February to March) brings whale activity and fledging penguin chicks. Each period has its rewards."
+      }
+    }
+  ]
+}
+  </script>
 
     <link rel="stylesheet" href="/assets/styles.css?v=3.010.400">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">

--- a/ports/tianjin.html
+++ b/ports/tianjin.html
@@ -67,52 +67,68 @@ All work on this project is offered as a gift to God.
   </script>
 
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "How far is Beijing from Tianjin cruise port?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Beijing is approximately 2 hours from Tianjin International Cruise Home Port by high-speed train or comfortable coach. Most cruise lines offer organized excursions with transportation included."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I visit the Great Wall from Tianjin in one day?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes - the Mutianyu or Badaling sections are both reachable as full-day excursions from Tianjin. Book a ship excursion or private tour to maximize your time and ensure you return before all-aboard."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What can I see in Tianjin itself if I don't go to Beijing?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Tianjin has charming Italian-style streets, the Five Great Avenues historic district, Ancient Culture Street for traditional crafts, and the beautiful Hai He River promenade. It's a wonderful alternative if you've already visited Beijing."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is the Forbidden City worth visiting from a cruise stop?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Absolutely - the Forbidden City is one of the world's greatest imperial palaces and a UNESCO World Heritage Site. Combined with Tiananmen Square and Temple of Heaven, it's an unforgettable full-day experience from Tianjin."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Do I need a visa to visit Tianjin and Beijing?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Many cruise passengers qualify for China's 144-hour visa-free transit policy for Beijing-Tianjin-Hebei region. Check with your cruise line and verify your nationality's requirements before arrival."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How far is Beijing from Tianjin cruise port?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Beijing is approximately 170 km (2-2.5 hours by coach, 30-35 minutes by bullet train from Tianjin Railway Station). Most cruise lines offer organized ship excursions with transportation included at a cost of $150-280 per person depending on itinerary. The fare for the bullet train alone is approximately ¥55 ($8)."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit the Great Wall from Tianjin in one day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — the Mutianyu or Badaling sections are both reachable as full-day excursions from Tianjin. Book a ship excursion or private tour to maximize your time and ensure you return before all-aboard. Expect 12-14 hours total for a Great Wall day trip."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What can I see in Tianjin itself if I don't go to Beijing?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tianjin has the charming Italian Quarter with European architecture, the Five Great Avenues historic district, Ancient Culture Street for traditional crafts and folk art, the remarkable Porcelain House, and the beautiful Hai River promenade. It is a wonderful alternative if you have already visited Beijing or prefer a less intensive port day."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need a visa to visit Tianjin and Beijing?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Many cruise passengers qualify for China's 144-hour visa-free transit policy for the Beijing-Tianjin-Hebei region. Check with your cruise line and verify your nationality's eligibility before arrival. Requirements can change, so always confirm with official sources."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the Forbidden City accessible for visitors with limited mobility?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The Forbidden City grounds are largely flat and the main pathway through the complex is wheelchair accessible. Ramps are available at major halls. However, some secondary halls have steps without ramps. The cruise terminal in Tianjin is also wheelchair accessible with lifts and level boarding."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I pack for Tianjin?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Essentials include comfortable walking shoes with good grip (especially for the Great Wall), sunscreen, layers for variable weather, a rain jacket, and a translation app on your phone. Spring and autumn days can be warm but evenings cool quickly."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best time of year to visit Tianjin?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "April-May and September-October offer the mildest weather and clearest skies. Summer (June-August) brings extreme heat and monsoon rains. Winter is bitterly cold. Peak cruise season aligns well with the best weather windows."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- LCP Optimization: Preload critical hero images -->

--- a/ports/ushuaia.html
+++ b/ports/ushuaia.html
@@ -58,44 +58,52 @@ Soli Deo Gloria
 
   <!-- JSON-LD: FAQPage -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Ushuaia?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at the Maipu Street terminal in Ushuaia's harbor, about 10 minutes' walk from the city center. The terminal is basic but functional. Taxis are available at the port, though most of the town is easily walkable."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I visit Antarctica from Ushuaia on a cruise stop?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "No — Antarctica expeditions require 10-21 days minimum and depart from Ushuaia as embarkation points, not port calls. The Drake Passage crossing alone takes 2 days each way. However, you can visit the Antarctic museums and see expedition ships departing. If Antarctica is your goal, book a dedicated expedition cruise."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What should I wear in Ushuaia?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Layers are essential! Base layer, fleece, windproof/waterproof jacket, hat, and gloves even in summer (December–March). Weather is highly variable and wind is constant and cold."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Tierra del Fuego National Park worth visiting?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Absolutely. It's the southernmost national park in the world and where the Pan-American Highway ends. Unique ecosystem, stunning scenery, and manageable hiking make it a must-see."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the best time to visit Ushuaia?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Spring and early autumn tend to offer the most comfortable conditions for sightseeing — mild temperatures, manageable crowds, and pleasant light for photography. Summer brings the warmest weather but also peak cruise traffic and higher prices. Winter visits can be rewarding for those who prefer quiet streets and authentic atmosphere, though some attractions may have reduced hours."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Ushuaia suitable for passengers with mobility challenges?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Accessibility varies by area. The port vicinity and main commercial streets are generally manageable, but older historic districts may feature cobblestones, stairs, and uneven surfaces. Consider booking an accessible ship excursion if you have concerns. The ship's shore excursion desk can advise on specific accessibility options for this port."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to exchange currency before arriving?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The local currency is ARS (USD accepted). Most tourist-facing businesses accept major credit cards. ATMs near the port offer competitive exchange rates. Carry some local cash for small purchases, markets, and tips. Avoid exchanging money on the ship — the rates are typically unfavorable compared to local bank ATMs."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I explore independently or should I book a ship excursion?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both options work well. Ship excursions guarantee return to the vessel and handle logistics, making them ideal for first-time visitors. Independent exploration costs less and allows more flexibility — just keep track of time and allow a 30-minute buffer before all-aboard. Many passengers combine approaches: an organized morning tour followed by free afternoon exploration."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I bring on a port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Comfortable walking shoes are essential — you will walk more than you expect. Sunscreen, a hat, and a refillable water bottle help in warm weather. Carry your ship card (or a photo of it), a small amount of local cash, and one credit card. Leave jewelry and unnecessary valuables on the ship. A lightweight daypack beats a purse or tote for all-day comfort."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/walvis-bay.html
+++ b/ports/walvis-bay.html
@@ -57,52 +57,68 @@ Soli Deo Gloria
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Walvis Bay?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at Walvis Bay's commercial deep-water port, Namibia's only major Atlantic harbor. The port handles cargo and cruise vessels. Organized excursions recommended as the terminal area is industrial. Swakopmund (30 min north) offers more tourist infrastructure."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I visit Sossusvlei and the red dunes from Walvis Bay?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, but it requires a full-day excursion (12-14 hours). The drive to Sossusvlei is 4-5 hours each way through the Namib Desert. You can see Big Daddy (380m), Dune 45, and Deadvlei. Book through your cruise line or reputable tour operator. Bring water, sun protection, and stamina."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "What is Sandwich Harbour?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Sandwich Harbour is where massive sand dunes crash directly into the Atlantic Ocean, creating one of the world's most surreal landscapes. 4x4 excursions navigate the beach at low tide. Bring cameras."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I see flamingos in Walvis Bay?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, thousands of pink flamingos (both greater and lesser species) wade in the lagoon year-round. Best viewing from the waterfront promenade. They are spectacular against the desert backdrop."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Walvis Bay accessible for wheelchair users?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The waterfront promenade is mostly flat and accessible. However, desert excursions like Sossusvlei and Sandwich Harbour involve rough terrain. Discuss mobility needs with your tour operator in advance. The Swakopmund boardwalk is wheelchair friendly."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Walvis Bay?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships dock at Walvis Bay's commercial deep-water port. The setting is industrial with cargo and fishing vessels. Organized excursions are recommended. Swakopmund (30 minutes north) offers better tourist infrastructure for independent visitors."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Sossusvlei and the red dunes from a cruise stop?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, but it requires a full-day excursion of 12-14 hours. The drive is 4-5 hours each way through the desert. You will see Big Daddy, Dune 45, and Deadvlei. Book a ship excursion for guaranteed return or use a reputable independent operator. Bring stamina, water, and sun protection."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "When can I see the flamingos?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Year-round. Walvis Bay lagoon hosts 50,000+ lesser and greater flamingos feeding in shallow water. Best viewing is from the waterfront promenade or from boat tours. Pelican Point adds the seal colony to the experience."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I wear?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Layers. Mornings are cold (10 C / 50 F), midday is warm in the sun (25 C / 77 F). Bring a hat, sunglasses, sunscreen, and sturdy shoes for dune climbing. Wind is common — a light jacket is useful."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Sandwich Harbour worth visiting?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely. The landscape where giant dunes meet the ocean is surreal and unforgettable. Requires a 4x4 and low tide. Half-day tours deliver dramatic scenery and wildlife. Tide-dependent — confirm timing with your operator."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Walvis Bay accessible for wheelchair users or those with mobility challenges?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The waterfront lagoon promenade is flat and wheelchair accessible. However, desert excursions such as Sossusvlei and Sandwich Harbour involve rough terrain unsuitable for wheelchairs. Discuss mobility needs with your tour operator in advance. The Swakopmund boardwalk is also accessible and offers good Atlantic views."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Should I visit Walvis Bay or Swakopmund?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Swakopmund (30 minutes north) has better tourist infrastructure, German colonial charm, cafes, and museums. Walvis Bay is industrial but is the gateway to flamingos, Sandwich Harbour, and Sossusvlei. Do both if time allows."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/wellington.html
+++ b/ports/wellington.html
@@ -58,60 +58,76 @@ Soli Deo Gloria
 
   <!-- JSON-LD: FAQPage (ICP-Lite) -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Where do cruise ships dock in Wellington?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships dock at Aotea Quay, about 2 kilometers from downtown Wellington. You can walk the scenic waterfront path or take a shuttle."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Te Papa Museum free to visit?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, general admission to Te Papa is free. Some special exhibitions may charge a fee of NZ$10-25. Don't miss the colossal squid."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "How windy is Windy Wellington?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Genuinely windy. Cook Strait funnels powerful southerly winds through the city. Bring layers and hold onto your hat."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I do Weta Workshop on a port day?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, but book ahead. It's 15-20 min from downtown by taxi or shuttle. Cost is around NZ$35 per person."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Wellington walkable for wheelchair users?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The waterfront is flat and accessible, but some hillside streets are steep. The cable car is wheelchair accessible at both stations."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Zealandia worth the trip?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "If you love wildlife and conservation, absolutely. It's the world's first fully-fenced urban ecosanctuary. About 10 minutes from downtown. Entry fee is NZ$21 for adults."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Where do cruise ships dock in Wellington?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships dock at Aotea Quay, about 2 km from downtown. The scenic waterfront walk takes 20-25 minutes, or take the free shuttle provided by most cruise lines. The path is flat and wheelchair accessible."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Te Papa really free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, general admission is free. Some special exhibitions charge a fee of NZ$10-25. The museum is open daily and you should allow at least 2-3 hours to explore properly."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How windy is \"Windy Wellington\"?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Genuinely windy. Cook Strait funnels powerful southerly winds through the city, making it one of the windiest capitals in the world. Wind speeds can reach 100+ km/h during storms, though average days see sustained winds of 20-30 km/h. Bring layers and a windproof jacket."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I do Weta Workshop on a port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, but book ahead. It is 15-20 min from downtown by taxi (NZ$20-30) or shuttle. Tours cost approximately NZ$35 per person and last about 90 minutes."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Wellington accessible for wheelchair users?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The waterfront is flat and fully accessible. Te Papa has excellent accessibility features. The Cable Car accommodates wheelchairs at both stations. However, some hillside streets are steep and may be challenging. Taxis can help bypass difficult terrain."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Zealandia worth the trip?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely, especially for wildlife and conservation enthusiasts. Entry costs NZ$21 for adults. It is the world's first fully-fenced urban ecosanctuary where you can see rare native birds thriving. Allow 2-3 hours including travel time from downtown."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the best time of year to visit Wellington?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Peak cruise season (October to March) offers the most reliable weather and warmest temperatures. Summer days average 20 degrees Celsius. Even in summer, bring layers — the wind makes it feel cooler than expected."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will rain ruin my port day?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Brief showers are common but rarely last long. Te Papa is an excellent indoor option for rainy days. Have a backup plan, but don't let the forecast discourage you — Wellington's weather changes quickly and often improves within the hour."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/ports/zakynthos.html
+++ b/ports/zakynthos.html
@@ -58,44 +58,60 @@ Soli Deo Gloria
 
   <!-- JSON-LD FAQPage -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "How do cruise ships dock at Zakynthos?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Ships anchor offshore and tender passengers to the main pier in Zakynthos Town. Tender ride takes 10-15 minutes depending on conditions. The pier puts you directly in the town center near St. Dionysios Church."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I visit Shipwreck Beach from the cruise port?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes, but only by boat. Navagio (Shipwreck) Beach is accessible only by water. Book a boat tour from Zakynthos Town or Porto Vromi. Tours typically include Blue Caves and viewing the wreck from above at the clifftop viewpoint. Half-day tours run €30-50."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Will I see sea turtles in Zakynthos?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Possibly. Loggerhead turtles nest on southern beaches (Gerakas, Daphni) May-October. Sightings not guaranteed but nesting areas have information centers and protected zones. Boat tours sometimes spot turtles in the water."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is there a beach I can walk to from the port?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Zakynthos Town has a small town beach (Krioneri) within walking distance, but it is not the island's best. For better beaches, take a taxi to Banana Beach (15-20 min) or book a boat tour to Navagio."
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do cruise ships dock at Zakynthos?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ships anchor offshore and tender passengers to the main pier in Zakynthos Town. The tender ride takes 10-15 minutes depending on sea conditions. The pier puts you directly in the town center near St. Dionysios Church. Those with wheelchair or mobility needs should request priority tender boarding from the ship's guest services desk."
       }
-    ]
-  }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I visit Shipwreck Beach from the cruise port?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, but only by boat. Navagio Beach is accessible only by water. Book a boat tour from Zakynthos Town or Porto Vromi at €30-50 for a half-day tour. Tours typically include Blue Caves and the clifftop viewpoint. Both ship excursion and independent options are available."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will I see sea turtles?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Possibly. Loggerhead turtles nest on southern beaches (Gerakas, Daphni) from May through October. Sightings are not guaranteed but nesting areas have information centers and protected zones. Boat tours sometimes spot turtles surfacing in the water near the coast."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a beach I can walk to from the port?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zakynthos Town has a small town beach (Krioneri) within walking distance, but it is not the island's best. For better beaches, take a taxi to Banana Beach at €25-30 each way (15-20 minutes) or book a boat tour to Navagio Beach."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need cash or can I use credit cards?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Euros are essential for some purchases. ATMs are available on the main square and near the harbor. Credit cards are accepted in most restaurants and shops, but boat tour operators and taxi drivers often prefer cash. Bring at least €50-100 in cash for flexibility."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Zakynthos accessible for those with limited mobility?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The town center is mostly flat and manageable, though some sidewalks are uneven. Tender boarding may require assistance — notify guest services in advance. Boat tours involve stepping onto and off small vessels. Bohali Castle requires uphill walking. Banana Beach has relatively easy access. Wheelchair users should plan carefully and communicate needs to tour operators ahead of time."
+      }
+    }
+  ]
+}
   </script>
 
   <!-- Twitter Card -->

--- a/scripts/port-weather-validator-core.js
+++ b/scripts/port-weather-validator-core.js
@@ -418,7 +418,9 @@ class PortWeatherValidator {
       // be double-counted into a false mismatch. The deeper "visible FAQ set vs
       // FAQPage schema drift" question is tracked separately (see #2444 follow-up).
       const qPrefixed = this.count(/<p><strong>Q:|<strong>Q:|<summary[^>]*>Q:/);
-      const summaryFAQs = this.count(/<details class="faq-item"><summary>/);
+      // Whitespace between <details class="faq-item"> and <summary> is legal HTML.
+      // The old single-line regex produced Page:0 on indented markup (#2444 / chilean-fjords).
+      const summaryFAQs = this.count(/<details class="faq-item"[^>]*>\s*<summary/);
       const divFAQs = this.count(/<div[^>]*class="(?:[^"]*\s)?faq-item(?:\s[^"]*)?"[^>]*>\s*<h[1-6]/);
       const vq = Math.max(qPrefixed, summaryFAQs, divFAQs);
       if (sq !== vq) this.log('error', 'FAQ_COUNT', `FAQ count mismatch`, `Schema: ${sq}, Page: ${vq}`);

--- a/tests/unit/port-weather-faq/extract.test.mjs
+++ b/tests/unit/port-weather-faq/extract.test.mjs
@@ -55,3 +55,14 @@ test("mixed formats accumulate across all four", () => {
   const q = extract(html);
   assert.deepEqual(q.sort(), ["One?", "Three?", "Two?"]);
 });
+
+test("FAQ_COUNT regex counts indented details.faq-item (not Page:0)", () => {
+  const v = new PortWeatherValidator("/virtual/petersburg.html");
+  v.content = `<details class="faq-item">
+        <summary>What is Petersburg Alaska known for?</summary>
+        <p>Little Norway.</p>
+      </details>`;
+  assert.equal(v.count(/<details class="faq-item"[^>]*>\s*<summary/), 1);
+  v.content = `<details class="faq-item" style="margin:0"><summary>Q?</summary></details>`;
+  assert.equal(v.count(/<details class="faq-item"[^>]*>\s*<summary/), 1);
+});


### PR DESCRIPTION
## Summary

Closes live `FAQ_COUNT` mismatches for HLS `itw-faq-count-prefix` / #2444.

- Validator: `<details class="faq-item">` may have attributes and whitespace before `<summary>` (Petersburg / indented markup was Page:0).
- Petersburg FAQ `<details>` tagged `class="faq-item"`.
- 39 other ports: FAQPage `mainEntity` expanded from visible Q&A already on the page (not invented).

Fleet `FAQ_COUNT` mismatches: **40 → 0**. Extract tests **8/8**. Mutation: drop one Holyhead schema Question → `FAQ_COUNT` errors; restored.

Barcelona-style dual-format pages still use Math.max (not a sum), so a 5-accordion + 5-inline page with schema 5 does not false-fail.

Soli Deo Gloria.
